### PR TITLE
Run UI tests in CI

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,7 +1,7 @@
 # Companion to ci.yml: PRs that don't touch app code (website, docs) still get
-# passing "Build and Test" and "UI Tests" checks, so branch protection can
-# require them unconditionally. The paths-ignore list must mirror ci.yml's
-# paths list.
+# passing "Build and Test", "Unit Tests (iOS 18)" and "UI Tests" checks, so
+# branch protection can require them unconditionally. The paths-ignore list
+# must mirror ci.yml's paths list.
 name: CI (no app changes)
 
 on:
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No app code changed — skipping build and tests."
+
+  test-ios18:
+    name: Unit Tests (iOS 18)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No app code changed — skipping iOS 18 tests."
 
   ui-test:
     name: UI Tests

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,6 +1,7 @@
 # Companion to ci.yml: PRs that don't touch app code (website, docs) still get
-# a passing "Build and Test" check, so branch protection can require it
-# unconditionally. The paths-ignore list must mirror ci.yml's paths list.
+# passing "Build and Test" and "UI Tests" checks, so branch protection can
+# require them unconditionally. The paths-ignore list must mirror ci.yml's
+# paths list.
 name: CI (no app changes)
 
 on:
@@ -19,3 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No app code changed — skipping build and tests."
+
+  ui-test:
+    name: UI Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No app code changed — skipping UI tests."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Builds the app and runs unit tests and UI tests on every PR that touches
-# app code. Branch protection requires the "Build and Test" and "UI Tests"
-# checks; ci-noop.yml provides the same check names for PRs that don't touch
-# app code.
+# app code. Branch protection requires the "Build and Test", "Unit Tests
+# (iOS 18)" and "UI Tests" checks; ci-noop.yml provides the same check names
+# for PRs that don't touch app code.
 name: CI
 
 on:
@@ -39,10 +39,37 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      # IPHONEOS_DEPLOYMENT_TARGET is 18.0, so the floor needs a runtime of its
-      # own: the compiler rejects an unavailable API, but a missing SF Symbol or
-      # a behaviour difference only shows up when the tests actually run there.
-      # The runner image ships iOS 26 only, so this usually downloads (~8 GB).
+      # UI tests run in the separate ui-test job so the unit-test signal stays
+      # fast. Simulator builds are ad-hoc signed, so no certificate is needed —
+      # but don't pass CODE_SIGNING_ALLOWED=NO: an unsigned test host can't
+      # reach the simulator keychain (errSecMissingEntitlement in
+      # EncryptionKeyManager tests).
+      # xcbeautify (preinstalled on macOS runners) keeps the log readable;
+      # --quiet drops passing-task noise but keeps warnings and errors;
+      # pipefail preserves xcodebuild's exit code through the pipe.
+      - name: Build and run unit tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Actuali/Actuali.xcodeproj \
+            -scheme Actuali \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+            -skip-testing:ActualiUITests \
+            | xcbeautify --quiet
+
+  # IPHONEOS_DEPLOYMENT_TARGET is 18.0, so the floor needs a runtime of its
+  # own: the compiler rejects an unavailable API, but a missing SF Symbol or
+  # a behaviour difference only shows up when the tests actually run there.
+  # A separate job so the ~4-minute runtime download (the runner image ships
+  # iOS 26 only) and this leg's test run overlap the iOS 26 leg instead of
+  # serializing behind it.
+  test-ios18:
+    name: Unit Tests (iOS 18)
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
       - name: Select iOS 18 simulator
         id: sim18
         run: |
@@ -68,26 +95,7 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      # UI tests run in the separate ui-test job so the unit-test signal stays
-      # fast. Simulator builds are ad-hoc signed, so no certificate is needed —
-      # but don't pass CODE_SIGNING_ALLOWED=NO: an unsigned test host can't
-      # reach the simulator keychain (errSecMissingEntitlement in
-      # EncryptionKeyManager tests).
-      # xcbeautify (preinstalled on macOS runners) keeps the log readable;
-      # --quiet drops passing-task noise but keeps warnings and errors;
-      # pipefail preserves xcodebuild's exit code through the pipe.
-      - name: Build and run unit tests
-        run: |
-          set -o pipefail
-          xcodebuild test \
-            -project Actuali/Actuali.xcodeproj \
-            -scheme Actuali \
-            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
-            -skip-testing:ActualiUITests \
-            | xcbeautify --quiet
-
-      # Same build products, so this leg is mostly just test execution.
-      - name: Run unit tests on iOS 18 (minimum supported)
+      - name: Build and run unit tests on iOS 18 (minimum supported)
         run: |
           set -o pipefail
           xcodebuild test \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,15 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
+      # A connected hardware keyboard makes XCUITest typeText silently drop
+      # keystrokes (or throw focus errors) on headless runners; the tests
+      # drive budget amounts by typing, so force the software keyboard.
+      - name: Disable simulator hardware keyboard
+        run: |
+          defaults write com.apple.iphonesimulator DevicePreferences \
+            -dict-add "${{ steps.sim.outputs.id }}" \
+            "<dict><key>ConnectHardwareKeyboard</key><false/></dict>"
+
       # UI tests are slower and flakier on shared runners, so failed tests
       # retry up to 3 runs before the job fails.
       - name: Build and run UI tests
@@ -126,4 +135,16 @@ jobs:
             -only-testing:ActualiUITests \
             -retry-tests-on-failure \
             -test-iterations 3 \
+            -resultBundlePath TestResults/ActualiUITests.xcresult \
             | xcbeautify --quiet
+
+      # The tests attach screenshots at each checkpoint; keep them (and the
+      # full activity log) when a run fails on the runner but not locally.
+      - name: Upload result bundle
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results
+          path: TestResults
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# Builds the app and runs unit tests on every PR that touches app code.
-# Branch protection requires the "Build and Test" check; ci-noop.yml provides
-# the same check name for PRs that don't touch app code.
+# Builds the app and runs unit tests and UI tests on every PR that touches
+# app code. Branch protection requires the "Build and Test" check; ci-noop.yml
+# provides the same check names for PRs that don't touch app code.
 name: CI
 
 on:
@@ -67,11 +67,11 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      # UI tests are skipped: too slow and flaky on shared runners. Simulator
-      # builds are ad-hoc signed, so no certificate is needed — but don't pass
-      # CODE_SIGNING_ALLOWED=NO: an unsigned test host can't reach the
-      # simulator keychain (errSecMissingEntitlement in EncryptionKeyManager
-      # tests).
+      # UI tests run in the separate ui-test job so the unit-test signal stays
+      # fast. Simulator builds are ad-hoc signed, so no certificate is needed —
+      # but don't pass CODE_SIGNING_ALLOWED=NO: an unsigned test host can't
+      # reach the simulator keychain (errSecMissingEntitlement in
+      # EncryptionKeyManager tests).
       # xcbeautify (preinstalled on macOS runners) keeps the log readable;
       # --quiet drops passing-task noise but keeps warnings and errors;
       # pipefail preserves xcodebuild's exit code through the pipe.
@@ -94,4 +94,36 @@ jobs:
             -scheme Actuali \
             -destination "platform=iOS Simulator,id=${{ steps.sim18.outputs.id }}" \
             -skip-testing:ActualiUITests \
+            | xcbeautify --quiet
+
+  ui-test:
+    name: UI Tests
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select simulator
+        id: sim
+        run: |
+          SIM_ID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid')
+          if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
+            echo "No available iPhone simulator on this runner" >&2
+            exit 1
+          fi
+          echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
+
+      # UI tests are slower and flakier on shared runners, so failed tests
+      # retry up to 3 runs before the job fails.
+      - name: Build and run UI tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Actuali/Actuali.xcodeproj \
+            -scheme Actuali \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+            -only-testing:ActualiUITests \
+            -retry-tests-on-failure \
+            -test-iterations 3 \
             | xcbeautify --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 # Builds the app and runs unit tests and UI tests on every PR that touches
-# app code. Branch protection requires the "Build and Test" check; ci-noop.yml
-# provides the same check names for PRs that don't touch app code.
+# app code. Branch protection requires the "Build and Test" and "UI Tests"
+# checks; ci-noop.yml provides the same check names for PRs that don't touch
+# app code.
 name: CI
 
 on:
@@ -114,9 +115,12 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      # A connected hardware keyboard makes XCUITest typeText silently drop
-      # keystrokes (or throw focus errors) on headless runners; the tests
-      # drive budget amounts by typing, so force the software keyboard.
+      # A connected hardware keyboard makes the simulator minimize the
+      # software keyboard, so keypad taps land on off-screen keys; the tests
+      # drive budget amounts through the keypad. This host-side pref only
+      # protects a device that has never seen a hardware keyboard (true for
+      # fresh runner sims) — a device that already remembers one needs its
+      # device-side com.apple.keyboard.preferences reset instead.
       - name: Disable simulator hardware keyboard
         run: |
           defaults write com.apple.iphonesimulator DevicePreferences \
@@ -124,7 +128,8 @@ jobs:
             "<dict><key>ConnectHardwareKeyboard</key><false/></dict>"
 
       # UI tests are slower and flakier on shared runners, so failed tests
-      # retry up to 3 runs before the job fails.
+      # retry up to 3 runs before the job fails. Two parallel workers (sim
+      # clones) roughly halve the test-execution phase.
       - name: Build and run UI tests
         run: |
           set -o pipefail
@@ -135,6 +140,8 @@ jobs:
             -only-testing:ActualiUITests \
             -retry-tests-on-failure \
             -test-iterations 3 \
+            -parallel-testing-enabled YES \
+            -parallel-testing-worker-count 2 \
             -resultBundlePath TestResults/ActualiUITests.xcresult \
             | xcbeautify --quiet
 

--- a/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
@@ -73,7 +73,7 @@ final class AddTransactionKeyboardUITests: XCTestCase {
         XCTAssertTrue(accountRow.waitForExistence(timeout: 10), "Chase Checking row not found")
         accountRow.tap()
 
-        let addButton = app.navigationBars.buttons["Add"]
+        let addButton = app.navigationBars.buttons["Add Transaction"]
         XCTAssertTrue(addButton.waitForExistence(timeout: 5), "'+' toolbar button not found")
         addButton.tap()
 

--- a/Actuali/ActualiUITests/AddTransactionPostSaveUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionPostSaveUITests.swift
@@ -27,7 +27,9 @@ final class AddTransactionPostSaveUITests: XCTestCase {
         XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
                       "keyboard did not dismiss")
 
-        let save = app.buttons["Add Transaction"].firstMatch
+        // Scoped to the form: the account detail's "+" toolbar button behind
+        // the sheet carries the same "Add Transaction" label since #181.
+        let save = app.collectionViews.buttons["Add Transaction"].firstMatch
         XCTAssertTrue(save.waitForExistence(timeout: 5), "save button not found")
         save.tap()
     }
@@ -44,7 +46,7 @@ final class AddTransactionPostSaveUITests: XCTestCase {
         XCTAssertTrue(accountRow.waitForExistence(timeout: 10), "Chase Checking row not found")
         accountRow.tap()
 
-        let addButton = app.navigationBars.buttons["Add"]
+        let addButton = app.navigationBars.buttons["Add Transaction"]
         XCTAssertTrue(addButton.waitForExistence(timeout: 5), "'+' toolbar button not found")
         addButton.tap()
 

--- a/Actuali/ActualiUITests/BudgetEntrySupport.swift
+++ b/Actuali/ActualiUITests/BudgetEntrySupport.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+extension XCTestCase {
+    /// Opens the category's edit-budget sheet and types a new amount.
+    /// The amount field interprets bare digits as cents ("100" → 1.00).
+    @MainActor
+    func setBudget(_ app: XCUIApplication, category: String, centsKeystrokes: String) {
+        let editButton = app.buttons["Edit budgeted amount for \(category)"]
+        var scrollsLeft = 8
+        while !editButton.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(editButton.isHittable, "edit button for \(category) not reachable")
+        editButton.tap()
+
+        let field = app.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
+        // The sheet autofocuses the field; the decimal pad appearing is the
+        // signal that it's ready. Enter the amount by tapping keypad keys —
+        // typeText's focus-dependent event synthesis flakes on CI runners.
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
+                      "keyboard did not appear for the amount field")
+        // Keypad taps cost over a second each, so clear only what's there.
+        // An empty field reports its placeholder as the value; deleting
+        // those few phantom characters is a harmless no-op.
+        let deleteKey = app.keys["Delete"]
+        let existing = (field.value as? String) ?? ""
+        for _ in 0..<min(existing.count, 10) { deleteKey.tap() }
+        for digit in centsKeystrokes {
+            app.keys[String(digit)].tap()
+        }
+
+        let saveButton = app.buttons["Save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")
+        saveButton.tap()
+        // Sheet dismissal returns us to the budget list.
+        XCTAssertTrue(field.waitForNonExistence(timeout: 5), "edit sheet did not dismiss")
+    }
+}

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -12,7 +12,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
 
@@ -39,7 +39,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
 

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -78,7 +78,7 @@ final class BudgetOptionsMenuUITests: XCTestCase {
 
         let optionsMenu = app.buttons["Budget options"]
         XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
-        XCTAssertTrue(app.buttons["All transactions for Groceries"].firstMatch
+        XCTAssertTrue(app.buttons["Details for Groceries"].firstMatch
             .waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
 

--- a/Actuali/ActualiUITests/BudgetSummaryPinUITests.swift
+++ b/Actuali/ActualiUITests/BudgetSummaryPinUITests.swift
@@ -14,7 +14,7 @@ final class BudgetSummaryPinUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
 

--- a/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
+++ b/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
@@ -71,20 +71,16 @@ final class BudgetTabBadgeUITests: XCTestCase {
 
         let field = app.textFields.firstMatch
         XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
-        field.tap()
-        // A tap that lands while the sheet is still animating in focuses
-        // nothing (seen on CI runners) — re-tap until focus takes.
-        var focusTries = 10
-        while !field.hasKeyboardFocus && focusTries > 0 {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-            if !field.hasKeyboardFocus { field.tap() }
-            focusTries -= 1
+        // The sheet autofocuses the field; the decimal pad appearing is the
+        // signal that it's ready. Enter the amount by tapping keypad keys —
+        // typeText's focus-dependent event synthesis flakes on CI runners.
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
+                      "keyboard did not appear for the amount field")
+        let deleteKey = app.keys["Delete"]
+        for _ in 0..<10 { deleteKey.tap() }
+        for digit in centsKeystrokes {
+            app.keys[String(digit)].tap()
         }
-        XCTAssertTrue(field.hasKeyboardFocus, "amount field never took keyboard focus")
-        // Focus select-alls the current value asynchronously; don't rely on
-        // that racing in our favor — backspace the old value away instead.
-        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))
-        field.typeText(centsKeystrokes)
 
         let saveButton = app.buttons["Save"]
         XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")
@@ -126,13 +122,5 @@ final class BudgetTabBadgeUITests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
-    }
-}
-
-extension XCUIElement {
-    /// XCUITest exposes keyboard focus only through the accessibility
-    /// attribute; there is no public iOS API for it.
-    var hasKeyboardFocus: Bool {
-        (value(forKey: "hasKeyboardFocus") as? Bool) ?? false
     }
 }

--- a/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
+++ b/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
@@ -56,39 +56,6 @@ final class BudgetTabBadgeUITests: XCTestCase {
         attachScreenshot(app, name: "4-badge-cleared")
     }
 
-    /// Opens the category's edit-budget sheet and types a new amount.
-    /// The amount field interprets bare digits as cents ("100" → 1.00).
-    @MainActor
-    private func setBudget(_ app: XCUIApplication, category: String, centsKeystrokes: String) {
-        let editButton = app.buttons["Edit budgeted amount for \(category)"]
-        var scrollsLeft = 8
-        while !editButton.isHittable && scrollsLeft > 0 {
-            app.swipeUp()
-            scrollsLeft -= 1
-        }
-        XCTAssertTrue(editButton.isHittable, "edit button for \(category) not reachable")
-        editButton.tap()
-
-        let field = app.textFields.firstMatch
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
-        // The sheet autofocuses the field; the decimal pad appearing is the
-        // signal that it's ready. Enter the amount by tapping keypad keys —
-        // typeText's focus-dependent event synthesis flakes on CI runners.
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
-                      "keyboard did not appear for the amount field")
-        let deleteKey = app.keys["Delete"]
-        for _ in 0..<10 { deleteKey.tap() }
-        for digit in centsKeystrokes {
-            app.keys[String(digit)].tap()
-        }
-
-        let saveButton = app.buttons["Save"]
-        XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")
-        saveButton.tap()
-        // Sheet dismissal returns us to the budget list.
-        XCTAssertTrue(field.waitForNonExistence(timeout: 5), "edit sheet did not dismiss")
-    }
-
     /// A SwiftUI Toggle row exposes itself as a switch, but taps on the row
     /// don't flip it — the actual control is a nested switch element.
     @MainActor

--- a/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
+++ b/Actuali/ActualiUITests/BudgetTabBadgeUITests.swift
@@ -72,6 +72,15 @@ final class BudgetTabBadgeUITests: XCTestCase {
         let field = app.textFields.firstMatch
         XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
         field.tap()
+        // A tap that lands while the sheet is still animating in focuses
+        // nothing (seen on CI runners) — re-tap until focus takes.
+        var focusTries = 10
+        while !field.hasKeyboardFocus && focusTries > 0 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if !field.hasKeyboardFocus { field.tap() }
+            focusTries -= 1
+        }
+        XCTAssertTrue(field.hasKeyboardFocus, "amount field never took keyboard focus")
         // Focus select-alls the current value asynchronously; don't rely on
         // that racing in our favor — backspace the old value away instead.
         field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))
@@ -117,5 +126,13 @@ final class BudgetTabBadgeUITests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+}
+
+extension XCUIElement {
+    /// XCUITest exposes keyboard focus only through the accessibility
+    /// attribute; there is no public iOS API for it.
+    var hasKeyboardFocus: Bool {
+        (value(forKey: "hasKeyboardFocus") as? Bool) ?? false
     }
 }

--- a/Actuali/ActualiUITests/CategoryNotesUITests.swift
+++ b/Actuali/ActualiUITests/CategoryNotesUITests.swift
@@ -17,8 +17,12 @@ final class CategoryNotesUITests: XCTestCase {
         XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
                       "Budget tab not found")
 
-        // Groceries is the demo category that ships annotated.
-        let groceries = app.buttons["All transactions for Groceries"]
+        // Groceries is the demo category that ships annotated. The spent pill
+        // opens the transactions view (#243 repurposed the name button for
+        // category details); its label ends with the current month.
+        let groceries = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Transactions for Groceries in'")
+        ).firstMatch
         var scrollsLeft = 8
         while !groceries.isHittable && scrollsLeft > 0 {
             app.swipeUp()
@@ -73,7 +77,9 @@ final class CategoryNotesUITests: XCTestCase {
         XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
                       "Budget tab not found")
 
-        let rent = app.buttons["All transactions for Rent"]
+        let rent = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Transactions for Rent in'")
+        ).firstMatch
         var scrollsLeft = 8
         while !rent.isHittable && scrollsLeft > 0 {
             app.swipeUp()

--- a/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
+++ b/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
@@ -118,7 +118,7 @@ final class IPadSplitLayoutUITests: XCTestCase {
         try XCTSkipUnless(app.windows.firstMatch.frame.width > 760,
                           "nothing to cap; this window is narrower than the cap")
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 15), "budget rows should load")
 
         let windowWidth = app.windows.firstMatch.frame.width

--- a/Actuali/ActualiUITests/NoteLinksUITests.swift
+++ b/Actuali/ActualiUITests/NoteLinksUITests.swift
@@ -17,7 +17,11 @@ final class NoteLinksUITests: XCTestCase {
         XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
                       "Budget tab not found")
 
-        let dining = app.buttons["All transactions for Dining Out"]
+        // The spent pill opens the transactions view (#243 repurposed the
+        // name button for category details); its label ends with the month.
+        let dining = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Transactions for Dining Out in'")
+        ).firstMatch
         var scrollsLeft = 8
         while !dining.isHittable && scrollsLeft > 0 {
             app.swipeUp()

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -76,20 +76,16 @@ final class OverspentCategoriesUITests: XCTestCase {
 
         let field = app.textFields.firstMatch
         XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
-        field.tap()
-        // A tap that lands while the sheet is still animating in focuses
-        // nothing (seen on CI runners) — re-tap until focus takes.
-        var focusTries = 10
-        while !field.hasKeyboardFocus && focusTries > 0 {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-            if !field.hasKeyboardFocus { field.tap() }
-            focusTries -= 1
+        // The sheet autofocuses the field; the decimal pad appearing is the
+        // signal that it's ready. Enter the amount by tapping keypad keys —
+        // typeText's focus-dependent event synthesis flakes on CI runners.
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
+                      "keyboard did not appear for the amount field")
+        let deleteKey = app.keys["Delete"]
+        for _ in 0..<10 { deleteKey.tap() }
+        for digit in centsKeystrokes {
+            app.keys[String(digit)].tap()
         }
-        XCTAssertTrue(field.hasKeyboardFocus, "amount field never took keyboard focus")
-        // Focus select-alls the current value asynchronously; don't rely on
-        // that racing in our favor — backspace the old value away instead.
-        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))
-        field.typeText(centsKeystrokes)
 
         let saveButton = app.buttons["Save"]
         XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -61,39 +61,6 @@ final class OverspentCategoriesUITests: XCTestCase {
         attachScreenshot(app, name: "3-overspent-filter-cleared")
     }
 
-    /// Opens the category's edit-budget sheet and types a new amount.
-    /// The amount field interprets bare digits as cents ("100" → 1.00).
-    @MainActor
-    private func setBudget(_ app: XCUIApplication, category: String, centsKeystrokes: String) {
-        let editButton = app.buttons["Edit budgeted amount for \(category)"]
-        var scrollsLeft = 8
-        while !editButton.isHittable && scrollsLeft > 0 {
-            app.swipeUp()
-            scrollsLeft -= 1
-        }
-        XCTAssertTrue(editButton.isHittable, "edit button for \(category) not reachable")
-        editButton.tap()
-
-        let field = app.textFields.firstMatch
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
-        // The sheet autofocuses the field; the decimal pad appearing is the
-        // signal that it's ready. Enter the amount by tapping keypad keys —
-        // typeText's focus-dependent event synthesis flakes on CI runners.
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
-                      "keyboard did not appear for the amount field")
-        let deleteKey = app.keys["Delete"]
-        for _ in 0..<10 { deleteKey.tap() }
-        for digit in centsKeystrokes {
-            app.keys[String(digit)].tap()
-        }
-
-        let saveButton = app.buttons["Save"]
-        XCTAssertTrue(saveButton.waitForExistence(timeout: 5), "Save button not shown")
-        saveButton.tap()
-        // Sheet dismissal returns us to the budget list.
-        XCTAssertTrue(field.waitForNonExistence(timeout: 5), "edit sheet did not dismiss")
-    }
-
     /// The status strip is pinned above the (possibly scrolled) budget list.
     @MainActor
     private func scrollToTop(_ app: XCUIApplication) {

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -77,6 +77,15 @@ final class OverspentCategoriesUITests: XCTestCase {
         let field = app.textFields.firstMatch
         XCTAssertTrue(field.waitForExistence(timeout: 5), "amount field not shown")
         field.tap()
+        // A tap that lands while the sheet is still animating in focuses
+        // nothing (seen on CI runners) — re-tap until focus takes.
+        var focusTries = 10
+        while !field.hasKeyboardFocus && focusTries > 0 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if !field.hasKeyboardFocus { field.tap() }
+            focusTries -= 1
+        }
+        XCTAssertTrue(field.hasKeyboardFocus, "amount field never took keyboard focus")
         // Focus select-alls the current value asynchronously; don't rely on
         // that racing in our favor — backspace the old value away instead.
         field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))

--- a/Actuali/ActualiUITests/TransactionSearchUITests.swift
+++ b/Actuali/ActualiUITests/TransactionSearchUITests.swift
@@ -36,9 +36,13 @@ final class TransactionSearchUITests: XCTestCase {
                       "no-match search should show the No Results state")
         XCTAssertFalse(netflixRow.exists)
 
-        // Clearing the query restores the unfiltered paged list.
+        // Clearing the query restores the unfiltered paged list. Any row
+        // proves the restore: the list is date-sorted and lazy, so the
+        // Netflix row itself sits below the fold on days before the 11th
+        // (the demo Netflix charge posts on the 11th of each month).
         searchField.buttons["Clear text"].tap()
-        XCTAssertTrue(netflixRow.waitForExistence(timeout: 10),
+        XCTAssertTrue(app.cells.firstMatch.waitForExistence(timeout: 10),
                       "clearing the search should restore the transaction list")
+        XCTAssertFalse(noResults.exists)
     }
 }


### PR DESCRIPTION
Closes #351 

## Why

CI has been skipping `ActualiUITests` ("too slow and flaky on shared runners"), so UI regressions only surface when someone runs the suite locally. The flakiness turned out to be real, diagnosable test bugs plus one runner-environment issue — not random runner instability.

## What

**CI**
- `ci.yml`: new `UI Tests` job running `-only-testing:ActualiUITests` in parallel with the existing unit-test job, with `-retry-tests-on-failure -test-iterations 3` and a 60-minute timeout. The fast unit-test check is unchanged.
- Disables the simulator hardware keyboard so the software keyboard behaves normally on headless runners.
- Uploads the `.xcresult` bundle (with the tests' checkpoint screenshots) as an artifact when the job fails, so runner-only failures are diagnosable.
- `ci-noop.yml`: matching `UI Tests` noop check, so branch protection can require it unconditionally (adding it there is a separate manual step).

**Test fixes**
- `TransactionSearchUITests`: asserted the Netflix row reappears after clearing the search, but the demo Netflix charge posts on the 11th of the month — on days 1–10 the newest Netflix row sits a month deep in the date-sorted lazy list, invisible to XCUITest. Failed every run before the 11th. Now asserts any transaction row returns (the actual intent — GH #65's bug was the list staying empty).
- `BudgetTabBadgeUITests`: Settings has grown (#158, #116, #141) and pushed the "Overspent Badge" toggle below the fold; lazy lists don't expose off-screen rows. Now scrolls until the toggle is hittable.
- `BudgetTabBadgeUITests` + `OverspentCategoriesUITests`: `typeText` into the edit-budget amount field failed on runners with 'Neither element nor any descendant has keyboard focus' — first-responder status flaps while the medium-detent sheet relayouts for the keyboard. The tests now wait for the decimal pad and tap keypad keys directly (plain element taps, the interaction that already proved reliable on runners).

**App**
- `AmountInputField` gains an `autofocus` option (`becomeFirstResponder` in `didMoveToWindow`), and the edit-budget sheet opts in. The sheet exists solely to enter an amount, so the keyboard coming up ready is a small UX win — and it removes the tap-during-sheet-animation race the tests kept losing. Other `AmountInputField` uses (add transaction, reconcile) are unchanged.

## How it was tested

- Full `ActualiUITests` suite (20 tests) passes locally on a dedicated fresh iPhone 17 / iOS 26.5 simulator using the exact CI invocation.
- The `UI Tests` CI job on this PR is green (earlier commits on this branch show the failure/fix progression on real runners).
- `AddTransactionKeyboardUITests` and `ReconciliationUITests` re-run locally to cover the `AmountInputField` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Budget amount fields now automatically focus when the edit screen opens, making entry faster.

- **Bug Fixes**
  - Improved budget and transaction input behavior for more reliable keyboard and keypad entry.
  - Clearing transaction searches now consistently restores available results and exits the “No Results” state.
  - Settings controls are more reliably located during scrolling.

- **Tests**
  - UI tests now run separately with simulator coverage, retries, and failure-result uploads.
  - Updated checks improve reliability for budget entry, overspent badges, categories, and transaction search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->