### PR TITLE
Show net inflow distinctly in the clean budget row's Spent caption

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -274,6 +274,17 @@ final class BudgetStore: ObservableObject {
         hideBalances ? Self.hiddenBalanceText : formatCurrencyWholeUnits(cents)
     }
 
+    /// The clean row's "Spent" caption, from the signed net activity
+    /// (negative = spending). Spending keeps the familiar positive amount,
+    /// but a net inflow keeps a leading "+" so a category that only received
+    /// deposits can't masquerade as spending (GH #102).
+    func displaySpentCaption(_ spentCents: Int) -> String {
+        guard !hideBalances else { return Self.hiddenBalanceText }
+        return spentCents > 0
+            ? "+\(formatCurrency(spentCents))"
+            : formatCurrency(-spentCents)
+    }
+
     /// Whether transaction saves record the payee's location (GH #24).
     /// Persisted to UserDefaults, defaults to on. Off silences every
     /// recording path, including Shortcuts automations.

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -560,9 +560,13 @@ struct CleanCategoryBudgetRow: View {
                     onShowTransactions(category, category.month)
                 } label: {
                     HStack(spacing: 4) {
-                        Text("Spent: \(budgetStore.displayBalance(abs(category.spent)))")
+                        // Green + signed so a deposit-only category doesn't
+                        // read as spending (GH #102).
+                        Text("Spent: \(budgetStore.displaySpentCaption(category.spent))")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(category.spent > 0
+                                ? AnyShapeStyle(Color.green)
+                                : AnyShapeStyle(.secondary))
                         Image(systemName: "list.bullet")
                             .font(.caption2)
                             .foregroundStyle(.tint)

--- a/Actuali/ActualiTests/BudgetStoreSpentCaptionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSpentCaptionTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// A category that only received money must not read like spending: the
+/// clean row's Spent caption keeps a leading "+" on a net inflow instead of
+/// collapsing it into the same positive amount as real spending (GH #102).
+@MainActor
+struct BudgetStoreSpentCaptionTests {
+
+    private func makeStore() -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        store.hideBalances = false
+        return store
+    }
+
+    @Test func spendingShowsAsPlainPositiveAmount() {
+        let store = makeStore()
+        defer { UserDefaults.standard.removeObject(forKey: "hideBalances") }
+        #expect(store.displaySpentCaption(-5000) == store.formatCurrency(5000))
+    }
+
+    @Test func netInflowKeepsALeadingPlus() {
+        let store = makeStore()
+        defer { UserDefaults.standard.removeObject(forKey: "hideBalances") }
+        #expect(store.displaySpentCaption(5000) == "+\(store.formatCurrency(5000))")
+    }
+
+    @Test func zeroShowsAsPlainZero() {
+        let store = makeStore()
+        defer { UserDefaults.standard.removeObject(forKey: "hideBalances") }
+        #expect(store.displaySpentCaption(0) == store.formatCurrency(0))
+    }
+
+    @Test func maskedWhenBalancesAreHidden() {
+        let store = makeStore()
+        store.hideBalances = true
+        defer { UserDefaults.standard.removeObject(forKey: "hideBalances") }
+        #expect(store.displaySpentCaption(5000) == BudgetStore.hiddenBalanceText)
+        #expect(store.displaySpentCaption(-5000) == BudgetStore.hiddenBalanceText)
+    }
+}


### PR DESCRIPTION
## What was wrong

`CategoryBudget.spent` is the signed net of the month's transactions (negative = net spending, positive = net inflow). The clean-style category row — the default — rendered its caption as `Spent: \(displayBalance(abs(category.spent)))`, and the `abs()` collapsed a +$50 deposit-only category and a −$50 spending category into the identical "Spent: $50.00". The detailed table style shows the raw signed value, so it was unaffected.

## The fix

New `BudgetStore.displaySpentCaption(_:)` drives the clean row's caption:

- Net spending keeps today's presentation: `Spent: $50.00`.
- Net inflow now renders `Spent: +$50.00`, tinted green, so income can't masquerade as spending.
- With Hide Balances on, both mask to `••••` as before.

## Verification

New unit suite `BudgetStoreSpentCaptionTests` (4 tests) written failing-first against the old `abs()` behavior, then made green. Full unit suite (same as CI, UI tests skipped):

```
✔ Test run with 691 tests in 98 suites passed after 2.848 seconds.
```

## Out of scope

The Reddit reports of summary/report totals being off (linked in the issue comment) are a different surface (reports engines, dashboard tracked in #120) — not touched here. One adjacent quirk noticed but left alone: `CategoryBudget.progressFraction` also uses `abs(spent)`, so a deposit-only category shows a partially filled progress bar as if money left. Happy to split that into its own issue if wanted.

Fixes #102