### PR TITLE
Read and write tracking-budget amounts from reflect_budgets

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1073,20 +1073,8 @@ class BudgetDatabase {
             // Envelope (zero_budgets) clamps negative leftover to 0 unless
             // the carryover flag is set. Tracking (reflect_budgets) drops
             // any prior leftover entirely unless the flag is set.
-            let hasZeroBudgets = try db.tableExists("zero_budgets")
-            let hasReflectBudgets = try db.tableExists("reflect_budgets")
-            let isEnvelope: Bool
-            let budgetsTable: String?
-            if hasZeroBudgets {
-                isEnvelope = true
-                budgetsTable = "zero_budgets"
-            } else if hasReflectBudgets {
-                isEnvelope = false
-                budgetsTable = "reflect_budgets"
-            } else {
-                isEnvelope = true
-                budgetsTable = nil
-            }
+            let budgetsTable = try Self.budgetTable(db)
+            let isEnvelope = budgetsTable != "reflect_budgets"
 
             // Bulk-load all budget rows up to and including the target month.
             // months are YYYYMM ints in the budgets tables.
@@ -1372,14 +1360,7 @@ class BudgetDatabase {
         guard monthInt > 0 else { return nil }
 
         return try dbQueue.read { db in
-            let table: String
-            if try db.tableExists("zero_budgets") {
-                table = "zero_budgets"
-            } else if try db.tableExists("reflect_budgets") {
-                table = "reflect_budgets"
-            } else {
-                return nil
-            }
+            guard let table = try Self.budgetTable(db) else { return nil }
 
             let existing = try Row.fetchOne(db, sql: """
                 SELECT id, amount FROM \(table) WHERE month = ? AND category = ?
@@ -1393,6 +1374,32 @@ class BudgetDatabase {
                 amount: existing?["amount"] ?? 0
             )
         }
+    }
+
+    /// Which budget table this file uses, or nil when it has neither. Real
+    /// Actual files contain BOTH zero_budgets and reflect_budgets (loot-core's
+    /// migrations create them unconditionally), so table existence says
+    /// nothing — the budgetType preference is the only signal of which one is
+    /// live: 'tracking' ('report' before the Actual 25.5 rename migration)
+    /// means reflect_budgets; anything else, including no row at all, means
+    /// envelope, matching upstream's default. When only one table exists the
+    /// preference can't override it — writing into a missing table would fail.
+    private static func budgetTable(_ db: Database) throws -> String? {
+        let hasZero = try db.tableExists("zero_budgets")
+        let hasReflect = try db.tableExists("reflect_budgets")
+        guard hasZero, hasReflect else {
+            if hasZero { return "zero_budgets" }
+            if hasReflect { return "reflect_budgets" }
+            return nil
+        }
+
+        var isTracking = false
+        if try db.tableExists("preferences") {
+            let value = try String.fetchOne(
+                db, sql: "SELECT value FROM preferences WHERE id = 'budgetType'")
+            isTracking = value == "tracking" || value == "report"
+        }
+        return isTracking ? "reflect_budgets" : "zero_budgets"
     }
 
     private static func monthStringToInt(_ month: String) -> Int {

--- a/Actuali/ActualiTests/BudgetDatabaseBudgetCellTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseBudgetCellTests.swift
@@ -8,21 +8,26 @@ struct BudgetDatabaseBudgetCellTests {
     private enum BudgetTable {
         case zero
         case reflect
+        case both
         case none
     }
 
-    private func makeDatabase(table: BudgetTable) throws -> (BudgetDatabase, URL) {
+    private func makeDatabase(
+        table: BudgetTable,
+        budgetTypePref: String? = nil
+    ) throws -> (BudgetDatabase, URL) {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-\(UUID().uuidString).sqlite")
         let queue = try DatabaseQueue(path: tempURL.path)
         try queue.write { db in
-            let tableName: String?
+            let tableNames: [String]
             switch table {
-            case .zero: tableName = "zero_budgets"
-            case .reflect: tableName = "reflect_budgets"
-            case .none: tableName = nil
+            case .zero: tableNames = ["zero_budgets"]
+            case .reflect: tableNames = ["reflect_budgets"]
+            case .both: tableNames = ["zero_budgets", "reflect_budgets"]
+            case .none: tableNames = []
             }
-            if let tableName {
+            for tableName in tableNames {
                 try db.execute(sql: """
                     CREATE TABLE \(tableName) (
                         id TEXT PRIMARY KEY,
@@ -32,6 +37,13 @@ struct BudgetDatabaseBudgetCellTests {
                         carryover INTEGER DEFAULT 0
                     )
                     """)
+            }
+            if let budgetTypePref {
+                try db.execute(sql: "CREATE TABLE preferences (id TEXT PRIMARY KEY, value TEXT)")
+                try db.execute(
+                    sql: "INSERT INTO preferences (id, value) VALUES ('budgetType', ?)",
+                    arguments: [budgetTypePref]
+                )
             }
         }
         return (try BudgetDatabase(path: tempURL), tempURL)
@@ -81,6 +93,56 @@ struct BudgetDatabaseBudgetCellTests {
         let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
         #expect(cell.table == "reflect_budgets")
         #expect(cell.rowId == "202607-cat-1")
+    }
+
+    /// Real Actual files always contain BOTH budget tables (loot-core's
+    /// migrations create them unconditionally); the budgetType preference is
+    /// the only thing that says which one the file actually uses. Issue #98:
+    /// picking by table existence always chose zero_budgets, so tracking
+    /// budgets read and wrote the wrong table.
+    @Test func bothTablesWithTrackingPrefUsesReflectTable() throws {
+        let (database, path) = try makeDatabase(table: .both, budgetTypePref: "tracking")
+        defer { cleanup(path) }
+
+        let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
+        #expect(cell.table == "reflect_budgets")
+    }
+
+    /// Files last written by Actual < 25.5 store the pre-rename value
+    /// ("report" instead of "tracking").
+    @Test func bothTablesWithLegacyReportPrefUsesReflectTable() throws {
+        let (database, path) = try makeDatabase(table: .both, budgetTypePref: "report")
+        defer { cleanup(path) }
+
+        let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
+        #expect(cell.table == "reflect_budgets")
+    }
+
+    @Test func bothTablesWithEnvelopePrefUsesZeroTable() throws {
+        let (database, path) = try makeDatabase(table: .both, budgetTypePref: "envelope")
+        defer { cleanup(path) }
+
+        let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
+        #expect(cell.table == "zero_budgets")
+    }
+
+    /// No budgetType preference row means envelope (upstream's default).
+    @Test func bothTablesWithoutPrefDefaultsToZeroTable() throws {
+        let (database, path) = try makeDatabase(table: .both)
+        defer { cleanup(path) }
+
+        let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
+        #expect(cell.table == "zero_budgets")
+    }
+
+    /// A tracking pref can't override a missing table — fall back to what
+    /// actually exists rather than writing into a table that isn't there.
+    @Test func trackingPrefWithOnlyZeroTableFallsBackToZeroTable() throws {
+        let (database, path) = try makeDatabase(table: .zero, budgetTypePref: "tracking")
+        defer { cleanup(path) }
+
+        let cell = try #require(try database.budgetCell(month: "2026-07", categoryId: "cat-1"))
+        #expect(cell.table == "zero_budgets")
     }
 
     @Test func noBudgetTablesYieldsNil() throws {

--- a/Actuali/ActualiTests/BudgetDatabaseToBudgetTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseToBudgetTests.swift
@@ -11,7 +11,9 @@ struct BudgetDatabaseToBudgetTests {
 
     private func makeDatabase(
         envelope: Bool = true,
-        withBufferTable: Bool = true
+        withBufferTable: Bool = true,
+        withBothBudgetTables: Bool = false,
+        budgetTypePref: String? = nil
     ) throws -> (BudgetDatabase, URL) {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-\(UUID().uuidString).sqlite")
@@ -76,16 +78,30 @@ struct BudgetDatabaseToBudgetTests {
                     ('acct-1', 'Checking', 0, 1.0);
             """)
 
-            let table = envelope ? "zero_budgets" : "reflect_budgets"
-            try db.execute(sql: """
-                CREATE TABLE \(table) (
-                    id TEXT PRIMARY KEY,
-                    month INTEGER,
-                    category TEXT,
-                    amount INTEGER DEFAULT 0,
-                    carryover INTEGER DEFAULT 0
-                );
-            """)
+            let tables = withBothBudgetTables
+                ? ["zero_budgets", "reflect_budgets"]
+                : [envelope ? "zero_budgets" : "reflect_budgets"]
+            for table in tables {
+                try db.execute(sql: """
+                    CREATE TABLE \(table) (
+                        id TEXT PRIMARY KEY,
+                        month INTEGER,
+                        category TEXT,
+                        amount INTEGER DEFAULT 0,
+                        carryover INTEGER DEFAULT 0
+                    );
+                """)
+            }
+
+            if let budgetTypePref {
+                try db.execute(sql: """
+                    CREATE TABLE preferences (id TEXT PRIMARY KEY, value TEXT);
+                """)
+                try db.execute(
+                    sql: "INSERT INTO preferences (id, value) VALUES ('budgetType', ?)",
+                    arguments: [budgetTypePref]
+                )
+            }
 
             if withBufferTable {
                 try db.execute(sql: """
@@ -255,6 +271,60 @@ struct BudgetDatabaseToBudgetTests {
 
         let june = try await db.fetchBudgetMonth(month: "2026-06")
         #expect(june.toBudget == nil)
+    }
+
+    /// Issue #98: real Actual files contain BOTH budget tables, and only the
+    /// budgetType preference says which one is in use. A tracking budget's
+    /// amounts live in reflect_budgets and must be read from there — not from
+    /// the (empty) zero_budgets table that also exists in the file.
+    @Test func trackingBudgetWithBothTablesReadsReflectAmounts() async throws {
+        let (db, url) = try makeDatabase(
+            withBothBudgetTables: true,
+            budgetTypePref: "tracking"
+        )
+        defer { cleanup(url) }
+
+        try insertBudget(db, table: "reflect_budgets", month: 202606, category: "cat-groceries", amount: 30_000)
+
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+        let groceries = try #require(june.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(groceries.budgeted == 30_000)
+        #expect(june.toBudget == nil)
+    }
+
+    /// Same as above with the pre-rename preference value written by
+    /// Actual < 25.5 ("report" instead of "tracking").
+    @Test func trackingBudgetWithLegacyReportPrefReadsReflectAmounts() async throws {
+        let (db, url) = try makeDatabase(
+            withBothBudgetTables: true,
+            budgetTypePref: "report"
+        )
+        defer { cleanup(url) }
+
+        try insertBudget(db, table: "reflect_budgets", month: 202606, category: "cat-groceries", amount: 30_000)
+
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+        let groceries = try #require(june.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(groceries.budgeted == 30_000)
+        #expect(june.toBudget == nil)
+    }
+
+    /// An envelope file that also has the (empty) reflect_budgets table keeps
+    /// reading zero_budgets.
+    @Test func envelopeBudgetWithBothTablesReadsZeroAmounts() async throws {
+        let (db, url) = try makeDatabase(
+            withBothBudgetTables: true,
+            budgetTypePref: "envelope"
+        )
+        defer { cleanup(url) }
+
+        try insertTransaction(db, date: 20260601, category: "cat-salary", amount: 100_000)
+        try insertBudget(db, month: 202606, category: "cat-groceries", amount: 30_000)
+
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+        let groceries = try #require(june.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(groceries.budgeted == 30_000)
+        #expect(june.toBudget == 70_000)
     }
 
     @Test func missingBufferTableIsTolerated() async throws {


### PR DESCRIPTION
## What was wrong

With a tracking budget, budgeted amounts synced from the server never appeared in the app, and edits made in the app landed where the server's tracking budget never looks (#98).

`BudgetDatabase` decided envelope vs. tracking by checking *which budget table exists*: use `zero_budgets` if present, otherwise `reflect_budgets`. But every real Actual file contains **both** tables — loot-core's migrations create them unconditionally — so the app always picked `zero_budgets`. A tracking budget's amounts live in `reflect_budgets`, so the app read an empty table (budgeted showed 0) and wrote its own edits into `zero_budgets`, the wrong dataset. This never surfaced in tests because every test fixture created only one of the two tables.

## The fix

Both the read path (`fetchBudgetMonth`) and the write path (`budgetCell`, which feeds `setBudgetAmount`/`transferBudget`'s CRDT dataset) now resolve the table through a shared helper that mirrors upstream `isTrackingBudget()` (loot-core `budget/actions.ts`): read the `budgetType` row from the `preferences` table — `tracking` (or the pre-rename `report`, still present in files last written by Actual < 25.5) selects `reflect_budgets`; anything else, including no row, defaults to envelope, matching upstream. When only one budget table exists the preference can't override it, so demo data and older partial files behave exactly as before.

## Verification

New tests create both tables plus the `budgetType` preference (the real-world shape) and cover `tracking`, legacy `report`, `envelope`, missing pref, and pref-vs-missing-table fallback. The four tracking-pref tests failed before the fix (`cell.table → "zero_budgets"`, `budgeted → 0`) and pass after.

Full unit suite on iPhone 17 / iOS 26.5 simulator:

```
✔ Test run with 729 tests in 103 suites passed after 4.763 seconds.
xcodebuild exit code: 0
```

Fixes #98