### PR TITLE
Push Shortcut/Wallet transactions to the server without opening the app

### DIFF
--- a/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
+++ b/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
@@ -115,12 +115,21 @@ struct LogTransactionIntent: AppIntent {
                 cleared: cleared
             )
 
-            let displayPayee = written.payeeName ?? payee
+            // The row is safely on disk either way, but an unreachable server
+            // means it only exists here. Say so rather than reporting a plain
+            // success, and ask iOS for an early wake so the queued write has a
+            // chance to land before the app is next opened (issue #139).
+            if !written.synced {
+                BackgroundRefresh.schedule(earliestIn: BackgroundRefresh.pendingWriteFlushInterval)
+            }
+
+            let displayPayee = written.transaction.payeeName ?? payee
             await TransactionLogNotifier.notifySuccess(
                 payee: displayPayee,
                 amountCents: amountCents,
                 currencyCode: store.currencyCode,
-                narrowSymbol: store.useNarrowCurrencySymbol
+                narrowSymbol: store.useNarrowCurrencySymbol,
+                synced: written.synced
             )
 
             let amountString = CurrencyAmountFormat.string(
@@ -128,9 +137,10 @@ struct LogTransactionIntent: AppIntent {
                 currencyCode: store.currencyCode,
                 narrowSymbol: store.useNarrowCurrencySymbol
             )
+            let verb = written.synced ? "Logged" : "Saved locally:"
             let dialogText = displayPayee.isEmpty
-                ? "Logged \(amountString)"
-                : "Logged \(amountString) at \(displayPayee)"
+                ? "\(verb) \(amountString)"
+                : "\(verb) \(amountString) at \(displayPayee)"
             return .result(dialog: IntentDialog(stringLiteral: dialogText))
         } catch {
             let mapped: LogTransactionError = (error as? LogTransactionError)

--- a/Actuali/Actuali/Services/BackgroundRefresh.swift
+++ b/Actuali/Actuali/Services/BackgroundRefresh.swift
@@ -36,19 +36,26 @@ enum BackgroundRefresh {
     /// a floor, and a high floor caps how many run windows iOS can offer.
     static let minimumInterval: TimeInterval = 60 * 60
 
-    static func makeRequest(now: Date) -> BGAppRefreshTaskRequest {
+    /// Floor used when a headless write couldn't be pushed. Shorter than
+    /// `minimumInterval` so a queued Shortcut transaction gets a chance to
+    /// reach the server before the user next opens the app — still only a hint,
+    /// and iOS may ignore it entirely (issue #139).
+    static let pendingWriteFlushInterval: TimeInterval = 15 * 60
+
+    static func makeRequest(now: Date, earliestIn: TimeInterval = minimumInterval) -> BGAppRefreshTaskRequest {
         let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
-        request.earliestBeginDate = now.addingTimeInterval(minimumInterval)
+        request.earliestBeginDate = now.addingTimeInterval(earliestIn)
         return request
     }
 
     static func schedule(using scheduler: BackgroundTaskRequesting = BGTaskScheduler.shared,
                          now: Date = Date(),
+                         earliestIn: TimeInterval = minimumInterval,
                          defaults: UserDefaults = .standard) {
         let status = BackgroundRefreshStatus(defaults: defaults)
         status.lastScheduleAttempt = now
         do {
-            try scheduler.submit(makeRequest(now: now))
+            try scheduler.submit(makeRequest(now: now, earliestIn: earliestIn))
             status.lastScheduleError = nil
         } catch {
             // Expected on simulator and when Background App Refresh is off.

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2492,6 +2492,13 @@ final class BudgetStore: ObservableObject {
         await syncClient?.flushPendingSync()
     }
 
+    /// Whether local writes are still waiting to reach the server. Meaningful
+    /// straight after `flushPendingSync()`: true there means the push failed and
+    /// the rows live only on this device until the next successful sync.
+    func hasPendingLocalWrites() async -> Bool {
+        await syncClient?.hasPendingLocalWrites() ?? false
+    }
+
     /// Sync when app enters foreground - only if a budget is loaded
     /// Uses rate-limited automatic sync to avoid redundant syncs
     func syncOnForeground() async {

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -636,6 +636,14 @@ actor SyncClient {
         }
     }
 
+    /// Whether local writes are still waiting to reach the server. Call after
+    /// `flushPendingSync()` to find out whether the push actually landed —
+    /// pushes are detached, so a write path can't return that answer itself
+    /// (issue #139).
+    func hasPendingLocalWrites() -> Bool {
+        hasUnsyncedLocalMessages()
+    }
+
     private func startPushTask(rateLimited: Bool) {
         pushNeededAfterCurrent = false
         // Assigned synchronously on the actor, so the body can't observe a

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -596,7 +596,7 @@ actor SyncClient {
     @discardableResult
     func automaticSync() async -> Bool {
         if shouldSkipAutomaticSync() {
-            logger.debug("automaticSync() skipped - rate limited (last sync < 1s ago)")
+            logger.debug("automaticSync() skipped - rate limited (last sync < 1s ago, nothing new locally)")
             return true
         }
         logger.debug("automaticSync() proceeding with sync")
@@ -662,13 +662,38 @@ actor SyncClient {
 
     // MARK: - Sync Logic
 
-    /// Returns true if automatic sync should be skipped due to rate limiting
+    /// Returns true if automatic sync should be skipped due to rate limiting.
+    ///
+    /// The window only ever suppresses a redundant *pull* — several foreground
+    /// triggers landing at once. It must never suppress a *push*: a skipped
+    /// sync drops the local write until something else syncs, and in the
+    /// headless Shortcuts/App Intent path nothing else does before the process
+    /// is suspended. `LogTransactionIntent` awaits `ensureBudgetReady()`, which
+    /// ends in the launch `syncOnForeground()`, so the Wallet write always
+    /// landed inside the window and only reached the server the next time the
+    /// app was opened (issue #139).
     private func shouldSkipAutomaticSync() -> Bool {
         guard let lastSync = lastSuccessfulSyncTime else {
             return false  // No previous sync, allow it
         }
-        let elapsed = Date().timeIntervalSince(lastSync)
-        return elapsed < 1.0  // Skip if less than 1 second since last sync
+        guard Date().timeIntervalSince(lastSync) < 1.0 else {
+            return false  // Outside the window
+        }
+        return !hasUnsyncedLocalMessages()
+    }
+
+    /// True when messages_crdt holds a message the last successful sync didn't
+    /// cover. HLC timestamps are fixed-width and sort lexicographically, so the
+    /// high-water mark comparison is exact.
+    private func hasUnsyncedLocalMessages() -> Bool {
+        guard let database else { return false }
+        guard let maxTimestamp = try? database.getMaxMessageTimestamp(), !maxTimestamp.isEmpty else {
+            return false  // Nothing recorded locally, nothing to push
+        }
+        guard let lastSynced = lastSyncedTimestamp, !lastSynced.isEmpty else {
+            return true  // Never reconciled — assume there's something to send
+        }
+        return maxTimestamp > lastSynced
     }
 
     /// - Returns: true iff the sync completed successfully.

--- a/Actuali/Actuali/Services/TransactionLogNotifier.swift
+++ b/Actuali/Actuali/Services/TransactionLogNotifier.swift
@@ -19,8 +19,11 @@ enum TransactionLoggedMarker {
 @MainActor
 enum TransactionLogNotifier {
 
+    /// - Parameter synced: false when the row is written locally but hasn't
+    ///   reached the server yet, which the banner says outright — otherwise the
+    ///   transaction looks logged while the budget on the server is unchanged.
     static func notifySuccess(payee: String, amountCents: Int, currencyCode: String,
-                              narrowSymbol: Bool = false) async {
+                              narrowSymbol: Bool = false, synced: Bool = true) async {
         let center = UNUserNotificationCenter.current()
 
         let granted: Bool
@@ -33,9 +36,10 @@ enum TransactionLogNotifier {
         guard granted else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "Logged transaction"
+        content.title = synced ? "Logged transaction" : "Saved locally"
         content.body = composeSuccessBody(payee: payee, amountCents: amountCents,
-                                          currencyCode: currencyCode, narrowSymbol: narrowSymbol)
+                                          currencyCode: currencyCode, narrowSymbol: narrowSymbol,
+                                          synced: synced)
         // No sound — quiet success banner that auto-dismisses.
         content.userInfo = TransactionLoggedMarker.userInfo
 
@@ -111,12 +115,16 @@ enum TransactionLogNotifier {
     }
 
     static func composeSuccessBody(payee: String, amountCents: Int, currencyCode: String,
-                                   narrowSymbol: Bool,
+                                   narrowSymbol: Bool, synced: Bool = true,
                                    locale: Locale = .autoupdatingCurrent) -> String {
         let amountString = CurrencyAmountFormat.string(cents: abs(amountCents),
                                                        currencyCode: currencyCode,
                                                        narrowSymbol: narrowSymbol,
                                                        locale: locale)
-        return payee.isEmpty ? amountString : "\(amountString) at \(payee)"
+        let prefix = payee.isEmpty ? amountString : "\(amountString) at \(payee)"
+        guard synced else {
+            return "\(prefix). Couldn't reach your server — it will sync when you open Actuali."
+        }
+        return prefix
     }
 }

--- a/Actuali/Actuali/Services/TransactionLogger.swift
+++ b/Actuali/Actuali/Services/TransactionLogger.swift
@@ -21,6 +21,14 @@ final class TransactionLogger {
         }
     }
 
+    /// The written row plus whether it reached the server. `synced == false`
+    /// means it is queued locally for the next successful sync, which in the
+    /// headless intent path may not happen until the app is opened (issue #139).
+    struct Result {
+        let transaction: Transaction
+        let synced: Bool
+    }
+
     private let store: BudgetStore
 
     init(store: BudgetStore) {
@@ -34,7 +42,7 @@ final class TransactionLogger {
     ///   - notes: optional notes from the caller
     ///   - date: transaction date
     ///   - cleared: whether the transaction is marked cleared in Actual
-    /// - Returns: the written transaction
+    /// - Returns: the written transaction and whether it reached the server
     func logTransaction(
         accountId: String,
         amountCents: Int,
@@ -42,7 +50,7 @@ final class TransactionLogger {
         notes: String?,
         date: Date,
         cleared: Bool = true
-    ) async throws -> Transaction {
+    ) async throws -> Result {
         guard let database = store.databaseForLogger else {
             throw LoggerError.noBudgetLoaded
         }
@@ -85,7 +93,11 @@ final class TransactionLogger {
         // moment it returns — wait for the push here so a Siri/Shortcuts log
         // still reaches the server before that happens.
         await store.flushPendingSync()
-        logger.info("Logged transaction \(transaction.id, privacy: .public) for \(payee.name, privacy: .public)")
-        return transaction
+        // The push is detached, so it can't report its own outcome: ask the
+        // queue instead. Anything still pending here means the server wasn't
+        // reachable and the row lives only on this device (issue #139).
+        let synced = !(await store.hasPendingLocalWrites())
+        logger.info("Logged transaction \(transaction.id, privacy: .public) for \(payee.name, privacy: .public), synced: \(synced, privacy: .public)")
+        return Result(transaction: transaction, synced: synced)
     }
 }

--- a/Actuali/ActualiTests/BackgroundRefreshTests.swift
+++ b/Actuali/ActualiTests/BackgroundRefreshTests.swift
@@ -28,6 +28,22 @@ struct BackgroundRefreshTests {
         #expect(request.earliestBeginDate == now.addingTimeInterval(BackgroundRefresh.minimumInterval))
     }
 
+    /// A headless write that couldn't be pushed asks for an earlier wake than
+    /// the routine refresh, so the queued transaction has a chance to reach the
+    /// server before the user next opens the app (issue #139).
+    @Test func pendingWriteFlushAsksForAnEarlierWakeThanTheRoutineRefresh() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let spy = SubmitSpy()
+
+        BackgroundRefresh.schedule(using: spy, now: now,
+                                   earliestIn: BackgroundRefresh.pendingWriteFlushInterval,
+                                   defaults: makeIsolatedDefaults())
+
+        #expect(BackgroundRefresh.pendingWriteFlushInterval < BackgroundRefresh.minimumInterval)
+        #expect(spy.submitted.first?.earliestBeginDate
+                == now.addingTimeInterval(BackgroundRefresh.pendingWriteFlushInterval))
+    }
+
     @Test func scheduleSubmitsOneRequestWithTaskIdentifier() {
         let spy = SubmitSpy()
 

--- a/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
+++ b/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
@@ -151,8 +151,10 @@ struct SyncClientPostWritePushTests {
         await syncClient.syncNow()
         #expect(PostWriteCaptureTransport.capturedBodies.count == 1)
 
-        // Intent write, milliseconds later.
+        // Intent write, milliseconds later. The push is detached (issue #125),
+        // so wait for it the way TransactionLogger does.
         try await syncClient.createTransaction(transaction())
+        await syncClient.flushPendingSync()
 
         // The canned server never echoes the messages back, so its merkle stays
         // empty and fullSync recurses on the diff — hence "more than one" rather

--- a/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
+++ b/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Captures every body POSTed to /sync/sync and answers with a canned,
+/// in-sync response (no messages, empty merkle).
+private final class PostWriteCaptureTransport: URLProtocol {
+    nonisolated(unsafe) static var capturedBodies: [Data] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        // URLSession delivers POST bodies to URLProtocol as a stream, not httpBody.
+        if let stream = request.httpBodyStream {
+            stream.open()
+            var body = Data()
+            let bufferSize = 16 * 1024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: bufferSize)
+                guard read > 0 else { break }
+                body.append(buffer, count: read)
+            }
+            stream.close()
+            Self.capturedBodies.append(body)
+        } else {
+            Self.capturedBodies.append(request.httpBody ?? Data())
+        }
+
+        var response = SyncResponse()
+        response.merkle = #"{"hash":0}"#
+        let data = (try? response.serializedData()) ?? Data()
+
+        let httpResponse = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/actual-sync"]
+        )!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Issue #139: Wallet/Shortcuts transactions didn't reach the server until the
+/// app was opened. `LogTransactionIntent` runs headless and awaits
+/// `ensureBudgetReady()`, which awaits the launch task — and that task ends in
+/// `syncOnForeground()`. The write then landed milliseconds after a successful
+/// sync, so `automaticSync()`'s 1-second rate limit *dropped* the push. The
+/// headless process was suspended before anything else synced, leaving the
+/// transaction local-only until the next app launch.
+///
+/// The rate limit exists to coalesce redundant *pull* syncs (several foreground
+/// triggers firing at once); it must never swallow a local write.
+@Suite(.serialized)
+struct SyncClientPostWritePushTests {
+
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeSyncClient(database: BudgetDatabase) async throws -> SyncClient {
+        PostWriteCaptureTransport.capturedBodies = []
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [PostWriteCaptureTransport.self]
+        let serverClient = ActualServerClient(session: URLSession(configuration: config))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("test-token")
+
+        let syncClient = SyncClient(serverClient: serverClient, nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        return syncClient
+    }
+
+    private func transaction(id: String = "txn-1") -> Transaction {
+        Transaction(
+            id: id,
+            accountId: "acct-1",
+            date: 20_260_811,
+            amount: -820,
+            payeeId: "payee-1",
+            payeeName: "Blue Bottle",
+            categoryId: nil,
+            categoryName: nil,
+            notes: nil,
+            cleared: true,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: "BLUE BOTTLE COFFEE"
+        )
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// The headless Shortcuts path: launch sync completes, then the intent
+    /// writes immediately. The write must still be pushed.
+    @Test func writeRightAfterASuccessfulSyncIsStillPushed() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let syncClient = try await makeSyncClient(database: database)
+
+        // Launch sync (BudgetStore.init -> loadTask -> syncOnForeground).
+        await syncClient.syncNow()
+        #expect(PostWriteCaptureTransport.capturedBodies.count == 1)
+
+        // Intent write, milliseconds later.
+        try await syncClient.createTransaction(transaction())
+
+        // The canned server never echoes the messages back, so its merkle stays
+        // empty and fullSync recurses on the diff — hence "more than one" rather
+        // than exactly one follow-up POST. What matters is that the write was
+        // sent at all: before the fix nothing was, and the transaction sat local
+        // -only until the app was next opened.
+        let pushes = PostWriteCaptureTransport.capturedBodies.dropFirst()
+        #expect(!pushes.isEmpty)
+        let pushedMessages = try pushes.reduce(0) {
+            try $0 + SyncRequest(serializedData: $1).messages.count
+        }
+        #expect(pushedMessages > 0)
+    }
+
+    /// The rate limit still does its job for pull-only triggers: nothing new
+    /// locally means no redundant round trip.
+    @Test func redundantPullSyncWithNoLocalWritesIsStillRateLimited() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let syncClient = try await makeSyncClient(database: database)
+
+        await syncClient.syncNow()
+        #expect(PostWriteCaptureTransport.capturedBodies.count == 1)
+
+        await syncClient.automaticSync()
+
+        #expect(PostWriteCaptureTransport.capturedBodies.count == 1)
+    }
+}

--- a/Actuali/ActualiTests/TransactionLogNotifierTests.swift
+++ b/Actuali/ActualiTests/TransactionLogNotifierTests.swift
@@ -61,4 +61,19 @@ struct TransactionLogNotifierTests {
         )
         #expect(bodyGBP == "£5.00 at Tesco")
     }
+
+    /// A write that never reached the server must not read as a plain success —
+    /// the transaction exists only on the phone until the next sync (issue #139).
+    @Test func composeSuccessBodySaysWhenTheRowIsOnlyLocal() {
+        let body = TransactionLogNotifier.composeSuccessBody(
+            payee: "Starbucks",
+            amountCents: 1250,
+            currencyCode: "USD",
+            narrowSymbol: false,
+            synced: false,
+            locale: enUS
+        )
+        #expect(body.hasPrefix("$12.50 at Starbucks."))
+        #expect(body.contains("sync when you open Actuali"))
+    }
 }

--- a/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
+++ b/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Answers /sync/sync either with a valid in-sync response or with a network
+/// failure, so the headless write path can be exercised against a reachable
+/// and an unreachable server.
+private final class SyncOutcomeTransport: URLProtocol {
+    nonisolated(unsafe) static var failWithOffline = false
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if Self.failWithOffline {
+            client?.urlProtocol(self, didFailWithError: NSError(
+                domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet))
+            return
+        }
+
+        var response = SyncResponse()
+        response.merkle = #"{"hash":0}"#
+        let data = (try? response.serializedData()) ?? Data()
+        let httpResponse = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/actual-sync"]
+        )!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Issue #139: the Shortcut used to report a plain success even when the row
+/// never left the phone. `logTransaction` now reports whether the push landed
+/// so `LogTransactionIntent` can say "Saved locally" instead.
+@MainActor
+@Suite(.serialized)
+struct TransactionLoggerSyncOutcomeTests {
+
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase, serverReachable: Bool) async throws -> BudgetStore {
+        SyncOutcomeTransport.failWithOffline = !serverReachable
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SyncOutcomeTransport.self]
+        let serverClient = ActualServerClient(session: URLSession(configuration: config))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("test-token")
+
+        let syncClient = SyncClient(serverClient: serverClient, nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+
+        let store = BudgetStore.previewInstance()
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    private func log(to store: BudgetStore) async throws -> TransactionLogger.Result {
+        try await TransactionLogger(store: store).logTransaction(
+            accountId: "acct-1",
+            amountCents: -820,
+            rawMerchant: "BLUE BOTTLE COFFEE",
+            notes: nil,
+            date: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func reachableServerReportsTheWriteAsSynced() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, serverReachable: true)
+
+        let result = try await log(to: store)
+
+        #expect(result.synced)
+    }
+
+    /// Unreachable server: the row is still written (nothing is lost), but the
+    /// caller is told it hasn't landed so the banner can say so.
+    @Test func unreachableServerReportsTheWriteAsUnsynced() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, serverReachable: false)
+
+        let result = try await log(to: store)
+
+        #expect(!result.synced)
+
+        let queue = try DatabaseQueue(path: url.path)
+        let rows = try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT id FROM transactions WHERE tombstone = 0")
+        }
+        #expect(rows.count == 1)
+        #expect(rows.first?["id"] == result.transaction.id)
+    }
+}


### PR DESCRIPTION
## What was wrong

Wallet/Shortcuts transactions logged via `LogTransactionIntent` were written locally but did not reach the Actual server until the app was next opened — the symptom reported in #139.

It isn't an iOS limitation. The headless path already syncs before it returns: since #184 the write kicks off a detached push and `TransactionLogger` awaits `flushPendingSync()` so a Siri/Shortcuts log still lands before iOS freezes the process. The push was being dropped by our own rate limit.

`LogTransactionIntent` runs headless (`openAppWhenRun = false`) and awaits `BudgetStore.ensureBudgetReady()`, which awaits the launch task — and that task ends in `syncOnForeground()`. So on every cold headless launch the intent's write lands *milliseconds* after a successful sync, and `shouldSkipAutomaticSync()` (skip if a sync succeeded < 1 s ago) suppressed the push. `flushPendingSync()` then dutifully awaited a task that did nothing, and the transaction sat local-only until the next app launch.

## Why this fixes it

**1. The rate limit no longer swallows pushes.** The 1-second window exists to coalesce redundant *pull* syncs when several foreground triggers land at once; it must never suppress a *push*. `shouldSkipAutomaticSync()` now skips only when `messages_crdt` holds nothing newer than `lastSyncedTimestamp` (HLC timestamps are fixed-width and sort lexicographically, so the high-water-mark comparison is exact). Pull-only triggers inside the window are still coalesced exactly as before, and #184's trailing-push coalescing is untouched.

This also fixes schedule posting: `SchedulePoster` loops `createTransaction`, and every occurrence after the first was dropped from the push for the same reason.

**2. A failed push is no longer silent.** The intent used to report "Logged transaction" even when the server was unreachable, so the row looked posted while the budget on the server was unchanged. Pushes are detached, so a write path can't report its own outcome — `TransactionLogger` instead asks the queue after `flushPendingSync()` via the new `hasPendingLocalWrites()`. Anything still unsynced there means the server wasn't reachable, and the banner reads "Saved locally — Couldn't reach your server, it will sync when you open Actuali". The intent dialog says the same.

**3. Best-effort flush.** When the push fails, the intent submits a `BGAppRefreshTaskRequest` with a 15-minute floor (shorter than the routine hourly refresh) so the queued write gets a chance to reach the server before the app is next opened. `earliestBeginDate` is only a hint and iOS may ignore it entirely, so this supplements the banner rather than replacing it.

Note this doesn't change the "post as cleared" behaviour — the intent already has a `Cleared` toggle, default on.

## How it was verified

New `SyncClientPostWritePushTests` reproduces the headless sequence against a `URLProtocol` stub: launch sync, then a write milliseconds later. Before the fix only one POST was captured, carrying zero messages:

```
✘ Test writeRightAfterASuccessfulSyncIsStillPushed() recorded an issue at SyncClientPostWritePushTests.swift:157:9: Expectation failed: (PostWriteCaptureTransport.capturedBodies.count → 1) == 2
✘ Test writeRightAfterASuccessfulSyncIsStillPushed() recorded an issue at SyncClientPostWritePushTests.swift:160:9: Expectation failed: !((request.messages → []).isEmpty → true → true)
✘ Test run with 2 tests in 1 suite failed after 0.114 seconds with 2 issues.
```

After the fix, with new coverage for the unsynced-write reporting, the flush floor, and the banner copy:

```
✔ Test writeRightAfterASuccessfulSyncIsStillPushed() passed after 3.661 seconds.
✔ Test redundantPullSyncWithNoLocalWritesIsStillRateLimited() passed after 0.011 seconds.
✔ Test reachableServerReportsTheWriteAsSynced() passed after 4.970 seconds.
✔ Test unreachableServerReportsTheWriteAsUnsynced() passed after 0.048 seconds.
✔ Test pendingWriteFlushAsksForAnEarlierWakeThanTheRoutineRefresh() passed after 0.488 seconds.
✔ Test composeSuccessBodySaysWhenTheRowIsOnlyLocal() passed after 4.451 seconds.
```

Full unit suite on top of the rebase onto #184 (iPhone 17 / iOS 26.5 simulator), exit code 0 — including #184's own `SyncClientOfflineWriteTests`:

```
✔ Suite SyncClientOfflineWriteTests passed after 0.712 seconds.
✔ Test run with 737 tests in 106 suites passed after 5.143 seconds.
```

Fixes #139