### PR TITLE
Refactor toolbar items in AccountDetailView

### DIFF
--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -150,13 +150,14 @@ struct AccountDetailView: View {
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
             }
-            ToolbarItemGroup(placement: .primaryAction) {
+            ToolbarItem(placement: .secondaryAction) {
                 Button {
                     showingReconcile = true
                 } label: {
-                    Image(systemName: "checkmark.seal")
+                    Label("Reconcile", systemImage: "checkmark.seal")
                 }
-                .accessibilityLabel("Reconcile")
+            }
+            ToolbarItem(placement: .primaryAction) {
                 Button {
                     showingAddTransaction = true
                 } label: {

--- a/Actuali/ActualiUITests/ReconciliationUITests.swift
+++ b/Actuali/ActualiUITests/ReconciliationUITests.swift
@@ -55,6 +55,11 @@ final class ReconciliationUITests: XCTestCase {
             NSPredicate(format: "label == 'Reconciled'")
         ).count, 0, "demo data starts with nothing reconciled")
 
+        // Reconcile sits in the toolbar's overflow menu, so open that first.
+        let moreButton = app.navigationBars.buttons["More"]
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 10))
+        moreButton.tap()
+
         let reconcileButton = app.buttons["Reconcile"]
         XCTAssertTrue(reconcileButton.waitForExistence(timeout: 10))
         reconcileButton.tap()


### PR DESCRIPTION
Move reconcile button along with import from wallet and Hide Cleared transactions buttons to declutter the page

Tested with Iphone 17 pro simulator