### PR TITLE
feat: explain the overspent badge with a tappable category list

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -20,6 +20,15 @@ struct BudgetMonth: Identifiable, Hashable {
         categoryBudgets.count(where: \.isOverspent)
     }
 
+    /// The categories behind `overspentCount`, worst first, so the badge can
+    /// be explained instead of leaving the user to hunt through the table
+    /// (GH #138).
+    var overspentCategories: [CategoryBudget] {
+        categoryBudgets
+            .filter(\.isOverspent)
+            .sorted { $0.available < $1.available }
+    }
+
     var totalBudgeted: Int {
         categoryBudgets.reduce(0) { $0 + $1.budgeted }
     }
@@ -72,6 +81,14 @@ struct CategoryBudget: Identifiable, Hashable {
 
     var isOverspent: Bool {
         available < 0
+    }
+
+    /// Overspending carried in from earlier months (negative, or 0 when the
+    /// carryover is a credit). Actual's web UI doesn't surface this either,
+    /// so a category can sit in the red with no visible cause in the current
+    /// month — the trigger for GH #138.
+    var rolledOverOverspending: Int {
+        min(carryover, 0)
     }
 
     /// Fill for the row's progress bar, 0...1. Measured against what the

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -90,6 +90,25 @@ struct BudgetView: View {
                             }
                         }
 
+                        // Explains the tab badge (GH #138): which categories
+                        // are overspent, including overspending rolled over
+                        // from earlier months. Shares the badge's Settings
+                        // toggle — off means no overspending callouts at all.
+                        if budgetStore.showOverspentBadge, budget.overspentCount > 0 {
+                            Section {
+                                NavigationLink {
+                                    OverspentCategoriesView()
+                                } label: {
+                                    Label {
+                                        Text("^[\(budget.overspentCount) Overspent Category](inflect: true)")
+                                    } icon: {
+                                        Image(systemName: "exclamationmark.circle.fill")
+                                            .foregroundStyle(.red)
+                                    }
+                                }
+                            }
+                        }
+
                         if budgetStore.uncategorizedCount > 0 {
                             Section {
                                 NavigationLink {

--- a/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
+++ b/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Explains the Budget tab's overspent badge (GH #138): every category in
+/// the red for the displayed month, worst first. Reads the live month from
+/// the store rather than a snapshot so fixing a category (via the pushed
+/// transaction list, or a sync) updates the list on the way back.
+struct OverspentCategoriesView: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+
+    var body: some View {
+        Group {
+            if let budget = budgetStore.currentBudgetMonth,
+               !budget.overspentCategories.isEmpty {
+                List {
+                    Section {
+                        ForEach(budget.overspentCategories) { category in
+                            OverspentCategoryRow(category: category)
+                        }
+                    } footer: {
+                        Text("Categories with a negative balance in \(MonthPicker.title(for: budget.month)). Balances include overspending rolled over from earlier months, which this month's transactions alone won't explain.")
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "Nothing Overspent",
+                    systemImage: "checkmark.circle",
+                    description: Text("No categories are overspent this month.")
+                )
+            }
+        }
+        .navigationTitle("Overspent Categories")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+/// One overspent category: name, group, and the negative balance, with a
+/// caption attributing any part that rolled over from earlier months.
+/// Tapping pushes the month's transactions — the same list as the budget
+/// table's "Spent" cell — to explain the in-month portion.
+struct OverspentCategoryRow: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    let category: CategoryBudget
+
+    var body: some View {
+        NavigationLink {
+            CategoryTransactionsView(
+                destination: CategoryTransactionsDestination(
+                    categoryId: category.categoryId,
+                    categoryName: category.categoryName,
+                    month: category.month
+                )
+            )
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(category.categoryName)
+                    Spacer()
+                    Text(budgetStore.displayBalance(category.available))
+                        .foregroundStyle(.red)
+                        .monospacedDigit()
+                }
+                Text(category.groupName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if category.rolledOverOverspending < 0 {
+                    Label {
+                        Text("Includes \(budgetStore.displayBalance(abs(category.rolledOverOverspending))) rolled over from earlier months")
+                    } icon: {
+                        Image(systemName: "arrow.uturn.forward")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OverspentCategoriesView()
+    }
+    .environmentObject(BudgetStore.previewInstance())
+}

--- a/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct BudgetMonthOverspentCountTests {
 
-    private func makeCategory(id: String, available: Int) -> CategoryBudget {
+    private func makeCategory(id: String, available: Int, carryover: Int = 0) -> CategoryBudget {
         CategoryBudget(
             month: "2026-07",
             categoryId: id,
@@ -16,7 +16,7 @@ struct BudgetMonthOverspentCountTests {
             budgeted: 10000,
             spent: 10000 - available,
             available: available,
-            carryover: 0
+            carryover: carryover
         )
     }
 
@@ -41,5 +41,38 @@ struct BudgetMonthOverspentCountTests {
 
     @Test func exactlyZeroAvailableIsNotOverspent() {
         #expect(makeMonth(availables: [0]).overspentCount == 0)
+    }
+
+    // MARK: - overspentCategories (the badge's explanation, GH #138)
+
+    @Test func overspentCategoriesListsOnlyTheOnesInTheRed() {
+        let month = makeMonth(availables: [5000, -200, 0, -1])
+        #expect(month.overspentCategories.map(\.available) == [-200, -1])
+    }
+
+    @Test func overspentCategoriesOrdersWorstFirst() {
+        let month = makeMonth(availables: [-1, -5000, 300, -200])
+        #expect(month.overspentCategories.map(\.available) == [-5000, -200, -1])
+    }
+
+    @Test func overspentCategoriesIsEmptyWhenNothingIsOverspent() {
+        #expect(makeMonth(availables: [5000, 0]).overspentCategories.isEmpty)
+    }
+
+    // MARK: - rolledOverOverspending
+
+    @Test func negativeCarryoverIsRolledOverOverspending() {
+        let category = makeCategory(id: "c", available: -1500, carryover: -1000)
+        #expect(category.rolledOverOverspending == -1000)
+    }
+
+    @Test func positiveCarryoverIsNotRolledOverOverspending() {
+        let category = makeCategory(id: "c", available: -500, carryover: 2000)
+        #expect(category.rolledOverOverspending == 0)
+    }
+
+    @Test func zeroCarryoverHasNoRolledOverOverspending() {
+        let category = makeCategory(id: "c", available: -500)
+        #expect(category.rolledOverOverspending == 0)
     }
 }

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+/// End-to-end check for the overspent badge's explanation (GH #138).
+///
+/// Demo data has no overspent categories, so the notice must start hidden.
+/// Overspending Coffee through the real edit sheet must surface a
+/// "1 Overspent Category" notice at the top of the Budget screen; tapping it
+/// must list Coffee with its negative balance, and restoring the budget must
+/// clear the notice again.
+final class OverspentCategoriesUITests: XCTestCase {
+
+    @MainActor
+    func testNoticeExplainsOverspentCategories() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "1"]
+        app.launch()
+
+        let budgetTab = app.tabBars.buttons["Budget"]
+        XCTAssertTrue(budgetTab.waitForExistence(timeout: 10), "Budget tab not found")
+
+        // Demo data is within budget everywhere: no notice at launch.
+        let notice = app.buttons["1 Overspent Category"]
+        XCTAssertFalse(notice.exists, "overspent notice shown with nothing overspent")
+
+        // Overspend Coffee by budgeting $1 against ~$19 already spent.
+        setBudget(app, category: "Coffee", centsKeystrokes: "100")
+        scrollToTop(app)
+        XCTAssertTrue(notice.waitForExistence(timeout: 10),
+                      "overspent notice did not appear after overspending Coffee")
+        attachScreenshot(app, name: "1-overspent-notice")
+
+        // The notice must explain itself: Coffee listed, in the red.
+        notice.tap()
+        let coffeeRow = app.buttons.containing(NSPredicate(format: "label CONTAINS 'Coffee'")).firstMatch
+        XCTAssertTrue(coffeeRow.waitForExistence(timeout: 5),
+                      "Coffee missing from the overspent list")
+        attachScreenshot(app, name: "2-overspent-list")
+
+        // Rows drill into the month's transactions.
+        coffeeRow.tap()
+        XCTAssertTrue(app.navigationBars["Coffee"].waitForExistence(timeout: 5),
+                      "tapping the overspent row did not open Coffee's transactions")
+        attachScreenshot(app, name: "3-category-transactions")
+
+        // Restore a healthy budget: the notice must disappear again.
+        app.navigationBars.buttons.firstMatch.tap() // back to the list
+        app.navigationBars.buttons.firstMatch.tap() // back to the budget
+        setBudget(app, category: "Coffee", centsKeystrokes: "10000")
+        scrollToTop(app)
+        XCTAssertTrue(waitForNonExistence(of: notice, timeout: 10),
+                      "overspent notice still shown after restoring the budget")
+        attachScreenshot(app, name: "4-notice-cleared")
+    }
+
+    /// Opens the category's edit-budget sheet and types a new amount.
+    /// The amount field interprets bare digits as cents ("100" → 1.00).
+    @MainActor
+    private func setBudget(_ app: XCUIApplication, category: String, centsKeystrokes: String) {
+        let editButton = app.buttons["Edit budgeted amount for \(category)"]
+        var scrollsLeft = 8
+        while !editButton.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(editButton.isHittable, "edit button for \(category) not reachable")
+        editButton.tap()
+
+        let field = app.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
+        field.tap()
+        // Focus select-alls the current value asynchronously; don't rely on
+        // that racing in our favor — backspace the old value away instead.
+        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))
+        field.typeText(centsKeystrokes)
+
+        let saveButton = app.buttons["Save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")
+        saveButton.tap()
+        // Sheet dismissal returns us to the budget list.
+        XCTAssertTrue(field.waitForNonExistence(timeout: 5), "edit sheet did not dismiss")
+    }
+
+    /// The notice lives at the top of the (possibly scrolled) budget list.
+    @MainActor
+    private func scrollToTop(_ app: XCUIApplication) {
+        for _ in 0..<8 where !app.navigationBars["Budget"].isHittable {
+            app.swipeDown()
+        }
+        app.swipeDown()
+    }
+
+    @MainActor
+    private func waitForNonExistence(of element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !element.exists { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        return false
+    }
+
+    @MainActor
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Closes #138

## What

The Budget tab's overspent badge (#68) could show a persistent count with no way to discover the cause — especially overspending that rolled over from a previous month, which the current month's rows alone don't explain (Actual's PWA doesn't surface it either).

- **Notice on the Budget screen**: a tappable "N Overspent Categories" row (mirroring the uncategorized-transactions notice) appears at the top of the budget list whenever the displayed month has categories in the red. It shares the existing **Overspent Badge** Settings toggle, so turning the badge off still disables every overspending callout.
- **Overspent Categories screen**: lists the categories driving the count, worst first, each with its group and negative balance. When part of the balance is overspending rolled over from earlier months (negative carryover), the row says so with the amount — the case from the original report. Tapping a row drills into the month's transactions, same as the budget table's Spent cell.

## How

- `BudgetMonth.overspentCategories` exposes the categories behind the existing `overspentCount`, sorted worst first
- `CategoryBudget.rolledOverOverspending` surfaces the negative portion of `carryover` (already computed by the envelope/tracking rollover chain in `BudgetDatabase`)
- New `OverspentCategoriesView` reads the live month from the store, so fixing a category updates the list on the way back

## Testing

- New unit tests for `overspentCategories` (filtering, worst-first ordering) and `rolledOverOverspending`; full `ActualiTests` target passes (617 tests, 87 suites)
- New `OverspentCategoriesUITests` end-to-end test: overspends Coffee in demo data via the real edit sheet, verifies the notice appears, lists Coffee in the red, drills into its transactions, and clears once the budget is restored — passes locally
- Note: the pre-existing `BudgetTabBadgeUITests` fails locally at its Settings-toggle step on unmodified `main` too (toggle off-screen in the lazy Settings list on the iPhone 17 simulator) — unrelated to this change