### PR TITLE
fix: land on the account's transaction list after adding a transaction

### DIFF
--- a/Actuali/Actuali/Services/NotificationRouter.swift
+++ b/Actuali/Actuali/Services/NotificationRouter.swift
@@ -33,6 +33,13 @@ final class NotificationRouter: NSObject, ObservableObject, UNUserNotificationCe
     @Published var pendingPrefill: TransactionPrefill?
     @Published var pendingAllAccountsNavigation = false
 
+    /// Account whose transaction list should open after the tab-hosted add
+    /// flow saves (see `AddTransactionView.saveTransaction`). Not set by
+    /// notifications, but this router is the app's cross-tab navigation
+    /// channel: `MainTabView` reacts by selecting the Accounts tab and
+    /// `AccountsListView` consumes the id by pushing the account.
+    @Published var pendingAccountNavigation: String?
+
     /// From a tapped new-transaction notification.
     @Published var destination: NotificationDestination?
 

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -90,9 +90,15 @@ struct AccountsListView: View {
             .navigationDestination(for: AllAccountsRoute.self) { _ in
                 TransactionsListView()
             }
-            .onAppear(perform: consumePendingAllAccountsNavigation)
+            .onAppear {
+                consumePendingAllAccountsNavigation()
+                consumePendingAccountNavigation()
+            }
             .onChange(of: notificationRouter.pendingAllAccountsNavigation) { _, pending in
                 if pending { consumePendingAllAccountsNavigation() }
+            }
+            .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
+                if accountId != nil { consumePendingAccountNavigation() }
             }
             .refreshable {
                 await budgetStore.sync()
@@ -113,6 +119,18 @@ struct AccountsListView: View {
         guard notificationRouter.pendingAllAccountsNavigation else { return }
         path = NavigationPath([AllAccountsRoute()])
         notificationRouter.pendingAllAccountsNavigation = false
+    }
+
+    /// A save in the tab-hosted add flow lands here: jump the stack straight
+    /// to the saved transaction's account (replacing anything the user had
+    /// pushed) and clear the signal. onChange covers the usual case; onAppear
+    /// covers a save before this tab was ever created, when the signal is
+    /// already pending as the view first appears.
+    private func consumePendingAccountNavigation() {
+        guard let accountId = notificationRouter.pendingAccountNavigation else { return }
+        notificationRouter.pendingAccountNavigation = nil
+        guard let account = budgetStore.accounts.first(where: { $0.id == accountId }) else { return }
+        path = NavigationPath([account])
     }
 }
 

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -46,7 +46,7 @@ struct MainTabView: View {
                 .badge(overspentCount)
                 .tag(1)
 
-            AddTransactionTabView(selectedTab: $selectedTab)
+            AddTransactionTabView()
                 .tabItem {
                     Label("Add", systemImage: "plus.circle.fill")
                 }
@@ -67,20 +67,17 @@ struct MainTabView: View {
         .onChange(of: notificationRouter.pendingAllAccountsNavigation) { _, pending in
             if pending { selectedTab = 0 }
         }
+        // A save in the tab-hosted add flow routes to the account's
+        // transaction list, which lives on the Accounts tab.
+        .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
+            if accountId != nil { selectedTab = 0 }
+        }
     }
 }
 
 struct AddTransactionTabView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
-    @Binding var selectedTab: Int
     @State private var showingDefaultAccountAlert = false
-
-    private var optionalTabBinding: Binding<Int?> {
-        Binding<Int?>(
-            get: { selectedTab },
-            set: { if let newValue = $0 { selectedTab = newValue } }
-        )
-    }
 
     var body: some View {
         let configuredId = budgetStore.defaultAccountId
@@ -90,7 +87,7 @@ struct AddTransactionTabView: View {
         let fallbackAccount = budgetStore.accounts.first { !$0.closed }
 
         if let account = validDefaultAccount ?? fallbackAccount {
-            AddTransactionView(accountId: account.id, selectedTab: optionalTabBinding)
+            AddTransactionView(accountId: account.id)
                 .onAppear {
                     if configuredId != nil && validDefaultAccount == nil {
                         budgetStore.defaultAccountId = nil

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -6,7 +6,6 @@ struct AddTransactionView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.isPresented) private var isPresented
-    @Binding var selectedTab: Int?
 
     private let editing: Transaction?
 
@@ -40,12 +39,10 @@ struct AddTransactionView: View {
         accountId: String,
         payee: String = "",
         amountCents: Int? = nil,
-        date: Date = Date(),
-        selectedTab: Binding<Int?> = .constant(nil)
+        date: Date = Date()
     ) {
         self.editing = nil
         _selectedAccountId = State(initialValue: accountId)
-        _selectedTab = selectedTab
         _amount = State(initialValue: amountCents.map { String(format: "%.2f", Double(abs($0)) / 100.0) } ?? "")
         _txType = State(initialValue: .expense)
         _payeeName = State(initialValue: payee)
@@ -59,7 +56,6 @@ struct AddTransactionView: View {
     /// Initializer for the "Edit" flow.
     init(editing: Transaction) {
         self.editing = editing
-        _selectedTab = .constant(nil)
         _selectedAccountId = State(initialValue: editing.accountId)
 
         let cents = abs(editing.amount)
@@ -578,13 +574,17 @@ struct AddTransactionView: View {
 
         do {
             try await budgetStore.saveTransaction(form, editing: editing)
-            if isEditing {
+            if isEditing || isPresented {
+                // Presented flows (edit, account-detail "+", notification
+                // prefill) close; the account-detail host is already the
+                // saved transaction's list.
                 dismiss()
             } else {
+                // The tab-hosted flow has nothing to dismiss: reset for the
+                // next entry and route to the saved transaction's account
+                // list so every add flow lands on the relevant list.
                 resetForm()
-                if selectedTab != nil {
-                    selectedTab = 0  // Navigate back to Accounts after save
-                }
+                NotificationRouter.shared.pendingAccountNavigation = form.accountId
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/Actuali/ActualiUITests/AddTransactionPostSaveUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionPostSaveUITests.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+/// Repro for the inconsistent post-save behaviour report (issue #124).
+///
+/// The add-transaction form had two different endings: the tab-hosted flow
+/// reset itself and switched to the Accounts overview, while the
+/// sheet-presented flow (account detail "+") stayed open with a blank form.
+/// Both must now end the same way: the form closes and the user lands on the
+/// saved transaction's account list.
+final class AddTransactionPostSaveUITests: XCTestCase {
+
+    /// Types an amount on the decimal pad and taps the save button.
+    @MainActor
+    private func enterAmountAndSave(in app: XCUIApplication) {
+        let amountField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == '0.00'")
+        ).firstMatch
+        XCTAssertTrue(amountField.waitForExistence(timeout: 10), "amount field not found")
+        amountField.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5),
+                      "keyboard did not appear")
+        amountField.typeText("500")
+
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 5), "no Done bar above the decimal pad")
+        done.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
+                      "keyboard did not dismiss")
+
+        let save = app.buttons["Add Transaction"].firstMatch
+        XCTAssertTrue(save.waitForExistence(timeout: 5), "save button not found")
+        save.tap()
+    }
+
+    @MainActor
+    func testSheetPresentedAddFlowDismissesToAccountListAfterSave() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "0"]
+        app.launch()
+
+        let accountRow = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS 'Chase Checking'")
+        ).firstMatch
+        XCTAssertTrue(accountRow.waitForExistence(timeout: 10), "Chase Checking row not found")
+        accountRow.tap()
+
+        let addButton = app.navigationBars.buttons["Add"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5), "'+' toolbar button not found")
+        addButton.tap()
+
+        let addTitle = app.navigationBars["Add Transaction"]
+        XCTAssertTrue(addTitle.waitForExistence(timeout: 5), "add sheet did not present")
+
+        enterAmountAndSave(in: app)
+
+        // The sheet must close itself, landing back on the account's
+        // transaction list — not stay open with a reset form.
+        XCTAssertTrue(addTitle.waitForNonExistence(timeout: 10),
+                      "add sheet stayed open after saving")
+        XCTAssertTrue(app.navigationBars["Chase Checking"].waitForExistence(timeout: 5),
+                      "did not land back on the account's transaction list")
+    }
+
+    @MainActor
+    func testTabHostedAddFlowNavigatesToAccountListAfterSave() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "2"]
+        app.launch()
+
+        // Demo data sets no default account, so the tab-hosted form falls
+        // back to the first open account: Chase Checking.
+        enterAmountAndSave(in: app)
+
+        // The form must end on the saved transaction's account list, not the
+        // Accounts overview.
+        XCTAssertTrue(app.navigationBars["Chase Checking"].waitForExistence(timeout: 10),
+                      "did not land on the account's transaction list after saving")
+    }
+}


### PR DESCRIPTION
Fixes #124

## Problem

The add-transaction form ended differently depending on where it was opened:

- **Add tab**: reset the form and switched to the Accounts overview.
- **Account detail "+" / notification prefill sheet**: stayed open with a blank form.

Reported by u/TrainingHighlight790 in the launch thread; behaviour should be consistent — close the form and land on the relevant transaction list.

## Fix

Every add flow now ends the same way: the form closes and the user lands on the saved transaction's account list.

- **Presented flows** (account detail "+", notification prefill) simply dismiss — the account-detail host is already the saved transaction's list. The edit flow keeps dismissing as before.
- **Tab-hosted flow** resets the form and raises a new `pendingAccountNavigation` signal on `NotificationRouter` (the existing cross-tab navigation channel, mirroring `pendingAllAccountsNavigation`): `MainTabView` selects the Accounts tab and `AccountsListView` consumes the account id by replacing its stack with that account's transaction list.
- The `selectedTab` binding `AddTransactionView` carried for its old tab switch is removed along with `AddTransactionTabView`'s binding plumbing.

## Testing

- New `AddTransactionPostSaveUITests` covering both reported flows: the sheet-presented save dismisses back to the account's list, and the tab-hosted save navigates to the account's list. Both pass on the iPhone 17 / iOS 26.5 simulator.
- Existing `AddTransactionKeyboardUITests` pass against the new code.
- Full unit suite: 611 tests in 87 suites, all passing.