### PR TITLE
Encrypted budget support (build 39 / v1.0.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Pods/
 
 # Website build output
 website/dist/
+
+# Local dev helpers (e.g. docker-compose test server)
+dev/

--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = GJGY9A384M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -356,12 +356,12 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -381,7 +381,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_TEAM = GJGY9A384M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -391,12 +391,12 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -394,6 +394,22 @@ final class BudgetStore: ObservableObject {
         downloadingBudgetId = nil
     }
 
+    /// Validate an encryption password for a budget, persist the derived key, then download it.
+    /// Returns nil on success, or a user-facing error message on failure (so the sheet can stay open).
+    func unlockAndOpen(_ remoteBudget: RemoteBudget, password: String) async -> String? {
+        do {
+            let keyInfo = try await serverClient.getKeyInfo(fileId: remoteBudget.id)
+            let loaded = try EncryptionKeyManager.deriveAndValidate(password: password, keyInfo: keyInfo)
+            try EncryptionKeyManager.store(loaded, fileId: remoteBudget.id)
+        } catch let e as EncryptionKeyError {
+            return e.errorDescription
+        } catch {
+            return error.localizedDescription
+        }
+        await downloadBudget(remoteBudget)
+        return error   // any download error surfaced by downloadBudget
+    }
+
     func loadLocalBudget(_ budgetId: String) async {
         isLoading = true
         error = nil

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -335,11 +335,6 @@ final class BudgetStore: ObservableObject {
     }
 
     func downloadBudget(_ remoteBudget: RemoteBudget) async {
-        guard !remoteBudget.isEncrypted else {
-            error = "Encrypted budgets are not yet supported"
-            return
-        }
-
         isLoading = true
         downloadingBudgetId = remoteBudget.id
         error = nil
@@ -351,22 +346,46 @@ final class BudgetStore: ObservableObject {
         database = nil
 
         do {
-            // Download the ZIP file
-            let zipData = try await serverClient.downloadFile(fileId: remoteBudget.id)
+            var loadedKey: LoadedKey?
+            if remoteBudget.isEncrypted {
+                guard let key = EncryptionKeyManager.load(fileId: remoteBudget.id) else {
+                    self.error = "This budget is encrypted. Enter its encryption password to open it."
+                    isLoading = false
+                    downloadingBudgetId = nil
+                    return
+                }
+                loadedKey = key
+            }
 
-            // Extract and import
+            // Download the (possibly encrypted) ZIP blob.
+            var zipData = try await serverClient.downloadFile(fileId: remoteBudget.id)
+
+            // Decrypt the whole blob for encrypted budgets.
+            if let loadedKey {
+                let info = try await serverClient.getFileInfo(fileId: remoteBudget.id)
+                guard let meta = info.encryptMeta else {
+                    throw ActualServerError.invalidResponse
+                }
+                guard meta.keyId == loadedKey.keyId else {
+                    try? EncryptionKeyManager.remove(fileId: remoteBudget.id)
+                    self.error = "This budget's encryption key has changed. Re-enter the password."
+                    isLoading = false
+                    downloadingBudgetId = nil
+                    return
+                }
+                guard let iv = meta.iv, let authTag = meta.authTag else {
+                    throw ActualServerError.invalidResponse
+                }
+                zipData = try SyncEncryption.decrypt(
+                    ciphertext: zipData, ivBase64: iv, authTagBase64: authTag, using: loadedKey.key
+                )
+            }
+
             let metadata = try await fileManager.importBudget(
-                from: zipData,
-                fileId: remoteBudget.id,
-                groupId: remoteBudget.groupId
+                from: zipData, fileId: remoteBudget.id, groupId: remoteBudget.groupId
             )
-
-            // Set as current budget
             currentBudgetId = metadata.id
-
-            // Load the budget
             await loadLocalBudget(metadata.id)
-
         } catch {
             self.error = error.localizedDescription
         }
@@ -439,12 +458,15 @@ final class BudgetStore: ObservableObject {
             }
 
             if let db = database {
+                let loadedKey = EncryptionKeyManager.load(fileId: fileId)
                 try await syncClient?.configure(
                     database: db,
                     fileId: fileId,
-                    groupId: groupId
+                    groupId: groupId,
+                    encryptionKey: loadedKey?.key,
+                    keyId: loadedKey?.keyId
                 )
-                logger.info("Sync configuration successful")
+                logger.info("Sync configuration successful (encrypted: \(loadedKey != nil, privacy: .public))")
             } else {
                 logger.error("Database is nil, cannot configure sync")
             }

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -277,7 +277,7 @@ actor ActualServerClient {
         guard let serverURL else { throw ActualServerError.invalidURL }
         guard let token else { throw ActualServerError.unauthorized }
 
-        let url = serverURL.appendingPathComponent("/user-get-key")
+        let url = serverURL.appendingPathComponent("/sync/user-get-key")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -66,6 +66,20 @@ struct FileInfoResponse: Codable, Sendable {
 
     struct EncryptMeta: Codable, Sendable {
         let keyId: String
+        let algorithm: String?
+        let iv: String?
+        let authTag: String?
+    }
+}
+
+struct KeyInfoResponse: Codable, Sendable {
+    let status: String
+    let data: KeyData?
+
+    struct KeyData: Codable, Sendable {
+        let id: String
+        let salt: String
+        let test: String?
     }
 }
 
@@ -257,6 +271,33 @@ actor ActualServerClient {
         }
 
         return fileInfo
+    }
+
+    func getKeyInfo(fileId: String) async throws -> ServerKeyInfo {
+        guard let serverURL else { throw ActualServerError.invalidURL }
+        guard let token else { throw ActualServerError.unauthorized }
+
+        let url = serverURL.appendingPathComponent("/user-get-key")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
+        request.httpBody = try JSONEncoder().encode(["token": token, "fileId": fileId])
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ActualServerError.invalidResponse
+        }
+        if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
+        guard httpResponse.statusCode == 200 else {
+            throw ActualServerError.httpError(statusCode: httpResponse.statusCode, message: String(data: data, encoding: .utf8))
+        }
+
+        let decoded = try JSONDecoder().decode(KeyInfoResponse.self, from: data)
+        guard decoded.status == "ok", let key = decoded.data else {
+            throw ActualServerError.invalidResponse
+        }
+        return ServerKeyInfo(id: key.id, salt: key.salt, test: key.test)
     }
 
     // MARK: - Sync

--- a/Actuali/Actuali/Services/Sync/EncryptionKeyManager.swift
+++ b/Actuali/Actuali/Services/Sync/EncryptionKeyManager.swift
@@ -1,0 +1,90 @@
+// Actuali/Actuali/Services/Sync/EncryptionKeyManager.swift
+
+import Foundation
+import CryptoKit
+
+/// Server response from POST /user-get-key.
+struct ServerKeyInfo: Codable, Sendable {
+    let id: String
+    let salt: String
+    let test: String?   // JSON string {value, meta:{keyId,algorithm,iv,authTag}}, or nil for legacy keys
+}
+
+/// A validated, in-memory encryption key for a budget.
+struct LoadedKey: Equatable, Sendable {
+    let keyId: String
+    let key: SymmetricKey
+}
+
+enum EncryptionKeyError: LocalizedError {
+    case invalidPassword
+    case unsupportedLegacyKey
+    case malformedTestMessage
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPassword:      return "Incorrect encryption password."
+        case .unsupportedLegacyKey: return "This budget uses an old encryption format that isn't supported."
+        case .malformedTestMessage: return "The server returned an unreadable encryption key test."
+        }
+    }
+}
+
+/// Derives, validates, persists, and retrieves a budget's E2EE key.
+/// Persists the derived key (never the password) in the Keychain, keyed by fileId.
+enum EncryptionKeyManager {
+
+    private struct StoredKey: Codable { let keyId: String; let base64Key: String }
+    private struct TestMessage: Codable {
+        let value: String
+        let meta: Meta
+        struct Meta: Codable { let keyId: String; let algorithm: String; let iv: String; let authTag: String }
+    }
+
+    private static func keychainKey(fileId: String) -> String { "encryptKey.\(fileId)" }
+
+    /// Derive the key from the password + server salt and validate it against the test message.
+    static func deriveAndValidate(password: String, keyInfo: ServerKeyInfo) throws -> LoadedKey {
+        guard let testJSON = keyInfo.test else { throw EncryptionKeyError.unsupportedLegacyKey }
+        guard let testData = testJSON.data(using: .utf8),
+              let test = try? JSONDecoder().decode(TestMessage.self, from: testData),
+              let ciphertext = Data(base64Encoded: test.value) else {
+            throw EncryptionKeyError.malformedTestMessage
+        }
+
+        // CRITICAL: salt is the UTF-8 bytes of the base64 salt string (matches Actual's Buffer.from(salt)).
+        let key = SyncEncryption.deriveKey(password: password, salt: Data(keyInfo.salt.utf8))
+
+        do {
+            _ = try SyncEncryption.decrypt(
+                ciphertext: ciphertext,
+                ivBase64: test.meta.iv,
+                authTagBase64: test.meta.authTag,
+                using: key
+            )
+        } catch {
+            throw EncryptionKeyError.invalidPassword
+        }
+        return LoadedKey(keyId: keyInfo.id, key: key)
+    }
+
+    static func store(_ loaded: LoadedKey, fileId: String) throws {
+        let stored = StoredKey(keyId: loaded.keyId, base64Key: loaded.key.withUnsafeBytes { Data($0).base64EncodedString() })
+        let json = String(data: try JSONEncoder().encode(stored), encoding: .utf8)!
+        try Keychain.set(json, for: keychainKey(fileId: fileId))
+    }
+
+    static func load(fileId: String) -> LoadedKey? {
+        guard let json = Keychain.get(for: keychainKey(fileId: fileId)),
+              let data = json.data(using: .utf8),
+              let stored = try? JSONDecoder().decode(StoredKey.self, from: data),
+              let keyData = Data(base64Encoded: stored.base64Key) else {
+            return nil
+        }
+        return LoadedKey(keyId: stored.keyId, key: SymmetricKey(data: keyData))
+    }
+
+    static func remove(fileId: String) throws {
+        try Keychain.remove(for: keychainKey(fileId: fileId))
+    }
+}

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -56,6 +56,7 @@ actor SyncClient {
 
     private var fileId: String?
     private var groupId: String?
+    private var encryptKeyId: String?
     private var lastSyncedTimestamp: String?
     private var lastSuccessfulSyncTime: Date?
 
@@ -82,11 +83,13 @@ actor SyncClient {
         database: BudgetDatabase,
         fileId: String,
         groupId: String,
-        encryptionKey: SymmetricKey? = nil
+        encryptionKey: SymmetricKey? = nil,
+        keyId: String? = nil
     ) async throws {
         self.database = database
         self.fileId = fileId
         self.groupId = groupId
+        self.encryptKeyId = keyId
         self.encoder = SyncEncoder(encryptionKey: encryptionKey)
 
         // Load saved clock state
@@ -382,7 +385,7 @@ actor SyncClient {
             messages: localMessages,
             fileId: fileId,
             groupId: groupId,
-            keyId: nil,  // TODO: Support encryption key ID
+            keyId: encryptKeyId,
             since: sinceTimestamp
         )
         logger.debug("Encoded request: \(requestData.count, privacy: .public) bytes")

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -59,6 +59,12 @@ actor SyncClient {
     private var encryptKeyId: String?
     private var lastSyncedTimestamp: String?
     private var lastSuccessfulSyncTime: Date?
+    /// The server's message high-water mark at budget-load time (max timestamp in
+    /// `messages_crdt` when `configure` ran, before any local writes this session).
+    /// On a fresh download `lastSyncedTimestamp` is nil, so this is the floor for
+    /// deciding which local messages are genuine post-download writes that must be
+    /// pushed — without it, the first local write is stranded (actios-4k4).
+    private var downloadBaselineTimestamp: String?
 
     // MARK: - Published State (for UI)
 
@@ -131,6 +137,9 @@ actor SyncClient {
             logger.warning("Failed to read max message timestamp for HLC restore: \(error, privacy: .public)")
             maxMessageTimestamp = nil
         }
+        // Capture the server's state at load as the baseline for the fresh-download
+        // sync path (no local writes have happened yet at configure time).
+        downloadBaselineTimestamp = maxMessageTimestamp
         for candidate in [lastSyncedTimestamp, maxMessageTimestamp] {
             if let candidate, let parsed = HLCTimestamp.parse(candidate) {
                 await clock.advance(to: parsed)
@@ -375,8 +384,17 @@ actor SyncClient {
         if since != nil || effectiveLastSynced != nil {
             localMessages = try database.getMessagesSince(sinceTimestamp)
         } else {
-            logger.debug("No valid lastSynced - not sending local messages (unknown state)")
-            localMessages = []
+            // Fresh download / no valid lastSynced. The local merkle is empty and we
+            // adopt the server's below, so merkle-diff recursion can't push local
+            // writes for us. Send everything newer than the download baseline (the
+            // server's high-water mark captured at load); those are genuine local
+            // writes made after download. Without this, a write made before the first
+            // sync completes is dropped when we adopt the server merkle and advance
+            // lastSynced past it (actios-4k4). The baseline keeps us from re-pushing
+            // the entire downloaded history.
+            let baseline = downloadBaselineTimestamp ?? ""
+            localMessages = try database.getMessagesSince(baseline)
+            logger.debug("No valid lastSynced - sending \(localMessages.count, privacy: .public) local message(s) since download baseline")
         }
         logger.debug("Found \(localMessages.count, privacy: .public) local messages to send")
 
@@ -419,11 +437,25 @@ actor SyncClient {
             if effectiveLastSynced == nil {
                 logger.info("No valid lastSynced - adopting server's merkle tree")
                 merkle = remoteMerkleTree
-                // The HLC has merged every message received above (and was
-                // seeded from local state in configure), so it is the
-                // high-water mark of everything we know about.
-                let current = await clock.current
-                lastSyncedTimestamp = current.toString()
+                // Advance lastSynced only to what we actually reconciled this pass:
+                // the download baseline plus the messages we sent and received. Using
+                // this instead of the raw clock high-water mark avoids skipping a
+                // local write that interleaved during the awaits above without being
+                // included in `localMessages` — such a write sorts above this mark
+                // (HLC timestamps order lexicographically) and is resent next sync
+                // (actios-4k4). Fall back to the clock only for a truly empty budget
+                // with nothing reconciled, so we still record that a sync happened.
+                let reconciled = ([downloadBaselineTimestamp]
+                    + localMessages.map { $0.timestamp.toString() }
+                    + remoteMessages.map { $0.timestamp.toString() })
+                    .compactMap { $0 }
+                    .filter { !$0.isEmpty }
+                    .max()
+                if let reconciled {
+                    lastSyncedTimestamp = reconciled
+                } else {
+                    lastSyncedTimestamp = (await clock.current).toString()
+                }
                 logger.debug("Set lastSyncedTimestamp to: \(self.lastSyncedTimestamp ?? "nil", privacy: .public)")
                 try saveClock()
                 return

--- a/Actuali/Actuali/Services/Sync/SyncEncryption.swift
+++ b/Actuali/Actuali/Services/Sync/SyncEncryption.swift
@@ -71,4 +71,23 @@ enum SyncEncryption {
 
         return SymmetricKey(data: derivedKey)
     }
+
+    /// Decrypt a blob whose IV/auth-tag arrive as base64 strings (file download blobs and the
+    /// `/user-get-key` test message). `algorithm` is currently always "aes-256-gcm".
+    static func decrypt(
+        ciphertext: Data,
+        ivBase64: String,
+        authTagBase64: String,
+        using key: SymmetricKey
+    ) throws -> Data {
+        guard let iv = Data(base64Encoded: ivBase64),
+              let authTag = Data(base64Encoded: authTagBase64) else {
+            throw SyncEncryptionError.decryptionFailed
+        }
+        var encrypted = EncryptedData()
+        encrypted.iv = iv
+        encrypted.authTag = authTag
+        encrypted.data = ciphertext
+        return try decrypt(encrypted, using: key)
+    }
 }

--- a/Actuali/Actuali/Views/EncryptionPasswordSheet.swift
+++ b/Actuali/Actuali/Views/EncryptionPasswordSheet.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct EncryptionPasswordSheet: View {
+    let budget: BudgetStore.RemoteBudget
+    @ObservedObject var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var password = ""
+    @State private var errorText: String?
+    @State private var isWorking = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    SecureField("Encryption password", text: $password)
+                        .textContentType(.password)
+                        .disabled(isWorking)
+                } header: {
+                    Text("End-to-End Encrypted")
+                } footer: {
+                    Text("“\(budget.name)” is end-to-end encrypted. Enter its encryption password to open it on this device. This is separate from your server password.")
+                }
+
+                if let errorText {
+                    Text(errorText).foregroundStyle(.red).font(.callout)
+                }
+            }
+            .navigationTitle("Unlock Budget")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.disabled(isWorking)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Unlock") { Task { await unlock() } }
+                        .disabled(password.isEmpty || isWorking)
+                }
+            }
+            .interactiveDismissDisabled(isWorking)
+        }
+    }
+
+    private func unlock() async {
+        isWorking = true
+        errorText = nil
+        let failure = await budgetStore.unlockAndOpen(budget, password: password)
+        isWorking = false
+        if let failure {
+            errorText = failure
+        } else {
+            dismiss()
+        }
+    }
+}

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     ]
     @State private var password = ""
     @State private var showingResetSyncConfirm = false
+    @State private var budgetToUnlock: BudgetStore.RemoteBudget?
 
     private static var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -127,13 +128,23 @@ struct SettingsView: View {
                         .disabled(budgetStore.downloadingBudgetId != nil)
 
                         ForEach(budgetStore.remoteBudgets.filter { $0.isEncrypted }) { budget in
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(budget.name)
-                                    .foregroundStyle(.secondary)
-                                Text("Encrypted budgets not yet supported")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                            Button {
+                                if EncryptionKeyManager.load(fileId: budget.id) != nil {
+                                    Task { await budgetStore.downloadBudget(budget) }
+                                } else {
+                                    budgetToUnlock = budget
+                                }
+                            } label: {
+                                HStack {
+                                    Image(systemName: "lock.fill").foregroundStyle(.secondary)
+                                    Text(budget.name)
+                                    Spacer()
+                                    if budgetStore.downloadingBudgetId == budget.id {
+                                        ProgressView()
+                                    }
+                                }
                             }
+                            .disabled(budgetStore.downloadingBudgetId != nil)
                         }
                     }
 
@@ -238,6 +249,9 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+            .sheet(item: $budgetToUnlock) { budget in
+                EncryptionPasswordSheet(budget: budget, budgetStore: budgetStore)
+            }
             .overlay {
                 if budgetStore.isLoading {
                     ProgressView()

--- a/Actuali/ActualiTests/ActualServerClientDecodingTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientDecodingTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct ActualServerClientDecodingTests {
+
+    @Test func decodesKeyInfoWithTest() throws {
+        let json = """
+        {"status":"ok","data":{"id":"kid-1","salt":"c2FsdA==","test":"{\\"value\\":\\"abc\\"}"}}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(KeyInfoResponse.self, from: json)
+        #expect(decoded.data?.id == "kid-1")
+        #expect(decoded.data?.salt == "c2FsdA==")
+        #expect(decoded.data?.test != nil)
+    }
+
+    @Test func decodesKeyInfoWithNullTest() throws {
+        let json = """
+        {"status":"ok","data":{"id":"kid-1","salt":"c2FsdA==","test":null}}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(KeyInfoResponse.self, from: json)
+        #expect(decoded.data?.test == nil)
+    }
+
+    @Test func decodesFullEncryptMeta() throws {
+        let json = """
+        {"status":"ok","data":{"fileId":"f1","groupId":"g1","name":"Budget","deleted":0,
+         "encryptMeta":{"keyId":"kid-1","algorithm":"aes-256-gcm","iv":"aXY=","authTag":"dGFn"}}}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(FileInfoResponse.self, from: json)
+        #expect(decoded.data?.encryptMeta?.keyId == "kid-1")
+        #expect(decoded.data?.encryptMeta?.iv == "aXY=")
+        #expect(decoded.data?.encryptMeta?.authTag == "dGFn")
+    }
+}

--- a/Actuali/ActualiTests/EncryptionKeyManagerTests.swift
+++ b/Actuali/ActualiTests/EncryptionKeyManagerTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+import CryptoKit
+@testable import Actuali
+
+struct EncryptionKeyManagerTests {
+
+    private struct Fixture: Codable {
+        let password: String
+        let wrongPassword: String
+        let salt: String
+        let keyId: String
+        let derivedKeyBase64: String
+        let test: String
+    }
+
+    private func loadFixture() throws -> Fixture {
+        let url = Bundle(for: BundleToken.self).url(forResource: "encryption-key-fixture", withExtension: "json")!
+        return try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: url))
+    }
+    private final class BundleToken {}
+
+    @Test func derivesKeyMatchingActualConvention() throws {
+        let fx = try loadFixture()
+        let key = SyncEncryption.deriveKey(password: fx.password, salt: Data(fx.salt.utf8))
+        let derived = key.withUnsafeBytes { Data($0).base64EncodedString() }
+        #expect(derived == fx.derivedKeyBase64)  // locks in the UTF-8-salt convention vs Actual
+    }
+
+    @Test func validatesCorrectPassword() throws {
+        let fx = try loadFixture()
+        let info = ServerKeyInfo(id: fx.keyId, salt: fx.salt, test: fx.test)
+        let loaded = try EncryptionKeyManager.deriveAndValidate(password: fx.password, keyInfo: info)
+        #expect(loaded.keyId == fx.keyId)
+    }
+
+    @Test func rejectsWrongPassword() throws {
+        let fx = try loadFixture()
+        let info = ServerKeyInfo(id: fx.keyId, salt: fx.salt, test: fx.test)
+        #expect(throws: EncryptionKeyError.invalidPassword) {
+            try EncryptionKeyManager.deriveAndValidate(password: fx.wrongPassword, keyInfo: info)
+        }
+    }
+
+    @Test func rejectsLegacyNilTest() throws {
+        let fx = try loadFixture()
+        let info = ServerKeyInfo(id: fx.keyId, salt: fx.salt, test: nil)
+        #expect(throws: EncryptionKeyError.unsupportedLegacyKey) {
+            try EncryptionKeyManager.deriveAndValidate(password: fx.password, keyInfo: info)
+        }
+    }
+
+    @Test func keychainRoundTrip() throws {
+        let fileId = "test-file-\(UUID().uuidString)"
+        let loaded = LoadedKey(keyId: "kid", key: SymmetricKey(size: .bits256))
+        try EncryptionKeyManager.store(loaded, fileId: fileId)
+        let fetched = EncryptionKeyManager.load(fileId: fileId)
+        #expect(fetched == loaded)
+        try EncryptionKeyManager.remove(fileId: fileId)
+        #expect(EncryptionKeyManager.load(fileId: fileId) == nil)
+    }
+}

--- a/Actuali/ActualiTests/Fixtures/encryption-key-fixture.json
+++ b/Actuali/ActualiTests/Fixtures/encryption-key-fixture.json
@@ -1,0 +1,8 @@
+{
+  "password": "correct horse battery staple",
+  "wrongPassword": "incorrect password",
+  "salt": "XfsOVKaxbU9A5bYyrQAasQrjy0Nvd3rllUW+ZRWCdTE=",
+  "keyId": "11111111-1111-1111-1111-111111111111",
+  "derivedKeyBase64": "C5SPIW2Fp7eRmnDhY8TmMUeJ6YgT4FCLWXbT4XJd/jE=",
+  "test": "{\"value\":\"q6+m+aF63TaiPBXc8fqlqmmUQ4VIJZzk4NFa/uPsmyQ=\",\"meta\":{\"keyId\":\"11111111-1111-1111-1111-111111111111\",\"algorithm\":\"aes-256-gcm\",\"iv\":\"AqLh9LX6BdIiavoO\",\"authTag\":\"ikPp5J5szWjUn3XlE1TQFg==\"}}"
+}

--- a/Actuali/ActualiTests/SyncEncoderTests.swift
+++ b/Actuali/ActualiTests/SyncEncoderTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+import CryptoKit
+@testable import Actuali
+
+struct SyncEncoderTests {
+
+    private func sampleMessage() -> CRDTMessage {
+        CRDTMessage(
+            timestamp: HLCTimestamp.parse("2026-06-24T00:00:00.000Z-0000-0123456789abcdef")!,
+            dataset: "transactions", row: "row-1", column: "amount", value: "S:100"
+        )
+    }
+
+    @Test func encodesKeyIdAndEncryptsWhenKeyPresent() throws {
+        let key = SymmetricKey(size: .bits256)
+        let encoder = SyncEncoder(encryptionKey: key)
+        let data = try encoder.encode(
+            messages: [sampleMessage()], fileId: "f1", groupId: "g1", keyId: "kid-1", since: "0"
+        )
+        let request = try SyncRequest(serializedData: data)
+        #expect(request.keyID == "kid-1")
+        #expect(request.messages.first?.isEncrypted == true)
+    }
+
+    @Test func plaintextWhenNoKey() throws {
+        let encoder = SyncEncoder()
+        let data = try encoder.encode(
+            messages: [sampleMessage()], fileId: "f1", groupId: "g1", keyId: nil, since: "0"
+        )
+        let request = try SyncRequest(serializedData: data)
+        #expect(request.messages.first?.isEncrypted == false)
+    }
+}

--- a/scripts/gen-encryption-fixture.mjs
+++ b/scripts/gen-encryption-fixture.mjs
@@ -1,0 +1,42 @@
+// scripts/gen-encryption-fixture.mjs
+// Generates a known-good encryption fixture mirroring Actual's E2EE key derivation.
+// Run: node scripts/gen-encryption-fixture.mjs > Actuali/ActualiTests/Fixtures/encryption-key-fixture.json
+import crypto from 'node:crypto';
+
+const password = 'correct horse battery staple';
+const keyId = '11111111-1111-1111-1111-111111111111';
+const salt = crypto.randomBytes(32).toString('base64');
+
+// CRITICAL: salt fed to PBKDF2 is the UTF-8 bytes of the base64 string (Buffer.from(salt)).
+const derivedKey = crypto.pbkdf2Sync(
+  Buffer.from(password, 'utf8'),
+  Buffer.from(salt),          // <-- utf8 bytes of the base64 string, NOT base64-decoded
+  10000,
+  32,
+  'sha512',
+);
+
+// Build the "test" message the way Actual does: encrypt a random payload, strip the auth tag.
+const iv = crypto.randomBytes(12);
+const cipher = crypto.createCipheriv('aes-256-gcm', derivedKey, iv);
+const testPlaintext = crypto.randomBytes(32);
+const ct = Buffer.concat([cipher.update(testPlaintext), cipher.final()]);
+const authTag = cipher.getAuthTag();
+
+const fixture = {
+  password,
+  wrongPassword: 'incorrect password',
+  salt,
+  keyId,
+  derivedKeyBase64: derivedKey.toString('base64'),
+  test: JSON.stringify({
+    value: ct.toString('base64'),
+    meta: {
+      keyId,
+      algorithm: 'aes-256-gcm',
+      iv: iv.toString('base64'),
+      authTag: authTag.toString('base64'),
+    },
+  }),
+};
+process.stdout.write(JSON.stringify(fixture, null, 2) + '\n');

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -10,6 +10,15 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "1.0.2",
+    build: 39,
+    date: "June 24, 2026",
+    highlights: [
+      "Encrypted budgets: Actuali now opens and syncs end-to-end encrypted budgets. Pick an encrypted budget in Settings and enter its encryption password to unlock it on this device — the password is kept in the device Keychain and is never sent to the server, and your data is encrypted before it syncs.",
+      "Sync: fixed the first transaction added right after opening a budget occasionally not reaching the server. Later transactions synced fine; now the first write made before the initial sync finishes is pushed correctly too.",
+    ],
+  },
+  {
     version: "1.0.1",
     build: 38,
     date: "June 21, 2026",


### PR DESCRIPTION
## Summary

Adds support for opening and syncing **end-to-end encrypted** Actual budgets on iOS. Support is optional — users can have a mix of encrypted and unencrypted budgets. Previously the app detected encrypted budgets and hard-blocked them with "Encrypted budgets are not yet supported."

The app reimplements Actual's sync natively in Swift, so the crypto matches Actual byte-for-byte: AES-256-GCM with `PBKDF2(password, salt, SHA-512, 10000)`. A Node-generated fixture test locks in the one subtle compatibility detail — the salt fed to PBKDF2 is the UTF-8 bytes of the base64 salt string (`Buffer.from(salt)`), not the decoded bytes.

## What's included

**Encrypted budget support (5 tasks):**
- `EncryptionKeyManager` — derives the key from the encryption password + server salt, validates it against the server's `/sync/user-get-key` test message, and persists the **derived key** (never the password) in the Keychain, keyed by file id.
- `ActualServerClient` — `/sync/user-get-key` call + full `encryptMeta` (keyId/algorithm/iv/authTag) decoding.
- Whole-file blob decryption on download, and `keyId` + key wired through `SyncClient` into both file decryption and per-message sync encryption.
- New `EncryptionPasswordSheet` (separate from server login) and selectable encrypted budgets in Settings.

**Fixes found during testing:**
- `/sync/user-get-key` path — the sync app is mounted at `/sync`; the call was missing the prefix (404).
- **First-write-after-download sync drop** (`actios-4k4`, pre-existing, encryption-independent): on a fresh download `lastSyncedTimestamp` is nil, so `fullSync` sent no local messages and then advanced `lastSynced` to the clock high-water mark when adopting the server merkle — stranding the first local write. Now it pushes everything newer than the download baseline and advances `lastSynced` only to what was actually reconciled (which also closes the interleave race).

**Release:** build 38→39, v1.0.1→1.0.2, iPhone locked to portrait, website changelog updated.

## Not included / intentional
- iPad support is **not** added — app target stays `TARGETED_DEVICE_FAMILY = 1` (iPhone only). A stray `_iPad` orientation key was removed.
- Out of scope: creating new encrypted budgets, key rotation, unencrypted→encrypted conversion.
- OAuth-readiness: the key flow depends only on the auth token + file id, never on password login, so a future OAuth flow slots in without touching this code.

## Testing
- Full `ActualiTests` suite passes; app builds clean for the simulator.
- New unit tests: key derivation against the Node oracle fixture, wrong-password / legacy-key rejection, Keychain round-trip, server-response decoding, encoder keyId round-trip.
- Verified end-to-end against a local `actualbudget/actual-server` instance: unlock an encrypted budget, download + decrypt, read data, and round-trip read/write sync (including the first-write case).
