### PR TITLE
Strip PR attributions from website changelog and serve v1.0.2 from GitHub Releases

### DIFF
--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -8,7 +8,7 @@ export const prerender = true;
 const REPO = "MattFaz/actuali";
 // Releases at or below this version are kept in the manual archive below.
 // Anything newer is pulled live from GitHub Releases at build time.
-const ARCHIVE_MAX_VERSION = "1.0.2";
+const ARCHIVE_MAX_VERSION = "1.0.1";
 
 interface GithubRelease {
   version: string;
@@ -100,8 +100,9 @@ function renderMarkdown(md: string): string {
 }
 
 // GitHub's auto-generated release notes wrap the change list in a
-// "## What's Changed" heading and end with a "**Full Changelog**: ..." line.
-// Drop both so the page shows just the bulleted changes.
+// "## What's Changed" heading, end with a "**Full Changelog**: ..." line, and
+// suffix each bullet with "by @user in <PR url>". Drop all three so the page
+// shows just the change text.
 function cleanReleaseBody(md: string): string {
   return (md || "")
     .replace(/\r\n/g, "\n")
@@ -112,6 +113,9 @@ function cleanReleaseBody(md: string): string {
       if (/^\*+\s*full changelog\b/i.test(t)) return false;
       return true;
     })
+    .map((line) =>
+      line.replace(/\s+by\s+@?[\w-]+\s+in\s+https:\/\/github\.com\/\S+\/pull\/\d+\s*$/i, "")
+    )
     .join("\n")
     .trim();
 }
@@ -165,15 +169,6 @@ try {
 }
 
 const archivedReleases: Release[] = [
-  {
-    version: "1.0.2",
-    build: 39,
-    date: "June 24, 2026",
-    highlights: [
-      "Encrypted budgets: Actuali now opens and syncs end-to-end encrypted budgets. Pick an encrypted budget in Settings and enter its encryption password to unlock it on this device — the password is kept in the device Keychain and is never sent to the server, and your data is encrypted before it syncs.",
-      "Sync: fixed the first transaction added right after opening a budget occasionally not reaching the server. Later transactions synced fine; now the first write made before the initial sync finishes is pushed correctly too.",
-    ],
-  },
   {
     version: "1.0.1",
     build: 38,


### PR DESCRIPTION
## Summary
- `cleanReleaseBody` in `website/src/pages/changelog.astro` now strips the trailing `by @user in https://github.com/.../pull/N` attribution that GitHub's auto-generated release notes append to each bullet, alongside the existing "What's Changed" / "Full Changelog" cleanup. The regex is anchored to end-of-line, so inline issue refs like `(#7)` are untouched.
- Lowered `ARCHIVE_MAX_VERSION` to `1.0.1` and removed the manual v1.0.2 archive entry — GitHub Releases start at v1.0.2, so it's now pulled live like everything newer.

## Testing
- Ran the cleaner against the live release bodies for v1.0.2–v1.0.4: all attributions removed, change text intact.
- Built the site (`npm run build`): generated `changelog/index.html` contains zero `pull/` URLs, and v1.0.2 renders exactly once (GitHub-sourced) in correct order between 1.0.3 and 1.0.1.

Note: the GitHub v1.0.2 release body is terser than the removed hand-written entry; editing the release notes on GitHub restores richer text on the next deploy.