### PR TITLE
feat: expand or collapse all category groups on the Budget screen

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -60,6 +60,18 @@ struct BudgetView: View {
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
+    // Expand/collapse all touch only the displayed budget's groups; ids
+    // remembered for other budget files stay put (GH #130).
+    private func collapseAllGroups() {
+        let groups = collapsedGroups.union(groupedCategories.map(\.id))
+        collapsedGroupsStorage = groups.sorted().joined(separator: ",")
+    }
+
+    private func expandAllGroups() {
+        let groups = collapsedGroups.subtracting(groupedCategories.map(\.id))
+        collapsedGroupsStorage = groups.sorted().joined(separator: ",")
+    }
+
     var body: some View {
         NavigationStack {
             Group {
@@ -224,6 +236,24 @@ struct BudgetView: View {
                     .accessibilityLabel("Previous month")
 
                     BudgetLayoutButton()
+
+                    // Whole-table expand/collapse (GH #130). A toolbar menu
+                    // rather than a long-press on the group headers: SwiftUI
+                    // context menus don't fire inside the clean style's
+                    // section headers.
+                    if budgetStore.currentBudgetMonth != nil {
+                        Menu {
+                            Button(action: expandAllGroups) {
+                                Label("Expand All Groups", systemImage: "chevron.down")
+                            }
+                            Button(action: collapseAllGroups) {
+                                Label("Collapse All Groups", systemImage: "chevron.right")
+                            }
+                        } label: {
+                            Image(systemName: "chevron.up.chevron.down")
+                        }
+                        .accessibilityLabel("Expand or collapse all groups")
+                    }
                 }
                 ToolbarItem(placement: .principal) {
                     MonthPicker(selectedMonth: $selectedMonth)

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -30,4 +30,48 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "expanding Essentials should restore its categories")
     }
+
+    @MainActor
+    func testToolbarMenuCollapsesAndExpandsAllGroups() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        app.tabBars.buttons["Budget"].tap()
+
+        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        XCTAssertTrue(groceries.waitForExistence(timeout: 10),
+                      "demo data should show the Essentials categories")
+
+        let menuButton = app.buttons["Expand or collapse all groups"]
+        XCTAssertTrue(menuButton.waitForExistence(timeout: 10),
+                      "the budget toolbar should offer the expand/collapse menu")
+        menuButton.tap()
+
+        let collapseAll = app.buttons["Collapse All Groups"]
+        XCTAssertTrue(collapseAll.waitForExistence(timeout: 10))
+        collapseAll.tap()
+
+        // Every group collapses, not just the first one.
+        XCTAssertTrue(app.buttons["Essentials, collapsed"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Lifestyle, collapsed"].waitForExistence(timeout: 10),
+                      "collapse all should also collapse the other groups")
+        XCTAssertFalse(groceries.exists,
+                       "collapse all should hide the category rows")
+
+        menuButton.tap()
+
+        let expandAll = app.buttons["Expand All Groups"]
+        XCTAssertTrue(expandAll.waitForExistence(timeout: 10))
+        expandAll.tap()
+
+        XCTAssertTrue(app.buttons["Essentials, expanded"].waitForExistence(timeout: 10))
+        // Transport sits right below Essentials, so it stays on screen; the
+        // lower groups scroll out of the lazy list's accessibility tree once
+        // everything is expanded, so they can't be asserted here.
+        XCTAssertTrue(app.buttons["Transport, expanded"].waitForExistence(timeout: 10),
+                      "expand all should also expand the other groups")
+        XCTAssertTrue(groceries.waitForExistence(timeout: 10),
+                      "expand all should restore the category rows")
+    }
 }


### PR DESCRIPTION
Closes #130

## What

Adds a chevron menu (`chevron.up.chevron.down`) to the Budget screen's leading toolbar, next to the layout button, with **Expand All Groups** and **Collapse All Groups** actions. The button only appears once a budget month is loaded.

## Why not a long-press menu on group headers?

The issue suggested either surface. A `.contextMenu` on the group header was tried first, but SwiftUI context menus don't present from `List` section headers — where the header lives in the default clean style — and the long-press falls through to the header's collapse toggle instead. The toolbar menu behaves identically in both display styles.

## Notes

- Expand/collapse all only touches the displayed budget's group ids in `collapsedBudgetGroups`, so collapsed state remembered for other budget files is preserved.
- New UI test `testToolbarMenuCollapsesAndExpandsAllGroups` drives the menu end to end (collapse all → category rows hidden, all groups collapsed → expand all restores them). Both `BudgetGroupCollapseUITests` pass locally on the iPhone 17 Pro simulator; CI skips UI tests as usual.