### PR TITLE
feat: add PHP currency (#112)

### DIFF
--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
         ("S$", "SGD"),
         ("HK$", "HKD"),
         ("CN¥", "CNY"),
+        ("₱", "PHP"),
         ("kr", "SEK"),
         ("kr", "NOK"),
         ("kr", "DKK"),


### PR DESCRIPTION
## Why

The Philippine Peso (PHP) is not in the app.

Closes #112 

## What
Add PHP in `currencyOptions`

## How it was tested

Ran on simulator

## Screenshots

<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/8ce3c7d2-41e0-4dfd-84ae-3883446e35ec" />
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/bef7fc7a-a5bc-4b72-ac88-d1c0505458f2" />

