### PR TITLE
feat: option to hide cleared transactions in transaction lists

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -225,6 +225,15 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether transaction lists show only uncleared transactions, so long
+    /// histories don't bury the items that still need attention (GH #133).
+    /// Persisted to UserDefaults, defaults to off.
+    @Published var hideClearedTransactions: Bool = false {
+        didSet {
+            UserDefaults.standard.set(hideClearedTransactions, forKey: "hideClearedTransactions")
+        }
+    }
+
     /// Categories the Budget list should show. With the hide toggle on, only
     /// exactly-zero available drops out: overspent (negative) categories stay
     /// visible so problems that need fixing are never masked.
@@ -483,6 +492,8 @@ final class BudgetStore: ObservableObject {
         // bool(forKey:) defaults to false — the correct opt-in default.
         _hideZeroBudgetCategories = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideZeroBudgetCategories"))
+        _hideClearedTransactions = Published(initialValue: UserDefaults.standard
+            .bool(forKey: "hideClearedTransactions"))
         _postScheduledTransactions = Published(initialValue: UserDefaults.standard
             .bool(forKey: "postScheduledTransactions"))
 
@@ -1014,11 +1025,13 @@ final class BudgetStore: ObservableObject {
         accountId: String? = nil,
         limit: Int = BudgetDatabase.transactionPageSize,
         offset: Int = 0,
-        search: String? = nil
+        search: String? = nil,
+        unclearedOnly: Bool = false
     ) async -> [Transaction] {
         do {
             return try await database?.fetchTransactions(
-                accountId: accountId, limit: limit, offset: offset, search: search
+                accountId: accountId, limit: limit, offset: offset, search: search,
+                unclearedOnly: unclearedOnly
             ) ?? []
         } catch is CancellationError {
             // The caller's task was cancelled (e.g. a superseded .task(id:)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -520,12 +520,15 @@ class BudgetDatabase {
     /// account and/or filtered by a free-text search. `search` applies the
     /// TransactionSearchMatcher semantics (payee, category, notes, and
     /// progressive amount matching) in SQL so it covers full history, not
-    /// just the loaded page.
+    /// just the loaded page. `unclearedOnly` drops cleared rows (which
+    /// includes reconciled ones — locking requires cleared first) in SQL for
+    /// the same reason: pages stay full-sized and cover full history.
     func fetchTransactions(
         accountId: String? = nil,
         limit: Int = BudgetDatabase.transactionPageSize,
         offset: Int = 0,
-        search: String? = nil
+        search: String? = nil,
+        unclearedOnly: Bool = false
     ) async throws -> [Transaction] {
         try await dbQueue.read { db in
             // The list's display payee: own payee first (transfer payees show
@@ -578,6 +581,10 @@ class BudgetDatabase {
             if let accountId {
                 sql += " AND t.acct = ?"
                 arguments.append(accountId)
+            }
+
+            if unclearedOnly {
+                sql += " AND (t.cleared = 0 OR t.cleared IS NULL)"
             }
 
             if let search {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -29,7 +29,8 @@ struct AccountDetailView: View {
         let accountId = account.id
         let created = TransactionPager { offset, limit, search in
             await store.fetchTransactions(
-                accountId: accountId, limit: limit, offset: offset, search: search
+                accountId: accountId, limit: limit, offset: offset, search: search,
+                unclearedOnly: store.hideClearedTransactions
             )
         }
         pager = created
@@ -53,7 +54,11 @@ struct AccountDetailView: View {
 
             Section("Recent Transactions") {
                 if let pager, pager.transactions.isEmpty {
-                    Text(searchQuery == nil ? "No transactions" : "No matching transactions")
+                    Text(searchQuery != nil
+                        ? "No matching transactions"
+                        : budgetStore.hideClearedTransactions
+                            ? "No uncleared transactions"
+                            : "No transactions")
                         .foregroundStyle(.secondary)
                 } else if let pager {
                     ForEach(pager.transactions) { transaction in
@@ -105,6 +110,9 @@ struct AccountDetailView: View {
                     }
                 }
             }
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
+            }
             ToolbarItemGroup(placement: .primaryAction) {
                 Button {
                     showingReconcile = true
@@ -149,6 +157,11 @@ struct AccountDetailView: View {
             // deletes, sheet edits, sync, scheduled posts), so those sites
             // carry no reload calls of their own. Concurrent reloads are
             // safe: the pager's generation counter keeps the newest.
+            Task { await reload() }
+        }
+        .onChange(of: budgetStore.hideClearedTransactions) {
+            // The pager's fetch closure reads the flag, so a reload is all a
+            // toggle flip needs.
             Task { await reload() }
         }
         .refreshable {

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -18,7 +18,10 @@ struct TransactionsListView: View {
         if let pager { return pager }
         let store = budgetStore
         let created = TransactionPager { offset, limit, search in
-            await store.fetchTransactions(limit: limit, offset: offset, search: search)
+            await store.fetchTransactions(
+                limit: limit, offset: offset, search: search,
+                unclearedOnly: store.hideClearedTransactions
+            )
         }
         pager = created
         return created
@@ -31,14 +34,20 @@ struct TransactionsListView: View {
     var body: some View {
         Group {
             if let pager, pager.transactions.isEmpty, !budgetStore.isLoading {
-                if searchQuery == nil {
+                if searchQuery != nil {
+                    ContentUnavailableView.search(text: searchText)
+                } else if budgetStore.hideClearedTransactions {
+                    ContentUnavailableView(
+                        "No Uncleared Transactions",
+                        systemImage: "checkmark.circle",
+                        description: Text("Everything is cleared. Turn off Hide Cleared Transactions to see the rest.")
+                    )
+                } else {
                     ContentUnavailableView(
                         "No Transactions",
                         systemImage: "list.bullet.rectangle",
                         description: Text("Transactions will appear here once you load a budget")
                     )
-                } else {
-                    ContentUnavailableView.search(text: searchText)
                 }
             } else if let pager {
                 List {
@@ -81,6 +90,11 @@ struct TransactionsListView: View {
         }
         .navigationTitle("All Accounts")
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
+        .toolbar {
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
+            }
+        }
         .task(id: searchText) {
             // Debounce keystrokes; the initial (empty) load runs immediately.
             if searchQuery != nil {
@@ -95,6 +109,11 @@ struct TransactionsListView: View {
             // deletes, sheet edits, sync, scheduled posts), so those sites
             // carry no reload calls of their own. Concurrent reloads are
             // safe: the pager's generation counter keeps the newest.
+            Task { await reload() }
+        }
+        .onChange(of: budgetStore.hideClearedTransactions) {
+            // The pager's fetch closure reads the flag, so a reload is all a
+            // toggle flip needs.
             Task { await reload() }
         }
         .refreshable {

--- a/Actuali/ActualiTests/BudgetDatabaseHideClearedTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseHideClearedTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+import GRDB
+@testable import Actuali
+
+/// Pins the `unclearedOnly` filter in `fetchTransactions` (GH #133): with the
+/// hide-cleared toggle on, transaction lists show only uncleared rows. The
+/// filter runs in SQL so pages stay full-sized and cover full history, and it
+/// composes with the account scope, search, and paging.
+@MainActor
+struct BudgetDatabaseHideClearedTests {
+
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    parent_id TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+            """)
+        }
+        let database = try BudgetDatabase(path: tempURL)
+        return (database, tempURL)
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func seedLookups(_ db: BudgetDatabase) async throws {
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name) VALUES
+                    ('acct-1', 'Checking'),
+                    ('acct-2', 'Savings');
+
+                INSERT INTO payees (id, name) VALUES
+                    ('payee-market', 'Market'),
+                    ('payee-cafe',   'Cafe');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-market', 'payee-market'),
+                    ('payee-cafe',   'payee-cafe');
+            """)
+        }
+    }
+
+    @Test func unclearedOnlyDropsClearedAndReconciledRows() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedLookups(db)
+
+        // Reconciled rows are always cleared too (locking requires cleared
+        // first), so the cleared filter must drop them as well.
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, description, amount, date, sort_order, cleared, reconciled) VALUES
+                    ('t-pending',    'acct-1', 'payee-market', -1000, 20260604, 4, 0, 0),
+                    ('t-cleared',    'acct-1', 'payee-market', -2000, 20260603, 3, 1, 0),
+                    ('t-reconciled', 'acct-1', 'payee-market', -3000, 20260602, 2, 1, 1);
+            """)
+        }
+
+        let uncleared = try await db.fetchTransactions(unclearedOnly: true)
+        #expect(uncleared.map(\.id) == ["t-pending"])
+    }
+
+    @Test func defaultReturnsEveryClearedState() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedLookups(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, description, amount, date, sort_order, cleared) VALUES
+                    ('t-pending', 'acct-1', 'payee-market', -1000, 20260602, 2, 0),
+                    ('t-cleared', 'acct-1', 'payee-market', -2000, 20260601, 1, 1);
+            """)
+        }
+
+        let all = try await db.fetchTransactions()
+        #expect(all.map(\.id) == ["t-pending", "t-cleared"])
+    }
+
+    @Test func unclearedOnlyComposesWithAccountScopeAndSearch() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedLookups(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, description, amount, date, sort_order, cleared) VALUES
+                    ('t-match',         'acct-1', 'payee-cafe',   -1000, 20260604, 4, 0),
+                    ('t-cleared-match', 'acct-1', 'payee-cafe',   -2000, 20260603, 3, 1),
+                    ('t-other-account', 'acct-2', 'payee-cafe',   -3000, 20260602, 2, 0),
+                    ('t-other-payee',   'acct-1', 'payee-market', -4000, 20260601, 1, 0);
+            """)
+        }
+
+        let matches = try await db.fetchTransactions(
+            accountId: "acct-1", search: "cafe", unclearedOnly: true
+        )
+        #expect(matches.map(\.id) == ["t-match"])
+    }
+
+    @Test func unclearedOnlyPagesOverFilteredResultSet() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedLookups(db)
+
+        // Uncleared rows interleaved with cleared ones: offsets must index
+        // into the filtered set, not the raw table, so page two picks up
+        // exactly where page one ended.
+        let values = (0..<6).map { i in
+            "('t-\(i)', 'acct-1', 'payee-market', -1000, \(20260601 + i), \(i), \(i % 2))"
+        }.joined(separator: ",\n")
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, description, amount, date, sort_order, cleared)
+                VALUES \(values);
+            """)
+        }
+
+        let pageOne = try await db.fetchTransactions(limit: 2, offset: 0, unclearedOnly: true)
+        #expect(pageOne.map(\.id) == ["t-4", "t-2"])
+
+        let pageTwo = try await db.fetchTransactions(limit: 2, offset: 2, unclearedOnly: true)
+        #expect(pageTwo.map(\.id) == ["t-0"])
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreHideClearedTransactionsTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreHideClearedTransactionsTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The "hide cleared transactions" toggle (GH #133) must default to off and
+/// persist like the other display settings.
+@MainActor
+struct BudgetStoreHideClearedTransactionsTests {
+
+    @Test func defaultsToFalse() {
+        UserDefaults.standard.removeObject(forKey: "hideClearedTransactions")
+        let store = BudgetStore.previewInstance()
+        #expect(store.hideClearedTransactions == false)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.hideClearedTransactions = true
+        #expect(UserDefaults.standard.bool(forKey: "hideClearedTransactions") == true)
+        store.hideClearedTransactions = false
+        #expect(UserDefaults.standard.bool(forKey: "hideClearedTransactions") == false)
+        UserDefaults.standard.removeObject(forKey: "hideClearedTransactions")
+    }
+}


### PR DESCRIPTION
## Summary
Adds a **Hide Cleared Transactions** toggle to the account transaction lists, so long histories don't bury the uncleared/pending items that still need attention.

Closes #133

## How it works
- New `hideClearedTransactions` setting on `BudgetStore`, persisted to UserDefaults and defaulting to off — same pattern as the Hide Spent Categories toggle from #103.
- The toggle lives in the toolbar overflow menu of both the account detail view and the All Accounts list, and the setting is shared between them.
- Filtering happens in SQL via a new `unclearedOnly` parameter on `fetchTransactions`, so pages stay full-sized and cover full history rather than thinning out the loaded page. It composes with the account scope, free-text search, and paging offsets.
- Reconciled transactions are hidden too: locking requires cleared first, so the cleared filter covers them.
- Empty states distinguish "No uncleared transactions" from "No transactions" so an all-cleared account isn't mistaken for an empty one.

## Testing
- New `BudgetDatabaseHideClearedTests`: filter drops cleared and reconciled rows, default returns everything, composes with account scope + search, and offsets page over the filtered result set.
- New `BudgetStoreHideClearedTransactionsTests`: defaults to off, persists to UserDefaults.
- Full unit suite (603 tests) passes locally on an iPhone 17 simulator.