### PR TITLE
Explain connection failures instead of showing raw CFNetwork errors

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -379,7 +379,7 @@ final class BudgetStore: ObservableObject {
 
     // MARK: - Private
 
-    private let serverClient = ActualServerClient()
+    private var serverClient = ActualServerClient()
     private var fileManager = BudgetFileManager.shared
     private var database: BudgetDatabase? {
         didSet {
@@ -659,6 +659,12 @@ final class BudgetStore: ObservableObject {
         loadTask = Task {}
     }
 
+    /// Test-only: swap in a server client wired to a stub transport so the
+    /// login and probe paths can be exercised without a reachable server.
+    func setServerClientForTesting(_ client: ActualServerClient) {
+        serverClient = client
+    }
+
     /// Test-only: swap in a file manager rooted at a temp directory so
     /// logout()'s full wipe can be exercised without touching the shared
     /// Budgets directory (parallel suites create real budgets there).
@@ -840,6 +846,12 @@ final class BudgetStore: ObservableObject {
         isLoading = false
     }
 
+    /// The login methods a server is assumed to offer when the probe can't tell
+    /// us — password auth is the safe assumption and keeps the flow usable.
+    private static let passwordOnlyLoginMethods = [
+        LoginMethod(method: "password", displayName: "Password", active: 1)
+    ]
+
     /// Probe the configured server for its available login methods so the UI can
     /// offer password and/or OpenID sign-in. Best-effort: on failure we fall back
     /// to password-only so the existing flow keeps working.
@@ -850,10 +862,19 @@ final class BudgetStore: ObservableObject {
             // Surface the actionable hint proactively rather than waiting for the
             // login attempt to fail with the same cryptic-looking response.
             error = ActualServerError.authProxyBlocked.localizedDescription
-            availableLoginMethods = [LoginMethod(method: "password", displayName: "Password", active: 1)]
+            availableLoginMethods = Self.passwordOnlyLoginMethods
+        } catch let probeError as ActualServerError where probeError.isConnectionFailure {
+            // The server isn't reachable, so falling back to password login
+            // would fail identically. Say why now — otherwise tapping Connect
+            // with an empty password looks like it did nothing at all.
+            error = probeError.localizedDescription
+            availableLoginMethods = Self.passwordOnlyLoginMethods
         } catch {
+            // Reachable, but the probe was unusable: older servers without the
+            // endpoint, or a proxy stripping the route. Stay quiet and let the
+            // login attempt report anything that's actually wrong.
             logger.error("Failed to fetch login methods: \(error.localizedDescription, privacy: .public)")
-            availableLoginMethods = [LoginMethod(method: "password", displayName: "Password", active: 1)]
+            availableLoginMethods = Self.passwordOnlyLoginMethods
         }
         // Only relevant when OpenID is offered; cheap enough to always refresh.
         if supportsOpenIDLogin {

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -23,11 +23,65 @@ enum ActualServerError: LocalizedError {
         case .unauthorized:
             return "Unauthorized - please log in again"
         case .networkError(let error):
-            return "Network error: \(error.localizedDescription)"
+            return Self.connectionFailureMessage(for: error)
         case .decodingError(let error):
             return "Failed to decode response: \(error.localizedDescription)"
         case .fileNotFound:
             return "Budget file not found"
+        }
+    }
+
+    /// Where the troubleshooting steps for each of these live.
+    private static let helpLink = "actuali.mfazz.com/support"
+
+    /// Turns a transport failure into something a non-technical user can act
+    /// on. Left to itself, CFNetwork surfaces strings like "TLS Error caused
+    /// the secure connection to fail" or a bare `NSURLErrorDomain error -1200`,
+    /// which tell the user nothing about what to change.
+    static func connectionFailureMessage(for error: Error) -> String {
+        guard let urlError = error as? URLError else {
+            return "Couldn't connect to your server: \(error.localizedDescription) See \(helpLink) for help."
+        }
+
+        switch urlError.code {
+        case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasUnknownRoot:
+            return """
+                Couldn't make a secure connection to your server — iOS doesn't trust its security \
+                certificate. This usually means the server is using its own self-signed certificate. \
+                See \(helpLink) for how to fix it.
+                """
+        case .serverCertificateHasBadDate, .serverCertificateNotYetValid:
+            return """
+                Your server's security certificate has expired, so iOS blocked the connection. \
+                Renewing the certificate on the server will fix this. See \(helpLink) for help.
+                """
+        case .appTransportSecurityRequiresSecureConnection:
+            return """
+                Actuali can only connect over a secure address. Check that your server URL starts \
+                with https:// — see \(helpLink) for help.
+                """
+        case .cannotFindHost, .dnsLookupFailed:
+            return """
+                Couldn't find a server at that address. Check the server URL for typos. \
+                See \(helpLink) for help.
+                """
+        case .cannotConnectToHost:
+            return """
+                Couldn't reach your server. If it's only available on your home network, connect to \
+                that network and try again. See \(helpLink) for help.
+                """
+        case .notConnectedToInternet:
+            return "Your device isn't connected to the internet."
+        case .timedOut:
+            return """
+                Your server took too long to respond. It may be offline, or blocked on this network. \
+                See \(helpLink) for help.
+                """
+        default:
+            return """
+                Couldn't connect to your server: \(urlError.localizedDescription) \
+                See \(helpLink) for help.
+                """
         }
     }
 }
@@ -141,7 +195,13 @@ actor ActualServerClient {
     /// always take precedence.
     private var customHeaders: [(name: String, value: String)] = []
 
-    init() {
+    /// - Parameter session: overridable so tests can drive the client through a
+    ///   stub transport; production callers take the default.
+    init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+            return
+        }
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 300
@@ -174,6 +234,19 @@ actor ActualServerClient {
             request.setValue(header.value, forHTTPHeaderField: header.name)
         }
         return request
+    }
+
+    /// Perform a request, translating transport failures into
+    /// `ActualServerError.networkError` so callers surface actionable guidance
+    /// instead of CFNetwork's raw description.
+    private func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let urlError as URLError where urlError.code != .cancelled {
+            // Cancellation is ordinary control flow (a superseded refresh, a
+            // screen the user left), so it propagates untouched.
+            throw ActualServerError.networkError(urlError)
+        }
     }
 
     /// Whether a response looks like an auth proxy's login page rather than the
@@ -216,7 +289,7 @@ actor ActualServerClient {
         let body = ["password": password]
         request.httpBody = try JSONEncoder().encode(body)
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -261,7 +334,7 @@ actor ActualServerClient {
         var request = makeRequest(url)
         request.httpMethod = "GET"
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -365,7 +438,7 @@ actor ActualServerClient {
         }
         request.httpBody = try JSONEncoder().encode(body)
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -405,7 +478,7 @@ actor ActualServerClient {
         request.httpMethod = "GET"
         request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -445,7 +518,7 @@ actor ActualServerClient {
         request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
         request.setValue(fileId, forHTTPHeaderField: "X-ACTUAL-FILE-ID")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -482,7 +555,7 @@ actor ActualServerClient {
         request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
         request.setValue(fileId, forHTTPHeaderField: "X-ACTUAL-FILE-ID")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
@@ -517,7 +590,7 @@ actor ActualServerClient {
         request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
         request.httpBody = try JSONEncoder().encode(["token": token, "fileId": fileId])
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
         }
@@ -551,7 +624,7 @@ actor ActualServerClient {
         request.setValue("application/actual-sync", forHTTPHeaderField: "Content-Type")
         request.httpBody = requestData
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await send(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -31,6 +31,14 @@ enum ActualServerError: LocalizedError {
         }
     }
 
+    /// Whether the server couldn't be reached at all, as opposed to answering
+    /// with something unusable. Callers that fall back to a degraded mode on
+    /// failure use this to tell "old server" apart from "no server".
+    var isConnectionFailure: Bool {
+        if case .networkError = self { return true }
+        return false
+    }
+
     /// Where the troubleshooting steps for each of these live.
     private static let helpLink = "actuali.mfazz.com/support"
 

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -189,6 +189,10 @@ struct SettingsView: View {
                                 // Discover available auth methods, then log in with
                                 // password directly when that's the active method.
                                 await budgetStore.checkLoginMethods()
+                                // A probe that couldn't reach the server has
+                                // already explained why; don't repeat the same
+                                // failure as a login attempt.
+                                guard budgetStore.error == nil else { return }
                                 if budgetStore.passwordLoginActive && !password.isEmpty {
                                     await budgetStore.login(password: password)
                                 }

--- a/Actuali/ActualiTests/BudgetStoreLoginProbeTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreLoginProbeTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Either fails the request outright or answers with a canned HTTP status, so
+/// the login-methods probe can be driven down both paths without a server.
+private final class ProbeTransport: URLProtocol {
+    enum Outcome {
+        case failure(URLError)
+        case status(Int)
+    }
+
+    nonisolated(unsafe) static var outcome = Outcome.failure(URLError(.secureConnectionFailed))
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        switch Self.outcome {
+        case .failure(let error):
+            client?.urlProtocol(self, didFailWithError: error)
+        case .status(let code):
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: code,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data("{}".utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+/// `checkLoginMethods` deliberately swallows probe failures and falls back to
+/// password login, which is right for older servers that lack the endpoint but
+/// wrong when the server can't be reached at all — the user tapped Connect and
+/// got no feedback whatsoever.
+@Suite(.serialized)
+@MainActor
+struct BudgetStoreLoginProbeTests {
+
+    private func makeStore(_ outcome: ProbeTransport.Outcome) async -> BudgetStore {
+        ProbeTransport.outcome = outcome
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ProbeTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: config))
+        try? await client.configure(serverURL: "https://budget.example.com")
+
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(client)
+        return store
+    }
+
+    @Test func unreachableServerTellsTheUserWhyInsteadOfFailingSilently() async {
+        let store = await makeStore(.failure(URLError(.secureConnectionFailed)))
+
+        await store.checkLoginMethods()
+
+        let message = try? #require(store.error)
+        #expect(message?.localizedCaseInsensitiveContains("certificate") == true)
+    }
+
+    /// Password login still has to be offered after a connection failure, so
+    /// the user can fix the server and retry without restarting the app.
+    @Test func passwordLoginRemainsAvailableAfterAConnectionFailure() async {
+        let store = await makeStore(.failure(URLError(.cannotConnectToHost)))
+
+        await store.checkLoginMethods()
+
+        #expect(store.passwordLoginActive)
+    }
+
+    /// The silent fallback exists for servers predating the endpoint, or
+    /// proxies stripping the route. A reachable server that simply can't
+    /// answer the probe must not raise an alert.
+    @Test func reachableServerWithAnUnusableProbeStillFallsBackQuietly() async {
+        let store = await makeStore(.status(500))
+
+        await store.checkLoginMethods()
+
+        #expect(store.error == nil)
+        #expect(store.passwordLoginActive)
+    }
+}

--- a/Actuali/ActualiTests/ServerConnectionErrorTests.swift
+++ b/Actuali/ActualiTests/ServerConnectionErrorTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Fails every request with a preset `URLError`, standing in for the transport
+/// layer so we can prove connection failures reach the user as plain-English
+/// guidance instead of CFNetwork's raw string.
+private final class FailingTransport: URLProtocol {
+    nonisolated(unsafe) static var failure = URLError(.secureConnectionFailed)
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: Self.failure)
+    }
+    override func stopLoading() {}
+}
+
+/// A user whose server is unreachable only ever sees the message these tests
+/// pin down, so each case asserts the wording actually names the cause and
+/// points somewhere they can act on it.
+@Suite(.serialized)
+struct ServerConnectionErrorTests {
+    private static let helpLink = "actuali.mfazz.com/support"
+
+    /// Drives a real `login` through a transport that fails with `code`, and
+    /// returns the error the app would see.
+    private func loginFailure(_ code: URLError.Code) async -> Error? {
+        FailingTransport.failure = URLError(code)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FailingTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: config))
+
+        do {
+            try await client.configure(serverURL: "https://budget.example.com")
+            _ = try await client.login(password: "hunter2")
+            Issue.record("Expected login to throw for \(code)")
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    /// The message the app would show for a login that fails with `code`.
+    private func loginFailureMessage(_ code: URLError.Code) async -> String {
+        await loginFailure(code)?.localizedDescription ?? ""
+    }
+
+    @Test func untrustedCertificateNamesTheCertificateAndLinksToHelp() async {
+        let message = await loginFailureMessage(.secureConnectionFailed)
+        #expect(message.localizedCaseInsensitiveContains("certificate"))
+        #expect(message.contains(Self.helpLink))
+    }
+
+    @Test func expiredCertificateSaysItExpired() async {
+        let message = await loginFailureMessage(.serverCertificateHasBadDate)
+        #expect(message.localizedCaseInsensitiveContains("expired"))
+        #expect(message.contains(Self.helpLink))
+    }
+
+    @Test func plainHTTPTellsTheUserToUseHTTPS() async {
+        let message = await loginFailureMessage(.appTransportSecurityRequiresSecureConnection)
+        #expect(message.contains("https://"))
+    }
+
+    @Test func unreachableHostMentionsTheLocalNetwork() async {
+        let message = await loginFailureMessage(.cannotConnectToHost)
+        #expect(message.localizedCaseInsensitiveContains("network"))
+        #expect(message.contains(Self.helpLink))
+    }
+
+    @Test func missingHostAsksTheUserToCheckTheURL() async {
+        let message = await loginFailureMessage(.cannotFindHost)
+        #expect(message.localizedCaseInsensitiveContains("address"))
+        #expect(message.contains(Self.helpLink))
+        // Guards against matching "URL" inside a leaked "NSURLErrorDomain".
+        #expect(!message.contains("NSURLErrorDomain"))
+    }
+
+    @Test func offlineDeviceBlamesTheInternetConnectionNotTheServer() async {
+        let message = await loginFailureMessage(.notConnectedToInternet)
+        #expect(message.localizedCaseInsensitiveContains("internet"))
+    }
+
+    /// Codes we don't map by hand still get the "couldn't connect" framing and
+    /// the help link rather than a bare system string.
+    @Test func unrecognisedTransportFailureStillOffersHelp() async {
+        let message = await loginFailureMessage(.unknown)
+        #expect(message.localizedCaseInsensitiveContains("connect"))
+        #expect(message.contains(Self.helpLink))
+    }
+
+    /// Cancellation is ordinary control flow — a superseded refresh, a screen
+    /// the user left — so it must reach callers untouched rather than being
+    /// dressed up as a connection failure the user should worry about.
+    @Test func cancellationIsNotReportedAsAConnectionFailure() async {
+        let error = await loginFailure(.cancelled)
+        #expect(!(error is ActualServerError))
+        #expect((error as? URLError)?.code == .cancelled)
+    }
+
+    /// Server-side rejections must keep their existing wording — the friendly
+    /// transport messages only apply to connection failures.
+    @Test func httpErrorsKeepTheirExistingMessage() {
+        let error = ActualServerError.httpError(statusCode: 403, message: "Forbidden")
+        #expect(error.localizedDescription == "HTTP error 403: Forbidden")
+    }
+}

--- a/website/src/pages/support.astro
+++ b/website/src/pages/support.astro
@@ -55,6 +55,58 @@ import Layout from "../layouts/Layout.astro";
     </section>
 
     <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Trouble connecting?</h2>
+      <p class="text-neutral-700">
+        <strong>Start here:</strong> open your server address in Safari on the
+        same iPhone. Whatever Safari says is almost always the real problem — if
+        Safari can't load it, or warns you the connection isn't private, Actuali
+        won't be able to connect either.
+      </p>
+      <ul class="list-disc space-y-2 pl-6 text-neutral-700">
+        <li>
+          <strong>"Couldn't make a secure connection" / "TLS error"</strong> —
+          iPhones only connect to servers with a security certificate they
+          trust, and won't let an app skip that check. If your server uses a
+          certificate it generated itself, iOS blocks the connection. Most
+          self-hosting setups can issue a free trusted certificate
+          automatically — tools like Caddy, Nginx Proxy Manager and Cloudflare
+          Tunnel all do this for you. Once Safari loads your server without a
+          warning, Actuali will connect.
+        </li>
+        <li>
+          <strong>"Your server's security certificate has expired"</strong> —
+          certificates need renewing periodically. Renew it on the server and
+          try again.
+        </li>
+        <li>
+          <strong>"Couldn't reach your server"</strong> — if it works at home
+          but not out and about, your server is only reachable on your home
+          network. You'll need a VPN back home, or to make the server available
+          over the internet, to sync while away.
+        </li>
+        <li>
+          <strong>"Couldn't find a server at that address"</strong> — check the
+          address for typos, and include the port number if your server uses
+          one (for example <code>https://budget.example.com:5006</code>).
+        </li>
+        <li>
+          <strong>"Forbidden" or a 403 error when logging in</strong> — usually
+          something sitting in front of your server is blocking the app. If
+          you've restricted access to certain networks or addresses, your phone
+          may not be on the allowed list. If you use a login gateway such as
+          Cloudflare Access or Authelia, add its credentials under
+          <strong>Custom HTTP headers</strong> in Actuali's Settings.
+        </li>
+      </ul>
+      <p class="text-neutral-700">
+        Still stuck? Email
+        <a href="mailto:actuali@mfazz.com" class="underline hover:text-neutral-900"
+          >actuali@mfazz.com</a
+        > with the exact message the app shows and we'll help.
+      </p>
+    </section>
+
+    <section class="space-y-3">
       <h2 class="text-xl font-semibold">Open source</h2>
       <p class="text-neutral-700">
         Actuali is open source. Browse the code, report issues, or contribute on


### PR DESCRIPTION
## What was wrong

Two failures compounded each other, both leaving the user with no idea why they couldn't connect.

**1. Transport errors were never translated.** `ActualServerError.networkError(Error)` was declared in `ActualServerClient.swift` but **never thrown** — no call site wrapped `session.data(for:)`. Every transport failure propagated as a raw `URLError` into `self.error = error.localizedDescription`. The user in #171 saw *"TLS Error caused the secure connection to fail"*; the test harness reproduces it as a bare `NSURLErrorDomain error -1200`.

**2. Connect could fail completely silently.** `checkLoginMethods()` swallowed *every* probe failure and fell back to password-only login. `SettingsView` only calls `login()` when the password field is non-empty — so tapping **Connect** with a bad URL and no password produced no alert, no spinner, nothing at all. Plausibly a large part of "can't get connected and can't tell why".

To be clear about scope: the underlying handshake failure is server-side or device-trust-side, and there is no app-side fix for it. Trusting arbitrary certificates via a `URLSessionDelegate` challenge handler, or setting `NSAllowsArbitraryLoads`, would be a real security regression on an app holding a budget token. The remedy is a user action, so this PR makes the app *say what the user needs to do* and documents it.

## Why this fixes it

- A private `send(_:)` helper wraps `URLError` in `.networkError` on the throwing request paths.
- `.networkError` maps the common codes to plain-English messages naming the cause and pointing at `actuali.mfazz.com/support`: untrusted certificate, expired certificate, plain HTTP, unreachable host, missing host, offline, timeout. Unmapped codes still get the "couldn't connect" framing and the help link.
- `URLError.cancelled` propagates untouched — ordinary control flow (a superseded refresh, a screen the user left), not a failure worth showing. A test pins this down; without the guard a cancelled sync reads as a connection error.
- `checkLoginMethods()` now separates "can't reach the server" from "server answered with something unusable" via `ActualServerError.isConnectionFailure`. The former surfaces the explanation; the latter keeps the quiet password-only fallback that older servers and route-stripping proxies depend on. `SettingsView` skips the follow-up login attempt once the probe has already explained the failure.
- The support page gains a **Trouble connecting?** section covering the same cases, plus the internal-IP/403 report from the same Reddit thread. It leads with "open your server address in Safari on the same iPhone" — the one diagnostic a non-technical user can actually run. Deliberately no ATS/CA-profile detail; it points at Caddy / Nginx Proxy Manager / Cloudflare Tunnel issuing a trusted certificate automatically.

`ActualServerClient.init(session:)` and `BudgetStore.setServerClientForTesting` are test seams only; the latter is `#if DEBUG`, matching the existing convention in that file.

## How it was verified

Both new suites drive real `login()` / `checkLoginMethods()` calls through a stub `URLProtocol` transport. Every assertion was watched failing first, e.g.:

```
✘ untrustedCertificateNamesTheCertificateAndLinksToHelp() recorded an issue:
  (message → "The operation couldn’t be completed. (NSURLErrorDomain error -1200.)")
    .localizedCaseInsensitiveContains("certificate")

✘ unreachableServerTellsTheUserWhyInsteadOfFailingSilently() recorded an issue:
  (message?.localizedCaseInsensitiveContains("certificate") → nil) == true
```

After the fix:

```
✔ Test untrustedCertificateNamesTheCertificateAndLinksToHelp() passed after 0.247 seconds.
✔ Test expiredCertificateSaysItExpired() passed after 0.001 seconds.
✔ Test plainHTTPTellsTheUserToUseHTTPS() passed after 0.001 seconds.
✔ Test unreachableHostMentionsTheLocalNetwork() passed after 0.001 seconds.
✔ Test missingHostAsksTheUserToCheckTheURL() passed after 0.001 seconds.
✔ Test offlineDeviceBlamesTheInternetConnectionNotTheServer() passed after 0.001 seconds.
✔ Test unrecognisedTransportFailureStillOffersHelp() passed after 0.001 seconds.
✔ Test cancellationIsNotReportedAsAConnectionFailure() passed after 0.002 seconds.
✔ Test httpErrorsKeepTheirExistingMessage() passed after 0.001 seconds.
✔ Test unreachableServerTellsTheUserWhyInsteadOfFailingSilently() passed after 0.007 seconds.
✔ Test passwordLoginRemainsAvailableAfterAConnectionFailure() passed after 0.001 seconds.
✔ Test reachableServerWithAnUnusableProbeStillFallsBackQuietly() passed after 0.001 seconds.
```

Full unit suite, Release build, and website build:

```
✔ Test run with 710 tests in 101 suites passed after 2.797 seconds.
XCODEBUILD_EXIT=0

** BUILD SUCCEEDED **   (-configuration Release)

20:56:35   ├─ /support/index.html (+18ms)
20:56:35 [build] Complete!
```

Also checked manually against `badssl.com`'s deliberately-broken endpoints (`self-signed`, `expired`, `untrusted-root`, `wrong.host`), which produce exactly these `URLError` codes.

## Not addressed

The original reporter's actual root cause is still unknown — the issue has no follow-up. This PR means that if they retry on a build with it, the app will tell them which of these they're hitting.

Fixes #171
