### PR TITLE
feat: show reconciled balance directly on accounts

### DIFF
--- a/Actuali/Actuali/Models/Account.swift
+++ b/Actuali/Actuali/Models/Account.swift
@@ -11,6 +11,15 @@ struct Account: Identifiable, Hashable {
     var balance: Int // Stored in cents
 }
 
+/// Cleared / uncleared / reconciled totals for one account (GH #134).
+/// Reconciled rows are a subset of cleared, so cleared + uncleared is the
+/// account balance while reconciled is informational.
+struct AccountBalanceBreakdown: Equatable {
+    let cleared: Int // Stored in cents, like Account.balance
+    let uncleared: Int
+    let reconciled: Int
+}
+
 enum AccountType: String, CaseIterable {
     case checking
     case savings

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1316,6 +1316,15 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Cleared / uncleared / reconciled totals for the account-detail
+    /// balance breakdown (GH #134). Nil when no budget is open or the read
+    /// fails — the breakdown is silently omitted rather than surfacing an
+    /// error for a purely informational row.
+    func balanceBreakdown(accountId: String) async -> AccountBalanceBreakdown? {
+        guard let database else { return nil }
+        return try? await database.balanceBreakdown(accountId: accountId)
+    }
+
     /// Finish reconciling: lock every cleared, not-yet-reconciled transaction
     /// in the account (reconciled = true), like upstream's lockTransactions.
     /// Returns the number of rows locked; 0 with `error` set on failure.

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -724,6 +724,34 @@ class BudgetDatabase {
         }
     }
 
+    /// Cleared / uncleared / reconciled totals for one account in a single
+    /// consistent read (GH #134). Reconciled rows are a subset of cleared,
+    /// so cleared + uncleared equals the account balance while reconciled is
+    /// informational. Same aggregate semantics as the fetchAccounts() balance
+    /// query (children count, parents excluded, orphaned children of
+    /// tombstoned parents excluded).
+    func balanceBreakdown(accountId: String) async throws -> AccountBalanceBreakdown {
+        try await dbQueue.read { db in
+            let row = try Row.fetchOne(db, sql: """
+                SELECT
+                    COALESCE(SUM(CASE WHEN t.cleared = 1 THEN t.amount ELSE 0 END), 0) AS cleared,
+                    COALESCE(SUM(CASE WHEN t.cleared = 0 OR t.cleared IS NULL THEN t.amount ELSE 0 END), 0) AS uncleared,
+                    COALESCE(SUM(CASE WHEN t.reconciled = 1 THEN t.amount ELSE 0 END), 0) AS reconciled
+                FROM transactions t
+                LEFT JOIN transactions p ON p.id = t.parent_id
+                WHERE t.acct = ?
+                  AND (t.tombstone = 0 OR t.tombstone IS NULL)
+                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isParent = 0 OR t.isParent IS NULL)
+                """, arguments: [accountId])
+            return AccountBalanceBreakdown(
+                cleared: row?["cleared"] ?? 0,
+                uncleared: row?["uncleared"] ?? 0,
+                reconciled: row?["reconciled"] ?? 0
+            )
+        }
+    }
+
     /// Every live cleared-but-not-yet-reconciled row in an account — parents
     /// and children included, because locking marks each stored row the way
     /// upstream's ungrouped batch update does. No display joins: callers

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -5,6 +5,8 @@ struct AccountDetailView: View {
     let account: Account
 
     @State private var pager: TransactionPager?
+    @State private var breakdown: AccountBalanceBreakdown?
+    @State private var showingBreakdown = false
     @State private var searchText = ""
     @State private var showingAddTransaction = false
     @State private var showingReconcile = false
@@ -37,17 +39,52 @@ struct AccountDetailView: View {
     }
 
     private func reload() async {
+        breakdown = await budgetStore.balanceBreakdown(accountId: account.id)
         await currentPager().loadFirstPage(search: searchQuery)
+    }
+
+    private func breakdownRow(_ title: String, amount: Int) -> some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(budgetStore.displayBalance(amount))
+                .foregroundStyle(.secondary)
+        }
+        .font(.subheadline)
     }
 
     var body: some View {
         List {
             Section {
-                HStack {
-                    Text("Current Balance")
-                    Spacer()
-                    Text(budgetStore.displayBalance(currentBalance))
-                        .fontWeight(.semibold)
+                // Tapping the balance reveals the cleared/uncleared/reconciled
+                // split (GH #134), so the reconciled figure can be checked
+                // against a bank statement without starting a reconciliation.
+                Button {
+                    withAnimation { showingBreakdown.toggle() }
+                } label: {
+                    HStack {
+                        Text("Current Balance")
+                        Spacer()
+                        Text(budgetStore.displayBalance(currentBalance))
+                            .fontWeight(.semibold)
+                        if breakdown != nil {
+                            Image(systemName: "chevron.down")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.tertiary)
+                                .rotationEffect(.degrees(showingBreakdown ? 180 : 0))
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Current Balance, \(budgetStore.displayBalance(currentBalance))")
+                .accessibilityHint(showingBreakdown ? "Hides the balance breakdown" : "Shows cleared, uncleared, and reconciled balances")
+
+                if showingBreakdown, let breakdown {
+                    breakdownRow("Cleared", amount: breakdown.cleared)
+                    breakdownRow("Uncleared", amount: breakdown.uncleared)
+                    breakdownRow("Reconciled", amount: breakdown.reconciled)
                 }
             }
 

--- a/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
@@ -207,6 +207,47 @@ struct BudgetStoreReconciliationTests {
         #expect(try await database.clearedBalance(accountId: "acct-1") == -1000)
     }
 
+    // MARK: - Balance breakdown
+
+    @Test func balanceBreakdownSplitsClearedUnclearedAndReconciled() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try insertRow(url, id: "t1", amount: -1000, cleared: true)
+        try insertRow(url, id: "t2", amount: -500, cleared: false)
+        try insertRow(url, id: "t3", amount: 300, cleared: true, reconciled: true)
+        try insertRow(url, id: "t4", acct: "acct-2", amount: -9999, cleared: true) // other account
+        try insertRow(url, id: "t5", amount: -800, cleared: true, tombstone: true) // deleted
+
+        let breakdown = try await database.balanceBreakdown(accountId: "acct-1")
+        #expect(breakdown.cleared == -700) // reconciled rows stay cleared
+        #expect(breakdown.uncleared == -500)
+        #expect(breakdown.reconciled == 300)
+    }
+
+    @Test func balanceBreakdownCountsChildrenNotParents() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        // Split: parent carries the total, children the portions. Counting
+        // both would double the split (same rule as the account balance).
+        try insertRow(url, id: "parent", amount: -1000, cleared: true, reconciled: true, isParent: true)
+        try insertRow(url, id: "child-a", amount: -600, cleared: true, reconciled: true, parentId: "parent")
+        try insertRow(url, id: "child-b", amount: -400, cleared: true, reconciled: true, parentId: "parent")
+
+        let breakdown = try await database.balanceBreakdown(accountId: "acct-1")
+        #expect(breakdown.cleared == -1000)
+        #expect(breakdown.reconciled == -1000)
+    }
+
+    @Test func balanceBreakdownIsZeroForEmptyAccount() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        let breakdown = try await database.balanceBreakdown(accountId: "acct-1")
+        #expect(breakdown == AccountBalanceBreakdown(cleared: 0, uncleared: 0, reconciled: 0))
+    }
+
     // MARK: - Dot tap: toggleCleared
 
     @Test func toggleClearedFlipsTheFlagAndEmitsMessage() async throws {

--- a/Actuali/ActualiUITests/ReconciliationUITests.swift
+++ b/Actuali/ActualiUITests/ReconciliationUITests.swift
@@ -73,4 +73,29 @@ final class ReconciliationUITests: XCTestCase {
         XCTAssertTrue(reconciled.waitForExistence(timeout: 20),
                       "locking should mark cleared transactions as reconciled")
     }
+
+    @MainActor
+    func testTappingBalanceRevealsBreakdown() throws {
+        let app = openChaseChecking()
+
+        let balanceRow = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Current Balance'")
+        ).firstMatch
+        XCTAssertTrue(balanceRow.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts["Reconciled"].exists,
+                       "breakdown starts collapsed")
+
+        balanceRow.tap()
+
+        // GH #134: the split appears in place, without a reconciliation.
+        XCTAssertTrue(app.staticTexts["Cleared"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Uncleared"].exists)
+        XCTAssertTrue(app.staticTexts["Reconciled"].exists)
+
+        balanceRow.tap()
+
+        let collapsed = NSPredicate(format: "exists == false")
+        expectation(for: collapsed, evaluatedWith: app.staticTexts["Reconciled"])
+        waitForExpectations(timeout: 10)
+    }
 }


### PR DESCRIPTION
## Why

The reconciled balance wasn't visible anywhere without starting a reconciliation, making it hard to compare against a bank statement. Closes #134.

## What

- The **Current Balance** row on the account detail screen is now tappable: tapping it expands an inline breakdown showing **Cleared**, **Uncleared**, and **Reconciled** balances (with a chevron indicating the expand/collapse state).
- New `balanceBreakdown(accountId:)` query on `BudgetDatabase` returns all three totals in a single consistent read, using the same aggregate semantics as the existing account-balance and cleared-balance queries (split children count, parents excluded, tombstoned rows and orphaned children excluded).
- The breakdown refreshes through the existing single reload path, so it stays current after edits, dot toggles, syncs, and reconciliation locks. Amounts respect the hide-balances privacy mask.

## How it was tested

- New unit tests in `BudgetStoreReconciliationTests` pinning the breakdown query semantics (cleared/uncleared/reconciled split, split parents not double-counted, empty account) — full unit suite passes (614 tests, 87 suites) on iPhone 17 / iOS 26.5 simulator.
- New UI test `testTappingBalanceRevealsBreakdown` verifying the breakdown starts collapsed, expands on tap with all three rows, and collapses again; full `ReconciliationUITests` suite passes locally.