### PR TITLE
Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select simulator
         id: sim

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # Full history: the build number is stamped as 100 + commit count, so a
       # shallow clone would produce low, colliding build numbers.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Why

The CI and TestFlight workflows pinned `actions/checkout@v4`, three majors behind latest stable (v7.0.1).

## What

- `actions/checkout` v4 → v7 in `ci.yml` and `testflight.yml` (the only third-party action used in any workflow).
- Checked v5–v7 release notes: breaking changes affect `pull_request_target`/`workflow_run` fork checkouts and the Node 24 runtime — neither applies to our `pull_request`/`push` triggers on GitHub-hosted runners.

## How it was tested

YAML re-validated; the `Build and Test` check on this PR exercises the bumped action directly.