### PR TITLE
fix: render off-budget and transfer transactions correctly, allow editing transfers

### DIFF
--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -31,9 +31,10 @@ struct Transaction: Identifiable, Hashable {
     // paths, so it is nil on fetched rows — dedup queries the column directly.
     var financialId: String? = nil
     // Payee's transfer_acct: the account on the other side when the payee is a
-    // transfer payee, nil otherwise. Only populated by the reports fetch, where
-    // engines need it to exclude transfers the way the WebUI does. Not synced
-    // (it lives on the payee, not the transaction).
+    // transfer payee, nil otherwise. Populated by the display and reports
+    // fetches so rows can render transfers as transfers and engines can
+    // exclude them the way the WebUI does. Not synced (it lives on the payee,
+    // not the transaction).
     var transferAcct: String? = nil
     // One entry per live child of a split parent, in entry order. Only
     // populated by fetchTransactions for isParent rows, so the list row can
@@ -64,6 +65,19 @@ struct Transaction: Identifiable, Hashable {
 
     var isOutflow: Bool {
         amount < 0
+    }
+
+    /// Whether this transaction still needs a category, mirroring the WebUI's
+    /// "uncategorized" filter (see `BudgetDatabase.uncategorizedWhere`): split
+    /// parents carry no category of their own (the children do), off-budget
+    /// accounts aren't categorized at all, and transfers only take a category
+    /// when the other side is off-budget — money leaving the budget still
+    /// needs one (GH #123, #104).
+    func needsCategory(offBudgetAccountIds: Set<String>) -> Bool {
+        guard categoryId == nil, !isParent else { return false }
+        guard !offBudgetAccountIds.contains(accountId) else { return false }
+        if let transferAcct { return offBudgetAccountIds.contains(transferAcct) }
+        return transferId == nil
     }
 
     /// Convert a dollar amount to integer cents, rounding half away from zero

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -14,6 +14,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case invalidAmount
     case missingTransferDestination
     case payeeCreationFailed(String)
+    case transferPartnerMissing
     case cannotConvertToTransfer
     case cannotConvertToSplit
     case splitNeedsTwoLines
@@ -35,6 +36,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "Select a destination account"
         case .payeeCreationFailed(let message):
             return "Failed to create payee: \(message)"
+        case .transferPartnerMissing:
+            return "The other side of this transfer no longer exists"
         case .cannotConvertToTransfer:
             return "Can't convert an existing transaction into a transfer"
         case .cannotConvertToSplit:
@@ -1210,6 +1213,93 @@ final class BudgetStore: ObservableObject {
         payees.first { $0.transferAccountId == accountId && !$0.tombstone }
     }
 
+    /// Ids of the off-budget accounts, for the category rules shared by the
+    /// transaction rows, the sync notification and transfer saves.
+    var offBudgetAccountIds: Set<String> {
+        Set(accounts.filter(\.offBudget).map(\.id))
+    }
+
+    /// Re-save an existing transfer: both legs take the new accounts, amount,
+    /// date, notes and cleared state, with payees remapped to the (possibly
+    /// re-targeted) accounts' transfer payees. `original` is whichever leg the
+    /// user opened; its partner is fetched through `transferId`. A category
+    /// survives only on an on-budget leg whose partner account is off-budget
+    /// (Actual's rule — money leaving the budget still needs a category);
+    /// every other configuration clears it.
+    func updateTransfer(
+        original: Transaction,
+        fromAccountId: String,
+        toAccountId: String,
+        amountCents: Int,
+        date: Int,
+        notes: String?,
+        cleared: Bool,
+        categoryId: String?
+    ) async throws {
+        guard let syncClient, let database else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        guard fromAccountId != toAccountId else {
+            throw BudgetStoreError.transferAccountsMatch
+        }
+        guard amountCents > 0 else {
+            throw BudgetStoreError.transferAmountNotPositive
+        }
+        guard let partnerId = original.transferId,
+              let partner = try await database.fetchTransaction(id: partnerId) else {
+            throw BudgetStoreError.transferPartnerMissing
+        }
+        let fromTransferPayee = transferPayee(forAccountId: fromAccountId)
+        let toTransferPayee = transferPayee(forAccountId: toAccountId)
+        guard let fromTransferPayee, let toTransferPayee else {
+            throw BudgetStoreError.transferPayeeMissing
+        }
+
+        let offBudgetIds = offBudgetAccountIds
+        // The edited leg takes the form's category, the partner keeps its own —
+        // then both are cleared unless that leg is the categorizable side.
+        func resolvedCategory(for leg: Transaction, accountId: String,
+                              otherAccountId: String) -> String? {
+            guard !offBudgetIds.contains(accountId),
+                  offBudgetIds.contains(otherAccountId) else { return nil }
+            return leg.id == original.id ? categoryId : leg.categoryId
+        }
+
+        // The opened row can be either leg; the negative one is the source.
+        let (sourceLeg, targetLeg) = original.amount < 0
+            ? (original, partner) : (partner, original)
+
+        var source = sourceLeg
+        source.accountId = fromAccountId
+        source.amount = -amountCents
+        source.payeeId = toTransferPayee.id
+        source.categoryId = resolvedCategory(for: sourceLeg, accountId: fromAccountId,
+                                             otherAccountId: toAccountId)
+        source.date = date
+        source.notes = notes
+        source.cleared = cleared
+
+        var target = targetLeg
+        target.accountId = toAccountId
+        target.amount = amountCents
+        target.payeeId = fromTransferPayee.id
+        target.categoryId = resolvedCategory(for: targetLeg, accountId: toAccountId,
+                                             otherAccountId: fromAccountId)
+        target.date = date
+        target.notes = notes
+        target.cleared = cleared
+
+        let sourceChanges = Self.changedFields(original: sourceLeg, updated: source)
+        if !sourceChanges.isEmpty {
+            try await syncClient.updateTransaction(source, changedFields: sourceChanges)
+        }
+        let targetChanges = Self.changedFields(original: targetLeg, updated: target)
+        if !targetChanges.isEmpty {
+            try await syncClient.updateTransaction(target, changedFields: targetChanges)
+        }
+        await refreshDataOnly()
+    }
+
     /// Update an existing transaction (optimistic local-first)
     func updateTransaction(_ updated: Transaction, original: Transaction) async throws {
         guard let syncClient else {
@@ -1505,12 +1595,26 @@ final class BudgetStore: ObservableObject {
 
         switch try Self.plan(for: form) {
         case .transfer(let toAccountId, let amountCents):
-            // Editing into a transfer would create a new transfer pair and orphan
-            // the original transaction (the UI hides the Transfer option when
-            // editing; this guards the path against state edge cases). Refuse
-            // rather than silently corrupt. See actios-7u6.
-            guard original == nil else {
-                throw BudgetStoreError.cannotConvertToTransfer
+            if let original {
+                // Only an existing transfer can be re-saved as one. Converting
+                // a plain transaction would create a new transfer pair and
+                // orphan the original (the UI hides the Transfer option for
+                // those; this guards the path against state edge cases).
+                // Refuse rather than silently corrupt. See actios-7u6.
+                guard original.transferId != nil else {
+                    throw BudgetStoreError.cannotConvertToTransfer
+                }
+                try await updateTransfer(
+                    original: original,
+                    fromAccountId: form.accountId,
+                    toAccountId: toAccountId,
+                    amountCents: amountCents,
+                    date: date,
+                    notes: notes,
+                    cleared: form.cleared,
+                    categoryId: form.categoryId
+                )
+                return
             }
             try await createTransfer(
                 fromAccountId: form.accountId,
@@ -2127,7 +2231,8 @@ final class BudgetStore: ObservableObject {
         }
         await NewTransactionNotifier.notify(about: fresh, currencyCode: currencyCode,
                                             narrowSymbol: useNarrowCurrencySymbol,
-                                            accountNames: accountNames)
+                                            accountNames: accountNames,
+                                            offBudgetAccountIds: offBudgetAccountIds)
     }
 
     /// Transactions that arrived via sync since the last check (advances the

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -465,7 +465,8 @@ class BudgetDatabase {
             t.transferred_id, t.cleared, t.reconciled, t.sort_order,
             t.tombstone, t.parent_id,
             COALESCE(pa.name, p.name) as payee_name,
-            c.name as category_name
+            c.name as category_name,
+            p.transfer_acct as transfer_acct
         FROM transactions t
         LEFT JOIN payee_mapping pm ON pm.id = t.description
         LEFT JOIN payees p ON p.id = pm.targetId
@@ -498,7 +499,8 @@ class BudgetDatabase {
             tombstone: row["tombstone"] == 1,
             sortOrder: row["sort_order"],
             importedPayee: row["imported_description"],
-            schedule: row["schedule"]
+            schedule: row["schedule"],
+            transferAcct: row["transfer_acct"]
         )
     }
 
@@ -541,7 +543,8 @@ class BudgetDatabase {
                     t.transferred_id, t.cleared, t.reconciled, t.sort_order,
                     t.tombstone, t.parent_id,
                     \(payeeNameSQL) as payee_name,
-                    c.name as category_name
+                    c.name as category_name,
+                    p.transfer_acct as transfer_acct
                 FROM transactions t
                 LEFT JOIN payee_mapping pm ON pm.id = t.description
                 LEFT JOIN payees p ON p.id = pm.targetId
@@ -657,7 +660,8 @@ class BudgetDatabase {
                     t.transferred_id, t.cleared, t.reconciled, t.sort_order,
                     t.tombstone, t.parent_id,
                     COALESCE(pa.name, p.name) as payee_name,
-                    c.name as category_name
+                    c.name as category_name,
+                    p.transfer_acct as transfer_acct
                 FROM transactions t
                 LEFT JOIN payee_mapping pm ON pm.id = t.description
                 LEFT JOIN payees p ON p.id = pm.targetId
@@ -810,7 +814,8 @@ class BudgetDatabase {
                     t.schedule,
                     t.transferred_id, t.cleared, t.reconciled, t.sort_order,
                     t.tombstone, t.parent_id,
-                    COALESCE(pa.name, p.name, ppa.name, pp.name) as payee_name
+                    COALESCE(pa.name, p.name, ppa.name, pp.name) as payee_name,
+                    p.transfer_acct as transfer_acct
                 \(Self.uncategorizedJoins)
                 -- Transfer payees carry no name; their display name is the
                 -- linked account's name (matches Actual's v_payees view).
@@ -844,7 +849,8 @@ class BudgetDatabase {
                     tombstone: row["tombstone"] == 1,
                     sortOrder: row["sort_order"],
                     importedPayee: row["imported_description"],
-                    schedule: row["schedule"]
+                    schedule: row["schedule"],
+                    transferAcct: row["transfer_acct"]
                 )
             }
         }

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -238,6 +238,11 @@ enum DemoDataSeeder {
         try insertCategoryGroup(db, id: incomeGroupId, name: "Income", isIncome: true, sortOrder: 0)
         let salaryId = UUID().uuidString
         try insertCategory(db, id: salaryId, name: "Salary", groupId: incomeGroupId, isIncome: true, sortOrder: 0)
+        // Actual books an on-budget account's opening balance to this income
+        // category at account creation; mirror that so the demo's starting
+        // balances don't sit in the uncategorized list.
+        let startingBalancesCategoryId = UUID().uuidString
+        try insertCategory(db, id: startingBalancesCategoryId, name: "Starting Balances", groupId: incomeGroupId, isIncome: true, sortOrder: 1)
 
         // Essentials
         let essentialsId = UUID().uuidString
@@ -318,6 +323,14 @@ enum DemoDataSeeder {
         try insertPayee(db, id: vanguardPayeeId, name: "Vanguard")
         try insertPayee(db, id: marketId, name: "Market Gain")
 
+        // Transfer payees — one per account, name-less with transfer_acct set,
+        // exactly as Actual creates them alongside each account. The add/edit
+        // transfer flows resolve each leg's payee through these; without them
+        // transfers can't be created in the demo.
+        for accountId in [chaseId, allyId, appleCardId, vanguardId] {
+            try insertPayee(db, id: UUID().uuidString, name: nil, transferAccountId: accountId)
+        }
+
         // --- Transactions ---
         // We generate ~6 full months of history plus the current month-to-date so
         // the Reports (net worth, cash flow, spending vs. average) have real trends.
@@ -337,10 +350,12 @@ enum DemoDataSeeder {
 
         var transactions: [(payee: String, category: String?, amount: Int, date: Int, account: String, cleared: Bool, startingBalance: Bool)] = []
 
-        // Starting balances ~`historyMonths` months ago, before the recurring flow.
+        // Starting balances ~`historyMonths` months ago, before the recurring
+        // flow. On-budget ones carry the Starting Balances income category
+        // (Actual's behavior); the off-budget brokerage takes none.
         let openDate = ymd(monthsAgo: historyMonths, day: 1)
-        transactions.append((startingBalanceId, nil, 1_050_000, openDate, allyId, true, true))
-        transactions.append((startingBalanceId, nil, 280_000, openDate, chaseId, true, true))
+        transactions.append((startingBalanceId, startingBalancesCategoryId, 1_050_000, openDate, allyId, true, true))
+        transactions.append((startingBalanceId, startingBalancesCategoryId, 280_000, openDate, chaseId, true, true))
         transactions.append((startingBalanceId, nil, 4_200_000, openDate, vanguardId, true, true))
 
         // Per-month spending template: (payee, category, account, day, base amount in cents).
@@ -543,10 +558,15 @@ enum DemoDataSeeder {
             """, arguments: [id, name, isIncome ? 1 : 0, groupId, sortOrder])
     }
 
-    private static func insertPayee(_ db: Database, id: String, name: String) throws {
+    private static func insertPayee(
+        _ db: Database,
+        id: String,
+        name: String?,
+        transferAccountId: String? = nil
+    ) throws {
         try db.execute(sql: """
-            INSERT INTO payees (id, name, tombstone) VALUES (?, ?, 0)
-            """, arguments: [id, name])
+            INSERT INTO payees (id, name, transfer_acct, tombstone) VALUES (?, ?, ?, 0)
+            """, arguments: [id, name, transferAccountId])
         // Required for the transactions JOIN to resolve payee name
         try db.execute(sql: """
             INSERT INTO payee_mapping (id, targetId) VALUES (?, ?)

--- a/Actuali/Actuali/Services/NewTransactionNotifier.swift
+++ b/Actuali/Actuali/Services/NewTransactionNotifier.swift
@@ -36,12 +36,14 @@ enum NewTransactionNotifier {
     static func notify(about transactions: [Transaction], currencyCode: String,
                        narrowSymbol: Bool = false,
                        accountNames: [String: String] = [:],
+                       offBudgetAccountIds: Set<String> = [],
                        settings: TransactionNotificationSettings = TransactionNotificationSettings(),
                        center: NotificationPosting = UNUserNotificationCenter.current()) async {
         guard settings.isEnabled else { return }
         guard let request = makeRequest(for: transactions, currencyCode: currencyCode,
                                         narrowSymbol: narrowSymbol,
-                                        accountNames: accountNames) else { return }
+                                        accountNames: accountNames,
+                                        offBudgetAccountIds: offBudgetAccountIds) else { return }
 
         let granted: Bool
         do {
@@ -62,10 +64,12 @@ enum NewTransactionNotifier {
 
     static func makeRequest(for transactions: [Transaction], currencyCode: String,
                             narrowSymbol: Bool = false,
-                            accountNames: [String: String] = [:]) -> UNNotificationRequest? {
+                            accountNames: [String: String] = [:],
+                            offBudgetAccountIds: Set<String> = []) -> UNNotificationRequest? {
         guard let content = makeContent(for: transactions, currencyCode: currencyCode,
                                         narrowSymbol: narrowSymbol,
-                                        accountNames: accountNames) else { return nil }
+                                        accountNames: accountNames,
+                                        offBudgetAccountIds: offBudgetAccountIds) else { return nil }
         return UNNotificationRequest(identifier: requestIdentifier, content: content, trigger: nil)
     }
 
@@ -75,7 +79,8 @@ enum NewTransactionNotifier {
 
     static func makeContent(for transactions: [Transaction], currencyCode: String,
                             narrowSymbol: Bool = false,
-                            accountNames: [String: String] = [:]) -> UNNotificationContent? {
+                            accountNames: [String: String] = [:],
+                            offBudgetAccountIds: Set<String> = []) -> UNNotificationContent? {
         guard !transactions.isEmpty else { return nil }
 
         let content = UNMutableNotificationContent()
@@ -90,7 +95,7 @@ enum NewTransactionNotifier {
 
         var lines = transactions.prefix(maxDetailLines).map {
             line(for: $0, currencyCode: currencyCode, narrowSymbol: narrowSymbol,
-                 accountNames: accountNames)
+                 accountNames: accountNames, offBudgetAccountIds: offBudgetAccountIds)
         }
         if transactions.count > maxDetailLines {
             lines.append("…and \(transactions.count - maxDetailLines) more")
@@ -102,9 +107,12 @@ enum NewTransactionNotifier {
 
     /// One transaction's detail: "$12.50 at Starbucks on Checking", with an
     /// uncategorized marker so each line says whether it still needs sorting.
+    /// Transfers and off-budget transactions never take a category, so they
+    /// carry no marker (GH #104, #123).
     private static func line(for transaction: Transaction, currencyCode: String,
                              narrowSymbol: Bool,
-                             accountNames: [String: String]) -> String {
+                             accountNames: [String: String],
+                             offBudgetAccountIds: Set<String>) -> String {
         var line = CurrencyAmountFormat.string(cents: abs(transaction.amount),
                                                currencyCode: currencyCode,
                                                narrowSymbol: narrowSymbol)
@@ -114,7 +122,7 @@ enum NewTransactionNotifier {
         if let account = accountNames[transaction.accountId], !account.isEmpty {
             line += " on \(account)"
         }
-        if transaction.categoryId == nil {
+        if transaction.needsCategory(offBudgetAccountIds: offBudgetAccountIds) {
             line += " · Needs a category"
         }
         return line

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -56,18 +56,34 @@ struct AddTransactionView: View {
         _cleared = State(initialValue: false)
     }
 
-    /// Initializer for the "Edit" flow.
+    /// Initializer for the "Edit" flow. Transfer legs load as transfers —
+    /// From/To derive from the leg's sign (the opened row can be either side)
+    /// with the partner account read off the transfer payee (GH #104).
     init(editing: Transaction) {
         self.editing = editing
         _selectedTab = .constant(nil)
-        _selectedAccountId = State(initialValue: editing.accountId)
 
         let cents = abs(editing.amount)
         let dollars = Double(cents) / 100.0
         _amount = State(initialValue: String(format: "%.2f", dollars))
-        _txType = State(initialValue: editing.amount < 0 ? .expense : .income)
+        if editing.transferId != nil {
+            _txType = State(initialValue: .transfer)
+            if editing.amount < 0 {
+                _selectedAccountId = State(initialValue: editing.accountId)
+                _transferToAccountId = State(initialValue: editing.transferAcct)
+            } else {
+                // Partner unknown (transfer payee missing): fall back to the
+                // leg's own account as From and let the user pick To.
+                _selectedAccountId = State(initialValue: editing.transferAcct ?? editing.accountId)
+                _transferToAccountId = State(initialValue:
+                    editing.transferAcct == nil ? nil : editing.accountId)
+            }
+        } else {
+            _txType = State(initialValue: editing.amount < 0 ? .expense : .income)
+            _selectedAccountId = State(initialValue: editing.accountId)
+            _transferToAccountId = State(initialValue: nil)
+        }
         _payeeName = State(initialValue: editing.payeeName ?? "")
-        _transferToAccountId = State(initialValue: nil)
         _selectedCategoryId = State(initialValue: editing.categoryId)
         _notes = State(initialValue: editing.notes ?? "")
         _date = State(initialValue: Transaction.date(fromYYYYMMDD: editing.date))
@@ -77,6 +93,22 @@ struct AddTransactionView: View {
     private var isEditing: Bool { editing != nil }
     private var isTransfer: Bool { txType == .transfer }
     private var isEditingSplitParent: Bool { editing?.isParent == true }
+    private var isEditingTransfer: Bool { editing?.transferId != nil }
+
+    /// A transfer leg takes a category only when it sits in an on-budget
+    /// account and the other side is off-budget — money leaving the budget
+    /// still needs one (Actual's rule). Tracks the live picker selections so
+    /// re-targeting the accounts shows/hides the row immediately.
+    private var editedTransferLegIsCategorizable: Bool {
+        guard let editing, editing.transferId != nil else { return false }
+        let legAccountId = editing.amount < 0 ? selectedAccountId : transferToAccountId
+        let otherAccountId = editing.amount < 0 ? transferToAccountId : selectedAccountId
+        guard let leg = budgetStore.accounts.first(where: { $0.id == legAccountId }),
+              let other = budgetStore.accounts.first(where: { $0.id == otherAccountId }) else {
+            return false
+        }
+        return !leg.offBudget && other.offBudget
+    }
     private var isSplitting: Bool { !splitLines.isEmpty && !unsplitRequested }
 
     /// Whether the form can offer the split option: a plain transaction in
@@ -210,14 +242,16 @@ struct AddTransactionView: View {
                         Picker("Type", selection: $txType) {
                             Text("Expense").tag(TransactionType.expense)
                             Text("Income").tag(TransactionType.income)
-                            if !isEditing {
+                            if !isEditing || isEditingTransfer {
                                 Text("Transfer").tag(TransactionType.transfer)
                             }
                         }
                         .pickerStyle(.segmented)
                         // A split parent's sign is the children's; flipping
                         // it would have to flip every line, so it stays fixed.
-                        .disabled(isEditingSplitParent)
+                        // A transfer stays a transfer: converting would orphan
+                        // the partner leg (the store refuses it).
+                        .disabled(isEditingSplitParent || isEditingTransfer)
                     }
 
                     HStack {
@@ -244,6 +278,20 @@ struct AddTransactionView: View {
                             Text("Select account").tag(String?.none)
                             ForEach(transferEligibleAccounts) { account in
                                 Text(account.name).tag(String?.some(account.id))
+                            }
+                        }
+                        if editedTransferLegIsCategorizable {
+                            NavigationLink {
+                                CategoryPickerView(selectedCategoryId: $selectedCategoryId) {
+                                    userPickedCategory = true
+                                }
+                            } label: {
+                                HStack {
+                                    Text("Category")
+                                    Spacer()
+                                    Text(selectedCategoryName)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                     } else {

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -128,15 +128,32 @@ struct TransactionRow: View {
         budgetStore.accounts.first { $0.id == transaction.accountId }?.name ?? "Unknown Account"
     }
 
-    /// Caption under the payee. Split parents show their children's
-    /// breakdown ("Food $6.00, Fun $4.00"); amounts are unsigned because the
-    /// row's total already carries the sign.
+    private var isInOffBudgetAccount: Bool {
+        budgetStore.offBudgetAccountIds.contains(transaction.accountId)
+    }
+
+    private var isTransfer: Bool {
+        transaction.transferId != nil || transaction.transferAcct != nil
+    }
+
+    /// Caption under the payee. Off-budget accounts aren't categorized at all
+    /// ("Off budget", GH #123); split parents show their children's breakdown
+    /// ("Food $6.00, Fun $4.00" — amounts unsigned because the row's total
+    /// already carries the sign); transfers that can't take a category show
+    /// "Transfer" instead of nagging "Uncategorized" (GH #104).
     private var categoryLabel: String {
+        if isInOffBudgetAccount {
+            return "Off budget"
+        }
         if let portions = transaction.splitPortions, !portions.isEmpty {
             return portions.map { portion in
                 let name = portion.categoryName ?? "Uncategorized"
                 return "\(name) \(budgetStore.displayBalance(abs(portion.amount)))"
             }.joined(separator: ", ")
+        }
+        if transaction.categoryName == nil, isTransfer,
+           !transaction.needsCategory(offBudgetAccountIds: budgetStore.offBudgetAccountIds) {
+            return "Transfer"
         }
         return transaction.categoryName ?? (transaction.isParent ? "Split" : "Uncategorized")
     }
@@ -175,7 +192,11 @@ struct TransactionRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 // Split parents may resolve no payee (mixed child payees) —
                 // label them "Split" like the desktop app, not "Unknown".
-                Text(transaction.payeeName ?? (transaction.isParent ? "Split" : "Unknown"))
+                // Off-budget rows say "No payee": they're commonly payee-less
+                // (balance adjustments) and "Unknown" read as a bug (GH #123).
+                Text(transaction.payeeName
+                     ?? (transaction.isParent ? "Split"
+                         : (isInOffBudgetAccount ? "No payee" : "Unknown")))
                     .font(.body)
                 HStack(spacing: 4) {
                     if transaction.isParent {

--- a/Actuali/ActualiTests/BudgetDatabaseTransferPayeeTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransferPayeeTests.swift
@@ -109,5 +109,10 @@ struct BudgetDatabaseTransferPayeeTests {
 
         #expect(spend?.payeeName == "Coffee Shop")
         #expect(transfer?.payeeName == "Savings")
+
+        // The payee's transfer_acct rides along so rows can render transfers
+        // as transfers and the edit form knows the other side (GH #104).
+        #expect(spend?.transferAcct == nil)
+        #expect(transfer?.transferAcct == "acct-savings")
     }
 }

--- a/Actuali/ActualiTests/BudgetStoreUpdateTransferTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreUpdateTransferTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// End-to-end coverage for editing an existing transfer through
+/// `saveTransaction` → `updateTransfer` (GH #104): both legs follow the
+/// form's amount/date/notes/cleared, re-targeting moves the partner leg and
+/// remaps both transfer payees, and categories survive only on an on-budget
+/// leg whose partner account is off-budget.
+@MainActor
+struct BudgetStoreUpdateTransferTests {
+
+    /// Upstream schema for every table the transaction fetch joins
+    /// (matches BudgetStoreSaveTransactionTests, plus accounts/categories
+    /// because `fetchTransaction` resolves display names).
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                );
+
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                INSERT INTO accounts (id, name, offbudget) VALUES
+                    ('acct-checking',  'Checking',  0),
+                    ('acct-savings',   'Savings',   0),
+                    ('acct-brokerage', 'Brokerage', 1);
+
+                -- One transfer payee per account, like Actual maintains.
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking',  NULL, 'acct-checking'),
+                    ('payee-savings',   NULL, 'acct-savings'),
+                    ('payee-brokerage', NULL, 'acct-brokerage');
+
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking',  'payee-checking'),
+                    ('payee-savings',   'payee-savings'),
+                    ('payee-brokerage', 'payee-brokerage');
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    /// Store wired to a real database and sync client, with the accounts and
+    /// transfer payees mirrored into the in-memory caches `updateTransfer`
+    /// reads (`accounts` for the off-budget rule, `payees` for payee lookup).
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        store.accounts = [
+            Account(id: "acct-checking", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+            Account(id: "acct-brokerage", name: "Brokerage", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 2, balance: 0),
+        ]
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-checking", tombstone: false),
+            Payee(id: "payee-savings", name: "", transferAccountId: "acct-savings", tombstone: false),
+            Payee(id: "payee-brokerage", name: "", transferAccountId: "acct-brokerage", tombstone: false),
+        ]
+        return store
+    }
+
+    /// Seed both legs of a Checking → Savings transfer for $25.00.
+    private func seedTransfer(into database: BudgetDatabase,
+                              sourceCategoryId: String? = nil) throws -> (source: Transaction, target: Transaction) {
+        let source = Transaction(
+            id: "leg-out", accountId: "acct-checking", date: 20260610, amount: -2500,
+            payeeId: "payee-savings", payeeName: nil, categoryId: sourceCategoryId,
+            categoryName: nil, notes: nil, cleared: false, reconciled: false,
+            transferId: "leg-in", isParent: false, parentId: nil, tombstone: false,
+            sortOrder: 1000, importedPayee: nil)
+        let target = Transaction(
+            id: "leg-in", accountId: "acct-savings", date: 20260610, amount: 2500,
+            payeeId: "payee-checking", payeeName: nil, categoryId: nil,
+            categoryName: nil, notes: nil, cleared: false, reconciled: false,
+            transferId: "leg-out", isParent: false, parentId: nil, tombstone: false,
+            sortOrder: 1000, importedPayee: nil)
+        try database.insertTransaction(source)
+        try database.insertTransaction(target)
+        return (source, target)
+    }
+
+    private func form(
+        accountId: String = "acct-checking",
+        amount: String = "25.00",
+        transferToAccountId: String? = "acct-savings",
+        categoryId: String? = nil,
+        notes: String = "",
+        cleared: Bool = false
+    ) -> BudgetStore.TransactionForm {
+        BudgetStore.TransactionForm(
+            accountId: accountId,
+            type: .transfer,
+            amount: amount,
+            payeeName: "",
+            transferToAccountId: transferToAccountId,
+            categoryId: categoryId,
+            notes: notes,
+            date: Transaction.date(fromYYYYMMDD: 20260715),
+            cleared: cleared
+        )
+    }
+
+    private func rows(path: URL) throws -> [String: Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        let all = try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions")
+        }
+        return Dictionary(uniqueKeysWithValues: all.map { ($0["id"] as String, $0) })
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func editingATransferUpdatesBothLegs() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let (source, _) = try seedTransfer(into: database)
+
+        var edit = form(amount: "40.00", notes: "moved more")
+        edit.cleared = true
+        try await store.saveTransaction(edit, editing: source)
+
+        let byId = try rows(path: path)
+        let out = try #require(byId["leg-out"])
+        let inn = try #require(byId["leg-in"])
+        #expect(out["amount"] == -4000)
+        #expect(inn["amount"] == 4000)
+        #expect(out["date"] == 20260715)
+        #expect(inn["date"] == 20260715)
+        #expect(out["notes"] == "moved more")
+        #expect(inn["notes"] == "moved more")
+        #expect(out["cleared"] == 1)
+        #expect(inn["cleared"] == 1)
+        // The pair link and transfer payees are untouched.
+        #expect(out["transferred_id"] == "leg-in")
+        #expect(inn["transferred_id"] == "leg-out")
+        #expect(out["description"] == "payee-savings")
+        #expect(inn["description"] == "payee-checking")
+    }
+
+    @Test func retargetingATransferMovesThePartnerLegAndRemapsPayees() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let (source, _) = try seedTransfer(into: database)
+
+        try await store.saveTransaction(
+            form(transferToAccountId: "acct-brokerage"), editing: source)
+
+        let byId = try rows(path: path)
+        let out = try #require(byId["leg-out"])
+        let inn = try #require(byId["leg-in"])
+        // The receiving leg moved to the new account, and each leg's payee
+        // now points at the other side's transfer payee.
+        #expect(inn["acct"] == "acct-brokerage")
+        #expect(out["acct"] == "acct-checking")
+        #expect(out["description"] == "payee-brokerage")
+        #expect(inn["description"] == "payee-checking")
+    }
+
+    @Test func editingTheDestinationLegUpdatesThePairToo() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let (_, target) = try seedTransfer(into: database)
+
+        // The user opened the +$25.00 leg in Savings; the form still speaks
+        // in From/To (Checking → Savings).
+        try await store.saveTransaction(form(amount: "10.00"), editing: target)
+
+        let byId = try rows(path: path)
+        #expect(try #require(byId["leg-out"])["amount"] == -1000)
+        #expect(try #require(byId["leg-in"])["amount"] == 1000)
+    }
+
+    @Test func categoryIsClearedWhenBothAccountsAreOnBudget() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        // A stray category on an on-budget↔on-budget transfer (the bug this
+        // fixes let users set one) is stripped on the next save.
+        let (source, _) = try seedTransfer(into: database, sourceCategoryId: "cat-food")
+
+        var edit = form()
+        edit.categoryId = "cat-food"
+        try await store.saveTransaction(edit, editing: source)
+
+        let byId = try rows(path: path)
+        #expect(try #require(byId["leg-out"])["category"] == nil)
+        #expect(try #require(byId["leg-in"])["category"] == nil)
+    }
+
+    @Test func categorySurvivesOnTheOnBudgetLegOfAnOffBudgetTransfer() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let (source, _) = try seedTransfer(into: database)
+
+        // Re-target to the off-budget Brokerage and categorize the edited
+        // (on-budget) leg — money leaving the budget still needs a category.
+        var edit = form(transferToAccountId: "acct-brokerage")
+        edit.categoryId = "cat-investing"
+        try await store.saveTransaction(edit, editing: source)
+
+        let byId = try rows(path: path)
+        #expect(try #require(byId["leg-out"])["category"] == "cat-investing")
+        #expect(try #require(byId["leg-in"])["category"] == nil)
+    }
+
+    @Test func missingPartnerLegIsRefusedAndLeavesTheRowIntact() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        let dangling = Transaction(
+            id: "leg-out", accountId: "acct-checking", date: 20260610, amount: -2500,
+            payeeId: "payee-savings", payeeName: nil, categoryId: nil,
+            categoryName: nil, notes: nil, cleared: false, reconciled: false,
+            transferId: "leg-gone", isParent: false, parentId: nil, tombstone: false,
+            sortOrder: 1000, importedPayee: nil)
+        try database.insertTransaction(dangling)
+
+        await #expect(throws: BudgetStoreError.transferPartnerMissing) {
+            try await store.saveTransaction(self.form(amount: "40.00"), editing: dangling)
+        }
+
+        let byId = try rows(path: path)
+        #expect(try #require(byId["leg-out"])["amount"] == -2500)
+    }
+}

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -54,4 +54,37 @@ struct DemoDataSeederTests {
         let summary = try #require(summaryMeta)
         #expect(SummaryEngine.compute(meta: summary, transactions: transactions, today: today).totalCents < 0)
     }
+
+    /// Every account needs a transfer payee (Actual creates one per account)
+    /// or the add/edit transfer flows fail with "Transfer payee not found".
+    @Test func everyAccountHasATransferPayee() async throws {
+        let database = try seedAndOpen()
+        let accounts = try await database.fetchAccounts()
+        let payees = try await database.fetchPayees()
+
+        #expect(!accounts.isEmpty)
+        for account in accounts {
+            #expect(payees.contains { $0.transferAccountId == account.id },
+                    "No transfer payee for \(account.name)")
+        }
+    }
+
+    /// On-budget starting balances carry the Starting Balances income category
+    /// (Actual's account-creation behavior), so the demo opens with a clean
+    /// uncategorized list; the off-budget brokerage's takes none and renders
+    /// as "Off budget" (GH #123).
+    @Test func startingBalancesAreCategorizedOnlyOnBudget() async throws {
+        let database = try seedAndOpen()
+        let accounts = try await database.fetchAccounts()
+        let transactions = try await database.fetchTransactions()
+
+        let startingBalances = transactions.filter { $0.payeeName == "Starting Balance" }
+        #expect(startingBalances.count == 3)
+        for transaction in startingBalances {
+            let account = try #require(accounts.first { $0.id == transaction.accountId })
+            #expect((transaction.categoryId == nil) == account.offBudget,
+                    "\(account.name) starting balance miscategorized")
+        }
+        #expect(try await database.fetchUncategorizedCount() == 0)
+    }
 }

--- a/Actuali/ActualiTests/NewTransactionNotifierTests.swift
+++ b/Actuali/ActualiTests/NewTransactionNotifierTests.swift
@@ -6,12 +6,14 @@ import UserNotifications
 struct NewTransactionNotifierTests {
 
     private func makeTransaction(id: String, payeeName: String? = nil,
-                                 categoryId: String? = nil, amount: Int = -1250) -> Transaction {
+                                 categoryId: String? = nil, amount: Int = -1250,
+                                 transferId: String? = nil,
+                                 transferAcct: String? = nil) -> Transaction {
         Transaction(id: id, accountId: "acct1", date: 20260707, amount: amount,
                     payeeId: nil, payeeName: payeeName, categoryId: categoryId,
                     categoryName: nil, notes: nil, cleared: false, reconciled: false,
-                    transferId: nil, isParent: false, parentId: nil, tombstone: false,
-                    sortOrder: nil, importedPayee: nil)
+                    transferId: transferId, isParent: false, parentId: nil, tombstone: false,
+                    sortOrder: nil, importedPayee: nil, transferAcct: transferAcct)
     }
 
     @Test func noContentForEmptyBatch() {
@@ -33,6 +35,38 @@ struct NewTransactionNotifierTests {
         let content = NewTransactionNotifier.makeContent(
             for: [makeTransaction(id: "t1", payeeName: "Starbucks")],
             currencyCode: "USD")
+
+        #expect(content?.body.localizedCaseInsensitiveContains("needs a category") == true)
+    }
+
+    /// A transfer between on-budget accounts can't take a category, so its
+    /// line must not nag for one (GH #104).
+    @Test func transferDoesNotAskForCategory() {
+        let content = NewTransactionNotifier.makeContent(
+            for: [makeTransaction(id: "t1", payeeName: "Savings",
+                                  transferId: "leg-2", transferAcct: "acct2")],
+            currencyCode: "USD")
+
+        #expect(content?.body.localizedCaseInsensitiveContains("needs a category") == false)
+    }
+
+    /// Off-budget accounts aren't categorized at all (GH #123).
+    @Test func offBudgetTransactionDoesNotAskForCategory() {
+        let content = NewTransactionNotifier.makeContent(
+            for: [makeTransaction(id: "t1", payeeName: "Broker")],
+            currencyCode: "USD", offBudgetAccountIds: ["acct1"])
+
+        #expect(content?.body.localizedCaseInsensitiveContains("needs a category") == false)
+    }
+
+    /// Money leaving the budget still needs a category: a transfer whose
+    /// other side is off-budget keeps the marker (matches the Budget tab's
+    /// uncategorized filter).
+    @Test func transferToOffBudgetAccountStillAsksForCategory() {
+        let content = NewTransactionNotifier.makeContent(
+            for: [makeTransaction(id: "t1", payeeName: "Brokerage",
+                                  transferId: "leg-2", transferAcct: "acct2")],
+            currencyCode: "USD", offBudgetAccountIds: ["acct2"])
 
         #expect(content?.body.localizedCaseInsensitiveContains("needs a category") == true)
     }

--- a/Actuali/ActualiTests/TransactionNeedsCategoryTests.swift
+++ b/Actuali/ActualiTests/TransactionNeedsCategoryTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Pins `Transaction.needsCategory(offBudgetAccountIds:)`, the shared rule
+/// behind the sync notification's "Needs a category" marker and the list
+/// rows' "Transfer" label (GH #123, #104). Mirrors the WebUI's uncategorized
+/// filter: split parents, off-budget accounts and transfers don't take a
+/// category — unless the transfer's other side is off-budget.
+struct TransactionNeedsCategoryTests {
+
+    private func makeTransaction(categoryId: String? = nil, isParent: Bool = false,
+                                 transferId: String? = nil,
+                                 transferAcct: String? = nil) -> Transaction {
+        Transaction(id: "t1", accountId: "acct1", date: 20260707, amount: -1250,
+                    payeeId: nil, payeeName: nil, categoryId: categoryId,
+                    categoryName: nil, notes: nil, cleared: false, reconciled: false,
+                    transferId: transferId, isParent: isParent, parentId: nil,
+                    tombstone: false, sortOrder: nil, importedPayee: nil,
+                    transferAcct: transferAcct)
+    }
+
+    @Test func uncategorizedOnBudgetTransactionNeedsOne() {
+        #expect(makeTransaction().needsCategory(offBudgetAccountIds: []))
+    }
+
+    @Test func categorizedTransactionDoesNot() {
+        #expect(!makeTransaction(categoryId: "food").needsCategory(offBudgetAccountIds: []))
+    }
+
+    @Test func splitParentDoesNot() {
+        // Categories live on the children; the parent never carries one.
+        #expect(!makeTransaction(isParent: true).needsCategory(offBudgetAccountIds: []))
+    }
+
+    @Test func offBudgetAccountTransactionDoesNot() {
+        #expect(!makeTransaction().needsCategory(offBudgetAccountIds: ["acct1"]))
+    }
+
+    @Test func onBudgetTransferDoesNot() {
+        let transfer = makeTransaction(transferId: "leg-2", transferAcct: "acct2")
+        #expect(!transfer.needsCategory(offBudgetAccountIds: []))
+    }
+
+    @Test func transferToOffBudgetAccountDoes() {
+        // Money leaving the budget still needs a category (Actual's rule).
+        let transfer = makeTransaction(transferId: "leg-2", transferAcct: "acct2")
+        #expect(transfer.needsCategory(offBudgetAccountIds: ["acct2"]))
+    }
+
+    @Test func transferWithoutPayeeInfoDoesNot() {
+        // transferred_id alone marks the row a transfer even when the payee
+        // row (and its transfer_acct) is unavailable.
+        #expect(!makeTransaction(transferId: "leg-2").needsCategory(offBudgetAccountIds: []))
+    }
+}


### PR DESCRIPTION
## Why

Off-budget transactions showed "Uncategorized" / "Unknown", and transfers showed as "Uncategorised" too — categorisable, nagging for a category in sync notifications, and impossible to re-target after creation (the edit form treated a transfer leg as a plain expense/income with the partner account's name as a payee string). Closes #123. Closes #104.

## What

- **List rows** (all transaction lists share `TransactionRow`): off-budget accounts show **"Off budget"** / **"No payee"**; transfers that can't take a category show **"Transfer"**. A transfer whose other side is off-budget still shows "Uncategorized" — money leaving the budget still needs a category, matching the Budget tab's uncategorized filter.
- **Sync notifications**: the "Needs a category" marker now uses a shared `Transaction.needsCategory` rule (mirrors `uncategorizedWhere`), so transfers and off-budget transactions stop asking to be categorised.
- **Edit form**: a transfer leg now loads as a Transfer — type locked (converting would orphan the partner leg), From/To pickers populated from the leg's sign and re-targetable, and a Category row only for the on-budget leg of an off-budget transfer. Editing a transfer no longer creates a stray real payee named after the account.
- **Store**: new `BudgetStore.updateTransfer` re-saves both legs — amount/date/notes/cleared applied to the pair, accounts re-targeted with transfer payees remapped, and categories kept only where Actual allows them (on-budget leg, off-budget partner). A dangling transfer (partner missing) is refused with a clear error.
- **Database**: the payee's `transfer_acct` now rides along on every display fetch so rows and the edit form know a transfer's other side.

## How it was tested

Added unit tests: `TransactionNeedsCategoryTests` (shared category rule), notifier coverage for transfer/off-budget/off-budget-transfer lines, `transfer_acct` population, and end-to-end `BudgetStoreUpdateTransferTests` (both-leg updates, re-targeting with payee remapping, editing from either leg, category clearing/preservation, missing-partner refusal). Full unit suite passes locally on the iPhone 17 simulator.