### PR TITLE
Trim the budget group header and make its totals optional

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -197,6 +197,16 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether the detailed style's group headers total their columns.
+    /// Persisted to UserDefaults, defaults to on. Groups with long names are
+    /// the reason this is optional: the totals cost the name real width, and
+    /// not every budget file makes the sums worth it.
+    @Published var showGroupTotals: Bool = true {
+        didSet {
+            UserDefaults.standard.set(showGroupTotals, forKey: "showGroupTotals")
+        }
+    }
+
     /// Whether the Budget tab shows a badge with the overspent-category
     /// count (GH #68). Persisted to UserDefaults, defaults to on.
     @Published var showOverspentBadge: Bool = true {
@@ -486,6 +496,8 @@ final class BudgetStore: ObservableObject {
         }
         _showBudgetProgressBars = Published(initialValue: UserDefaults.standard
             .object(forKey: "showBudgetProgressBars") as? Bool ?? true)
+        _showGroupTotals = Published(initialValue: UserDefaults.standard
+            .object(forKey: "showGroupTotals") as? Bool ?? true)
         _showOverspentBadge = Published(initialValue: UserDefaults.standard
             .object(forKey: "showOverspentBadge") as? Bool ?? true)
         _hideBalances = Published(initialValue: UserDefaults.standard

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -39,6 +39,13 @@ struct BudgetOptionsMenu: View {
             // Amount masking isn't here: it's app-wide, so it lives in
             // Settings (GH #158) rather than in any one tab's menu.
             Section {
+                // Only the detailed style has columns for a group header to
+                // total, so the clean style doesn't offer the switch.
+                if budgetStore.budgetDisplayStyle == .detailed {
+                    Toggle(isOn: $budgetStore.showGroupTotals) {
+                        Label("Group Totals", systemImage: "sum")
+                    }
+                }
                 Toggle(isOn: $budgetStore.hideZeroBudgetCategories) {
                     Label("Hide Spent Categories", systemImage: "line.3.horizontal.decrease")
                 }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -161,7 +161,7 @@ struct BudgetView: View {
                                     BudgetGroupHeader(
                                         name: group.name,
                                         isCollapsed: isCollapsed,
-                                        totals: group.totals,
+                                        totals: budgetStore.showGroupTotals ? group.totals : nil,
                                         onToggleCollapse: { toggleCollapsed(group.id) }
                                     )
                                     .listRowBackground(Color(.tertiarySystemFill))
@@ -652,8 +652,14 @@ struct BudgetAmountPill: View {
     }
 }
 
-/// Group header row: collapse control and group name; optionally shows
-/// numeric totals (Budgeted / Spent / Balance) aligned to the table columns.
+/// Group header row: collapse control and group name; optionally shows the
+/// group's Spent and Balance totals in the table's rightmost two columns.
+///
+/// Budgeted is deliberately absent. Pills are laid out from the trailing
+/// edge, so omitting it hands its ~76 pt back to the group name — which
+/// needs the room, since group names run longer than category names — while
+/// Spent and Balance stay in their columns. The per-category Budgeted cells
+/// are still there in the rows below for anyone who wants them.
 struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
@@ -676,10 +682,6 @@ struct BudgetGroupHeader: View {
                     .minimumScaleFactor(0.85)
                 Spacer(minLength: 4)
                 if let totals {
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(totals.budgeted),
-                        dimmed: totals.budgeted == 0
-                    )
                     BudgetAmountPill(
                         text: budgetStore.displayBudgetCell(totals.spent),
                         dimmed: totals.spent == 0
@@ -707,7 +709,6 @@ struct BudgetGroupHeader: View {
         guard let totals else { return "\(name), \(state)" }
         return """
             \(name), \(state), \
-            budgeted \(budgetStore.displayBalance(totals.budgeted)), \
             spent \(budgetStore.displayBalance(totals.spent)), \
             balance \(budgetStore.displayBalance(totals.balance))
             """

--- a/Actuali/ActualiTests/BudgetStoreGroupTotalsTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreGroupTotalsTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The Budget menu's group-totals switch defaults to on and writes through to
+/// UserDefaults, like the other display settings.
+///
+/// The restore-on-launch half isn't covered here: `previewInstance()` is built
+/// by an init that skips every UserDefaults read, and the real init does file
+/// system work no unit test should trigger. Same gap as the other display
+/// settings suites.
+@MainActor
+struct BudgetStoreGroupTotalsTests {
+
+    @Test func groupTotalsShowByDefault() {
+        #expect(BudgetStore.previewInstance().showGroupTotals)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.showGroupTotals = false
+        #expect(UserDefaults.standard.object(forKey: "showGroupTotals") as? Bool == false)
+        store.showGroupTotals = true
+        #expect(UserDefaults.standard.object(forKey: "showGroupTotals") as? Bool == true)
+    }
+}


### PR DESCRIPTION
## Why

Group header totals (#154) cost the group name most of its width — three 70 pt pills left roughly 110 pt for the name on a phone, so real budget files were wrapping mid-word ("Accommoda-tion"). Some people also just don't want totals in the header at all.

## What

- **Budgeted pill dropped from group headers.** The pills lay out from the trailing edge, so removing it needs no placeholder: Spent and Balance stay in their columns and the name gets ~76 pt back. Per-category Budgeted cells are unchanged in the rows below.
- **New Group Totals switch** in the Budget options menu, alongside the other display toggles. It only appears in the Detailed layout — the clean style's header is a plain section title with no columns to total, so the switch would be a no-op there. Persisted like the other display settings, defaulting to on.
- VoiceOver's header label follows the visible pills (name, state, spent, balance).

## How it was tested

- `BudgetStoreGroupTotalsTests` covers the new setting's default and its write-through to UserDefaults. The restore-on-launch path isn't covered — `previewInstance()` is built by an init that skips every UserDefaults read, and the real init does file system work a unit test shouldn't trigger. Same gap as the other display-settings suites; noted in the test file.
- Full suite green: 663 tests in 93 suites, iPhone 17 Pro / iOS 26.2 simulator.
- Ran on that simulator against a real budget file, in both layouts and with the toggle on and off.