### PR TITLE
feat: refreshing reconcile account balance after submission

### DIFF
--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -11,6 +11,10 @@ struct AccountDetailView: View {
     @State private var showingWalletImport = false
     @State private var editingTransaction: Transaction?
 
+    private var currentBalance: Int {
+        budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
+    }
+
     private var searchQuery: String? {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
         return trimmed.isEmpty ? nil : trimmed
@@ -42,7 +46,7 @@ struct AccountDetailView: View {
                 HStack {
                     Text("Current Balance")
                     Spacer()
-                    Text(budgetStore.displayBalance(account.balance))
+                    Text(budgetStore.displayBalance(currentBalance))
                         .fontWeight(.semibold)
                 }
             }


### PR DESCRIPTION
## Why

Previously the old "current balance" account value was stale after reconciling. this fix refreshes to the new account balance.

## What

- "Current balance" value now refreshes after reconciling

## How it was tested

- Ran on simulator, iOS26.5
- Performed a reconciliation using the demo budget and verified the change worked as expected

## Screenshots

<!-- For UI changes: before/after screenshots or a short screen recording. Delete this section if not applicable. -->
| **Before** | **After** |
|---|---|
| <img alt="before" src="https://github.com/user-attachments/assets/d9b317d0-86ff-4e3b-b6ec-6de4b46306ea" /> | <img alt="after" src="https://github.com/user-attachments/assets/c4cc3f85-99c7-458d-b21c-ae9532f26e85" /> |