### PR TITLE
feat: clarify demo mode is sandboxed from real budgets

### DIFF
--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -462,7 +462,7 @@ enum DemoDataSeeder {
         // the current month, so the net-worth/cash-flow trends always cover the
         // seeded data regardless of when the demo is loaded. Ordered by `y`.
         try insertWidget(db, type: "markdown-card", y: 0, width: 12, height: 2, meta: """
-            {"content":"**Welcome to the demo** 👋\\n\\nThis is sample data so you can explore Actuali without a server. Connect your own Actual Budget server in **Settings** to use your real budget."}
+            {"content":"**Welcome to the demo** 👋\\n\\nThis is sample data stored only on this device \u{2014} nothing you do here can touch a server or a real budget. When you\u{2019}re ready, connect your own Actual Budget server in **Settings**."}
             """)
         try insertWidget(db, type: "net-worth-card", y: 1, width: 12, height: 2, meta: """
             {"name":"Net Worth","timeFrame":{"start":"2024-01","end":"2024-06","mode":"sliding-window"},"interval":"Monthly"}

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -249,7 +249,7 @@ struct SettingsView: View {
                     Text("Server Connection")
                 } footer: {
                     if !budgetStore.isConnected {
-                        Text("Example: https://actual.example.com\n\nBehind an auth proxy like Cloudflare Access? Add a service token under \u{201C}Custom HTTP headers.\u{201D}\n\nNo server? Tap \u{201C}Try the demo budget\u{201D} to explore the app with sample data.")
+                        Text("Example: https://actual.example.com\n\nBehind an auth proxy like Cloudflare Access? Add a service token under \u{201C}Custom HTTP headers.\u{201D}\n\nNo server? Tap \u{201C}Try the demo budget\u{201D} to explore the app with sample data. The demo runs entirely on this device \u{2014} it never connects to a server or touches a real budget.")
                     }
                 }
 


### PR DESCRIPTION
Closes #137

The demo entry point didn't say that demo mode is fully sandboxed, so users couldn't tell whether trying it could affect a real budget.

- **Settings connect-screen footer**: the "Try the demo budget" hint now adds *"The demo runs entirely on this device — it never connects to a server or touches a real budget."*
- **Demo welcome card** (Reports dashboard markdown widget): now reads *"This is sample data stored only on this device — nothing you do here can touch a server or a real budget."*

Verified with a simulator build and the `DemoDataSeederTests` suite (2 passed).