### PR TITLE
Sync a freshly downloaded budget right away and show a syncing banner

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -145,6 +145,13 @@ final class BudgetStore: ObservableObject {
     @Published var syncState: SyncState = .idle
     @Published var lastSyncTime: Date?
 
+    /// True from the moment a budget is opened until its first sync attempt
+    /// finishes. Everything on screen until then comes from the downloaded
+    /// server snapshot (or the local copy the last launch left behind), which
+    /// can trail the server by hours or days — the UI says so rather than
+    /// presenting those figures as final (GH #126).
+    @Published private(set) var isInitialSyncing = false
+
     /// Whether we may WRITE payee_locations CRDT messages (server >= 26.4.0,
     /// probed via `GET /info` after each budget load). Persisted per server
     /// URL so offline launches keep the last known answer.
@@ -736,6 +743,9 @@ final class BudgetStore: ObservableObject {
         // the same task, before the load, so the initial sync below is
         // authenticated.
         if let budgetId = currentBudgetId, fileManager.budgetExists(budgetId) {
+            // Set before the task so the very first render already knows the
+            // numbers it is about to draw are provisional (GH #126).
+            isInitialSyncing = true
             loadTask = Task {
                 if let token { await configureSavedSession(token: token) }
                 await loadLocalBudget(budgetId)
@@ -743,6 +753,7 @@ final class BudgetStore: ObservableObject {
                 // loadLocalBudget has wired syncClient, so the scenePhase
                 // foreground sync no-ops. Sync here once the client exists.
                 await syncOnForeground()
+                isInitialSyncing = false
             }
         } else if let token {
             Task { await configureSavedSession(token: token) }
@@ -978,6 +989,9 @@ final class BudgetStore: ObservableObject {
         payees = []
         lastSyncTime = nil
         syncState = .idle
+        // No budget left to catch up — an in-flight initial sync's banner must
+        // not outlive the budget it described.
+        isInitialSyncing = false
         dataVersion += 1
     }
 
@@ -1028,6 +1042,10 @@ final class BudgetStore: ObservableObject {
         syncClient = nil
         database = nil
 
+        // Whether the budget actually got opened, so the initial sync below
+        // runs only when there is something to catch up.
+        var opened = false
+
         do {
             var loadedKey: LoadedKey?
             if remoteBudget.isEncrypted {
@@ -1068,6 +1086,8 @@ final class BudgetStore: ObservableObject {
                 from: zipData, fileId: remoteBudget.id, groupId: remoteBudget.groupId
             )
             currentBudgetId = metadata.id
+            isInitialSyncing = true
+            opened = true
             await loadLocalBudget(metadata.id)
         } catch {
             self.error = error.localizedDescription
@@ -1075,6 +1095,21 @@ final class BudgetStore: ObservableObject {
 
         isLoading = false
         downloadingBudgetId = nil
+
+        // Outside the download spinner: the budget is on screen from here, it
+        // just isn't caught up yet.
+        if opened { await runInitialSync() }
+    }
+
+    /// The first sync after a budget is opened. A downloaded budget is a server
+    /// snapshot that can trail the server's message log by hours or days, so
+    /// catch it up immediately instead of leaving those figures on screen until
+    /// the next foreground or pull-to-refresh — which is how "outdated numbers"
+    /// survived a fresh setup (GH #126).
+    private func runInitialSync() async {
+        defer { isInitialSyncing = false }
+        guard syncClient != nil else { return }
+        await sync()
     }
 
     /// Validate an encryption password for a budget, persist the derived key, then download it.

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -107,6 +107,7 @@ struct AccountsListView: View {
                 }
             }
         }
+        .initialSyncBanner()
     }
 
     /// Tapping a success notification lands here: jump the stack straight to

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -345,6 +345,7 @@ struct BudgetView: View {
                 }
             }
         }
+        .initialSyncBanner()
     }
 
     /// Open the move-money sheet for a tapped balance (GH #128): cover

--- a/Actuali/Actuali/Views/Components/InitialSyncBanner.swift
+++ b/Actuali/Actuali/Views/Components/InitialSyncBanner.swift
@@ -1,0 +1,73 @@
+// Actuali/Actuali/Views/Components/InitialSyncBanner.swift
+
+import SwiftUI
+
+/// Full-width notice pinned above a screen's content while a budget's first
+/// sync is still running. Until it lands the balances on screen come from the
+/// server snapshot the app downloaded, which can be hours or days behind — so
+/// say so, instead of letting the user read stale figures as final (GH #126).
+struct InitialSyncBanner: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Syncing — amounts may not be up to date yet")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("initialSyncBanner")
+        .accessibilityLabel("Syncing. Amounts may not be up to date yet.")
+        .accessibilityAddTraits(.updatesFrequently)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
+
+/// Stacks `InitialSyncBanner` above the modified view while the store's first
+/// sync is in flight.
+///
+/// Apply this OUTSIDE a tab's `NavigationStack`, not inside it: a
+/// `safeAreaInset` on the stack's content offsets the scroll view, which
+/// swallows the large navigation title and leaves the toolbar buttons clipped
+/// behind the banner. Stacking above the whole navigation stack shrinks its
+/// frame instead, so the bar lays out normally underneath.
+private struct InitialSyncBannerModifier: ViewModifier {
+    @EnvironmentObject private var budgetStore: BudgetStore
+
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            if budgetStore.isInitialSyncing {
+                InitialSyncBanner()
+            }
+            content
+        }
+        .animation(.easeInOut(duration: 0.2), value: budgetStore.isInitialSyncing)
+    }
+}
+
+extension View {
+    func initialSyncBanner() -> some View {
+        modifier(InitialSyncBannerModifier())
+    }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        InitialSyncBanner()
+        NavigationStack {
+            List {
+                Text("Checking")
+                Text("Savings")
+            }
+            .navigationTitle("Accounts")
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -38,6 +38,7 @@ struct ReportsTabView: View {
                 await reload()
             }
         }
+        .initialSyncBanner()
     }
 
     private func reload() async {

--- a/Actuali/ActualiTests/BudgetStoreInitialSyncTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreInitialSyncTests.swift
@@ -1,0 +1,313 @@
+import Combine
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Answers the budget download with a canned ZIP and fails every other request,
+/// so `downloadBudget` can run end to end without a server while the sync leg
+/// that follows it fails fast and locally.
+private final class BudgetDownloadTransport: URLProtocol {
+    nonisolated(unsafe) static var zipData = Data()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard request.url?.path.contains("download-user-file") == true else {
+            client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/zip"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.zipData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// GH #126: a first-time setup downloaded the budget, showed the snapshot's
+/// balances, and then just sat there — nothing synced until the user
+/// pull-to-refreshed or backgrounded and reopened the app, and nothing on
+/// screen said the figures weren't final. The server snapshot in that ZIP can
+/// trail the server's message log by hours or days, so those numbers read as
+/// current when they weren't ("had me scared for a second").
+@Suite(.serialized)
+@MainActor
+struct BudgetStoreInitialSyncTests {
+
+    // MARK: - Fixtures
+
+    /// A budget ZIP shaped like the one `/sync/download-user-file` returns:
+    /// `db.sqlite` on the upstream schema plus `metadata.json`.
+    private func makeBudgetZip(budgetId: String) throws -> Data {
+        let dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        // Scoped so the connection is released before the bytes are read.
+        do {
+            let queue = try DatabaseQueue(path: dbURL.path)
+            try queue.write { db in
+                try db.execute(sql: Self.upstreamSchema)
+                try db.execute(sql: """
+                    INSERT INTO accounts (id, name, type, sort_order)
+                    VALUES ('acct-1', 'Checking', 'checking', 1.0);
+                    """)
+            }
+        }
+
+        let metadata = BudgetMetadata(
+            id: budgetId,
+            budgetName: "Test Budget",
+            cloudFileId: nil,
+            groupId: nil,
+            resetClock: nil,
+            lastUploaded: nil,
+            encryptKeyId: nil
+        )
+        return StoredZip.archive([
+            (name: "db.sqlite", data: try Data(contentsOf: dbURL)),
+            (name: "metadata.json", data: try JSONEncoder().encode(metadata))
+        ])
+    }
+
+    /// Store wired to a disposable Budgets directory and a stubbed transport,
+    /// so `downloadBudget` exercises the real download → import → load → sync
+    /// path without touching the shared app-support directory or a server.
+    private func makeStore(zip: Data, root rootDirectory: URL) async throws -> BudgetStore {
+        BudgetDownloadTransport.zipData = zip
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [BudgetDownloadTransport.self]
+        let serverClient = ActualServerClient(session: URLSession(configuration: config))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("test-token")
+
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(serverClient)
+        store.setFileManagerForTesting(BudgetFileManager(rootDirectoryForTesting: rootDirectory))
+        return store
+    }
+
+    private func makeRootDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("budgets-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// `currentBudgetId`'s didSet and the notification watermark both persist
+    /// to UserDefaults; restore them so tests leave the host app's defaults as
+    /// they found them.
+    private func cleanUp(root: URL, budgetId: String?, savedBudgetId: String?) {
+        try? FileManager.default.removeItem(at: root)
+        UserDefaults.standard.set(savedBudgetId, forKey: "currentBudgetId")
+        if let budgetId {
+            UserDefaults.standard.removeObject(
+                forKey: "transactionNotificationWatermark.\(budgetId)")
+        }
+    }
+
+    private static let remoteBudget = BudgetStore.RemoteBudget(
+        id: "cloud-file-1", name: "Test Budget", groupId: "group-1", isEncrypted: false
+    )
+
+    // MARK: - Tests
+
+    /// The bug: nothing kicked off a sync after the download, so the snapshot's
+    /// figures stayed on screen until some other event happened to sync.
+    @Test func freshDownloadSyncsTheSnapshotImmediately() async throws {
+        let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
+        let root = try makeRootDirectory()
+        let budgetId = "test-initial-sync-\(UUID().uuidString)"
+        defer { cleanUp(root: root, budgetId: budgetId, savedBudgetId: savedBudgetId) }
+        let store = try await makeStore(zip: try makeBudgetZip(budgetId: budgetId), root: root)
+
+        await store.downloadBudget(Self.remoteBudget)
+
+        // The budget opened...
+        #expect(store.error == nil)
+        #expect(store.accounts.map(\.name) == ["Checking"])
+        // ...and its first sync ran as part of opening it, rather than waiting
+        // for a pull-to-refresh or a foreground transition.
+        #expect(store.lastSyncTime != nil)
+    }
+
+    /// The other half of the report — "no clear indication that a sync is still
+    /// in progress". The flag the banner reads has to go up while the first
+    /// sync is in flight and come back down when it lands.
+    @Test func initialSyncIsFlaggedWhileItRunsAndClearedAfterwards() async throws {
+        let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
+        let root = try makeRootDirectory()
+        let budgetId = "test-initial-sync-\(UUID().uuidString)"
+        defer { cleanUp(root: root, budgetId: budgetId, savedBudgetId: savedBudgetId) }
+        let store = try await makeStore(zip: try makeBudgetZip(budgetId: budgetId), root: root)
+
+        var observed: [Bool] = []
+        let subscription = store.$isInitialSyncing.sink { observed.append($0) }
+        defer { subscription.cancel() }
+
+        #expect(store.isInitialSyncing == false)
+        await store.downloadBudget(Self.remoteBudget)
+
+        #expect(observed.contains(true), "the syncing state was never published")
+        #expect(store.isInitialSyncing == false, "the syncing state never cleared")
+    }
+
+    /// A download that never lands leaves nothing to catch up, so the banner
+    /// must not be left hanging over an unchanged budget.
+    @Test func failedDownloadDoesNotLeaveTheSyncingStateStuckOn() async throws {
+        let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
+        let root = try makeRootDirectory()
+        defer { cleanUp(root: root, budgetId: nil, savedBudgetId: savedBudgetId) }
+        // Not a ZIP: the import fails and downloadBudget surfaces the error.
+        let store = try await makeStore(zip: Data("not a zip".utf8), root: root)
+
+        await store.downloadBudget(Self.remoteBudget)
+
+        #expect(store.error != nil)
+        #expect(store.isInitialSyncing == false)
+    }
+
+    // MARK: - Upstream schema
+
+    /// The tables `loadLocalBudget` reads and `SyncClient.configure` needs,
+    /// matching the schema an Actual server ships in a budget ZIP.
+    private static let upstreamSchema = """
+        CREATE TABLE accounts (
+            id TEXT PRIMARY KEY, name TEXT, type TEXT, offbudget INTEGER DEFAULT 0,
+            closed INTEGER DEFAULT 0, tombstone INTEGER DEFAULT 0, sort_order REAL,
+            account_id TEXT, balance_current INTEGER, balance_available INTEGER,
+            balance_limit INTEGER, mask TEXT, official_name TEXT, subtype TEXT, bank TEXT
+        );
+        CREATE TABLE transactions (
+            id TEXT PRIMARY KEY, isParent INTEGER DEFAULT 0, isChild INTEGER DEFAULT 0,
+            acct TEXT, category TEXT, amount INTEGER, description TEXT, notes TEXT,
+            date INTEGER, financial_id TEXT, type TEXT, location TEXT, error TEXT,
+            imported_description TEXT, starting_balance_flag INTEGER DEFAULT 0,
+            transferred_id TEXT, sort_order REAL, tombstone INTEGER DEFAULT 0,
+            cleared INTEGER DEFAULT 0, reconciled INTEGER DEFAULT 0, parent_id TEXT,
+            schedule TEXT
+        );
+        CREATE TABLE categories (
+            id TEXT PRIMARY KEY, name TEXT, is_income INTEGER DEFAULT 0, cat_group TEXT,
+            sort_order REAL, tombstone INTEGER DEFAULT 0, hidden BOOLEAN NOT NULL DEFAULT 0
+        );
+        CREATE TABLE category_groups (
+            id TEXT PRIMARY KEY, name TEXT UNIQUE, is_income INTEGER DEFAULT 0,
+            sort_order REAL, tombstone INTEGER DEFAULT 0, hidden BOOLEAN NOT NULL DEFAULT 0
+        );
+        CREATE TABLE payees (
+            id TEXT PRIMARY KEY, name TEXT, category TEXT, tombstone INTEGER DEFAULT 0,
+            transfer_acct TEXT
+        );
+        CREATE TABLE payee_mapping (id TEXT PRIMARY KEY, targetId TEXT);
+        CREATE TABLE category_mapping (id TEXT PRIMARY KEY, transferId TEXT);
+        CREATE TABLE zero_budgets (
+            id TEXT PRIMARY KEY, month INTEGER, category TEXT, amount INTEGER DEFAULT 0,
+            carryover INTEGER DEFAULT 0
+        );
+        CREATE TABLE preferences (id TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE messages_crdt (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL UNIQUE,
+            dataset TEXT NOT NULL, row TEXT NOT NULL, column TEXT NOT NULL, value BLOB NOT NULL
+        );
+        CREATE TABLE messages_clock (id INTEGER PRIMARY KEY, clock TEXT);
+        CREATE TABLE db_version (version TEXT PRIMARY KEY);
+        CREATE TABLE __migrations__ (id INT PRIMARY KEY NOT NULL);
+        """
+}
+
+/// Builds an uncompressed ZIP in memory. Hand-rolled because ZIPFoundation is
+/// linked into the app target only; stored entries are the simplest thing it
+/// will read back, and that read is what these tests are exercising.
+private enum StoredZip {
+    static func archive(_ entries: [(name: String, data: Data)]) -> Data {
+        var payload = Data()
+        var central = Data()
+
+        for entry in entries {
+            let name = Data(entry.name.utf8)
+            let crc = crc32(entry.data)
+            let size = UInt32(entry.data.count)
+            let offset = UInt32(payload.count)
+
+            payload += le32(0x0403_4b50)      // local file header
+            payload += le16(20)               // version needed
+            payload += le16(0)                // flags
+            payload += le16(0)                // method: stored
+            payload += le16(0)                // mod time
+            payload += le16(0x21)             // mod date: 1980-01-01
+            payload += le32(crc)
+            payload += le32(size)             // compressed size
+            payload += le32(size)             // uncompressed size
+            payload += le16(UInt16(name.count))
+            payload += le16(0)                // extra field length
+            payload += name
+            payload += entry.data
+
+            central += le32(0x0201_4b50)      // central directory header
+            central += le16(20)               // version made by
+            central += le16(20)               // version needed
+            central += le16(0)                // flags
+            central += le16(0)                // method: stored
+            central += le16(0)                // mod time
+            central += le16(0x21)             // mod date
+            central += le32(crc)
+            central += le32(size)
+            central += le32(size)
+            central += le16(UInt16(name.count))
+            central += le16(0)                // extra field length
+            central += le16(0)                // comment length
+            central += le16(0)                // disk number start
+            central += le16(0)                // internal attributes
+            central += le32(0)                // external attributes
+            central += le32(offset)
+            central += name
+        }
+
+        let centralOffset = UInt32(payload.count)
+        var output = payload
+        output += central
+        output += le32(0x0605_4b50)           // end of central directory
+        output += le16(0)                     // this disk
+        output += le16(0)                     // disk with central directory
+        output += le16(UInt16(entries.count))
+        output += le16(UInt16(entries.count))
+        output += le32(UInt32(central.count))
+        output += le32(centralOffset)
+        output += le16(0)                     // comment length
+        return output
+    }
+
+    private static func le16(_ value: UInt16) -> Data {
+        Data([UInt8(value & 0xff), UInt8(value >> 8)])
+    }
+
+    private static func le32(_ value: UInt32) -> Data {
+        Data([
+            UInt8(value & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 24) & 0xff)
+        ])
+    }
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc ^= UInt32(byte)
+            for _ in 0..<8 {
+                // Branch-free: subtract the low bit from zero to get the mask.
+                crc = (crc >> 1) ^ (0xEDB8_8320 & (0 &- (crc & 1)))
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}


### PR DESCRIPTION
## What was wrong

Two things compounded during first-time setup:

1. **`downloadBudget` never started a sync.** It downloaded the ZIP, imported it, called `loadLocalBudget`, and stopped. Nothing else on that path syncs — `syncOnForeground()` only fires from `init()` (already past by then) and from the `scenePhase` `.active` transition, and `sync()` only from pull-to-refresh or Settings' Sync Now. So a fresh connection sat on the downloaded snapshot until the user happened to pull down or background and reopen the app.
2. **Nothing on screen said the numbers were provisional.** The only sync indication was the small `SyncStatusView` spinner in the Accounts toolbar; the Budget tab had none.

That snapshot is the server's periodic export, so it can trail the live message log by hours or days. The reporter read those balances as current — *"had me scared for a second."*

## Why this fixes it

- `downloadBudget` now hands the load straight to a first sync (`runInitialSync`), run *after* `isLoading`/`downloadingBudgetId` are cleared so the budget is already on screen while the catch-up happens rather than sitting behind the download spinner.
- New `@Published private(set) var isInitialSyncing` on `BudgetStore` spans budget-open → first-sync-completion, covering both the download path and the cold-launch load in `init()`. `logout()` clears it so a banner can't outlive the budget it described.
- The Accounts, Budget and Reports tabs stack an `InitialSyncBanner` — *"Syncing — amounts may not be up to date yet"* — above their navigation stacks while the flag is set.

One layout note worth keeping: the banner is applied **outside** each `NavigationStack`, not inside as a `safeAreaInset`. An inset offsets the scroll view, which swallows the large navigation title entirely and leaves the toolbar buttons clipped behind the banner (verified on the simulator before switching approaches).

## How it was verified

New `BudgetStoreInitialSyncTests` drives the real download → import → load → sync path against a stubbed `URLProtocol` transport and a disposable Budgets directory, using a hand-built stored ZIP containing an upstream-schema `db.sqlite` plus `metadata.json`.

Against the pre-fix behaviour (initial-sync call temporarily reverted), the two bug-capturing tests fail:

```
◇ Test freshDownloadSyncsTheSnapshotImmediately() started.
✘ Test freshDownloadSyncsTheSnapshotImmediately() recorded an issue at BudgetStoreInitialSyncTests.swift:139:9: Expectation failed: (store.lastSyncTime → nil) != nil
✘ Test freshDownloadSyncsTheSnapshotImmediately() failed after 0.181 seconds with 1 issue.
◇ Test initialSyncIsFlaggedWhileItRunsAndClearedAfterwards() started.
✘ Test initialSyncIsFlaggedWhileItRunsAndClearedAfterwards() recorded an issue at BudgetStoreInitialSyncTests.swift:159:9: Expectation failed: (observed → [false]).contains(true)
✘ Test initialSyncIsFlaggedWhileItRunsAndClearedAfterwards() failed after 0.160 seconds with 1 issue.
✔ Test failedDownloadDoesNotLeaveTheSyncingStateStuckOn() passed after 0.007 seconds.
✘ Test run with 3 tests in 1 suite failed after 0.354 seconds with 2 issues.
```

With the fix, the full unit suite is green:

```
✔ Test run with 732 tests in 104 suites passed after 5.474 seconds.
```

(`xcodebuild test -scheme Actuali -destination "platform=iOS Simulator,id=…" -skip-testing:ActualiUITests`, iPhone 17 / iOS 26.5 — the same invocation CI runs.)

UI tests were also run locally (23 tests). `BudgetTabBadgeUITests.testBadgeTracksOverspentCategories` fails, but it fails identically on the unmodified branch — pre-existing, unrelated, and not part of CI. `BackgroundRefreshRowUITests` failed once and passed on re-run (flaky).

The banner itself was checked visually on the simulator on both the Accounts and Budget tabs — navigation titles and toolbar controls render correctly underneath it.

## Notes

- The banner also shows on a cold launch, not just after a fresh download, for as long as the launch sync is in flight. That's usually under a second, and it seemed like the honest reading of *"no clear indication that a sync is still in progress"* — happy to scope it to fresh downloads only if you'd rather avoid the flash on every launch.
- Reports gets the banner too (second commit). Its net worth / cash flow / age-of-money figures come from the same pre-sync snapshot, read as authoritative summaries, and it's the one tab with no toolbar sync glyph either.
- Not touched, flagging as adjacent: there's no UI-test coverage for the banner, since triggering an initial sync needs a reachable server.

Fixes #126

