### PR TITLE
Build and upload to TestFlight on merge to main

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,0 +1,20 @@
+# Companion to ci.yml: PRs that don't touch app code (website, docs) still get
+# a passing "Build and Test" check, so branch protection can require it
+# unconditionally. The paths-ignore list must mirror ci.yml's paths list.
+name: CI (no app changes)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "Actuali/**"
+      - ".github/workflows/ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No app code changed — skipping build and tests."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# Builds the app and runs unit tests on every PR that touches app code.
+# Branch protection requires the "Build and Test" check; ci-noop.yml provides
+# the same check name for PRs that don't touch app code.
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - "Actuali/**"
+      - ".github/workflows/ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Rapid pushes to the same PR cancel the stale run.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select simulator
+        id: sim
+        run: |
+          SIM_ID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid')
+          if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
+            echo "No available iPhone simulator on this runner" >&2
+            exit 1
+          fi
+          echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
+
+      # UI tests are skipped: too slow and flaky on shared runners. Simulator
+      # builds are ad-hoc signed, so no certificate is needed — but don't pass
+      # CODE_SIGNING_ALLOWED=NO: an unsigned test host can't reach the
+      # simulator keychain (errSecMissingEntitlement in EncryptionKeyManager
+      # tests).
+      - name: Build and run unit tests
+        run: |
+          xcodebuild test \
+            -project Actuali/Actuali.xcodeproj \
+            -scheme Actuali \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+            -skip-testing:ActualiUITests

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,81 @@
+# Builds the app and uploads it to TestFlight on every merge to main that
+# touches app code. Design + one-time secret setup:
+# docs/superpowers/specs/2026-08-07-testflight-cd-design.md
+name: TestFlight
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Actuali/**"
+      - ".github/workflows/testflight.yml"
+      - "dev/exportOptions.plist"
+  workflow_dispatch:
+
+# Serialize uploads so two quick merges can't race each other.
+concurrency:
+  group: testflight
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      # Full history: the build number is stamped as 100 + commit count, so a
+      # shallow clone would produce low, colliding build numbers.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Import distribution certificate
+        env:
+          DIST_CERT_P12_BASE64: ${{ secrets.DIST_CERT_P12_BASE64 }}
+          DIST_CERT_P12_PASSWORD: ${{ secrets.DIST_CERT_P12_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo -n "$DIST_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN_PATH" \
+            -P "$DIST_CERT_P12_PASSWORD" -A -t cert -f pkcs12
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          rm "$RUNNER_TEMP/cert.p12"
+
+      - name: Write App Store Connect API key
+        env:
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+        run: echo -n "$ASC_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Archive
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcodebuild archive \
+            -project Actuali/Actuali.xcodeproj \
+            -scheme Actuali \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/Actuali.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+      - name: Upload to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Actuali.xcarchive" \
+            -exportOptionsPlist dev/exportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -12,6 +12,9 @@ on:
       - "dev/exportOptions.plist"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Serialize uploads so two quick merges can't race each other.
 concurrency:
   group: testflight

--- a/Actuali/Actuali.xcodeproj/xcshareddata/xcschemes/Actuali.xcscheme
+++ b/Actuali/Actuali.xcodeproj/xcshareddata/xcschemes/Actuali.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7550B852EE7B4F7007026DC"
+               BuildableName = "Actuali.app"
+               BlueprintName = "Actuali"
+               ReferencedContainer = "container:Actuali.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A79D4A9C2FA1F8F000D5A2DF"
+               BuildableName = "ActualiTests.xctest"
+               BlueprintName = "ActualiTests"
+               ReferencedContainer = "container:Actuali.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB0000000000000000000CDF"
+               BuildableName = "ActualiUITests.xctest"
+               BlueprintName = "ActualiUITests"
+               ReferencedContainer = "container:Actuali.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7550B852EE7B4F7007026DC"
+            BuildableName = "Actuali.app"
+            BlueprintName = "Actuali"
+            ReferencedContainer = "container:Actuali.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7550B852EE7B4F7007026DC"
+            BuildableName = "Actuali.app"
+            BlueprintName = "Actuali"
+            ReferencedContainer = "container:Actuali.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/dev/exportOptions.plist
+++ b/dev/exportOptions.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+	<key>teamID</key>
+	<string>GJGY9A384M</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Why

Merges to `main` currently reach TestFlight only via a manual archive-and-upload from Xcode, and PRs get no build/test verification at all. This automates both: PRs must build and pass unit tests before merging, and any merge touching app code builds, signs, and uploads to TestFlight (~15 min later, internal testers get it automatically after Apple processing).

## What

**Release (merge to `main`):**
- **`.github/workflows/testflight.yml`** — on push to `main` (paths-filtered to `Actuali/**`, plus `workflow_dispatch` for manual runs): archives with `xcodebuild` on a `macos-26` runner (free for public repos) and uploads via `-exportArchive` with `destination: upload`. No fastlane, no third-party actions beyond `actions/checkout`. A `concurrency` group serializes uploads so two quick merges can't race.
- **`dev/exportOptions.plist`** — `app-store-connect` method, `manageAppVersionAndBuildNumber: false` so build numbers come from the commit-count stamp (#80), not Xcode.
- **Shared `Actuali` scheme** — `xcodebuild` on a fresh clone can't see per-user schemes; this commits the scheme so CI (and contributors) get it.

**PR gate:**
- **`.github/workflows/ci.yml`** — on PRs touching `Actuali/**`: builds and runs the `ActualiTests` unit suite on an iOS simulator. No secrets involved, so fork PRs run it safely. UI tests are skipped (slow/flaky on shared runners). Stale runs are cancelled when a PR is force-pushed.
- **`.github/workflows/ci-noop.yml`** — same `Build and Test` check name for PRs that *don't* touch app code, so the check can be required unconditionally without blocking website/docs PRs.
- Branch protection on `main` now requires `Build and Test` to pass before merge (admins can bypass).

⚠️ Note for currently-open PRs (#80, #92, #95, #101, #103): the required check first runs on a PR after this merges **and** the PR gets a new push (or close/reopen) — until then GitHub shows the check as "expected".

## Before this can run — one-time setup

1. **Merge #80 first.** Without the commit-count build stamp, every CI build carries the static `CURRENT_PROJECT_VERSION` and the second upload is rejected as a duplicate. (The workflow checks out with `fetch-depth: 0` specifically so #80's `git rev-list --count` sees full history.)
2. Add five repo secrets (Settings → Secrets and variables → Actions):

| Secret | Contents |
|-|-|
| `DIST_CERT_P12_BASE64` | Apple Distribution cert + key exported as `.p12`, then `base64 -i cert.p12 \| pbcopy` |
| `DIST_CERT_P12_PASSWORD` | Password chosen when exporting the `.p12` |
| `ASC_KEY_ID` | App Store Connect API key ID (ASC → Users and Access → Integrations, create a Team key with **App Manager** role) |
| `ASC_ISSUER_ID` | Issuer UUID from the same page |
| `ASC_KEY_P8_BASE64` | The downloaded `.p8`, base64-encoded |

Forks don't receive secrets and the TestFlight workflow only triggers on `main`, so contributor PRs can't touch them. External-tester distribution stays manual (it involves beta review).

## How it was tested

- Full unit suite (595 tests, 84 suites, UI tests skipped) run locally with the exact CI command — passes. Notably `CODE_SIGNING_ALLOWED=NO` had to be avoided: an unsigned test host gets `errSecMissingEntitlement` from the simulator keychain in `EncryptionKeyManagerTests`.
- `plutil -lint` on `exportOptions.plist`, XML validation on the scheme, YAML parse on all workflows.
- `xcodebuild -list` confirms the shared `Actuali` scheme is visible without per-user data.
- The CI workflow is running on this very PR. TestFlight upload can only be proven with the secrets in place — first verification is a `workflow_dispatch` run after setup.