### PR TITLE
Refresh cached views when budget data changes elsewhere

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -131,6 +131,11 @@ final class BudgetStore: ObservableObject {
     @Published var categoryGroups: [CategoryGroup] = []
     @Published var payees: [Payee] = []
     @Published var currentBudgetMonth: BudgetMonth?
+    /// Bumped every time the published data snapshot above is republished
+    /// (budget load, local mutation, sync). Views that cache their own
+    /// fetches (transaction pagers, report widgets) key reloads on this so
+    /// changes made elsewhere in the app reach them without a pull-down.
+    @Published private(set) var dataVersion = 0
     @Published var syncState: SyncState = .idle
     @Published var lastSyncTime: Date?
 
@@ -808,6 +813,7 @@ final class BudgetStore: ObservableObject {
             categoryGroups = fetchedGroups
             payees = fetchedPayees
             currentBudgetMonth = fetchedBudgetMonth
+            dataVersion += 1
 
             // Configure sync client
             let nodeId = UserDefaults.standard.string(forKey: "nodeId") ?? {
@@ -941,6 +947,7 @@ final class BudgetStore: ObservableObject {
             categoryGroups = fetchedGroups
             payees = fetchedPayees
             currentBudgetMonth = fetchedBudgetMonth
+            dataVersion += 1
         } catch is CancellationError {
             // The caller's task was cancelled (e.g. a .refreshable task the
             // system tore down). Nothing failed — never alarm the user.

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -57,20 +57,14 @@ struct AccountDetailView: View {
                             editingTransaction = transaction
                         } label: {
                             TransactionRow(transaction: transaction, showAccount: false, onToggleCleared: {
-                                Task {
-                                    await budgetStore.toggleCleared(transaction)
-                                    await reload()
-                                }
+                                Task { await budgetStore.toggleCleared(transaction) }
                             })
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             Button(role: .destructive) {
-                                Task {
-                                    await budgetStore.deleteTransaction(transaction)
-                                    await reload()
-                                }
+                                Task { await budgetStore.deleteTransaction(transaction) }
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
@@ -121,35 +115,19 @@ struct AccountDetailView: View {
                 }
             }
         }
-        .sheet(isPresented: $showingReconcile, onDismiss: {
-            Task {
-                await reload()
-            }
-        }) {
+        .sheet(isPresented: $showingReconcile) {
             ReconcileView(account: account)
                 .environmentObject(budgetStore)
         }
-        .sheet(isPresented: $showingWalletImport, onDismiss: {
-            Task {
-                await reload()
-            }
-        }) {
+        .sheet(isPresented: $showingWalletImport) {
             WalletImportView(preselectedAccountId: account.id)
                 .environmentObject(budgetStore)
         }
-        .sheet(isPresented: $showingAddTransaction, onDismiss: {
-            Task {
-                await reload()
-            }
-        }) {
+        .sheet(isPresented: $showingAddTransaction) {
             AddTransactionView(accountId: account.id)
                 .environmentObject(budgetStore)
         }
-        .sheet(item: $editingTransaction, onDismiss: {
-            Task {
-                await reload()
-            }
-        }) { transaction in
+        .sheet(item: $editingTransaction) { transaction in
             AddTransactionView(editing: transaction)
                 .environmentObject(budgetStore)
         }
@@ -162,9 +140,11 @@ struct AccountDetailView: View {
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
-            // The store republished its data (edit on another tab, sync,
-            // scheduled post) — refresh the cached page. Concurrent reloads
-            // are safe: the pager's generation counter keeps the newest.
+            // The store republished its data — refresh the cached page. This
+            // is the single reload path for every mutation (row toggles,
+            // deletes, sheet edits, sync, scheduled posts), so those sites
+            // carry no reload calls of their own. Concurrent reloads are
+            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .refreshable {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -161,6 +161,12 @@ struct AccountDetailView: View {
             }
             await reload()
         }
+        .onChange(of: budgetStore.dataVersion) {
+            // The store republished its data (edit on another tab, sync,
+            // scheduled post) — refresh the cached page. Concurrent reloads
+            // are safe: the pager's generation counter keeps the newest.
+            Task { await reload() }
+        }
         .refreshable {
             await budgetStore.sync()
             await reload()

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -49,7 +49,10 @@ struct DashboardView: View {
                 }
                 .padding()
             }
-            .task { await loadTransactions() }
+            // Keyed to dataVersion so widgets recompute when transactions
+            // change anywhere in the app (edits on other tabs, sync,
+            // scheduled posts) — not just on first appearance.
+            .task(id: budgetStore.dataVersion) { await loadTransactions() }
         }
     }
 

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -47,20 +47,14 @@ struct TransactionsListView: View {
                             editingTransaction = transaction
                         } label: {
                             TransactionRow(transaction: transaction, onToggleCleared: {
-                                Task {
-                                    await budgetStore.toggleCleared(transaction)
-                                    await reload()
-                                }
+                                Task { await budgetStore.toggleCleared(transaction) }
                             })
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             Button(role: .destructive) {
-                                Task {
-                                    await budgetStore.deleteTransaction(transaction)
-                                    await reload()
-                                }
+                                Task { await budgetStore.deleteTransaction(transaction) }
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
@@ -96,21 +90,18 @@ struct TransactionsListView: View {
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
-            // The store republished its data (edit on another tab, sync,
-            // scheduled post) — refresh the cached page. Concurrent reloads
-            // are safe: the pager's generation counter keeps the newest.
+            // The store republished its data — refresh the cached page. This
+            // is the single reload path for every mutation (row toggles,
+            // deletes, sheet edits, sync, scheduled posts), so those sites
+            // carry no reload calls of their own. Concurrent reloads are
+            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .refreshable {
             await budgetStore.sync()
             await reload()
         }
-        .sheet(item: $editingTransaction, onDismiss: {
-            Task {
-                await budgetStore.refreshData()
-                await reload()
-            }
-        }) { transaction in
+        .sheet(item: $editingTransaction) { transaction in
             AddTransactionView(editing: transaction)
                 .environmentObject(budgetStore)
         }

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -95,6 +95,12 @@ struct TransactionsListView: View {
             }
             await reload()
         }
+        .onChange(of: budgetStore.dataVersion) {
+            // The store republished its data (edit on another tab, sync,
+            // scheduled post) — refresh the cached page. Concurrent reloads
+            // are safe: the pager's generation counter keeps the newest.
+            Task { await reload() }
+        }
         .refreshable {
             await budgetStore.sync()
             await reload()

--- a/Actuali/ActualiTests/BudgetStoreDataVersionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreDataVersionTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// `dataVersion` is the store's change signal: views that cache their own
+/// fetches (transaction pagers, report widgets) key reloads on it, so it must
+/// bump whenever the published data snapshot is republished — after a local
+/// mutation and after a sync.
+@MainActor
+struct BudgetStoreDataVersionTests {
+
+    /// Every table `refreshDataOnly()` reads, so the refresh completes
+    /// without error (matches BudgetStoreSyncCancellationTests).
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    parent_id TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    cat_group TEXT,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_groups (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                INSERT INTO accounts (id, name, type, sort_order) VALUES
+                    ('acct-1', 'Checking', 'checking', 1.0);
+                INSERT INTO transactions (id, acct, amount, date, cleared, sort_order) VALUES
+                    ('t1', 'acct-1', -500, 20260701, 0, 1.0);
+            """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    /// Store wired to a real database and sync client. The server client is
+    /// unconfigured, so the network leg fails fast and locally; the data
+    /// refresh afterwards runs against the fixture for real.
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func localMutationBumpsDataVersion() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+        let before = store.dataVersion
+
+        // The cross-tab scenario the signal exists for: a dot-tap toggle on
+        // one screen must announce itself to every cached list.
+        let transaction = Transaction(
+            id: "t1",
+            accountId: "acct-1",
+            date: 20260701,
+            amount: -500,
+            payeeId: nil,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: nil,
+            cleared: false,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: 1,
+            importedPayee: nil
+        )
+        await store.toggleCleared(transaction)
+
+        #expect(store.error == nil)
+        #expect(store.dataVersion > before)
+    }
+
+    @Test func syncBumpsDataVersion() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+        let before = store.dataVersion
+
+        await store.sync()
+
+        #expect(store.error == nil)
+        #expect(store.dataVersion > before)
+    }
+}


### PR DESCRIPTION
## Why

Views that cache their own fetches — the Reports dashboard and the transaction lists (all-accounts and per-account) — only reloaded on their own triggers (own edits, search, pull-down). Edits made on other tabs, sync results, and scheduled-transaction posts stayed invisible until a pull-to-refresh. Complements #101, which fixed the same class of staleness for the account balance header.

## What

- `BudgetStore` now publishes a `dataVersion` counter, bumped whenever the data snapshot is republished (budget load, every mutation, every sync path — all funnel through `refreshDataOnly()`).
- The Reports dashboard keys its transaction load on it; both transaction lists reload their pager when it changes. Concurrent reloads are already safe via the pager's generation counter.
- Cleanup: the per-site reloads this replaces (row toggles, swipe deletes, sheet `onDismiss` handlers — including a heavyweight `refreshData()` on the all-accounts edit sheet) are removed; the version signal is now the single reload path.
- Known tradeoff: a sync landing mid-scroll resets a transaction list to its first page — same behavior as after an in-list edit today.

## How it was tested

- New `BudgetStoreDataVersionTests`: a local mutation (`toggleCleared`) and a `sync()` each bump `dataVersion`.
- Full `ActualiTests` suite passes on iPhone 17 simulator, iOS 26.5 (re-ran targeted suites after the cleanup commit).