### PR TITLE
Improve logout functionality to clear local data

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -691,18 +691,34 @@ final class BudgetStore: ObservableObject {
         isLoading = false
     }
 
-    func logout() {
+func logout() {
         Task {
             await serverClient.setToken(nil)
         }
         try? Keychain.remove(for: "authToken")
         // Defensively remove any legacy UserDefaults copy
         UserDefaults.standard.removeObject(forKey: "authToken")
+
+        // Wipe every locally-synced budget's database and metadata from
+        // disk — disconnecting should leave nothing behind, not just the
+        // auth token (GH: disconnect should clear local data).
+        for local in fileManager.listLocalBudgets() {
+            try? fileManager.deleteBudget(local.id)
+        }
+
         isConnected = false
         remoteBudgets = []
         // Re-probe on the next connection in case the server URL changes.
         availableLoginMethods = []
         ownerExists = true
+
+        // Clear everything currently loaded in memory too, so nothing from
+        // the old budget lingers in the UI post-disconnect.
+        currentBudgetId = nil
+        currentBudgetMonth = nil
+        accounts = []
+        categoryGroups = []
+        payees = []
     }
 
     /// Load the auth token, migrating from UserDefaults to Keychain on first run.

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -320,7 +320,7 @@ final class BudgetStore: ObservableObject {
     // MARK: - Private
 
     private let serverClient = ActualServerClient()
-    private let fileManager = BudgetFileManager.shared
+    private var fileManager = BudgetFileManager.shared
     private var database: BudgetDatabase? {
         didSet {
             // The cached poster holds the database strongly; drop it whenever
@@ -463,6 +463,13 @@ final class BudgetStore: ObservableObject {
     /// database, simulating an init()-time load that failed (actios-tq4w).
     func simulateFailedInitialLoadForTesting() {
         loadTask = Task {}
+    }
+
+    /// Test-only: swap in a file manager rooted at a temp directory so
+    /// logout()'s full wipe can be exercised without touching the shared
+    /// Budgets directory (parallel suites create real budgets there).
+    func setFileManagerForTesting(_ manager: BudgetFileManager) {
+        fileManager = manager
     }
     #endif
 
@@ -691,7 +698,11 @@ final class BudgetStore: ObservableObject {
         isLoading = false
     }
 
-func logout() {
+    /// Clear the server session and, by default, wipe all local budget data.
+    /// - Parameter clearLocalData: pass `false` to keep budget files on disk
+    ///   (the demo entry point clears the session without destroying data;
+    ///   only an explicit Disconnect wipes it).
+    func logout(clearLocalData: Bool = true) {
         Task {
             await serverClient.setToken(nil)
         }
@@ -699,11 +710,28 @@ func logout() {
         // Defensively remove any legacy UserDefaults copy
         UserDefaults.standard.removeObject(forKey: "authToken")
 
-        // Wipe every locally-synced budget's database and metadata from
-        // disk — disconnecting should leave nothing behind, not just the
-        // auth token (GH: disconnect should clear local data).
-        for local in fileManager.listLocalBudgets() {
-            try? fileManager.deleteBudget(local.id)
+        // Close the open database and sync client BEFORE touching files.
+        // A deleted-but-open database stays readable through its fd (the
+        // "vnode unlinked" hazard downloadBudget also guards against), and a
+        // live sync client would let the next foreground refresh republish
+        // the wiped budget's data from that orphaned connection.
+        syncStateCancellable?.cancel()
+        syncStateCancellable = nil
+        syncClient = nil
+        database = nil
+
+        if clearLocalData {
+            // Wipe every locally-synced budget's database and metadata from
+            // disk — disconnecting should leave nothing behind, not just the
+            // auth token (GH: disconnect should clear local data). Encrypted
+            // budgets' Keychain keys go too: they must not outlive the files
+            // they unlock.
+            for local in fileManager.listLocalBudgets() {
+                if let fileId = local.cloudFileId {
+                    try? EncryptionKeyManager.remove(fileId: fileId)
+                }
+                try? fileManager.deleteBudget(local.id)
+            }
         }
 
         isConnected = false
@@ -713,12 +741,18 @@ func logout() {
         ownerExists = true
 
         // Clear everything currently loaded in memory too, so nothing from
-        // the old budget lingers in the UI post-disconnect.
+        // the old budget lingers in the UI post-disconnect. The dataVersion
+        // bump makes views that cache their own fetches drop them.
         currentBudgetId = nil
         currentBudgetMonth = nil
         accounts = []
+        transactions = []
+        uncategorizedCount = 0
         categoryGroups = []
         payees = []
+        lastSyncTime = nil
+        syncState = .idle
+        dataVersion += 1
     }
 
     /// Load the auth token, migrating from UserDefaults to Keychain on first run.
@@ -965,8 +999,10 @@ func logout() {
     /// letting users (and App Review) explore the app without configuring a server.
     /// Logs out any active server session so sync cannot fire against a real server.
     func loadDemoData() async {
-        // Log out any active session so sync doesn't try to fire against a real server
-        logout()
+        // Log out any active session so sync doesn't try to fire against a
+        // real server — but keep local budget files: trying the demo must
+        // never destroy a user's synced data.
+        logout(clearLocalData: false)
         do {
             try DemoDataSeeder.seed()
             currentBudgetId = DemoDataSeeder.budgetId

--- a/Actuali/Actuali/Services/Database/BudgetFileManager.swift
+++ b/Actuali/Actuali/Services/Database/BudgetFileManager.swift
@@ -39,13 +39,28 @@ class BudgetFileManager {
 
     private let fileManager = FileManager.default
 
-    private init() {}
+    /// Non-nil only in tests: roots budgetsDirectory somewhere disposable.
+    private let rootDirectoryOverride: URL?
+
+    private init() {
+        rootDirectoryOverride = nil
+    }
+
+    #if DEBUG
+    /// Test-only: a file manager rooted at a custom directory so destructive
+    /// operations (logout's full wipe) can run isolated from the shared
+    /// Budgets directory while suites execute in parallel.
+    init(rootDirectoryForTesting: URL) {
+        rootDirectoryOverride = rootDirectoryForTesting
+    }
+    #endif
 
     // MARK: - Directories
 
     var budgetsDirectory: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let budgetsDir = appSupport.appendingPathComponent("Budgets", isDirectory: true)
+        let base = rootDirectoryOverride
+            ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let budgetsDir = base.appendingPathComponent("Budgets", isDirectory: true)
 
         if !fileManager.fileExists(atPath: budgetsDir.path) {
             try? fileManager.createDirectory(at: budgetsDir, withIntermediateDirectories: true)

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -72,6 +72,7 @@ struct SettingsView: View {
     ]
     @State private var password = ""
     @State private var showingResetSyncConfirm = false
+    @State private var showingDisconnectConfirm = false
     @State private var showingWalletImport = false
     @State private var budgetToUnlock: BudgetStore.RemoteBudget?
     @State private var showingBudgetSelectPrompt = false
@@ -241,8 +242,7 @@ struct SettingsView: View {
                         }
 
                         Button("Disconnect", role: .destructive) {
-                            budgetStore.logout()
-                            password = ""
+                            showingDisconnectConfirm = true
                         }
                     }
                 } header: {
@@ -536,6 +536,19 @@ struct SettingsView: View {
                 if budgetStore.isLoading {
                     ProgressView()
                 }
+            }
+            .confirmationDialog(
+                "Disconnect and remove data?",
+                isPresented: $showingDisconnectConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Disconnect & Remove Data", role: .destructive) {
+                    budgetStore.logout()
+                    password = ""
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Signs out and deletes this device's copy of your budgets. Any changes that haven't synced to the server yet will be lost. Your data on the server is not affected.")
             }
             .confirmationDialog(
                 "Reset sync state?",

--- a/Actuali/ActualiTests/BudgetStoreLogoutTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreLogoutTests.swift
@@ -1,0 +1,161 @@
+import CryptoKit
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Coverage for logout()'s local-data wipe: disconnecting must close the open
+/// database and sync client before deleting budget files (the same
+/// vnode-unlink hazard downloadBudget guards against), clear every piece of
+/// published budget state so nothing resurfaces on the next foreground
+/// refresh, and remove encrypted budgets' keys from the Keychain.
+@MainActor
+struct BudgetStoreLogoutTests {
+
+    /// Store + file manager rooted in a unique temp directory. logout wipes
+    /// *all* local budgets, and suites run in parallel against the shared
+    /// Budgets directory, so isolation is mandatory for these tests.
+    private func makeIsolatedStore() throws -> (BudgetStore, BudgetFileManager) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logout-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let manager = BudgetFileManager(rootDirectoryForTesting: root)
+        let store = BudgetStore.previewInstance()
+        store.setFileManagerForTesting(manager)
+        return (store, manager)
+    }
+
+    /// On-disk budget with the metadata.json that listLocalBudgets() keys on.
+    private func seedBudget(
+        id: String,
+        cloudFileId: String? = nil,
+        encryptKeyId: String? = nil,
+        in manager: BudgetFileManager
+    ) throws {
+        let dir = manager.budgetDirectory(for: id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("stub".utf8).write(to: manager.databasePath(for: id))
+        let metadata = BudgetMetadata(
+            id: id,
+            budgetName: "Test Budget",
+            cloudFileId: cloudFileId,
+            groupId: nil,
+            resetClock: nil,
+            lastUploaded: nil,
+            encryptKeyId: encryptKeyId
+        )
+        try JSONEncoder().encode(metadata).write(to: manager.metadataPath(for: id))
+    }
+
+    private func makeOpenDatabase() throws -> BudgetDatabase {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logout-db-\(UUID().uuidString).sqlite")
+        return try BudgetDatabase(path: url)
+    }
+
+    private func makeSyncClient() -> SyncClient {
+        SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+    }
+
+    @Test func deletesEveryLocalBudgetFromDisk() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", in: manager)
+        try seedBudget(id: "budget-b", in: manager)
+        #expect(manager.listLocalBudgets().count == 2)
+
+        store.logout()
+
+        #expect(manager.listLocalBudgets().isEmpty)
+        #expect(!manager.budgetExists("budget-a"))
+        #expect(!manager.budgetExists("budget-b"))
+    }
+
+    /// The open GRDB connection must be closed before the files go — an
+    /// unlinked-but-open database stays readable through its fd, so a later
+    /// foreground refresh would republish the "deleted" budget's data.
+    @Test func tearsDownDatabaseAndSyncClient() async throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", in: manager)
+        store.configureForTesting(database: try makeOpenDatabase(), syncClient: makeSyncClient())
+
+        store.logout()
+
+        #expect(store.databaseForLogger == nil)
+        // The sync client is gone too: with no client and no saved budget,
+        // a background sync reports "nothing to sync".
+        #expect(await store.syncInBackground() == false)
+    }
+
+    @Test func clearsAllPublishedBudgetState() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, _) = try makeIsolatedStore()
+        store.currentBudgetId = "budget-a"
+        store.accounts = [
+            Account(id: "a1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 100)
+        ]
+        store.transactions = [
+            Transaction(id: "t1", accountId: "a1", date: 20260810, amount: -500,
+                        payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+                        notes: nil, cleared: false, reconciled: false, transferId: nil,
+                        isParent: false, parentId: nil, tombstone: false, sortOrder: nil,
+                        importedPayee: nil)
+        ]
+        store.uncategorizedCount = 3
+        store.payees = [Payee(id: "p1", name: "Grocer")]
+        store.lastSyncTime = Date()
+
+        store.logout()
+
+        #expect(store.currentBudgetId == nil)
+        #expect(store.accounts.isEmpty)
+        #expect(store.transactions.isEmpty)
+        #expect(store.uncategorizedCount == 0)
+        #expect(store.payees.isEmpty)
+        #expect(store.lastSyncTime == nil)
+    }
+
+    /// "Leave nothing behind" includes the Keychain: an encrypted budget's
+    /// derived key must not outlive the budget files it unlocks.
+    @Test func removesEncryptionKeysForDeletedBudgets() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        let fileId = "cloud-file-\(UUID().uuidString)"
+        try seedBudget(id: "budget-enc", cloudFileId: fileId, encryptKeyId: "key-1", in: manager)
+        try EncryptionKeyManager.store(
+            LoadedKey(keyId: "key-1", key: SymmetricKey(size: .bits256)),
+            fileId: fileId
+        )
+        defer { try? EncryptionKeyManager.remove(fileId: fileId) }
+
+        store.logout()
+
+        #expect(EncryptionKeyManager.load(fileId: fileId) == nil)
+    }
+
+    /// The demo entry point (loadDemoData) clears the session so sync can't
+    /// fire against a real server, but it must not destroy locally-synced
+    /// budgets — only an explicit Disconnect wipes data.
+    @Test func preservesLocalDataWhenAskedTo() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", in: manager)
+        store.configureForTesting(database: try makeOpenDatabase(), syncClient: makeSyncClient())
+
+        store.logout(clearLocalData: false)
+
+        // The session and open connections still reset...
+        #expect(store.isConnected == false)
+        #expect(store.databaseForLogger == nil)
+        // ...but the on-disk budget survives.
+        #expect(manager.budgetExists("budget-a"))
+        #expect(manager.listLocalBudgets().count == 1)
+    }
+}


### PR DESCRIPTION
Why

Disconnect only cleared the auth token — the local database, cached accounts, categories, and payees stayed on disk and in memory. Someone tapping Disconnect would reasonably expect their data to actually be gone, not just be logged out of the server.

What
logout() now deletes every locally-synced budget's database and metadata from disk via BudgetFileManager.deleteBudget(_:).
Resets in-memory state (currentBudgetId, currentBudgetMonth, accounts, categoryGroups, payees) so nothing from the old budget lingers in the UI after disconnecting.

No other behavior changes — sign-in, demo mode, and the rest of Settings are untouched.

Tested on iphone 17 pro simulator