### PR TITLE
Don't make local writes wait on the server push

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2484,6 +2484,14 @@ final class BudgetStore: ObservableObject {
         await refreshDataOnly()
     }
 
+    /// Wait for the background push a local write kicked off (see
+    /// `SyncClient.scheduleAutomaticSync`). Only headless callers that can be
+    /// suspended right after writing need this — interactive flows must never
+    /// block on the network (issue #125).
+    func flushPendingSync() async {
+        await syncClient?.flushPendingSync()
+    }
+
     /// Sync when app enters foreground - only if a budget is loaded
     /// Uses rate-limited automatic sync to avoid redundant syncs
     func syncOnForeground() async {

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -57,6 +57,13 @@ actor SyncClient {
     private var retryDelay: TimeInterval = 5
     private let maxRetryDelay: TimeInterval = 300  // 5 min cap
 
+    /// The detached push kicked off by the most recent local write (see
+    /// `scheduleAutomaticSync`). Nil when no push is in flight.
+    private var pushTask: Task<Void, Never>?
+    /// Set when a write lands while `pushTask` is running, so its messages get
+    /// a trailing push instead of waiting for the next sync event.
+    private var pushNeededAfterCurrent = false
+
     private var fileId: String?
     private var groupId: String?
     private var encryptKeyId: String?
@@ -196,8 +203,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 4. Sync to push the transaction to the server (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background (never blocks the caller)
+        scheduleAutomaticSync()
     }
 
     /// Create both legs of a transfer atomically (optimistic local-first).
@@ -223,8 +230,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Transfer stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 3. Sync to push both legs to the server (rate-limited)
-        await automaticSync()
+        // 3. Push both legs to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Create a split parent and its children atomically (optimistic
@@ -251,8 +258,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Split stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 3. Sync to push all rows to the server (rate-limited)
-        await automaticSync()
+        // 3. Push all rows to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Update an existing transaction (optimistic local-first)
@@ -285,8 +292,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Update many transactions that share one set of changed fields, in a
@@ -318,8 +325,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Batch stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 3. Sync (rate-limited)
-        await automaticSync()
+        // 3. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Create a payee (optimistic local-first)
@@ -375,8 +382,8 @@ actor SyncClient {
         merkle = merkle.pruned()
         try saveClock()
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Tombstone a recorded payee location (optimistic local-first).
@@ -398,8 +405,8 @@ actor SyncClient {
         merkle = merkle.pruned()
         try saveClock()
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Tombstone several recorded payee locations at once ("Clear All
@@ -429,8 +436,8 @@ actor SyncClient {
         merkle = merkle.pruned()
         try saveClock()
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Set the budgeted amount for a category in a month (optimistic
@@ -470,8 +477,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Move budgeted funds between two categories in a month, or between a
@@ -517,8 +524,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Advance a schedule's next date after posting (optimistic local-first).
@@ -554,8 +561,8 @@ actor SyncClient {
         try saveClock()
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
-        // 4. Sync (rate-limited)
-        await automaticSync()
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
     }
 
     /// Force immediate sync (pull-to-refresh)
@@ -594,6 +601,63 @@ actor SyncClient {
         }
         logger.debug("automaticSync() proceeding with sync")
         return await performSync()
+    }
+
+    /// Start `automaticSync()` in the background and return immediately.
+    ///
+    /// Every write path commits its rows and CRDT messages *before* calling
+    /// this, so pushing them is catch-up work the writer must not wait on.
+    /// Awaiting it here made adding a transaction hang for the whole
+    /// URLSession timeout (30s per request) whenever the server was
+    /// unreachable, because the UI awaits the write all the way down from the
+    /// save button (issue #125). Failures still reach `stateSubject` and the
+    /// retry ladder exactly as before.
+    ///
+    /// Writes that arrive while a push is in flight coalesce onto a single
+    /// trailing push: a burst (split save, Wallet import) doesn't stampede the
+    /// server, and messages written mid-push still go out.
+    private func scheduleAutomaticSync() {
+        guard pushTask == nil else {
+            logger.debug("scheduleAutomaticSync() - push in flight, coalescing onto a trailing sync")
+            pushNeededAfterCurrent = true
+            return
+        }
+        startPushTask(rateLimited: true)
+    }
+
+    /// Callers that may be suspended right after writing (App Intents run
+    /// headless and can be frozen as soon as they return their result) await
+    /// this so the deferred push still gets its chance. Drains trailing pushes
+    /// too — `finishPushTask` has already swapped `pushTask` by the time a
+    /// task's `value` returns.
+    func flushPendingSync() async {
+        while let pushTask {
+            await pushTask.value
+        }
+    }
+
+    private func startPushTask(rateLimited: Bool) {
+        pushNeededAfterCurrent = false
+        // Assigned synchronously on the actor, so the body can't observe a
+        // stale `pushTask` before this returns.
+        pushTask = Task {
+            if rateLimited {
+                await automaticSync()
+            } else {
+                // This push exists *because* new local messages landed during
+                // the previous one, so the 1s rate limiter must not swallow it.
+                await performSync()
+            }
+            finishPushTask()
+        }
+    }
+
+    private func finishPushTask() {
+        pushTask = nil
+        if pushNeededAfterCurrent {
+            logger.debug("finishPushTask() - running the coalesced trailing sync")
+            startPushTask(rateLimited: false)
+        }
     }
 
     // MARK: - Sync Logic

--- a/Actuali/Actuali/Services/TransactionLogger.swift
+++ b/Actuali/Actuali/Services/TransactionLogger.swift
@@ -80,6 +80,11 @@ final class TransactionLogger {
         try await store.createTransaction(transaction)
         // With when-in-use permission, background automations get no fix and silently skip.
         store.recordPayeeLocationIfAppropriate(payeeId: payee.id)
+        // Writes push in the background so the UI never waits on the network
+        // (issue #125), but an App Intent runs headless and can be frozen the
+        // moment it returns — wait for the push here so a Siri/Shortcuts log
+        // still reaches the server before that happens.
+        await store.flushPendingSync()
         logger.info("Logged transaction \(transaction.id, privacy: .public) for \(payee.name, privacy: .public)")
         return transaction
     }

--- a/Actuali/ActualiTests/SyncClientOfflineWriteTests.swift
+++ b/Actuali/ActualiTests/SyncClientOfflineWriteTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// A server that accepts the connection and then never answers in time — what
+/// an unreachable self-hosted server looks like to URLSession (the request
+/// hangs until the timeout rather than failing fast).
+private final class StallingSyncTransport: URLProtocol {
+    /// Seconds each request stalls before failing. Long enough that awaiting
+    /// it is unmistakable in a timing assertion, short enough not to wedge the
+    /// suite.
+    static let stall: TimeInterval = 3
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var attempts = 0
+
+    static func resetAttempts() {
+        lock.withLock { attempts = 0 }
+    }
+
+    static var attemptCount: Int {
+        lock.withLock { attempts }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.withLock { Self.attempts += 1 }
+        Thread.sleep(forTimeInterval: Self.stall)
+        client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+    }
+
+    override func stopLoading() {}
+}
+
+/// Issue #125: adding a transaction hung for the full network timeout when the
+/// server was unreachable. The row and its CRDT messages are committed locally
+/// before the push, so the push must not be awaited by the caller — the write
+/// returns immediately and the sync is deferred to the retry ladder.
+@Suite(.serialized)
+struct SyncClientOfflineWriteTests {
+
+    /// transactions and messages_crdt normally come from the downloaded budget
+    /// file, so create them with the upstream schema.
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    /// Sync client whose every request stalls, standing in for a server that
+    /// is down or off-network.
+    private func makeSyncClient(database: BudgetDatabase) async throws -> SyncClient {
+        StallingSyncTransport.resetAttempts()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StallingSyncTransport.self]
+        let serverClient = ActualServerClient(session: URLSession(configuration: config))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("test-token")
+
+        let syncClient = SyncClient(serverClient: serverClient, nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        return syncClient
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func transaction(id: String) -> Transaction {
+        Transaction(
+            id: id,
+            accountId: "acct-1",
+            date: 20260811,
+            amount: -1234,
+            payeeId: "payee-1",
+            payeeName: "Coffee",
+            categoryId: "cat-1",
+            categoryName: nil,
+            notes: nil,
+            cleared: false,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+    }
+
+    private func rowExists(_ database: BudgetDatabase, id: String) throws -> Bool {
+        try database.dbQueueForTesting.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM transactions WHERE id = ?", arguments: [id]) ?? 0
+        } > 0
+    }
+
+    /// The whole bug: the caller must not wait on the network round trip.
+    @Test func createTransactionReturnsWithoutWaitingForTheServer() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let syncClient = try await makeSyncClient(database: database)
+
+        let start = Date()
+        try await syncClient.createTransaction(transaction(id: "tx-offline-1"))
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.0, "createTransaction blocked for \(elapsed)s waiting on an unreachable server")
+        // Local-first: the transaction is already durable on return.
+        #expect(try rowExists(database, id: "tx-offline-1"))
+    }
+
+    /// Deferred, not dropped: the push still goes out, just off the caller's
+    /// thread.
+    @Test func pushStillHappensAfterTheWriteReturns() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let syncClient = try await makeSyncClient(database: database)
+
+        try await syncClient.createTransaction(transaction(id: "tx-offline-2"))
+
+        var observed = StallingSyncTransport.attemptCount
+        for _ in 0..<40 where observed == 0 {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            observed = StallingSyncTransport.attemptCount
+        }
+        #expect(observed >= 1, "the deferred sync never reached the server")
+    }
+}


### PR DESCRIPTION
## What was wrong

Every `SyncClient` write path — `createTransaction`, `createTransfer`, `createSplit`, the update/delete paths, `createPayee`, `setBudgetAmount`, `transferBudget`, `advanceScheduleNextDate` — committed its rows and CRDT messages locally and then `await automaticSync()`, a full HTTP round trip to `/sync/sync`, before returning.

The add flow awaits that entire chain from the save button (`AddTransactionView.saveTransaction` → `BudgetStore.saveTransaction` → `SyncClient.createTransaction`), so when the server is unreachable the form stays in its loading state for the whole `URLSession` timeout (`timeoutIntervalForRequest = 30`, and connection stalls can drag longer) — the "stuck" feeling in the report. The local write was never the slow part: the row and its messages were already durable at step 1, and the thing being awaited was pure catch-up work.

## Why this fixes it

`scheduleAutomaticSync()` starts the push in a detached actor task and returns immediately, so a write completes at local-commit speed regardless of server reachability. Nothing else about sync changes: failures still publish through `stateSubject` (so `SyncStatusView` shows the offline/connection error) and still land on the existing exponential-backoff retry ladder.

Two details worth calling out:

- **Coalescing.** Writes that arrive while a push is in flight set a flag instead of spawning their own push, so a burst (split save, Wallet import) doesn't stampede the server. The single trailing push calls `performSync()` directly rather than `automaticSync()` — it exists *because* new local messages landed mid-push, so the 1s rate limiter must not swallow it.
- **App Intents.** They run headless and can be frozen the moment they return, so a fire-and-forget push could sit unsent until the app is next opened. `TransactionLogger` now awaits the new `flushPendingSync()` to preserve today's behaviour for Siri/Shortcuts logging. Interactive callers never use it.

## How it was verified

New `SyncClientOfflineWriteTests` drives a real `SyncClient` through a `URLProtocol` stub that stalls 3s then fails with `cannotConnectToHost` — what an unreachable self-hosted server looks like to `URLSession`. It asserts the write returns in under 1s, that the row is already in the local DB on return, and that the push still reaches the server afterwards (deferred, not dropped).

Failing before the fix:

```
✘ Test createTransactionReturnsWithoutWaitingForTheServer() recorded an issue at
  SyncClientOfflineWriteTests.swift:144:9: Expectation failed: (elapsed → 3.0443410873413086) < 1.0
✘ Test createTransactionReturnsWithoutWaitingForTheServer() failed after 3.077 seconds with 1 issue.
✔ Test pushStillHappensAfterTheWriteReturns() passed after 3.040 seconds.
✘ Test run with 2 tests in 1 suite failed after 6.120 seconds with 1 issue.
```

Passing after:

```
✔ Test createTransactionReturnsWithoutWaitingForTheServer() passed after 0.053 seconds.
✔ Test pushStillHappensAfterTheWriteReturns() passed after 0.081 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.137 seconds.
```

Full unit suite (`xcodebuild test -skip-testing:ActualiUITests`, iPhone 17 simulator):

```
✔ Test run with 731 tests in 104 suites passed after 4.730 seconds.
** TEST SUCCEEDED **
```

## Not included

The issue also floats a visible "offline — will sync later" state. `AccountsListView` already surfaces `SyncStatusView`, which now shows the connection-failure explanation from #178 while the deferred push retries, so I left the add screen's UI alone rather than widen scope.

Fixes #125
