### PR TITLE
feat: add Philippine Peso (PHP) currency

### DIFF
--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -34,6 +34,7 @@ struct SettingsView: View {
         ("zł", "PLN"),
         ("R$", "BRL"),
         ("MX$", "MXN"),
+        ("₱", "PHP"),
         ("R", "ZAR")
     ]
     @State private var password = ""


### PR DESCRIPTION
Adds ₱ PHP to the currency picker in Settings.

Closes #112