### PR TITLE
Bump version to 1.0.8

### DIFF
--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -497,7 +497,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mfazz.ActualiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
## Why

The TestFlight upload (after #109 fixed signing) was rejected by App Store Connect: version **1.0.7 is already approved on the App Store**, so its pre-release train is closed for new builds (`ITMS-90062`/`90186`). Every future TestFlight build must carry a higher `CFBundleShortVersionString`.

## What

`MARKETING_VERSION` 1.0.7 → 1.0.8 on the app target (both configurations). Test targets untouched. Build numbers keep coming from the commit-count stamp (#80) — this is only the user-facing version.

## How it was tested

Merging this triggers the TestFlight workflow, which is the real test — signing and upload auth already verified working in the #109 run (the failure was solely this version check).