### PR TITLE
feat: adding the same amount input keyboard to the reconcile view

### DIFF
--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -46,10 +46,14 @@ struct ReconcileView: View {
                     HStack {
                         Text("Bank Balance")
                         Spacer()
-                        AmountInputField(text: $balanceText)
-                            .keyboardType(.numbersAndPunctuation)
-                            .multilineTextAlignment(.trailing)
-                            .fontWeight(.semibold)
+                        // Credit-card and overdrawn accounts reconcile against
+                        // a negative bank balance, so the sign toggle is needed.
+                        AmountInputField(
+                            text: $balanceText,
+                            alignment: .right,
+                            allowsNegative: true,
+                            weight: .semibold
+                        )
                     }
                 } footer: {
                     Text("Enter the current balance of the bank account you want to reconcile with.")

--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -46,7 +46,7 @@ struct ReconcileView: View {
                     HStack {
                         Text("Bank Balance")
                         Spacer()
-                        TextField("0.00", text: $balanceText)
+                        AmountInputField(text: $balanceText)
                             .keyboardType(.numbersAndPunctuation)
                             .multilineTextAlignment(.trailing)
                             .fontWeight(.semibold)

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -587,11 +587,13 @@ private struct SplitLineRow: View {
 /// so 1, ., 0 produces 1.0.
 struct AmountInputField: UIViewRepresentable {
     @Binding var text: String
+    var alignment: NSTextAlignment = .right
 
     func makeUIView(context: Context) -> UITextField {
         let field = UITextField()
         field.keyboardType = .decimalPad
         field.placeholder = "0.00"
+        field.textAlignment = alignment
         field.delegate = context.coordinator
         field.text = text
         field.font = .preferredFont(forTextStyle: .body)

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -585,9 +585,14 @@ private struct SplitLineRow: View {
 /// taps `.` (or `,` in comma-decimal locales), the field switches to standard
 /// decimal entry where prior digits are reinterpreted as the integer part —
 /// so 1, ., 0 produces 1.0.
+///
+/// With `allowsNegative`, a ± button joins the keyboard toolbar; sign is
+/// otherwise handled outside the field (e.g. the expense/income toggle).
 struct AmountInputField: UIViewRepresentable {
     @Binding var text: String
-    var alignment: NSTextAlignment = .right
+    var alignment: NSTextAlignment = .natural
+    var allowsNegative = false
+    var weight: UIFont.Weight = .regular
 
     func makeUIView(context: Context) -> UITextField {
         let field = UITextField()
@@ -596,21 +601,39 @@ struct AmountInputField: UIViewRepresentable {
         field.textAlignment = alignment
         field.delegate = context.coordinator
         field.text = text
-        field.font = .preferredFont(forTextStyle: .body)
+        if weight == .regular {
+            field.font = .preferredFont(forTextStyle: .body)
+        } else {
+            // Weighted variant of the body style so Dynamic Type still scales.
+            let descriptor = UIFontDescriptor
+                .preferredFontDescriptor(withTextStyle: .body)
+                .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: weight]])
+            field.font = UIFont(descriptor: descriptor, size: 0)
+        }
         field.adjustsFontForContentSizeCategory = true
         // The SwiftUI keyboard toolbar only attaches to SwiftUI text fields,
         // and the decimal pad has no return key — without this accessory bar
         // there is no way to dismiss the keyboard from this field.
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
-        toolbar.items = [
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(
-                title: "Done", style: .done,
-                target: field, action: #selector(UIResponder.resignFirstResponder)
-            ),
-        ]
+        var items: [UIBarButtonItem] = []
+        if allowsNegative {
+            // The decimal pad has no minus key, so this button is the only
+            // touchscreen affordance for entering a negative amount.
+            items.append(UIBarButtonItem(
+                image: UIImage(systemName: "plus.forwardslash.minus"),
+                style: .plain,
+                target: context.coordinator, action: #selector(Coordinator.toggleSign)
+            ))
+        }
+        items.append(UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil))
+        items.append(UIBarButtonItem(
+            title: "Done", style: .done,
+            target: field, action: #selector(UIResponder.resignFirstResponder)
+        ))
+        toolbar.items = items
         toolbar.sizeToFit()
         field.inputAccessoryView = toolbar
+        context.coordinator.textField = field
         context.coordinator.sync(fromDisplay: text)
         return field
     }
@@ -629,15 +652,18 @@ struct AmountInputField: UIViewRepresentable {
 
     final class Coordinator: NSObject, UITextFieldDelegate {
         var parent: AmountInputField
+        weak var textField: UITextField?
         private var integerDigits: String = ""
         private var hasDecimalPoint: Bool = false
         private var fractionDigits: String = ""
+        private var isNegative: Bool = false
 
         init(_ parent: AmountInputField) {
             self.parent = parent
         }
 
         func sync(fromDisplay value: String) {
+            isNegative = parent.allowsNegative && value.hasPrefix("-")
             if value.isEmpty {
                 integerDigits = ""
                 hasDecimalPoint = false
@@ -670,6 +696,7 @@ struct AmountInputField: UIViewRepresentable {
                 integerDigits = ""
                 hasDecimalPoint = false
                 fractionDigits = ""
+                isNegative = false
             }
 
             if string.isEmpty {
@@ -689,7 +716,20 @@ struct AmountInputField: UIViewRepresentable {
             }
         }
 
+        @objc func toggleSign() {
+            guard parent.allowsNegative else { return }
+            isNegative.toggle()
+            if let textField {
+                applyDisplay(to: textField)
+            }
+        }
+
         private func handleCharacter(_ character: Character) {
+            // Hardware-keyboard minus; the on-screen path is the ± toolbar button.
+            if character == "-", parent.allowsNegative {
+                isNegative.toggle()
+                return
+            }
             if character == "." || character == "," {
                 hasDecimalPoint = true
                 return
@@ -713,21 +753,25 @@ struct AmountInputField: UIViewRepresentable {
                 }
             } else if !integerDigits.isEmpty {
                 integerDigits.removeLast()
+            } else {
+                isNegative = false
             }
         }
 
         private func computeDisplay() -> String {
+            let sign = isNegative ? "-" : ""
             if !hasDecimalPoint && integerDigits.isEmpty {
-                return ""
+                // A bare "-" so a sign toggled before any digits stays visible.
+                return sign
             }
             if hasDecimalPoint {
                 let whole = integerDigits.isEmpty ? "0" : integerDigits
-                return whole + "." + fractionDigits
+                return sign + whole + "." + fractionDigits
             }
             let cents = Int(integerDigits) ?? 0
             let dollars = cents / 100
             let pennies = cents % 100
-            return "\(dollars).\(String(format: "%02d", pennies))"
+            return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
         }
 
         private func applyDisplay(to textField: UITextField) {

--- a/Actuali/ActualiTests/AmountInputFieldTests.swift
+++ b/Actuali/ActualiTests/AmountInputFieldTests.swift
@@ -1,0 +1,131 @@
+import Testing
+import SwiftUI
+import UIKit
+@testable import Actuali
+
+/// Drives AmountInputField's UITextFieldDelegate coordinator directly,
+/// simulating keystrokes the way UIKit delivers them.
+@MainActor
+struct AmountInputFieldTests {
+
+    final class TextBox {
+        var value: String
+        init(_ value: String = "") { self.value = value }
+    }
+
+    /// Builds a coordinator wired to a real UITextField, mirroring makeUIView.
+    private func makeField(
+        initial: String = "",
+        allowsNegative: Bool = false
+    ) -> (coordinator: AmountInputField.Coordinator, textField: UITextField, box: TextBox) {
+        let box = TextBox(initial)
+        let field = AmountInputField(
+            text: Binding(get: { box.value }, set: { box.value = $0 }),
+            allowsNegative: allowsNegative
+        )
+        let coordinator = field.makeCoordinator()
+        let textField = UITextField()
+        textField.text = initial
+        coordinator.textField = textField
+        coordinator.sync(fromDisplay: initial)
+        return (coordinator, textField, box)
+    }
+
+    private func type(
+        _ string: String,
+        into coordinator: AmountInputField.Coordinator,
+        _ textField: UITextField
+    ) {
+        for character in string {
+            let end = (textField.text as NSString?)?.length ?? 0
+            _ = coordinator.textField(
+                textField,
+                shouldChangeCharactersIn: NSRange(location: end, length: 0),
+                replacementString: String(character)
+            )
+        }
+    }
+
+    private func backspace(
+        _ coordinator: AmountInputField.Coordinator,
+        _ textField: UITextField
+    ) {
+        let length = (textField.text as NSString?)?.length ?? 0
+        _ = coordinator.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: max(0, length - 1), length: min(1, length)),
+            replacementString: ""
+        )
+    }
+
+    @Test func calculatorModeShiftsDigitsIntoCents() {
+        let (coordinator, textField, box) = makeField()
+        type("120", into: coordinator, textField)
+        #expect(textField.text == "1.20")
+        #expect(box.value == "1.20")
+    }
+
+    @Test func toggleSignNegatesAndRestores() {
+        let (coordinator, textField, box) = makeField(allowsNegative: true)
+        type("5", into: coordinator, textField)
+        #expect(box.value == "0.05")
+        coordinator.toggleSign()
+        #expect(textField.text == "-0.05")
+        #expect(box.value == "-0.05")
+        coordinator.toggleSign()
+        #expect(box.value == "0.05")
+    }
+
+    @Test func toggleSignBeforeTypingCarriesIntoAmount() {
+        let (coordinator, textField, box) = makeField(allowsNegative: true)
+        coordinator.toggleSign()
+        #expect(textField.text == "-")
+        type("250", into: coordinator, textField)
+        #expect(box.value == "-2.50")
+    }
+
+    @Test func prefilledNegativeAmountKeepsSignWhenEdited() {
+        // Reconcile prefills e.g. a credit card's cleared balance.
+        let (coordinator, textField, box) = makeField(initial: "-123.4", allowsNegative: true)
+        type("5", into: coordinator, textField)
+        #expect(box.value == "-123.45")
+    }
+
+    @Test func fullReplaceResetsSign() {
+        // Tapping the field selects all; the next digit replaces everything.
+        let (coordinator, textField, box) = makeField(initial: "-123.45", allowsNegative: true)
+        _ = coordinator.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 7),
+            replacementString: "9"
+        )
+        #expect(box.value == "0.09")
+    }
+
+    @Test func backspaceClearsBareSign() {
+        let (coordinator, textField, box) = makeField(allowsNegative: true)
+        coordinator.toggleSign()
+        #expect(textField.text == "-")
+        backspace(coordinator, textField)
+        #expect(textField.text == "")
+        type("7", into: coordinator, textField)
+        #expect(box.value == "0.07")
+    }
+
+    @Test func hardwareKeyboardMinusTogglesSign() {
+        let (coordinator, textField, box) = makeField(allowsNegative: true)
+        type("120-", into: coordinator, textField)
+        #expect(box.value == "-1.20")
+    }
+
+    @Test func minusIsIgnoredWhenNegativeNotAllowed() {
+        let (coordinator, textField, box) = makeField(initial: "-1.20")
+        type("-", into: coordinator, textField)
+        #expect(box.value.hasPrefix("-") == false)
+        coordinator.toggleSign()
+        // Sign toggle exists but sync/full-replace never mark unsigned fields
+        // negative; typed digits keep the amount positive.
+        type("5", into: coordinator, textField)
+        #expect(textField.text?.hasPrefix("-") == false)
+    }
+}


### PR DESCRIPTION
First up, love the project! I was testing the app a little and noticed that the reconcile view was using a normal input instead of the add transaction keyboard.

## Why

Makes reconciling accounts more inline with other transaction interactions.

## What

Uses the `AddTransactionView.swift` view instead of a text field.

## How it was tested

Ran on simulator, build passes, no suites to update.

## Screenshots

| **Before** | **After** |
|---|---|
| <img width="554" height="1041" alt="Screenshot 2026-07-28 at 16 13 10" src="https://github.com/user-attachments/assets/38051e22-a457-409b-b2fa-e13151b908cf" /> | <img width="554" height="1041" alt="Screenshot 2026-07-28 at 16 11 08" src="https://github.com/user-attachments/assets/14afa3c0-7e99-45a4-9f14-5ff4615b6b3d" /> |
