### PR TITLE
Bump version to 1.0.7

### DIFF
--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
Bumps MARKETING_VERSION from 1.0.6 to 1.0.7 in the app target (Debug + Release) now that 1.0.6 is going to the App Store. All future work targets 1.0.7. Build number stays at 78.