### PR TITLE
feat: hide spent categories

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -212,6 +212,14 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether Budget hides categories with no budget left this month.
+    /// Persisted to UserDefaults, defaults to off.
+    @Published var hideZeroBudgetCategories: Bool = false {
+        didSet {
+            UserDefaults.standard.set(hideZeroBudgetCategories, forKey: "hideZeroBudgetCategories")
+        }
+    }
+
     /// One consistent-width replacement keeps masked amounts visually stable
     /// while avoiding a numeric value in the UI. Bullets read as the familiar
     /// passcode-style "hidden" treatment while inheriting each label's font,
@@ -458,6 +466,8 @@ final class BudgetStore: ObservableObject {
             .object(forKey: "showOverspentBadge") as? Bool ?? true)
         _hideBalances = Published(initialValue: UserDefaults.standard
             .object(forKey: "hideBalances") as? Bool ?? false)
+        _hideZeroBudgetCategories = Published(initialValue: UserDefaults.standard
+            .object(forKey: "hideZeroBudgetCategories") as? Bool ?? false)
         _recordPayeeLocations = Published(initialValue: UserDefaults.standard
             .object(forKey: "recordPayeeLocations") as? Bool ?? true)
         // bool(forKey:) defaults to false — the correct opt-in default.

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -220,6 +220,13 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Categories the Budget list should show. With the hide toggle on, only
+    /// exactly-zero available drops out: overspent (negative) categories stay
+    /// visible so problems that need fixing are never masked.
+    func visibleCategoryBudgets(_ categories: [CategoryBudget]) -> [CategoryBudget] {
+        hideZeroBudgetCategories ? categories.filter { $0.available != 0 } : categories
+    }
+
     /// One consistent-width replacement keeps masked amounts visually stable
     /// while avoiding a numeric value in the UI. Bullets read as the familiar
     /// passcode-style "hidden" treatment while inheriting each label's font,
@@ -466,11 +473,11 @@ final class BudgetStore: ObservableObject {
             .object(forKey: "showOverspentBadge") as? Bool ?? true)
         _hideBalances = Published(initialValue: UserDefaults.standard
             .object(forKey: "hideBalances") as? Bool ?? false)
-        _hideZeroBudgetCategories = Published(initialValue: UserDefaults.standard
-            .object(forKey: "hideZeroBudgetCategories") as? Bool ?? false)
         _recordPayeeLocations = Published(initialValue: UserDefaults.standard
             .object(forKey: "recordPayeeLocations") as? Bool ?? true)
         // bool(forKey:) defaults to false — the correct opt-in default.
+        _hideZeroBudgetCategories = Published(initialValue: UserDefaults.standard
+            .bool(forKey: "hideZeroBudgetCategories"))
         _postScheduledTransactions = Published(initialValue: UserDefaults.standard
             .bool(forKey: "postScheduledTransactions"))
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -169,6 +169,11 @@ struct BudgetView: View {
                                 }
                             }
                         }
+                        Section {
+                            Toggle("Hide Spent Categories", isOn: $budgetStore.hideZeroBudgetCategories)
+                        } footer: {
+                            Text("Hides categories with no budget left this month")
+                        }
                     }
                     // The clean style keeps the stock section rhythm; the
                     // detailed table packs its group cards tighter.
@@ -277,7 +282,10 @@ struct BudgetView: View {
 
     var groupedCategories: [CategoryGroupSection] {
         guard let budget = budgetStore.currentBudgetMonth else { return [] }
-        let byGroup = Dictionary(grouping: budget.categoryBudgets, by: { $0.groupId })
+        let categories = budgetStore.hideZeroBudgetCategories
+            ? budget.categoryBudgets.filter { $0.available != 0 }
+            : budget.categoryBudgets
+        let byGroup = Dictionary(grouping: categories, by: { $0.groupId })
         return byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -282,9 +282,7 @@ struct BudgetView: View {
 
     var groupedCategories: [CategoryGroupSection] {
         guard let budget = budgetStore.currentBudgetMonth else { return [] }
-        let categories = budgetStore.hideZeroBudgetCategories
-            ? budget.categoryBudgets.filter { $0.available != 0 }
-            : budget.categoryBudgets
+        let categories = budgetStore.visibleCategoryBudgets(budget.categoryBudgets)
         let byGroup = Dictionary(grouping: categories, by: { $0.groupId })
         return byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in

--- a/Actuali/ActualiTests/BudgetStoreHideSpentCategoriesTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreHideSpentCategoriesTests.swift
@@ -2,12 +2,32 @@ import Foundation
 import Testing
 @testable import Actuali
 
-/// The "hide spent categories" toggle must default to off and persist like
-/// the other display settings.
+/// The "hide spent categories" toggle must default to off, persist like the
+/// other display settings, and hide exactly the zero-available categories —
+/// overspent (negative) ones stay visible so problems are never masked.
 @MainActor
 struct BudgetStoreHideSpentCategoriesTests {
 
+    private func makeCategories(availables: [Int]) -> [CategoryBudget] {
+        availables.enumerated().map { index, available in
+            CategoryBudget(
+                month: "2026-08",
+                categoryId: "cat\(index)",
+                categoryName: "Category \(index)",
+                groupId: "g1",
+                groupName: "Everyday",
+                groupSortOrder: 0,
+                categorySortOrder: 0,
+                budgeted: 10000,
+                spent: 10000 - available,
+                available: available,
+                carryover: 0
+            )
+        }
+    }
+
     @Test func defaultsToFalse() {
+        UserDefaults.standard.removeObject(forKey: "hideZeroBudgetCategories")
         let store = BudgetStore.previewInstance()
         #expect(store.hideZeroBudgetCategories == false)
     }
@@ -18,5 +38,24 @@ struct BudgetStoreHideSpentCategoriesTests {
         #expect(UserDefaults.standard.bool(forKey: "hideZeroBudgetCategories") == true)
         store.hideZeroBudgetCategories = false
         #expect(UserDefaults.standard.bool(forKey: "hideZeroBudgetCategories") == false)
+        UserDefaults.standard.removeObject(forKey: "hideZeroBudgetCategories")
+    }
+
+    @Test func hidesOnlyZeroAvailableWhenEnabled() {
+        let store = BudgetStore.previewInstance()
+        store.hideZeroBudgetCategories = true
+        defer { UserDefaults.standard.removeObject(forKey: "hideZeroBudgetCategories") }
+
+        let visible = store.visibleCategoryBudgets(makeCategories(availables: [-100, 0, 500, 0]))
+        #expect(visible.map(\.available) == [-100, 500])
+    }
+
+    @Test func showsAllWhenDisabled() {
+        let store = BudgetStore.previewInstance()
+        store.hideZeroBudgetCategories = false
+        defer { UserDefaults.standard.removeObject(forKey: "hideZeroBudgetCategories") }
+
+        let visible = store.visibleCategoryBudgets(makeCategories(availables: [-100, 0, 500]))
+        #expect(visible.count == 3)
     }
 }

--- a/Actuali/ActualiTests/BudgetStoreHideSpentCategoriesTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreHideSpentCategoriesTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The "hide spent categories" toggle must default to off and persist like
+/// the other display settings.
+@MainActor
+struct BudgetStoreHideSpentCategoriesTests {
+
+    @Test func defaultsToFalse() {
+        let store = BudgetStore.previewInstance()
+        #expect(store.hideZeroBudgetCategories == false)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.hideZeroBudgetCategories = true
+        #expect(UserDefaults.standard.bool(forKey: "hideZeroBudgetCategories") == true)
+        store.hideZeroBudgetCategories = false
+        #expect(UserDefaults.standard.bool(forKey: "hideZeroBudgetCategories") == false)
+    }
+}


### PR DESCRIPTION
## Why

When using Actual Budget & actuali, I want to see which categories still have spendable budget. However, it can get hard to see this info at a glance when there are too many categories in the list.

I wanted a way to be able to hide categories that have been fully spent and only see accounts with budget.

## What

Added a toggle at the bottom of the Budget screen to handle this, and save it to the `BudgetStore`.

## How it was tested

- Ran on simulator with iOS26.5

## Screenshots

Here you can see that there are many categories with remaining 0 budget. After toggling, only over budget or under budget categories are shown. This way we don't hide over budget categories that need to be fixed.

<img width="1084" height="2058" alt="2026-08-0513 27 06-ezgif com-optimize" src="https://github.com/user-attachments/assets/626b81fd-d90a-438c-8a2e-732eab0eab3d" />

