### PR TITLE
feat: add Armenian Dram (AMD) currency

### DIFF
--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -35,6 +35,7 @@ struct SettingsView: View {
         ("R$", "BRL"),
         ("MX$", "MXN"),
         ("₱", "PHP"),
+        ("֏", "AMD"),
         ("R", "ZAR")
     ]
     @State private var password = ""


### PR DESCRIPTION
Adds ֏ AMD to the currency picker in Settings. Follow-up to #113, which merged before the AMD commit was pushed.

Closes #100