### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->
+
+## Why
+
+<!-- What problem does this solve, or what motivated the change? Link the issue if there is one, e.g. "Closes #42". -->
+
+## What
+
+<!-- What changed, from the user's or reviewer's point of view. Bullet points are fine. -->
+
+## How it was tested
+
+<!-- e.g. unit/UI tests added or updated, ran on simulator/device (which iOS version), manual steps taken. -->
+
+## Screenshots
+
+<!-- For UI changes: before/after screenshots or a short screen recording. Delete this section if not applicable. -->


### PR DESCRIPTION
## Why
PRs in this repo already follow a consistent Why / What structure — this makes that the default for contributors instead of tribal knowledge.

## What
- New `.github/PULL_REQUEST_TEMPLATE.md` with **Why**, **What**, **How it was tested**, and an optional **Screenshots** section for UI changes, matching the style of recent merged PRs (#84–#87).

## How it was tested
Docs-only change; GitHub picks the template up automatically once merged to main.