### PR TITLE
docs: add Siri & Shortcuts guide to website

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -90,7 +90,7 @@ const appStore = "https://apps.apple.com/app/actuali/id6764063765";
             <a
               href="https://actualbudget.org"
               class="underline decoration-neutral-300 underline-offset-2 hover:text-neutral-700"
-              >Actual Budget</a
+              > Actual Budget</a
             >. Not affiliated with Actual Budget.
           </p>
         </div>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -104,6 +104,9 @@ const appStore = "https://apps.apple.com/app/actuali/id6764063765";
           <a href="/guides/wallet-automation" class="transition hover:text-neutral-900"
             >Wallet Automation</a
           >
+          <a href="/guides/shortcuts" class="transition hover:text-neutral-900"
+            >Siri &amp; Shortcuts</a
+          >
           <a href="/privacy" class="transition hover:text-neutral-900">Privacy</a>
           <a href={appStore} class="transition hover:text-neutral-900"
             >App Store</a

--- a/website/src/pages/guides/shortcuts.astro
+++ b/website/src/pages/guides/shortcuts.astro
@@ -1,0 +1,117 @@
+---
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout
+  title="Siri & Shortcuts · Actuali"
+  description="Log transactions, check balances, and route purchases to the right account with Siri and the Shortcuts app."
+>
+  <article class="mx-auto max-w-3xl space-y-6">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">Siri &amp; Shortcuts</h1>
+      <p class="text-neutral-500">
+        Actuali ships a set of Shortcuts actions so you can log transactions, check balances, and build your own
+        automations — by voice, from a widget, or entirely in the background.
+      </p>
+    </header>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Ask Siri</h2>
+      <p class="text-neutral-700">
+        These phrases work as soon as the app is installed — no setup needed. Siri fills in the account or category you
+        name, or asks if you leave it out.
+      </p>
+      <ul class="list-disc space-y-2 pl-6 text-neutral-700">
+        <li>"Log transaction in <strong>Actuali</strong>"</li>
+        <li>"Check <em>Everyday</em> balance in <strong>Actuali</strong>"</li>
+        <li>"How much is left in <em>Groceries</em> in <strong>Actuali</strong>"</li>
+        <li>"List accounts in <strong>Actuali</strong>"</li>
+      </ul>
+      <p class="text-neutral-700">
+        Balance answers are spoken back with your budget's currency, and they work even when the app isn't running.
+      </p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Actions in the Shortcuts app</h2>
+      <p class="text-neutral-700">
+        Search for <strong>Actuali</strong> when adding an action to any shortcut or automation:
+      </p>
+      <ul class="list-disc space-y-2 pl-6 text-neutral-700">
+        <li>
+          <strong>Log Transaction</strong> — add a transaction with amount, payee, account, date, and notes. Used by the
+          <a href="/guides/wallet-automation" class="underline hover:text-neutral-900">Apple Wallet automation</a> to log
+          tap-to-pay purchases automatically.
+        </li>
+        <li><strong>Get Account Balance</strong> — the current balance of an account (or your default account).</li>
+        <li><strong>Get Category Balance</strong> — how much is left in a category this month.</li>
+        <li>
+          <strong>Get Accounts</strong>, <strong>Get Categories</strong>, <strong>Get Payees</strong> — return lists you
+          can feed into menus, filters, or other steps when building bigger shortcuts.
+        </li>
+      </ul>
+      <p class="text-neutral-700">
+        The balance actions also return their result as a value, so a shortcut can speak it, show it, or use it in a
+        calculation.
+      </p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Route purchases to the right account</h2>
+      <p class="text-neutral-700">
+        If you log from more than one card, you don't need a separate automation account setting for each. The
+        <strong>Log Transaction</strong> action has an optional <strong>Card or Account Hint</strong> field: pass it the
+        card name from a Wallet automation (or any text that identifies the card), and Actuali picks the account for
+        you.
+      </p>
+      <ol class="list-decimal space-y-2 pl-6 text-neutral-700">
+        <li>
+          In Actuali, open <strong>Settings</strong> → <strong>Preferences</strong> →
+          <strong>Card &amp; Account Mappings</strong>.
+        </li>
+        <li>
+          Add a keyword for each card — the last 4 digits (<em>1234</em>) or the bank name (<em>HSBC</em>) — and choose
+          the account it should route to.
+        </li>
+        <li>
+          In your shortcut, set the <strong>Card or Account Hint</strong> field on Log Transaction to the card's name or
+          number (from a Wallet automation, use the <strong>Card</strong> variable).
+        </li>
+      </ol>
+      <p class="text-neutral-700">
+        Matching is deliberately cautious: a hint that doesn't clearly match one account falls back to the account set
+        in the shortcut, or your default account — a transaction is never silently routed on a guess.
+      </p>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Troubleshooting</h2>
+      <ul class="list-disc space-y-2 pl-6 text-neutral-700">
+        <li>
+          <strong>Siri doesn't recognise the phrases?</strong> Give iOS a minute after installing or updating the app —
+          the system registers App Shortcuts in the background. Saying the app name ("in Actuali") is required.
+        </li>
+        <li>
+          <strong>"Select an account" error?</strong> Choose an account in the shortcut's action, add a card mapping
+          that matches your hint, or set a Default Account in Actuali's Settings.
+        </li>
+        <li>
+          <strong>"Open Actuali and select a budget first"?</strong> The app needs to have loaded your budget once —
+          open it and pick your budget, then the actions work headless from then on.
+        </li>
+        <li>
+          <strong>Hint routes to the wrong account?</strong> Check your mappings for overlapping keywords — the longest
+          matching keyword wins. Keywords match whole words, so <em>Cash</em> won't match <em>cashback</em>.
+        </li>
+      </ul>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold">Questions?</h2>
+      <p class="text-neutral-700">
+        See the <a href="/support" class="underline hover:text-neutral-900">support page</a> or email
+        <a href="mailto:actuali@mfazz.com" class="underline hover:text-neutral-900">actuali@mfazz.com</a>.
+      </p>
+    </section>
+  </article>
+</Layout>

--- a/website/src/pages/guides/wallet-automation.astro
+++ b/website/src/pages/guides/wallet-automation.astro
@@ -132,7 +132,9 @@ import Layout from "../../layouts/Layout.astro";
         </li>
         <li>
           <strong>Wrong account?</strong> Each automation can target its own account — edit the automation and set the Account
-          field to match the card.
+          field to match the card. Or skip per-automation accounts entirely with
+          <a href="/guides/shortcuts" class="underline hover:text-neutral-900">card &amp; account mappings</a>, which route
+          each card to the right account automatically.
         </li>
       </ul>
     </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -153,7 +153,7 @@ const privacy = [
           Your Actual Budget,
           <span
             class="bg-gradient-to-r from-violet-700 to-violet-500 bg-clip-text text-transparent"
-            >on iOS.</span
+            > on iOS.</span
           >
         </h1>
         <p
@@ -163,7 +163,7 @@ const privacy = [
           <a
             href="https://actualbudget.org"
             class="font-medium text-violet-700 underline decoration-violet-200 underline-offset-2 hover:decoration-violet-500"
-            >Actual Budget</a
+            > Actual Budget</a
           >. Local-first, offline-capable, and built to feel right at home on
           iPhone.
         </p>
@@ -390,7 +390,7 @@ const privacy = [
           <a
             href="/changelog"
             class="font-medium text-white underline decoration-white/40 underline-offset-2 hover:decoration-white"
-            >changelog</a
+            > changelog </a
           >
           to see what's new.
         </p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -63,7 +63,7 @@ const supported = [
   {
     icon: "bolt",
     title: "Siri, Shortcuts & Wallet",
-    body: 'Log a transaction with Siri, a Home Screen widget, or an automation — amounts work even when they arrive as text. Pair it with the <a href="/guides/wallet-automation" class="font-medium text-violet-700 underline decoration-violet-200 underline-offset-2 hover:decoration-violet-500">Apple Wallet automation guide</a> to log Apple Pay purchases as you make them. If a background log ever fails, tapping the notification opens a prefilled form so nothing is lost.',
+    body: 'Log transactions and ask for account or category balances with Siri, a Home Screen widget, or an automation — see the <a href="/guides/shortcuts" class="font-medium text-violet-700 underline decoration-violet-200 underline-offset-2 hover:decoration-violet-500">Siri &amp; Shortcuts guide</a>. Pair it with the <a href="/guides/wallet-automation" class="font-medium text-violet-700 underline decoration-violet-200 underline-offset-2 hover:decoration-violet-500">Apple Wallet automation guide</a> to log Apple Pay purchases as you make them, routed to the right account by card. If a background log ever fails, tapping the notification opens a prefilled form so nothing is lost.',
   },
   {
     icon: "search",

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -13,9 +13,9 @@ const effectiveDate = "April 19, 2026";
 
     <section class="space-y-3">
       <p class="text-neutral-700">
-        Actuali ("the app") is a native iOS client for
+        Actuali ("the app") is a native iOS client for 
         <a href="https://actualbudget.org" class="underline hover:text-neutral-900"
-          >Actual Budget</a
+          > Actual Budget</a
         >, a local-first personal finance tool. This policy explains what
         information the app handles and where it goes.
       </p>
@@ -109,7 +109,7 @@ const effectiveDate = "April 19, 2026";
         Questions about this policy or the app? Email
         <a
           href="mailto:actuali@mfazz.com"
-          class="underline hover:text-neutral-900">actuali@mfazz.com</a
+          class="underline hover:text-neutral-900"> actuali@mfazz.com</a
         >.
       </p>
     </section>

--- a/website/src/pages/support.astro
+++ b/website/src/pages/support.astro
@@ -9,7 +9,7 @@ import Layout from "../layouts/Layout.astro";
       <p class="text-neutral-500">
         Help with Actuali, the native iOS client for self-hosted
         <a href="https://actualbudget.org" class="underline hover:text-neutral-900"
-          >Actual Budget</a
+          > Actual Budget</a
         >.
       </p>
     </header>
@@ -31,7 +31,7 @@ import Layout from "../layouts/Layout.astro";
           <strong>Do I need my own server?</strong> Yes — Actuali is a companion
           client for
           <a href="https://actualbudget.org" class="underline hover:text-neutral-900"
-            >Actual Budget</a
+            > Actual Budget</a
           >. Sync requires the Actual server you host. The demo budget works
           without one.
         </li>
@@ -40,7 +40,7 @@ import Layout from "../layouts/Layout.astro";
           device and syncs only to the server you configure. Nothing is sent to
           the developer. See the
           <a href="/privacy" class="underline hover:text-neutral-900"
-            >privacy policy</a
+            > privacy policy</a
           >.
         </li>
         <li>
@@ -60,7 +60,7 @@ import Layout from "../layouts/Layout.astro";
         Actuali is open source. Browse the code, report issues, or contribute on
         <a
           href="https://github.com/MattFaz/actuali"
-          class="underline hover:text-neutral-900">GitHub</a
+          class="underline hover:text-neutral-900"> GitHub</a
         >.
       </p>
     </section>
@@ -70,7 +70,7 @@ import Layout from "../layouts/Layout.astro";
       <p class="text-neutral-700">
         Found a bug or need help? Email
         <a href="mailto:actuali@mfazz.com" class="underline hover:text-neutral-900"
-          >actuali@mfazz.com</a
+          > actuali@mfazz.com</a
         > and we'll get back to you.
       </p>
     </section>


### PR DESCRIPTION
## Why

#143 added Siri balance phrases, five new Shortcuts actions, and card-to-account mapping, but the website only documents the Wallet automation. New users have no way to discover the voice phrases or the hint-based routing.

## What

- New page **/guides/shortcuts**: Siri phrases, the six Shortcuts actions, a card & account mappings walkthrough, and troubleshooting (including the conservative matching rules — longest keyword wins, whole-word matching, no guessing on ambiguity).
- Footer nav link alongside the Wallet Automation guide.
- Wallet guide's "Wrong account?" troubleshooting tip now points at card mappings as the no-per-automation-setup alternative.
- Index page "Siri, Shortcuts & Wallet" blurb links the new guide and mentions balance queries and card routing.

## Notes

The features this documents are merged to main but not yet in the App Store build. Since the site deploys on push to main, consider holding this until the next release ships — or merge now if the release is imminent.

## How it was tested

`npm run build` succeeds; /guides/shortcuts generates alongside the existing routes.