### PR TITLE
Import Apple Card/Cash/Savings transactions from Wallet via FinanceKit picker (#55)

### DIFF
--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 81;
+				CURRENT_PROJECT_VERSION = 82;
 				DEVELOPMENT_TEAM = GJGY9A384M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -423,6 +423,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Actuali;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSRequiresIPhoneOS = YES;
+				INFOPLIST_KEY_NSFinancialDataUsageDescription = "Actuali imports the Wallet transactions you select into your budget. They are stored in your budget file on your own server.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Actuali uses your location to suggest nearby payees and remember where you transact. Location data stays in your budget file on your own server.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -452,7 +453,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 81;
+				CURRENT_PROJECT_VERSION = 82;
 				DEVELOPMENT_TEAM = GJGY9A384M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -460,6 +461,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Actuali;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSRequiresIPhoneOS = YES;
+				INFOPLIST_KEY_NSFinancialDataUsageDescription = "Actuali imports the Wallet transactions you select into your budget. They are stored in your budget file on your own server.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Actuali uses your location to suggest nearby payees and remember where you transact. Location data stays in your budget file on your own server.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -25,6 +25,10 @@ struct Transaction: Identifiable, Hashable {
     var tombstone: Bool
     var sortOrder: Double? // Timestamp in ms, determines order within same date
     var importedPayee: String? // Original payee text from import / Shortcut entry
+    // Bank-import dedup key (Actual's imported_id, stored as financial_id).
+    // Set at creation time by the Wallet import; not read back by the fetch
+    // paths, so it is nil on fetched rows — dedup queries the column directly.
+    var financialId: String? = nil
     // Payee's transfer_acct: the account on the other side when the payee is a
     // transfer payee, nil otherwise. Only populated by the reports fetch, where
     // engines need it to exclude transfers the way the WebUI does. Not synced
@@ -95,7 +99,7 @@ extension Transaction: CRDTSyncable {
     static var datasetName: String { "transactions" }
 
     var syncableFields: [String: Any?] {
-        [
+        var fields: [String: Any?] = [
             "acct": accountId,
             "date": date,
             "description": payeeId,      // payeeId maps to "description" column
@@ -112,5 +116,12 @@ extension Transaction: CRDTSyncable {
             "sort_order": sortOrder ?? Date().timeIntervalSince1970 * 1000,
             "imported_description": importedPayee
         ]
+        // Only present on imported transactions — keeps inserts for ordinary
+        // transactions identical (messagesForInsert emits every listed field,
+        // nil included).
+        if let financialId {
+            fields["financial_id"] = financialId
+        }
+        return fields
     }
 }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -982,6 +982,67 @@ final class BudgetStore: ObservableObject {
         await refreshDataOnly()
     }
 
+    struct WalletImportResult: Equatable {
+        var imported: Int
+        var skippedDuplicates: Int
+    }
+
+    /// Import Wallet transactions picked via the FinanceKit transaction
+    /// picker into an account (GH #55, Tier 1). Candidates whose
+    /// `financial_id` already exists on the account are skipped, so
+    /// re-importing an overlapping selection is safe. Each import runs the
+    /// rules pass, same as manual entry.
+    func importWalletTransactions(
+        _ candidates: [WalletImportCandidate],
+        accountId: String
+    ) async throws -> WalletImportResult {
+        guard let database, let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        var existing = try database.existingFinancialIds(accountId: accountId)
+        var imported = 0
+        var skipped = 0
+        for candidate in candidates {
+            guard !existing.contains(candidate.id) else {
+                skipped += 1
+                continue
+            }
+            existing.insert(candidate.id)
+            let payeeName = candidate.payeeName.isEmpty ? nil : candidate.payeeName
+            let payeeId = try await resolvePayeeId(name: candidate.payeeName, editing: nil)
+            let transaction = Transaction(
+                id: UUID().uuidString,
+                accountId: accountId,
+                date: Transaction.yyyymmdd(from: candidate.date),
+                amount: candidate.amountCents,
+                payeeId: payeeId,
+                payeeName: payeeName,
+                categoryId: nil,
+                categoryName: nil,
+                notes: nil,
+                cleared: candidate.cleared,
+                reconciled: false,
+                transferId: nil,
+                isParent: false,
+                parentId: nil,
+                tombstone: false,
+                sortOrder: nil,  // Set to Date.now() during insert
+                importedPayee: payeeName,
+                financialId: candidate.id
+            )
+            try await syncClient.createTransaction(transaction)
+            imported += 1
+        }
+        await refreshDataOnly()
+        return WalletImportResult(imported: imported, skippedDuplicates: skipped)
+    }
+
+    /// Dedup keys already on an account, for marking picker selections that
+    /// were imported before. Read-only convenience for `WalletImportView`.
+    func walletFinancialIds(accountId: String) -> Set<String> {
+        (try? database?.existingFinancialIds(accountId: accountId)) ?? []
+    }
+
     /// Create a paired transfer between two accounts. Writes both legs with linked
     /// `transferId`s and uses the existing transfer payee for each side.
     /// - Parameters:

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1836,8 +1836,8 @@ class BudgetDatabase {
         // children keep their entry order under the parent.
         let sortOrder = transaction.sortOrder ?? Date().timeIntervalSince1970 * 1000
         try db.execute(sql: """
-            INSERT INTO transactions (id, acct, date, description, category, amount, notes, cleared, reconciled, transferred_id, isParent, isChild, parent_id, tombstone, sort_order, imported_description)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO transactions (id, acct, date, description, category, amount, notes, cleared, reconciled, transferred_id, isParent, isChild, parent_id, tombstone, sort_order, imported_description, financial_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, arguments: [
                 transaction.id,
                 transaction.accountId,
@@ -1854,8 +1854,22 @@ class BudgetDatabase {
                 transaction.parentId,
                 transaction.tombstone ? 1 : 0,
                 sortOrder,
-                transaction.importedPayee
+                transaction.importedPayee,
+                transaction.financialId
             ])
+    }
+
+    /// All bank-import dedup keys (`financial_id`) already present on an
+    /// account. Tombstoned rows are deliberately included: a user who deleted
+    /// an imported transaction shouldn't see it resurrected by a re-import.
+    func existingFinancialIds(accountId: String) throws -> Set<String> {
+        try dbQueue.read { db in
+            let ids = try String.fetchAll(db, sql: """
+                SELECT financial_id FROM transactions
+                WHERE acct = ? AND financial_id IS NOT NULL
+                """, arguments: [accountId])
+            return Set(ids)
+        }
     }
 
     // MARK: - Transaction Update

--- a/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
+++ b/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// A Wallet (FinanceKit) transaction reduced to the fields Actuali imports.
+/// Framework-independent so mapping and dedup stay unit-testable — the thin
+/// FinanceKit bridge lives in `WalletImportView` (GH #55, Tier 1).
+struct WalletImportCandidate: Identifiable, Hashable {
+    /// FinanceKit transaction UUID, lowercased — stored as `financial_id`
+    /// (Actual's imported_id) for dedup across imports.
+    let id: String
+    var amountCents: Int   // signed like Transaction.amount (negative = outflow)
+    var payeeName: String
+    var date: Date
+    var cleared: Bool
+}
+
+enum WalletImportMapper {
+
+    /// The subset of FinanceKit.TransactionStatus Actuali cares about.
+    enum Status {
+        case authorized
+        case memo
+        case pending
+        case booked
+        case rejected
+    }
+
+    /// Map one Wallet transaction to an import candidate.
+    /// - Returns: `nil` for rejected transactions (the money never moved) and
+    ///   for amounts that don't fit integer cents.
+    static func candidate(
+        id: UUID,
+        amount: Decimal,
+        isCredit: Bool,
+        merchantName: String?,
+        transactionDescription: String,
+        status: Status,
+        date: Date
+    ) -> WalletImportCandidate? {
+        guard status != .rejected else { return nil }
+        guard let unsignedCents = cents(from: amount) else { return nil }
+
+        // Wallet merchant strings carry the same processor noise as the
+        // Shortcuts flow ("SQ *", store numbers) — normalize the same way.
+        let rawPayee: String
+        if let merchantName, !merchantName.isEmpty {
+            rawPayee = merchantName
+        } else {
+            rawPayee = transactionDescription
+        }
+        let payee = MerchantNormalizer.normalize(rawPayee)
+
+        return WalletImportCandidate(
+            id: id.uuidString.lowercased(),
+            amountCents: isCredit ? unsignedCents : -unsignedCents,
+            payeeName: payee,
+            date: date,
+            cleared: status == .booked
+        )
+    }
+
+    /// Decimal → integer cents, rounding half away from zero (NSDecimalNumber
+    /// plain rounding), mirroring `Transaction.cents(fromDollars:)`.
+    static func cents(from amount: Decimal) -> Int? {
+        let magnitude = amount.magnitude
+        let scaled = NSDecimalNumber(decimal: magnitude)
+            .multiplying(byPowerOf10: 2)
+            .rounding(accordingToBehavior: NSDecimalNumberHandler(
+                roundingMode: .plain,
+                scale: 0,
+                raiseOnExactness: false,
+                raiseOnOverflow: false,
+                raiseOnUnderflow: false,
+                raiseOnDivideByZero: false
+            ))
+        let value = scaled.doubleValue
+        guard value.isFinite, abs(value) <= 9_007_199_254_740_992 else { return nil }
+        return Int(value)
+    }
+}

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -8,6 +8,7 @@ struct AccountDetailView: View {
     @State private var searchText = ""
     @State private var showingAddTransaction = false
     @State private var showingReconcile = false
+    @State private var showingWalletImport = false
     @State private var editingTransaction: Transaction?
 
     private var searchQuery: String? {
@@ -97,6 +98,15 @@ struct AccountDetailView: View {
         .navigationTitle(account.name)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
         .toolbar {
+            if WalletImportView.isSupported {
+                ToolbarItem(placement: .secondaryAction) {
+                    Button {
+                        showingWalletImport = true
+                    } label: {
+                        Label("Import from Wallet", systemImage: "wallet.pass")
+                    }
+                }
+            }
             ToolbarItemGroup(placement: .primaryAction) {
                 Button {
                     showingReconcile = true
@@ -117,6 +127,14 @@ struct AccountDetailView: View {
             }
         }) {
             ReconcileView(account: account)
+                .environmentObject(budgetStore)
+        }
+        .sheet(isPresented: $showingWalletImport, onDismiss: {
+            Task {
+                await reload()
+            }
+        }) {
+            WalletImportView(preselectedAccountId: account.id)
                 .environmentObject(budgetStore)
         }
         .sheet(isPresented: $showingAddTransaction, onDismiss: {

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -26,6 +26,7 @@ struct SettingsView: View {
     ]
     @State private var password = ""
     @State private var showingResetSyncConfirm = false
+    @State private var showingWalletImport = false
     @State private var budgetToUnlock: BudgetStore.RemoteBudget?
     @State private var showingBudgetSelectPrompt = false
     @State private var transactionNotificationsEnabled = TransactionNotificationSettings().isEnabled
@@ -393,10 +394,21 @@ struct SettingsView: View {
                     } label: {
                         Label("Log Wallet Payments Automatically", systemImage: "wallet.pass")
                     }
+                    if WalletImportView.isSupported {
+                        Button {
+                            showingWalletImport = true
+                        } label: {
+                            Label("Import Wallet Transactions", systemImage: "square.and.arrow.down")
+                        }
+                    }
                 } header: {
                     Text("Automations")
                 } footer: {
-                    Text("Set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet.")
+                    if WalletImportView.isSupported {
+                        Text("Set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions directly.")
+                    } else {
+                        Text("Set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet.")
+                    }
                 }
 
                 Section {
@@ -424,6 +436,10 @@ struct SettingsView: View {
             .task { await refreshNotificationPermissionState() }
             .sheet(item: $budgetToUnlock) { budget in
                 EncryptionPasswordSheet(budget: budget, budgetStore: budgetStore)
+            }
+            .sheet(isPresented: $showingWalletImport) {
+                WalletImportView()
+                    .environmentObject(budgetStore)
             }
             .overlay {
                 if budgetStore.isLoading {

--- a/Actuali/Actuali/Views/WalletImportView.swift
+++ b/Actuali/Actuali/Views/WalletImportView.swift
@@ -1,0 +1,230 @@
+import FinanceKit
+import FinanceKitUI
+import SwiftUI
+
+/// Import Apple Card / Apple Cash / Savings transactions from Wallet via the
+/// FinanceKit transaction picker (GH #55, Tier 1). The picker needs no
+/// FinanceKit entitlement — the user hand-picks transactions and access is
+/// one-time, so this works for any App Store build. Full automatic sync
+/// (Tier 2) needs Apple's managed FinanceKit entitlement and is tracked
+/// separately.
+struct WalletImportView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    /// Whether this device can offer Wallet transactions at all (Apple Card /
+    /// Apple Cash are US-only; unsupported devices hide the entry points).
+    static let isSupported = FinanceStore.isDataAvailable(.financialData)
+
+    @State private var selectedAccountId: String?
+    @State private var walletSelection: [FinanceKit.Transaction] = []
+    @State private var alreadyImportedIds: Set<String> = []
+    @State private var isImporting = false
+    @State private var result: BudgetStore.WalletImportResult?
+    @State private var errorMessage: String?
+
+    init(preselectedAccountId: String? = nil) {
+        _selectedAccountId = State(initialValue: preselectedAccountId)
+    }
+
+    private var openAccounts: [Account] {
+        budgetStore.accounts.filter { !$0.closed }
+    }
+
+    /// Wallet selection mapped to import candidates, picker order preserved.
+    private var candidates: [WalletImportCandidate] {
+        walletSelection.compactMap { Self.candidate(from: $0) }
+    }
+
+    private var importableCount: Int {
+        candidates.filter { !alreadyImportedIds.contains($0.id) }.count
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if Self.isSupported {
+                    accountSection
+                    selectionSection
+                    if !candidates.isEmpty {
+                        candidatesSection
+                    }
+                    if let result {
+                        resultSection(result)
+                    }
+                    if let errorMessage {
+                        Section {
+                            Text(errorMessage)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                } else {
+                    Section {
+                        Text("Wallet transactions aren't available on this device. Apple Card, Apple Cash and Savings are required, and are currently US-only.")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Import from Wallet")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(result == nil ? "Cancel" : "Done") { dismiss() }
+                }
+            }
+            .task(id: selectedAccountId) {
+                refreshAlreadyImported()
+            }
+        }
+    }
+
+    private var accountSection: some View {
+        Section {
+            Picker("Account", selection: $selectedAccountId) {
+                Text("Select Account").tag(String?.none)
+                ForEach(openAccounts) { account in
+                    Text(account.name).tag(Optional(account.id))
+                }
+            }
+        } footer: {
+            Text("Transactions you pick from Wallet are added to this account and sync to your Actual server like any other transaction.")
+        }
+    }
+
+    private var selectionSection: some View {
+        Section {
+            TransactionPicker(selection: $walletSelection) {
+                Label(
+                    walletSelection.isEmpty
+                        ? "Select Wallet Transactions"
+                        : "Change Selection",
+                    systemImage: "wallet.pass"
+                )
+            }
+        } footer: {
+            Text("Apple shares only the transactions you pick — Actuali has no ongoing access to your Wallet.")
+        }
+    }
+
+    private var candidatesSection: some View {
+        Section {
+            ForEach(candidates) { candidate in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(candidate.payeeName)
+                        Text(candidate.date.formatted(date: .abbreviated, time: .omitted))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if alreadyImportedIds.contains(candidate.id) {
+                        Text("Imported")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(budgetStore.formatCurrency(candidate.amountCents))
+                        .foregroundStyle(candidate.amountCents < 0 ? .primary : Color.green)
+                }
+            }
+
+            Button {
+                importNow()
+            } label: {
+                if isImporting {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                } else {
+                    Text("Import \(importableCount) Transaction\(importableCount == 1 ? "" : "s")")
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .disabled(isImporting || importableCount == 0 || selectedAccountId == nil)
+        } header: {
+            Text("Selected")
+        } footer: {
+            if importableCount < candidates.count {
+                Text("Transactions marked Imported already exist in this account and will be skipped.")
+            }
+        }
+    }
+
+    private func resultSection(_ result: BudgetStore.WalletImportResult) -> some View {
+        Section {
+            Label {
+                Text(summary(for: result))
+            } icon: {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+        }
+    }
+
+    private func summary(for result: BudgetStore.WalletImportResult) -> String {
+        var text = "Imported \(result.imported) transaction\(result.imported == 1 ? "" : "s")"
+        if result.skippedDuplicates > 0 {
+            text += ", skipped \(result.skippedDuplicates) duplicate\(result.skippedDuplicates == 1 ? "" : "s")"
+        }
+        return text
+    }
+
+    private func importNow() {
+        guard let accountId = selectedAccountId else { return }
+        let toImport = candidates
+        isImporting = true
+        errorMessage = nil
+        Task {
+            do {
+                let outcome = try await budgetStore.importWalletTransactions(
+                    toImport, accountId: accountId
+                )
+                result = BudgetStore.WalletImportResult(
+                    imported: outcome.imported + (result?.imported ?? 0),
+                    skippedDuplicates: outcome.skippedDuplicates + (result?.skippedDuplicates ?? 0)
+                )
+                walletSelection = []
+                refreshAlreadyImported()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isImporting = false
+        }
+    }
+
+    private func refreshAlreadyImported() {
+        guard let accountId = selectedAccountId else {
+            alreadyImportedIds = []
+            return
+        }
+        alreadyImportedIds = budgetStore.walletFinancialIds(accountId: accountId)
+    }
+
+    /// Bridge FinanceKit's transaction into the framework-free candidate the
+    /// mapper and store work with.
+    private static func candidate(from transaction: FinanceKit.Transaction) -> WalletImportCandidate? {
+        WalletImportMapper.candidate(
+            id: transaction.id,
+            amount: transaction.transactionAmount.amount,
+            isCredit: transaction.creditDebitIndicator == .credit,
+            merchantName: transaction.merchantName,
+            transactionDescription: transaction.transactionDescription,
+            status: Self.status(from: transaction.status),
+            date: transaction.transactionDate
+        )
+    }
+
+    private static func status(from status: FinanceKit.TransactionStatus) -> WalletImportMapper.Status {
+        switch status {
+        case .authorized: .authorized
+        case .memo: .memo
+        case .pending: .pending
+        case .booked: .booked
+        case .rejected: .rejected
+        @unknown default: .booked
+        }
+    }
+}
+
+#Preview {
+    WalletImportView()
+        .environmentObject(BudgetStore.previewInstance())
+}

--- a/Actuali/ActualiTests/BudgetDatabaseCategoryTransactionsTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseCategoryTransactionsTests.swift
@@ -63,6 +63,7 @@ struct BudgetDatabaseCategoryTransactionsTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseReportsFetchTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseReportsFetchTests.swift
@@ -61,6 +61,7 @@ struct BudgetDatabaseReportsFetchTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseSplitTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseSplitTests.swift
@@ -59,6 +59,7 @@ struct BudgetDatabaseSplitTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseTransactionPagingSearchTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransactionPagingSearchTests.swift
@@ -60,6 +60,7 @@ struct BudgetDatabaseTransactionPagingSearchTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
@@ -25,6 +25,7 @@ struct BudgetDatabaseTransferAtomicityTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     sort_order REAL,
                     tombstone INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseTransferPayeeTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransferPayeeTests.swift
@@ -58,6 +58,7 @@ struct BudgetDatabaseTransferPayeeTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetDatabaseUncategorizedTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseUncategorizedTests.swift
@@ -62,6 +62,7 @@ struct BudgetDatabaseUncategorizedTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
@@ -29,6 +29,7 @@ struct BudgetStoreReconciliationTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     sort_order REAL,
                     tombstone INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
@@ -26,6 +26,7 @@ struct BudgetStoreSaveTransactionTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     sort_order REAL,
                     tombstone INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
@@ -57,6 +57,7 @@ struct BudgetStoreSplitSaveTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetStoreSyncCancellationTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSyncCancellationTests.swift
@@ -41,6 +41,7 @@ struct BudgetStoreSyncCancellationTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     cleared INTEGER DEFAULT 0,
                     reconciled INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/BudgetStoreWalletImportTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreWalletImportTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetStoreWalletImportTests {
+
+    /// Upstream schema, matching BudgetStoreSaveTransactionTests (real budget
+    /// files always have financial_id — it's Actual's bank-import dedup key).
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    private func transactionRows(path: URL) throws -> [Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions ORDER BY financial_id")
+        }
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func candidate(
+        id: String,
+        amountCents: Int = -820,
+        payeeName: String = "Blue Bottle",
+        date: Date = Date(timeIntervalSince1970: 1_750_000_000),
+        cleared: Bool = true
+    ) -> WalletImportCandidate {
+        WalletImportCandidate(
+            id: id, amountCents: amountCents, payeeName: payeeName,
+            date: date, cleared: cleared
+        )
+    }
+
+    @Test func importWritesRowsWithFinancialId() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        let result = try await store.importWalletTransactions([
+            candidate(id: "aaa-1", amountCents: -820, payeeName: "Blue Bottle"),
+            candidate(id: "aaa-2", amountCents: 1500, payeeName: "Refund", cleared: false)
+        ], accountId: "acct-1")
+
+        #expect(result == BudgetStore.WalletImportResult(imported: 2, skippedDuplicates: 0))
+
+        let rows = try transactionRows(path: url)
+        #expect(rows.count == 2)
+        #expect(rows[0]["financial_id"] == "aaa-1")
+        #expect(rows[0]["amount"] == -820)
+        #expect(rows[0]["cleared"] == 1)
+        #expect(rows[0]["acct"] == "acct-1")
+        #expect(rows[1]["financial_id"] == "aaa-2")
+        #expect(rows[1]["amount"] == 1500)
+        #expect(rows[1]["cleared"] == 0)
+
+        // Payee resolved and linked (description column holds the payee id).
+        let payeeId: String? = rows[0]["description"]
+        #expect(payeeId != nil)
+    }
+
+    @Test func importEmitsFinancialIdCRDTMessage() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        _ = try await store.importWalletTransactions(
+            [candidate(id: "bbb-1")], accountId: "acct-1")
+
+        let queue = try DatabaseQueue(path: url.path)
+        let financialIdMessages = try await queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM messages_crdt
+                WHERE dataset = 'transactions' AND column = 'financial_id'
+                """) ?? 0
+        }
+        #expect(financialIdMessages == 1)
+    }
+
+    @Test func reimportSkipsExistingFinancialIds() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        _ = try await store.importWalletTransactions(
+            [candidate(id: "ccc-1"), candidate(id: "ccc-2")], accountId: "acct-1")
+        let second = try await store.importWalletTransactions(
+            [candidate(id: "ccc-1"), candidate(id: "ccc-2"), candidate(id: "ccc-3")],
+            accountId: "acct-1")
+
+        #expect(second == BudgetStore.WalletImportResult(imported: 1, skippedDuplicates: 2))
+        #expect(try transactionRows(path: url).count == 3)
+    }
+
+    @Test func duplicateWithinBatchImportsOnce() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        let result = try await store.importWalletTransactions(
+            [candidate(id: "ddd-1"), candidate(id: "ddd-1")], accountId: "acct-1")
+
+        #expect(result == BudgetStore.WalletImportResult(imported: 1, skippedDuplicates: 1))
+        #expect(try transactionRows(path: url).count == 1)
+    }
+
+    @Test func deletedImportStaysDeletedOnReimport() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        _ = try await store.importWalletTransactions(
+            [candidate(id: "eee-1")], accountId: "acct-1")
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: "UPDATE transactions SET tombstone = 1")
+        }
+
+        let second = try await store.importWalletTransactions(
+            [candidate(id: "eee-1")], accountId: "acct-1")
+        #expect(second == BudgetStore.WalletImportResult(imported: 0, skippedDuplicates: 1))
+    }
+
+    @Test func manualSaveLeavesFinancialIdNull() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveTransaction(BudgetStore.TransactionForm(
+            accountId: "acct-1",
+            type: .expense,
+            amount: "10.50",
+            payeeName: "Corner Shop",
+            transferToAccountId: nil,
+            categoryId: nil,
+            notes: "",
+            date: Date(),
+            cleared: true,
+            recordLocation: false
+        ))
+
+        let rows = try transactionRows(path: url)
+        #expect(rows.count == 1)
+        let financialId: String? = rows[0]["financial_id"]
+        #expect(financialId == nil)
+
+        let queue = try DatabaseQueue(path: url.path)
+        let financialIdMessages = try await queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM messages_crdt WHERE column = 'financial_id'
+                """) ?? 0
+        }
+        #expect(financialIdMessages == 0)
+    }
+}

--- a/Actuali/ActualiTests/NewTransactionDetectorTests.swift
+++ b/Actuali/ActualiTests/NewTransactionDetectorTests.swift
@@ -29,6 +29,7 @@ struct NewTransactionDetectorTests {
                     notes TEXT,
                     date INTEGER,
                     imported_description TEXT,
+                    financial_id TEXT,
                     transferred_id TEXT,
                     sort_order REAL,
                     tombstone INTEGER DEFAULT 0,

--- a/Actuali/ActualiTests/WalletImportMapperTests.swift
+++ b/Actuali/ActualiTests/WalletImportMapperTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct WalletImportMapperTests {
+
+    private func candidate(
+        id: UUID = UUID(),
+        amount: Decimal = Decimal(string: "8.20")!,
+        isCredit: Bool = false,
+        merchantName: String? = "Blue Bottle",
+        transactionDescription: String = "BLUE BOTTLE COFFEE #123",
+        status: WalletImportMapper.Status = .booked,
+        date: Date = Date(timeIntervalSince1970: 1_750_000_000)
+    ) -> WalletImportCandidate? {
+        WalletImportMapper.candidate(
+            id: id,
+            amount: amount,
+            isCredit: isCredit,
+            merchantName: merchantName,
+            transactionDescription: transactionDescription,
+            status: status,
+            date: date
+        )
+    }
+
+    @Test func debitMapsToNegativeCents() throws {
+        let mapped = try #require(candidate(amount: Decimal(string: "8.20")!, isCredit: false))
+        #expect(mapped.amountCents == -820)
+    }
+
+    @Test func creditMapsToPositiveCents() throws {
+        let mapped = try #require(candidate(amount: Decimal(string: "8.20")!, isCredit: true))
+        #expect(mapped.amountCents == 820)
+    }
+
+    @Test func negativeDecimalUsesMagnitude() throws {
+        // Sign is carried by creditDebitIndicator, never by the decimal.
+        let mapped = try #require(candidate(amount: Decimal(string: "-8.20")!, isCredit: false))
+        #expect(mapped.amountCents == -820)
+    }
+
+    @Test func subCentAmountRoundsHalfAwayFromZero() throws {
+        let mapped = try #require(candidate(amount: Decimal(string: "10.005")!, isCredit: false))
+        #expect(mapped.amountCents == -1001)
+    }
+
+    @Test func merchantNameIsNormalized() throws {
+        let mapped = try #require(candidate(merchantName: "SQ *BLUE BOTTLE #123"))
+        #expect(mapped.payeeName == "Blue Bottle")
+    }
+
+    @Test func missingMerchantFallsBackToDescription() throws {
+        let mapped = try #require(candidate(
+            merchantName: nil, transactionDescription: "TST* JOES DINER"))
+        #expect(mapped.payeeName == "Joes Diner")
+    }
+
+    @Test func emptyMerchantFallsBackToDescription() throws {
+        let mapped = try #require(candidate(
+            merchantName: "", transactionDescription: "JOES DINER"))
+        #expect(mapped.payeeName == "Joes Diner")
+    }
+
+    @Test func bookedIsCleared() throws {
+        let mapped = try #require(candidate(status: .booked))
+        #expect(mapped.cleared)
+    }
+
+    @Test func pendingAndAuthorizedAreUncleared() throws {
+        #expect(try #require(candidate(status: .pending)).cleared == false)
+        #expect(try #require(candidate(status: .authorized)).cleared == false)
+    }
+
+    @Test func rejectedIsDropped() {
+        #expect(candidate(status: .rejected) == nil)
+    }
+
+    @Test func financialIdIsLowercasedUUID() throws {
+        let id = UUID()
+        let mapped = try #require(candidate(id: id))
+        #expect(mapped.id == id.uuidString.lowercased())
+    }
+
+    @Test func datePassesThrough() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let mapped = try #require(candidate(date: date))
+        #expect(mapped.date == date)
+    }
+}


### PR DESCRIPTION
## Summary

Tier 1 of FinanceKit support (#55): import Apple Card, Apple Cash and Savings transactions from Wallet using the **FinanceKitUI TransactionPicker**. The picker requires **no managed FinanceKit entitlement** — the user hand-picks transactions and Apple grants one-time, ephemeral access — so this ships on any App Store/TestFlight build.

## What's included

- **`WalletImportMapper`** — maps FinanceKit transactions to Actual transactions: credit/debit indicator carries the sign (Decimal → integer cents, half-away-from-zero), merchant names cleaned via the existing `MerchantNormalizer`, `booked` → cleared, `rejected` transactions dropped.
- **Dedup via `financial_id`** — imports write Actual's bank-import dedup key (the FinanceKit transaction UUID). Re-importing an overlapping selection skips existing rows, and tombstoned rows count as existing so a deleted import is never resurrected. Ordinary (non-import) transactions are untouched: `financial_id` is only emitted when set, so their CRDT messages are byte-identical to before (regression-tested).
- **`WalletImportView`** — target-account picker → Apple's transaction picker → review list with "Imported" badges on duplicates → import with result summary. Rules run on each imported transaction, same as manual entry, and everything syncs as normal CRDT messages.
- **Entry points** — toolbar button on Account Detail (preselects that account) and Settings → Automations. Both hidden when `FinanceStore.isDataAvailable(.financialData)` is false, so non-US users never see them.
- `NSFinancialDataUsageDescription` in both build configs (Apple's docs say `NSFinancialDataDescription`, but the runtime wants the `Usage` variant).
- Build 82.

## Testing

- 18 new unit tests (mapper mapping/rounding/status handling; store import incl. dedup, within-batch dupes, tombstone behaviour, CRDT `financial_id` message, manual-save regression guard).
- Full `ActualiTests` bundle green post-merge with main (reconciliation/notifications/balance visibility).
- ⚠️ **Not device-verified**: the picker returns no data in the simulator and Apple Card is US-only. Needs a TestFlight run by a US Apple Card holder — the volunteers on #55 are the natural testers.

## Tier 2 (not in this PR)

Full automatic sync via `FinanceStore` background delivery requires Apple's managed FinanceKit entitlement (organization-level developer account, case-by-case approval). Tracked separately.