### PR TITLE
feat: enable splitting and unsplitting of existing transactions

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1392,6 +1392,11 @@ final class BudgetStore: ObservableObject {
         var date: Date
         var cleared: Bool
         var splits: [SplitLineForm] = []
+        /// The edit form's "Remove Split": the user asked to collapse an
+        /// existing split parent into a single transaction. Only meaningful
+        /// when editing a parent; ignored otherwise (the view never sets it
+        /// for the add flow or plain transactions).
+        var collapseSplit: Bool = false
         /// Per-save opt-out for payee location recording (GH #24). Defaults
         /// on so Shortcuts and existing callers keep recording.
         var recordLocation: Bool = true
@@ -1518,15 +1523,21 @@ final class BudgetStore: ObservableObject {
 
         case .split(let amountCents, let lines):
             if let original {
-                // Editing an existing split parent: reconcile its children
-                // against the form's lines. Converting a non-split into a
-                // split stays refused — that would leave its history
-                // (transfer links, reconciliation) on a parent whose
-                // children were never reconciled.
-                guard original.isParent else {
-                    throw BudgetStoreError.cannotConvertToSplit
+                if original.isParent {
+                    // Editing an existing split parent: reconcile its children
+                    // against the form's lines.
+                    try await updateSplit(
+                        original: original, form: form,
+                        amountCents: amountCents, lines: lines,
+                        date: date, notes: notes
+                    )
+                    return
                 }
-                try await updateSplit(
+                // Editing a plain transaction into a split: the original row
+                // becomes the parent and the form's lines its children.
+                // Transfers and split children stay refused — see
+                // convertToSplit.
+                try await convertToSplit(
                     original: original, form: form,
                     amountCents: amountCents, lines: lines,
                     date: date, notes: notes
@@ -1604,6 +1615,16 @@ final class BudgetStore: ObservableObject {
             let payeeName = form.payeeName.isEmpty ? nil : form.payeeName
 
             if let original {
+                // "Remove Split": collapse the parent into a single
+                // transaction — demote the parent and tombstone its
+                // children in the same save.
+                if original.isParent, form.collapseSplit {
+                    try await collapseSplit(
+                        original: original, form: form,
+                        amountCents: amountCents, date: date, notes: notes
+                    )
+                    return
+                }
                 // Split parents: the amount is the children's sum and the
                 // category lives on the children — never overwrite either
                 // from the form.
@@ -1778,6 +1799,157 @@ final class BudgetStore: ObservableObject {
         // children would be invisible in the list but still feed reports.
         let keptIds = Set(lines.compactMap(\.childId))
         for child in existingChildren where !keptIds.contains(child.id) {
+            var deleted = child
+            deleted.tombstone = true
+            try await syncClient.updateTransaction(deleted, changedFields: ["tombstone"])
+        }
+
+        await refreshDataOnly()
+        if form.recordLocation, let payeeId {
+            recordPayeeLocationIfAppropriate(payeeId: payeeId)
+        }
+    }
+
+    /// Convert an ordinary (non-split) transaction into a split: the
+    /// original row becomes the parent — no category of its own, amount set
+    /// to the children's sum, history (reconciled, sort order, imported
+    /// payee) preserved — and the form's lines become its children, slotting
+    /// in below the parent like new lines in `updateSplit`. Transfers are
+    /// refused because the paired row in the other account references this
+    /// one through `transferId`, and splitting would orphan that link;
+    /// split children are refused because there is no row of their own to
+    /// promote to parent.
+    private func convertToSplit(
+        original: Transaction,
+        form: TransactionForm,
+        amountCents: Int,
+        lines: [SplitPlanLine],
+        date: Int,
+        notes: String?
+    ) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        guard original.transferId == nil, original.parentId == nil else {
+            throw BudgetStoreError.cannotConvertToSplit
+        }
+
+        let payeeId = try await resolvePayeeId(name: form.payeeName, editing: original)
+        let payeeName = form.payeeName.isEmpty ? nil : form.payeeName
+
+        let parent = Transaction(
+            id: original.id,
+            accountId: form.accountId,
+            date: date,
+            amount: amountCents,
+            payeeId: payeeId,
+            payeeName: payeeName,
+            categoryId: nil,  // split parents never carry a category
+            categoryName: nil,
+            notes: notes,
+            cleared: form.cleared,
+            reconciled: original.reconciled,
+            transferId: nil,
+            isParent: true,
+            parentId: nil,
+            tombstone: original.tombstone,
+            sortOrder: original.sortOrder,
+            importedPayee: original.importedPayee
+        )
+        let parentChanges = Self.changedFields(original: original, updated: parent)
+        if !parentChanges.isEmpty {
+            try await syncClient.updateTransaction(parent, changedFields: parentChanges)
+        }
+
+        // Children inherit the parent's payee unless the line names its own
+        // (Actual's makeChild semantics). Rules are skipped, matching
+        // createSplit/updateSplit — every field came from the form.
+        var nextSort = original.sortOrder ?? Date().timeIntervalSince1970 * 1000
+        for line in lines {
+            nextSort -= 1
+            let childPayeeId: String?
+            let childPayeeName: String?
+            if let lineName = line.payeeName, lineName != payeeName {
+                childPayeeId = try await resolvePayeeId(name: lineName, editing: nil)
+                childPayeeName = lineName
+            } else {
+                childPayeeId = payeeId
+                childPayeeName = payeeName
+            }
+            try await syncClient.createTransaction(Transaction(
+                id: UUID().uuidString,
+                accountId: form.accountId,
+                date: date,
+                amount: line.amountCents,
+                payeeId: childPayeeId,
+                payeeName: childPayeeName,
+                categoryId: line.categoryId,
+                categoryName: nil,
+                notes: line.notes,
+                cleared: form.cleared,
+                reconciled: false,
+                transferId: nil,
+                isParent: false,
+                parentId: original.id,
+                tombstone: false,
+                sortOrder: nextSort,
+                importedPayee: nil
+            ), applyRules: false)
+        }
+
+        await refreshDataOnly()
+        if form.recordLocation, let payeeId {
+            recordPayeeLocationIfAppropriate(payeeId: payeeId)
+        }
+    }
+
+    /// Collapse a split parent back into a single transaction (the edit
+    /// form's "Remove Split"): the parent row keeps its id and history
+    /// (reconciled, sort order, imported payee), picks up the form's amount
+    /// and category, and is demoted (isParent = false). Every live child is
+    /// tombstoned in the same save — orphaned children would be invisible in
+    /// the list but still feed reports, so leaving them would double-count
+    /// the collapsed amount. Mirrors Actual's desktop "un-split".
+    private func collapseSplit(
+        original: Transaction,
+        form: TransactionForm,
+        amountCents: Int,
+        date: Int,
+        notes: String?
+    ) async throws {
+        guard let syncClient, let database else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        guard original.isParent else { return }
+
+        let payeeId = try await resolvePayeeId(name: form.payeeName, editing: original)
+        let payeeName = form.payeeName.isEmpty ? nil : form.payeeName
+
+        let updated = Transaction(
+            id: original.id,
+            accountId: form.accountId,
+            date: date,
+            amount: amountCents,
+            payeeId: payeeId,
+            payeeName: payeeName,
+            categoryId: form.categoryId,
+            categoryName: nil,
+            notes: notes,
+            cleared: form.cleared,
+            reconciled: original.reconciled,
+            transferId: original.transferId,
+            isParent: false,
+            parentId: nil,
+            tombstone: original.tombstone,
+            sortOrder: original.sortOrder,
+            importedPayee: original.importedPayee
+        )
+        let changes = Self.changedFields(original: original, updated: updated)
+        if !changes.isEmpty {
+            try await syncClient.updateTransaction(updated, changedFields: changes)
+        }
+
+        for child in try await database.fetchChildTransactions(parentId: original.id) {
             var deleted = child
             deleted.tombstone = true
             try await syncClient.updateTransaction(deleted, changedFields: ["tombstone"])

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -26,6 +26,11 @@ struct AddTransactionView: View {
     @State private var nearbyPayees: [NearbyPayee] = []
     @State private var saveLocation = true
     @State private var splitLines: [BudgetStore.SplitLineForm] = []
+    /// True while the edit form's "Remove Split" is toggled on an existing
+    /// split parent: the lines are kept in memory (so tapping "Split into
+    /// multiple categories" undoes the toggle instantly) but the form shows
+    /// the category picker and saves as a single transaction.
+    @State private var unsplitRequested = false
 
     @FocusState private var payeeFocused: Bool
 
@@ -72,7 +77,16 @@ struct AddTransactionView: View {
     private var isEditing: Bool { editing != nil }
     private var isTransfer: Bool { txType == .transfer }
     private var isEditingSplitParent: Bool { editing?.isParent == true }
-    private var isSplitting: Bool { !splitLines.isEmpty }
+    private var isSplitting: Bool { !splitLines.isEmpty && !unsplitRequested }
+
+    /// Whether the form can offer the split option: a plain transaction in
+    /// either flow, or an existing parent mid-"Remove Split" (as an undo).
+    /// Transfers are excluded — they pair two accounts through `transferId`
+    /// and splitting would orphan the partner leg (the store refuses it), so
+    /// the button stays hidden rather than failing on save.
+    private var canSplitIntoCategories: Bool {
+        editing?.transferId == nil && (!isEditingSplitParent || unsplitRequested)
+    }
 
     /// Cents still unassigned across the split lines, nil while the total or
     /// any line doesn't parse yet.
@@ -303,7 +317,7 @@ struct AddTransactionView: View {
                             }
                         }
 
-                        if isEditingSplitParent && !isSplitting {
+                        if isEditingSplitParent && !isSplitting && !unsplitRequested {
                             // Placeholder while the children load into the
                             // editable split lines below.
                             HStack {
@@ -325,9 +339,9 @@ struct AddTransactionView: View {
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            if !isEditing {
+                            if canSplitIntoCategories {
                                 Button {
-                                    splitLines = [.init(), .init()]
+                                    startSplit()
                                 } label: {
                                     Label("Split into multiple categories", systemImage: "arrow.triangle.branch")
                                 }
@@ -406,18 +420,25 @@ struct AddTransactionView: View {
                 // Load a split parent's children as editable lines. Inherited
                 // payees load as empty so a parent payee edit follows through
                 // to them, mirroring Actual's cascade rule.
-                if let editing, editing.isParent, splitLines.isEmpty {
-                    splitLines = await budgetStore.fetchSplitChildren(parentId: editing.id).map { child in
-                        BudgetStore.SplitLineForm(
-                            childId: child.id,
-                            categoryId: child.categoryId,
-                            amount: String(format: "%.2f", Double(abs(child.amount)) / 100.0),
-                            notes: child.notes ?? "",
-                            payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
-                        )
-                    }
-                }
+                await loadSplitChildren()
             }
+        }
+    }
+
+    /// Load a split parent's children as editable lines. Inherited payees
+    /// load as empty so a parent payee edit follows through to them,
+    /// mirroring Actual's cascade rule. Reused both on first appearance and
+    /// when the user undoes an unsplit after swiping the lines away.
+    private func loadSplitChildren() async {
+        guard let editing, editing.isParent, splitLines.isEmpty else { return }
+        splitLines = await budgetStore.fetchSplitChildren(parentId: editing.id).map { child in
+            BudgetStore.SplitLineForm(
+                childId: child.id,
+                categoryId: child.categoryId,
+                amount: String(format: "%.2f", Double(abs(child.amount)) / 100.0),
+                notes: child.notes ?? "",
+                payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
+            )
         }
     }
 
@@ -429,21 +450,46 @@ struct AddTransactionView: View {
                 SplitLineRow(line: $line)
             }
             .onDelete { offsets in
-                splitLines.remove(atOffsets: offsets)
+                if isEditingSplitParent {
+                    // Swiping away every line on an existing parent is the
+                    // same intent as "Remove Split": switch to
+                    // single-transaction mode and seed the collapse category
+                    // from a removed line (the parent carries none). The
+                    // lines are gone from memory, so undoing via the split
+                    // button reloads them from the database.
+                    let removed = offsets.compactMap { splitLines[$0] }
+                    splitLines.remove(atOffsets: offsets)
+                    if splitLines.isEmpty {
+                        unsplitRequested = true
+                        if let category = removed.first(where: { $0.categoryId != nil })?.categoryId {
+                            selectedCategoryId = category
+                        }
+                    }
+                } else {
+                    splitLines.remove(atOffsets: offsets)
+                }
             }
             Button {
                 splitLines.append(.init())
             } label: {
                 Label("Add Line", systemImage: "plus")
             }
-            // An existing split stays a split — un-splitting would have to
-            // collapse the children into the parent, which we don't support.
-            if !isEditingSplitParent {
-                Button(role: .destructive) {
+            // Tapping "Remove Split" on an existing parent switches the form
+            // to single-transaction mode: keep the lines in memory for an
+            // instant undo and seed the collapse category from the first
+            // line that has one (the parent itself carries none). In the add
+            // flow it just clears the lines, as before.
+            Button(role: .destructive) {
+                if isEditingSplitParent {
+                    unsplitRequested = true
+                    if let first = splitLines.first(where: { $0.categoryId != nil }) {
+                        selectedCategoryId = first.categoryId
+                    }
+                } else {
                     splitLines = []
-                } label: {
-                    Text("Remove Split")
                 }
+            } label: {
+                Text("Remove Split")
             }
         } header: {
             Text("Split")
@@ -452,6 +498,33 @@ struct AddTransactionView: View {
                 Text("\(budgetStore.formatCurrency(remaining)) left to assign")
                     .foregroundStyle(.red)
             }
+        }
+    }
+
+    /// Begin a split from the form. The add flow starts from two empty
+    /// lines; editing a plain transaction seeds the first line with the
+    /// transaction's current category and full amount so nothing is lost if
+    /// the user only fills the second line — mirroring Actual's desktop
+    /// behavior of moving the row's category onto the first sub-row. An
+    /// existing parent undoing "Remove Split" just re-enters split mode: the
+    /// children were kept in `splitLines`, so nothing needs reloading.
+    private func startSplit() {
+        unsplitRequested = false
+        guard !isEditingSplitParent else {
+            // Existing parent: if the lines were kept (Remove Split toggle)
+            // they reappear instantly; if they were swiped away, reload them.
+            if splitLines.isEmpty {
+                Task { await loadSplitChildren() }
+            }
+            return
+        }
+        if isEditing {
+            splitLines = [
+                .init(categoryId: selectedCategoryId, amount: amount),
+                .init()
+            ]
+        } else {
+            splitLines = [.init(), .init()]
         }
     }
 
@@ -498,7 +571,8 @@ struct AddTransactionView: View {
             notes: notes,
             date: date,
             cleared: cleared,
-            splits: isTransfer ? [] : splitLines,
+            splits: isTransfer ? [] : (unsplitRequested ? [] : splitLines),
+            collapseSplit: unsplitRequested,
             recordLocation: saveLocation
         )
 
@@ -528,6 +602,7 @@ struct AddTransactionView: View {
         cleared = false
         errorMessage = nil
         splitLines = []
+        unsplitRequested = false
     }
 }
 

--- a/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
@@ -242,7 +242,71 @@ struct BudgetStoreSplitSaveTests {
         ])
     }
 
-    @Test func editingIntoASplitIsRejected() async throws {
+    @Test func editingAFlatTransactionIntoASplitConvertsIt() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        let original = Transaction(
+            id: "tx-1", accountId: "acct-1", date: 20260610, amount: -500,
+            payeeId: nil, payeeName: nil, categoryId: "cat-food", categoryName: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: nil,
+            isParent: false, parentId: nil, tombstone: false, sortOrder: 50,
+            importedPayee: nil
+        )
+        try database.insertTransaction(original)
+
+        var edit = form(amount: "5.00", payeeName: "Market", splits: [
+            .init(categoryId: "cat-food", amount: "3.00"),
+            .init(categoryId: "cat-fun", amount: "2.00")
+        ])
+        edit.date = Transaction.date(fromYYYYMMDD: 20260610)
+        try await store.saveTransaction(edit, editing: original)
+
+        let all = try rows(path: path)
+        #expect(all.count == 3)
+
+        // The original row became the parent: split flag on, category moved
+        // to the children, amount = the children's sum, history (sort order,
+        // id) preserved.
+        let parent = all[0]
+        #expect(parent["id"] == "tx-1")
+        #expect(parent["isParent"] == 1)
+        #expect(parent["isChild"] == 0)
+        #expect(parent["category"] == nil)
+        #expect(parent["amount"] == -500)
+        #expect(parent["sort_order"] == 50)
+        let market = try #require(store.payees.first { $0.name == "Market" })
+        #expect(parent["description"] == market.id)
+
+        let first = all[1], second = all[2]
+        for child in [first, second] {
+            #expect(child["isChild"] == 1)
+            #expect(child["isParent"] == 0)
+            #expect(child["parent_id"] == "tx-1")
+            // Children inherit the parent's payee (Actual's makeChild semantics)
+            #expect(child["description"] == market.id)
+        }
+        #expect(first["amount"] == -300)
+        #expect(first["category"] == "cat-food")
+        #expect(second["amount"] == -200)
+        #expect(second["category"] == "cat-fun")
+        // Children slot in below the parent, keeping entry order
+        let parentSort: Double = try #require(parent["sort_order"])
+        let firstSort: Double = try #require(first["sort_order"])
+        let secondSort: Double = try #require(second["sort_order"])
+        #expect(firstSort < parentSort)
+        #expect(secondSort < firstSort)
+
+        // The parent edit and both children produced CRDT messages
+        let queue = try DatabaseQueue(path: path.path)
+        let messageRows = try await queue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(DISTINCT row) FROM messages_crdt WHERE dataset = 'transactions'") ?? -1
+        }
+        #expect(messageRows == 3)
+    }
+
+    @Test func editingATransferIntoASplitIsRejected() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
@@ -250,8 +314,8 @@ struct BudgetStoreSplitSaveTests {
         let original = Transaction(
             id: "tx-1", accountId: "acct-1", date: 20260610, amount: -500,
             payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
-            notes: nil, cleared: false, reconciled: false, transferId: nil,
-            isParent: false, parentId: nil, tombstone: false, sortOrder: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: "tx-2",
+            isParent: false, parentId: nil, tombstone: false, sortOrder: 50,
             importedPayee: nil
         )
         try database.insertTransaction(original)
@@ -260,6 +324,8 @@ struct BudgetStoreSplitSaveTests {
             .init(categoryId: "cat-food", amount: "3.00"),
             .init(categoryId: "cat-fun", amount: "2.00")
         ])
+        // Splitting a transfer would orphan the paired leg in the other
+        // account — it must be refused and the row left intact.
         await #expect(throws: BudgetStoreError.cannotConvertToSplit) {
             try await store.saveTransaction(edit, editing: original)
         }
@@ -267,6 +333,67 @@ struct BudgetStoreSplitSaveTests {
         let all = try rows(path: path)
         #expect(all.count == 1)
         #expect(all[0]["amount"] == -500)
+        #expect(all[0]["isParent"] == 0)
+    }
+
+    @Test func removingSplitFromAParentCollapsesItToSingleTransaction() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await database.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, category, description, amount, date, isParent, isChild, parent_id, sort_order) VALUES
+                    ('parent', 'acct-1', NULL,       NULL, -1000, 20260601, 1, 0, NULL,     10),
+                    ('c-1',    'acct-1', 'cat-food', NULL,  -600, 20260601, 0, 1, 'parent',  9),
+                    ('c-2',    'acct-1', 'cat-fun',  NULL,  -400, 20260601, 0, 1, 'parent',  8);
+            """)
+        }
+
+        let original = Transaction(
+            id: "parent", accountId: "acct-1", date: 20260601, amount: -1000,
+            payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: nil,
+            isParent: true, parentId: nil, tombstone: false, sortOrder: 10,
+            importedPayee: nil
+        )
+
+        // The edit form after "Remove Split": no split lines, a category
+        // seeded from the first child, collapseSplit set.
+        var edit = form(amount: "10.00", payeeName: "Market")
+        edit.categoryId = "cat-food"
+        edit.collapseSplit = true
+        edit.date = Transaction.date(fromYYYYMMDD: 20260601)
+        try await store.saveTransaction(edit, editing: original)
+
+        let all = try rows(path: path)
+        #expect(all.count == 3)
+        let byId = Dictionary(uniqueKeysWithValues: all.map { ($0["id"] as String, $0) })
+
+        // The parent row was demoted to a single transaction: keeps its id
+        // and sort order, gains the picked category and form amount.
+        let parent = try #require(byId["parent"])
+        #expect(parent["isParent"] == 0)
+        #expect(parent["isChild"] == 0)
+        #expect(parent["category"] == "cat-food")
+        #expect(parent["amount"] == -1000)
+        #expect(parent["sort_order"] == 10)
+        let market = try #require(store.payees.first { $0.name == "Market" })
+        #expect(parent["description"] == market.id)
+
+        // Children are tombstoned so they stop feeding reports.
+        for id in ["c-1", "c-2"] {
+            let child = try #require(byId[id])
+            #expect(child["tombstone"] == 1)
+            #expect(child["parent_id"] == "parent")
+        }
+
+        // Parent demotion + both child tombstones produced CRDT messages
+        let queue = try DatabaseQueue(path: path.path)
+        let messageRows = try await queue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(DISTINCT row) FROM messages_crdt WHERE dataset = 'transactions'") ?? -1
+        }
+        #expect(messageRows == 3)
     }
 
     @Test func editingASplitParentProtectsAmountAndCategoryAndCascadesSharedFields() async throws {


### PR DESCRIPTION
<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->

## Why

Existing transactions cannot be turned into split transactions and vice versa. Closes #118 

<!-- What problem does this solve, or what motivated the change? Link the issue if there is one, e.g. "Closes #42". -->

## What

- Edit any transaction into a split: the "Split into multiple categories" button now appears in the Edit flow, not just Add. Saving converts the existing row into a split parent, with the original category/amount seeded into the first line (nothing
   lost).
- Un-split an existing split: the "Remove Split" action now works on existing split parents (both the button and swiping away all lines). The form switches to single-transaction mode, seeds the collapse category from a line, and saving demotes the
   parent and tombstones its children so reports don't double-count.
- Instant undo: tapping "Split into multiple categories" while in the un-split state reverts immediately (kept lines, or reloaded from DB if they were swiped away).
- Transfers still can't be split: the button is hidden for transfer transactions and the store refuses, to protect the paired transfer leg.
- Store: new collapseSplit flag on TransactionForm and a collapseSplit(...) path in BudgetStore.saveTransaction; conversion of a flat transaction now routes to a new convertToSplit(...) instead of being refused.
- Tests: added conversion, collapse, and transfer-guard coverage; all 611 unit tests pass.

## How it was tested

Added unit tests and tested manually via simulator

## Screenshots

Splitting
https://github.com/user-attachments/assets/28721b05-bc40-463f-be19-bf664bc2d517

Removing split
https://github.com/user-attachments/assets/b516505e-49d6-4707-a5df-9967e631ec5c

Removing split lines
https://github.com/user-attachments/assets/24384d7c-acb5-46b1-a4ef-55b2fe6ce552

