### PR TITLE
fix: archive with manual distribution signing in CI

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -63,20 +63,23 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: ASC_KEY_PATH="$RUNNER_TEMP/AuthKey.p8" ruby dev/scripts/install-appstore-profile.rb
 
+      # Manual signing for the archive too: automatic signing at archive time
+      # signs with a development certificate, and a fresh runner has no key for
+      # any existing one — so every run minted a new cert until the account hit
+      # its certificate limit and archiving started failing. The script edits
+      # the app target's Release config in this (ephemeral) checkout; the
+      # settings can't go on the xcodebuild command line because they'd also
+      # apply to SPM package targets, which reject explicit profiles.
+      - name: Switch Release signing to manual distribution
+        run: ruby dev/scripts/set-manual-signing.rb
+
       - name: Archive
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           xcodebuild archive \
             -project Actuali/Actuali.xcodeproj \
             -scheme Actuali \
             -destination "generic/platform=iOS" \
-            -archivePath "$RUNNER_TEMP/Actuali.xcarchive" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$RUNNER_TEMP/AuthKey.p8" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+            -archivePath "$RUNNER_TEMP/Actuali.xcarchive"
 
       - name: Upload to TestFlight
         env:

--- a/dev/scripts/set-manual-signing.rb
+++ b/dev/scripts/set-manual-signing.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# Flips the app target's Release configuration to manual distribution signing.
+# Run in the CI checkout before archiving (never committed): automatic signing
+# at archive time signs with a development certificate, and a fresh runner has
+# no key for an existing one, so every run minted a new cert until the account
+# hit its certificate limit. The overrides can't go on the xcodebuild command
+# line because they would also apply to SPM package targets, which reject
+# explicitly specified provisioning profiles.
+PBXPROJ = File.expand_path("../../Actuali/Actuali.xcodeproj/project.pbxproj", __dir__)
+
+src = File.read(PBXPROJ)
+
+# The app target's Release XCBuildConfiguration: the only Release-named block
+# whose buildSettings carry the app bundle identifier. buildSettings blocks
+# contain no nested braces, so [^}] safely spans one.
+app_release = /=\ \{\s*
+    isa\ =\ XCBuildConfiguration;\s*
+    buildSettings\ =\ \{[^}]*PRODUCT_BUNDLE_IDENTIFIER\ =\ com\.mfazz\.ActualiOS;[^}]*\};\s*
+    name\ =\ Release;/mx
+
+abort "App Release configuration not found in #{PBXPROJ}" unless src =~ app_release
+
+updated = src.sub(app_release) do |block|
+  unless block.include?("CODE_SIGN_STYLE = Automatic;")
+    abort "Expected CODE_SIGN_STYLE = Automatic in the app Release configuration"
+  end
+  block.sub("CODE_SIGN_STYLE = Automatic;", <<~SETTINGS.strip)
+    CODE_SIGN_IDENTITY = "Apple Distribution";
+    \t\t\t\tCODE_SIGN_STYLE = Manual;
+    \t\t\t\tPROVISIONING_PROFILE_SPECIFIER = "Actuali App Store";
+  SETTINGS
+end
+
+File.write(PBXPROJ, updated)
+puts "Release signing set to manual (Apple Distribution / Actuali App Store)"


### PR DESCRIPTION
## Why

The TestFlight job failed on the Archive step ([run 31175008039](https://github.com/MattFaz/actuali/actions/runs/31175008039/job/92854976551)):

> Choose a certificate to revoke. Your account has reached the maximum number of certificates.
> No profiles for 'com.mfazz.ActualiOS' were found

The workflow imports the distribution certificate and installs the App Store profile, but only the **export** step used them. The **archive** step still ran with the project's automatic signing, which signs archives with a *development* certificate — and since every fresh runner has no private key for an existing dev cert, each run minted a new one until the account hit its certificate limit.

## What

- `dev/scripts/set-manual-signing.rb`: flips the app target's Release configuration to manual signing (`Apple Distribution` / `Actuali App Store`) in the CI checkout. It aborts loudly if the expected settings block isn't found.
- `testflight.yml`: run the script before archiving; drop `-allowProvisioningUpdates` and the API-key args from the archive step (no longer needed — the profile is already installed and no cert/profile creation happens).

The settings can't simply be passed as `xcodebuild` command-line overrides: those apply to every target, and the SPM package targets (GRDB, SwiftProtobuf, ZIPFoundation) error with *"does not support provisioning profiles"* — verified locally.

## Testing

Reproduced the SPM failure with CLI overrides locally, then ran the full flow as CI will: applied the script and ran the exact `xcodebuild archive` command → **ARCHIVE SUCCEEDED**, product signed by `Apple Distribution: Matthew Farrell (GJGY9A384M)` with the `Actuali App Store` profile embedded (verified via `codesign -dvv` and the embedded mobileprovision).