### PR TITLE
Fix TestFlight export: manual signing with API-installed profile

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -54,6 +54,15 @@ jobs:
           ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
         run: echo -n "$ASC_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
 
+      # Export uses manual signing: automatic signing at export time insists on
+      # cloud-managed distribution certificates, which App Manager API keys
+      # aren't allowed to create ("Cloud signing permission error").
+      - name: Install App Store provisioning profile
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: ASC_KEY_PATH="$RUNNER_TEMP/AuthKey.p8" ruby dev/scripts/install-appstore-profile.rb
+
       - name: Archive
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -78,7 +87,6 @@ jobs:
             -archivePath "$RUNNER_TEMP/Actuali.xcarchive" \
             -exportOptionsPlist dev/exportOptions.plist \
             -exportPath "$RUNNER_TEMP/export" \
-            -allowProvisioningUpdates \
             -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"

--- a/dev/exportOptions.plist
+++ b/dev/exportOptions.plist
@@ -8,6 +8,15 @@
 	<string>upload</string>
 	<key>teamID</key>
 	<string>GJGY9A384M</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.mfazz.ActualiOS</key>
+		<string>Actuali App Store</string>
+	</dict>
 	<key>uploadSymbols</key>
 	<true/>
 	<key>manageAppVersionAndBuildNumber</key>

--- a/dev/scripts/install-appstore-profile.rb
+++ b/dev/scripts/install-appstore-profile.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# Downloads the App Store provisioning profile from App Store Connect and
+# installs it where xcodebuild looks up profiles for manually-signed exports.
+# Auth: ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_PATH (path to the .p8); optional
+# PROFILE_NAME (defaults to "Actuali App Store").
+require "openssl"
+require "base64"
+require "json"
+require "net/http"
+require "fileutils"
+
+key_id = ENV.fetch("ASC_KEY_ID")
+issuer = ENV.fetch("ASC_ISSUER_ID")
+key_path = ENV.fetch("ASC_KEY_PATH")
+profile_name = ENV.fetch("PROFILE_NAME", "Actuali App Store")
+
+b64 = ->(s) { Base64.urlsafe_encode64(s).delete("=") }
+key = OpenSSL::PKey.read(File.read(File.expand_path(key_path)))
+now = Time.now.to_i
+header = b64.({ alg: "ES256", kid: key_id, typ: "JWT" }.to_json)
+payload = b64.({ iss: issuer, iat: now, exp: now + 600, aud: "appstoreconnect-v1" }.to_json)
+signing_input = "#{header}.#{payload}"
+der = key.sign(OpenSSL::Digest::SHA256.new, signing_input)
+# JWT ES256 wants the raw 64-byte r||s signature, not DER.
+r, s = OpenSSL::ASN1.decode(der).value.map { |i| i.value.to_s(2).rjust(32, "\x00")[-32..] }
+jwt = "#{signing_input}.#{b64.(r + s)}"
+
+uri = URI("https://api.appstoreconnect.apple.com/v1/profiles?" \
+          "filter[profileType]=IOS_APP_STORE" \
+          "&filter[name]=#{URI.encode_www_form_component(profile_name)}" \
+          "&fields[profiles]=name,profileContent,uuid,profileState")
+res = Net::HTTP.get_response(uri, { "Authorization" => "Bearer #{jwt}" })
+abort "ASC API returned #{res.code}: #{res.body[0, 500]}" unless res.code == "200"
+
+profile = JSON.parse(res.body)["data"].find { |p| p.dig("attributes", "profileState") == "ACTIVE" }
+abort "No ACTIVE profile named '#{profile_name}' found" unless profile
+
+content = Base64.decode64(profile.dig("attributes", "profileContent"))
+uuid = profile.dig("attributes", "uuid")
+
+# Xcode 16+ reads the UserData location; older tooling reads MobileDevice.
+["~/Library/MobileDevice/Provisioning Profiles",
+ "~/Library/Developer/Xcode/UserData/Provisioning Profiles"].each do |dir|
+  dir = File.expand_path(dir)
+  FileUtils.mkdir_p(dir)
+  File.write(File.join(dir, "#{uuid}.mobileprovision"), content)
+end
+puts "Installed profile '#{profile_name}' (#{uuid})"


### PR DESCRIPTION
## Why

The first TestFlight run (after #107) failed at the export step with `Cloud signing permission error` + `No profiles for 'com.mfazz.ActualiOS' were found`. Root cause: `xcodebuild -exportArchive` with automatic signing insists on **cloud-managed** distribution certificates, which App Manager API keys aren't permitted to create (only Admin keys are) — and it ignores manually created portal profiles.

## What

- **`dev/exportOptions.plist`** — switch export to `signingStyle: manual` with `signingCertificate: Apple Distribution` and the `Actuali App Store` provisioning profile (created in the developer portal via the ASC API; expires Aug 2027 alongside the cert).
- **`dev/scripts/install-appstore-profile.rb`** — downloads the ACTIVE `Actuali App Store` profile via the ASC API (using the existing repo secrets) and installs it where xcodebuild looks. Rotation-proof: regenerating the profile in the portal requires no repo change.
- **`.github/workflows/testflight.yml`** — run that script before export; drop the now-unneeded `-allowProvisioningUpdates` from the export step (the auth-key flags stay, they authenticate the upload itself). The Archive step is untouched — its automatic signing worked fine.

## How it was tested

Full pipeline locally with the exact CI commands and real credentials: profile install script → `xcodebuild archive` → `-exportArchive` with a copy of this plist (`destination: export` instead of `upload` so nothing was uploaded). Export succeeded; `DistributionSummary.plist` confirms it signed with the Apple Distribution cert and the `Actuali App Store` profile. Merging this PR will trigger the TestFlight workflow (it touches the workflow file), which verifies the final upload leg.