### PR TITLE
Fetch changelog releases in a pre-build script so GITHUB_TOKEN works and failures abort the build

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -28,3 +28,6 @@ pnpm-debug.log*
 .dev.vars*
 !.dev.vars.example
 !.env.example
+
+# fetched at build time by scripts/fetch-releases.mjs
+src/data/github-releases.json

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,9 @@
     "node": ">=22.12.0"
   },
   "scripts": {
+    "predev": "node scripts/fetch-releases.mjs",
     "dev": "astro dev",
+    "prebuild": "node scripts/fetch-releases.mjs",
     "build": "astro build",
     "preview": "npm run build && wrangler dev",
     "astro": "astro",

--- a/website/scripts/fetch-releases.mjs
+++ b/website/scripts/fetch-releases.mjs
@@ -41,7 +41,9 @@ if (!res.ok) {
   const hint =
     res.status === 403 && !githubToken
       ? " (unauthenticated rate limit — set the GITHUB_TOKEN build secret)"
-      : "";
+      : res.status === 401
+        ? " (GITHUB_TOKEN is set but GitHub rejected it — expired, revoked, or mispasted; generate a fine-grained PAT with public-repo read access and update the Cloudflare build secret)"
+        : "";
   console.error(`Changelog: GitHub releases fetch failed (${res.status})${hint}`);
   process.exit(1);
 }

--- a/website/scripts/fetch-releases.mjs
+++ b/website/scripts/fetch-releases.mjs
@@ -1,0 +1,65 @@
+// Fetches GitHub releases for the changelog page and writes them to
+// src/data/github-releases.json before `astro build` runs.
+//
+// This must run in plain Node (not in the page frontmatter): Astro's
+// Cloudflare adapter prerenders pages inside an emulated Workers runtime
+// where build-shell env vars like GITHUB_TOKEN are invisible and thrown
+// errors are caught and rendered as a 500 page while the build still exits
+// 0. Here the token is readable and a failure aborts the whole build.
+//
+// Authenticate when a token is available. Cloudflare's build runners share
+// egress IPs, so the unauthenticated GitHub limit (60 req/hr/IP) is often
+// already exhausted and the fetch 403s. A token raises the limit to 5,000
+// req/hr. Set GITHUB_TOKEN as a build secret in Cloudflare (Workers &
+// Pages > Settings > Build > Variables and secrets).
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = "MattFaz/actuali";
+const OUT_FILE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "data",
+  "github-releases.json"
+);
+
+const githubToken = process.env.GITHUB_TOKEN;
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "actuali-website",
+};
+if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
+
+const res = await fetch(
+  `https://api.github.com/repos/${REPO}/releases?per_page=100`,
+  { headers }
+);
+if (!res.ok) {
+  const hint =
+    res.status === 403 && !githubToken
+      ? " (unauthenticated rate limit — set the GITHUB_TOKEN build secret)"
+      : "";
+  console.error(`Changelog: GitHub releases fetch failed (${res.status})${hint}`);
+  process.exit(1);
+}
+
+const data = await res.json();
+const releases = data
+  .filter((r) => !r.draft && !r.prerelease)
+  .map((r) => ({
+    tag_name: r.tag_name,
+    published_at: r.published_at,
+    body: r.body,
+  }));
+
+if (releases.length === 0) {
+  console.error("Changelog: GitHub returned no published releases — refusing to build an empty changelog.");
+  process.exit(1);
+}
+
+await mkdir(dirname(OUT_FILE), { recursive: true });
+await writeFile(OUT_FILE, JSON.stringify(releases, null, 2) + "\n");
+console.log(`Changelog: wrote ${releases.length} releases to src/data/github-releases.json`);

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -103,8 +103,8 @@ function renderMarkdown(md: string): string {
 
 // GitHub's auto-generated release notes wrap the change list in a
 // "## What's Changed" heading, end with a "**Full Changelog**: ..." line, and
-// suffix each bullet with "by @user in <PR url>". Drop all three so the page
-// shows just the change text.
+// suffix each bullet with "by @user in <PR url>". Drop all of that, plus
+// issue/PR number refs like "(#7)", so the page shows just the change text.
 function cleanReleaseBody(md: string): string {
   return (md || "")
     .replace(/\r\n/g, "\n")
@@ -116,7 +116,9 @@ function cleanReleaseBody(md: string): string {
       return true;
     })
     .map((line) =>
-      line.replace(/\s+by\s+@?[\w-]+\s+in\s+https:\/\/github\.com\/\S+\/pull\/\d+\s*$/i, "")
+      line
+        .replace(/\s+by\s+@?[\w-]+\s+in\s+https:\/\/github\.com\/\S+\/pull\/\d+\s*$/i, "")
+        .replace(/\s*\(#\d+\)/g, "")
     )
     .join("\n")
     .trim();

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
+// Fetched by scripts/fetch-releases.mjs before `astro build` (see that file
+// for why the fetch can't live here in the frontmatter).
+import rawReleases from "../data/github-releases.json";
 
 // This page is rendered at build time. Run `npm run deploy` before each
 // release so the latest GitHub release shows up here.
 export const prerender = true;
 
-const REPO = "MattFaz/actuali";
 // Releases at or below this version are kept in the manual archive below.
 // Anything newer is pulled live from GitHub Releases at build time.
 const ARCHIVE_MAX_VERSION = "1.0.1";
@@ -121,52 +123,18 @@ function cleanReleaseBody(md: string): string {
 }
 
 const cutoff = parseVersion(ARCHIVE_MAX_VERSION);
-// Authenticate the fetch when a token is available. Cloudflare's build runners
-// share egress IPs, so the unauthenticated GitHub limit (60 req/hr/IP) is often
-// already exhausted and the fetch 403s — silently dropping us to the archive.
-// A token raises the limit to 5,000 req/hr. Set GITHUB_TOKEN as a build env var
-// in Cloudflare (Workers & Pages > Settings > Variables and Secrets).
-const githubToken = process.env.GITHUB_TOKEN;
-let githubReleases: GithubRelease[] = [];
-try {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "User-Agent": "actuali-website",
-  };
-  if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
-  const res = await fetch(
-    `https://api.github.com/repos/${REPO}/releases?per_page=100`,
-    { headers }
-  );
-  if (res.ok) {
-    const data = (await res.json()) as Array<{
-      tag_name: string;
-      published_at: string;
-      body: string;
-      draft: boolean;
-      prerelease: boolean;
-    }>;
-    githubReleases = data
-      .filter((r) => !r.draft && !r.prerelease)
-      .filter((r) => compareVersions(parseVersion(r.tag_name), cutoff) > 0)
-      .sort((a, b) => compareVersions(parseVersion(b.tag_name), parseVersion(a.tag_name)))
-      .map((r) => ({
-        version: (r.tag_name || "").replace(/^v/, ""),
-        date: formatDate(r.published_at),
-        bodyHtml: renderMarkdown(cleanReleaseBody(r.body || "")),
-      }));
-  } else {
-    // Fail the build loudly. A silent fallback here is what shipped an
-    // archive-only changelog (missing v1.0.3) while the deploy looked green.
-    const hint = res.status === 403 && !githubToken
-      ? " (unauthenticated rate limit — set the GITHUB_TOKEN build env var)"
-      : "";
-    throw new Error(`GitHub releases fetch failed (${res.status})${hint}`);
-  }
-} catch (err) {
-  console.error("Changelog: GitHub releases fetch failed.", err);
-  throw err;
-}
+const githubReleases: GithubRelease[] = (rawReleases as Array<{
+  tag_name: string;
+  published_at: string;
+  body: string;
+}>)
+  .filter((r) => compareVersions(parseVersion(r.tag_name), cutoff) > 0)
+  .sort((a, b) => compareVersions(parseVersion(b.tag_name), parseVersion(a.tag_name)))
+  .map((r) => ({
+    version: (r.tag_name || "").replace(/^v/, ""),
+    date: formatDate(r.published_at),
+    bodyHtml: renderMarkdown(cleanReleaseBody(r.body || "")),
+  }));
 
 const archivedReleases: Release[] = [
   {


### PR DESCRIPTION
## Problem
Deploy-hook/release-triggered Cloudflare builds were intermittently shipping a broken changelog page. Two compounding issues, both caused by Astro 7's Cloudflare adapter prerendering pages inside an emulated Workers runtime:

1. **`GITHUB_TOKEN` never reached the page code.** Build-shell env vars aren't visible in the prerender runtime, so the Cloudflare build secret was silently ignored and every build made an unauthenticated GitHub API call — subject to the 60 req/hr per-IP limit shared across all Cloudflare build customers. Whether a build 403'd was a lottery on runner IP. (Verified: building with `GITHUB_TOKEN=bogus` previously succeeded — the Authorization header was never sent.)
2. **The "fail loudly" `throw` didn't fail the build.** The adapter's prerender handler catches render errors and writes a 500 page to `changelog/index.html`, and the build exits 0 — so wrangler deployed the broken page and the build log showed ✨ Success.

## Fix
Move the GitHub releases fetch into `website/scripts/fetch-releases.mjs`, run via npm `predev`/`prebuild` hooks. Plain Node sees `process.env.GITHUB_TOKEN`, and a failed (or empty) fetch exits non-zero so the build aborts before anything deploys. The page now imports the fetched JSON (gitignored, generated at build time).

## Testing
- `npm run build` (no token): script writes 3 releases, build succeeds, page renders v1.0.4/1.0.3/1.0.2 with zero PR attribution links.
- `GITHUB_TOKEN=bogus npm run build`: fetch fails with 401 and npm exits 1 — proving the token now reaches the request and that failures genuinely abort the build.

Requires the existing `GITHUB_TOKEN` build secret in Cloudflare (already configured) — it will now actually be used.