### PR TITLE
Derive the sync merkle from the message log instead of adopting the server's

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1088,6 +1088,12 @@ final class BudgetStore: ObservableObject {
             currentBudgetId = metadata.id
             isInitialSyncing = true
             opened = true
+            // The initial sync below can pull weeks of history, and this file's
+            // messages_crdt rowids come from whichever client uploaded it, so a
+            // watermark left by a previous copy of the same budget points at
+            // unrelated messages — high enough to pass the detector's guard, low
+            // enough to announce all that history as new transactions.
+            NewTransactionDetector.forgetWatermark(budgetId: metadata.id)
             await loadLocalBudget(metadata.id)
         } catch {
             self.error = error.localizedDescription

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1755,6 +1755,33 @@ class BudgetDatabase {
         }
     }
 
+    /// Rebuild the sync merkle from `messages_crdt`.
+    ///
+    /// The trie is nothing but the XOR of every stored message's timestamp hash,
+    /// so the message log — not the tree cached in `messages_clock` — is its
+    /// source of truth. Re-deriving lets a persisted tree that drifted from the
+    /// log be repaired instead of quietly misreporting parity with the server
+    /// (see `SyncClient.fullSync`).
+    ///
+    /// A long-lived budget's log runs to hundreds of thousands of rows, so this
+    /// avoids `HLCTimestamp` entirely: it hashes each stored timestamp string
+    /// directly (`HLCTimestamp.hash()` murmurs `toString()`, which is exactly
+    /// the text the log holds) and reads the trie's minute off the ISO-8601
+    /// prefix arithmetically.
+    func deriveMerkleFromMessageLog() throws -> MerkleTree {
+        try dbQueue.read { db in
+            guard try db.tableExists("messages_crdt") else { return MerkleTree() }
+
+            var buckets: [Int64: Int32] = [:]
+            let cursor = try String.fetchCursor(db, sql: "SELECT timestamp FROM messages_crdt")
+            while let timestamp = try cursor.next() {
+                guard let minutes = HLCTimestamp.minutesSinceEpoch(of: timestamp) else { continue }
+                buckets[minutes * 60_000, default: 0] ^= Int32(bitPattern: MurmurHash3.hash(timestamp))
+            }
+            return MerkleTree.building(from: buckets).pruned()
+        }
+    }
+
     func getMessagesSince(_ since: String) throws -> [CRDTMessage] {
         try dbQueue.read { db in
             let rows = try Row.fetchAll(db, sql: """

--- a/Actuali/Actuali/Services/NewTransactionDetector.swift
+++ b/Actuali/Actuali/Services/NewTransactionDetector.swift
@@ -15,10 +15,24 @@ struct NewTransactionDetector {
         self.defaults = defaults
     }
 
+    private static func watermarkKey(budgetId: String) -> String {
+        "transactionNotificationWatermark.\(budgetId)"
+    }
+
+    /// Drop the watermark for a budget whose file was just downloaded. The new
+    /// snapshot's messages_crdt rowids come from whichever client uploaded it,
+    /// so a watermark left by a previous copy of the same budget points at
+    /// unrelated messages — high enough to pass the `watermark <= maxId` guard
+    /// below, low enough for the first catch-up sync to look like a pile of new
+    /// transactions. Forgetting it makes the next detection re-baseline.
+    static func forgetWatermark(budgetId: String, defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: watermarkKey(budgetId: budgetId))
+    }
+
     func detectNewTransactions(in database: BudgetDatabase,
                                budgetId: String,
                                localNode: String) async throws -> [Transaction] {
-        let key = "transactionNotificationWatermark.\(budgetId)"
+        let key = Self.watermarkKey(budgetId: budgetId)
         let maxId = try await database.fetchMaxMessageId()
 
         guard let watermark = (defaults.object(forKey: key) as? NSNumber)?.int64Value,

--- a/Actuali/Actuali/Services/Sync/HLCTimestamp.swift
+++ b/Actuali/Actuali/Services/Sync/HLCTimestamp.swift
@@ -67,6 +67,50 @@ struct HLCTimestamp: Comparable, Hashable, Codable, CustomStringConvertible {
         return HLCTimestamp(millis: millis, counter: counter, node: node)
     }
 
+    /// Minutes since the Unix epoch for a timestamp string, read straight off
+    /// its ISO-8601 prefix (`YYYY-MM-DDTHH:MM`, always UTC).
+    ///
+    /// `parse` builds an `ISO8601DateFormatter` per call, which dominates any
+    /// pass over a whole message log — and the Merkle trie only ever needs the
+    /// minute (`MerkleTree` keys on `millis / 1000 / 60`), never the full
+    /// timestamp. Returns nil if the prefix isn't well formed.
+    static func minutesSinceEpoch(of string: String) -> Int64? {
+        var iterator = string.utf8.makeIterator()
+        // Fixed-width fields, each followed by one separator ("-", "-", "T", ":").
+        func field(digits: Int, separator: Bool) -> Int? {
+            var value = 0
+            for _ in 0..<digits {
+                guard let byte = iterator.next(), byte >= 48, byte <= 57 else { return nil }
+                value = value * 10 + Int(byte - 48)
+            }
+            if separator, iterator.next() == nil { return nil }
+            return value
+        }
+        guard let year = field(digits: 4, separator: true),
+              let month = field(digits: 2, separator: true),
+              let day = field(digits: 2, separator: true),
+              let hour = field(digits: 2, separator: true),
+              let minute = field(digits: 2, separator: false),
+              (1...12).contains(month), (1...31).contains(day),
+              hour < 24, minute < 60
+        else { return nil }
+
+        return daysSinceEpoch(year: year, month: month, day: day) * 1440
+            + Int64(hour * 60 + minute)
+    }
+
+    /// Days from 1970-01-01 to a proleptic-Gregorian date (Howard Hinnant's
+    /// `days_from_civil`), shifting the year to start in March so the leap day
+    /// lands at the end of the cycle.
+    private static func daysSinceEpoch(year: Int, month: Int, day: Int) -> Int64 {
+        let shiftedYear = year - (month <= 2 ? 1 : 0)
+        let era = (shiftedYear >= 0 ? shiftedYear : shiftedYear - 399) / 400
+        let yearOfEra = shiftedYear - era * 400                                  // [0, 399]
+        let dayOfYear = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1 // [0, 365]
+        let dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+        return Int64(era) * 146_097 + Int64(dayOfEra) - 719_468
+    }
+
     // MARK: - Comparable
 
     static func < (lhs: HLCTimestamp, rhs: HLCTimestamp) -> Bool {

--- a/Actuali/Actuali/Services/Sync/MerkleTree.swift
+++ b/Actuali/Actuali/Services/Sync/MerkleTree.swift
@@ -92,13 +92,30 @@ struct MerkleTree {
     /// Insert a timestamp and return a new tree (non-mutating version)
     /// Use this in actor contexts where mutating methods can't be called after await
     func inserting(_ timestamp: HLCTimestamp) -> MerkleTree {
-        let hash = timestamp.hash()
-        let key = minuteKey(from: timestamp.millis)
+        folding(hash: timestamp.hash(), intoMinuteOf: timestamp.millis)
+    }
 
+    /// Build a trie from minute buckets, where each entry maps a time to the XOR
+    /// of every message hash falling in that time's minute.
+    ///
+    /// Equivalent to `inserting(_:)` per message: every timestamp within a minute
+    /// walks the identical path, and XOR is associative, so folding a minute's
+    /// combined hash in one walk lands the same value in every node along it.
+    /// Rebuilding a whole message log costs one walk per active minute this way
+    /// instead of one per message.
+    static func building(from minuteBuckets: [Int64: Int32]) -> MerkleTree {
+        var tree = MerkleTree()
+        for (millis, hash) in minuteBuckets {
+            tree = tree.folding(hash: hash, intoMinuteOf: millis)
+        }
+        return tree
+    }
+
+    private func folding(hash: Int32, intoMinuteOf millis: Int64) -> MerkleTree {
         // XOR hash into root
         var newRoot = root
         newRoot.hash ^= hash
-        newRoot = insertKey(node: newRoot, key: key, hash: hash)
+        newRoot = insertKey(node: newRoot, key: minuteKey(from: millis), hash: hash)
 
         return MerkleTree(root: newRoot)
     }

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -78,6 +78,10 @@ actor SyncClient {
     /// deciding which local messages are genuine post-download writes that must be
     /// pushed — without it, the first local write is stranded (actios-4k4).
     private var downloadBaselineTimestamp: String?
+    /// Whether the merkle has been re-derived from `messages_crdt` this session.
+    /// See the top of `fullSync` for why that must happen before the first
+    /// comparison against the server's tree.
+    private var hasDerivedMerkleFromLog = false
 
     // MARK: - Published State (for UI)
 
@@ -134,8 +138,8 @@ actor SyncClient {
                     logger.notice("Recovered lastSyncedTimestamp from messages_crdt: \(recovered, privacy: .public)")
                 } else {
                     // Nothing trustworthy to recover from (empty budget).
-                    // Leave nil — fullSync's no-lastSynced path adopts the
-                    // server's state rather than fabricating a timestamp.
+                    // Leave nil — fullSync's no-lastSynced path syncs from the
+                    // snapshot's floor rather than fabricating a timestamp.
                     lastSyncedTimestamp = nil
                     logger.notice("No recoverable lastSyncedTimestamp - deferring to first sync")
                 }
@@ -618,15 +622,16 @@ actor SyncClient {
         await performSync()
     }
 
-    /// Recover from a stuck out-of-sync state by discarding the local Merkle
-    /// tree and last-synced marker, then running a sync. The fresh-download
-    /// branch in `fullSync` will adopt the server's Merkle tree, which
-    /// resolves persistent divergence at the cost of orphaning any local
-    /// writes since the last successful sync (callers should warn the user).
+    /// Recover from a stuck out-of-sync state by discarding the last-synced
+    /// marker, then running a sync: the next pass re-requests everything after
+    /// the local message log's high-water mark rather than after the last
+    /// successful sync. The Merkle tree is deliberately left alone — it is
+    /// re-derived from the message log on the next sync anyway, and blanking it
+    /// used to hand `fullSync` an excuse to adopt the server's tree and declare
+    /// parity it hadn't earned (#99, #121).
     func resetSyncState() async {
-        logger.notice("resetSyncState() - clearing local merkle and lastSyncedTimestamp")
+        logger.notice("resetSyncState() - clearing lastSyncedTimestamp")
         syncTask?.cancel()
-        merkle = MerkleTree()
         lastSyncedTimestamp = nil
         retryDelay = 5
         try? saveClock()
@@ -784,6 +789,39 @@ actor SyncClient {
 
         logger.debug("fullSync() attempt #\(attemptCount, privacy: .public), since: \(since ?? "nil", privacy: .public), lastSynced: \(self.lastSyncedTimestamp ?? "nil", privacy: .public)")
 
+        // The merkle must describe our own message log and nothing else: a
+        // mismatch with the server's tree is the ONLY signal that we're missing
+        // messages, so a tree claiming more than we hold makes the missing
+        // window unreachable. Two ways the persisted tree drifts from the log:
+        //
+        //  - an older build overwrote it with the server's tree whenever the
+        //    first sync had no lastSyncedTimestamp, recording parity for
+        //    messages sync had skipped (#99). The lie is self-consistent — both
+        //    sides then fold in the same new messages — so every later diff
+        //    matched and the gap survived re-syncs and app updates, leaving
+        //    balances stuck at stale, usually higher, amounts (#121).
+        //  - `receiveMessages` commits to messages_crdt but the tree is only
+        //    persisted at the end of a successful pass, so being killed in
+        //    between drops timestamps from the tree that the log kept.
+        //
+        // Re-deriving from the log before the first comparison of a session
+        // repairs both, and the diff recursion below then heals the data. One
+        // pass over the log per session, one trie walk per active minute.
+        if !hasDerivedMerkleFromLog {
+            hasDerivedMerkleFromLog = true
+            do {
+                let derived = try database.deriveMerkleFromMessageLog()
+                if derived.root.hash != merkle.root.hash {
+                    logger.notice("Merkle disagreed with the message log (persisted \(self.merkle.root.hash, privacy: .public), derived \(derived.root.hash, privacy: .public)) - re-deriving")
+                    merkle = derived
+                }
+            } catch {
+                // Keep the persisted tree: a sync with a possibly stale merkle
+                // still beats no sync at all.
+                logger.warning("Could not derive merkle from message log: \(error, privacy: .public)")
+            }
+        }
+
         // Determine sync starting point
         // Use provided 'since', then lastSyncedTimestamp (if non-empty), then fallback
         let effectiveLastSynced = lastSyncedTimestamp.flatMap { $0.isEmpty ? nil : $0 }
@@ -798,8 +836,7 @@ actor SyncClient {
             // floor: everything the server has after it is missing locally no
             // matter how old. A fabricated recent window here (formerly 24h)
             // silently skipped every message between an older file snapshot
-            // and yesterday, and the merkle adoption below then made the gap
-            // permanent (issue #99).
+            // and yesterday (issue #99).
             logger.notice("No valid lastSyncedTimestamp, using snapshot high-water mark")
             sinceTimestamp = baseline
         } else {
@@ -819,14 +856,13 @@ actor SyncClient {
         if since != nil || effectiveLastSynced != nil {
             localMessages = try database.getMessagesSince(sinceTimestamp)
         } else {
-            // Fresh download / no valid lastSynced. The local merkle is empty and we
-            // adopt the server's below, so merkle-diff recursion can't push local
-            // writes for us. Send everything newer than the download baseline (the
-            // server's high-water mark captured at load); those are genuine local
-            // writes made after download. Without this, a write made before the first
-            // sync completes is dropped when we adopt the server merkle and advance
-            // lastSynced past it (actios-4k4). The baseline keeps us from re-pushing
-            // the entire downloaded history.
+            // Fresh download / no valid lastSynced, so there's no last-synced
+            // window to send from. Send everything newer than the download
+            // baseline (the server's high-water mark captured at load); those
+            // are genuine local writes made after download, and a write made
+            // before the first sync completes would otherwise sit unsent until
+            // something else changed it (actios-4k4). The baseline keeps us from
+            // re-pushing the entire downloaded history.
             let baseline = downloadBaselineTimestamp ?? ""
             localMessages = try database.getMessagesSince(baseline)
             logger.debug("No valid lastSynced - sending \(localMessages.count, privacy: .public) local message(s) since download baseline")
@@ -863,38 +899,15 @@ actor SyncClient {
         logger.debug("Local merkle hash: \(self.merkle.root.hash, privacy: .public), remote: \(remoteMerkle.hash, privacy: .public)")
 
         if let diffTime = merkle.diff(with: remoteMerkleTree) {
-            // Not in sync - recurse from divergence point
+            // Not in sync - recurse from divergence point. This is the only way
+            // a missing window is ever recovered, so it runs no matter how the
+            // sync state got here: an older build short-circuited it whenever
+            // lastSyncedTimestamp was nil and adopted the server's tree
+            // instead, which recorded parity we hadn't earned and made the gap
+            // permanent (#99, #121). The merkle is derived from our own message
+            // log above, so the divergence point is real and each pass narrows
+            // it; `attemptCount` still bounds a pathological case.
             logger.debug("Merkle diff found at time: \(diffTime, privacy: .public), recursing...")
-
-            // Special case: if we don't have a valid lastSynced, don't recurse.
-            // This happens after downloading a budget or recovering from bad state.
-            // Instead, adopt the server's merkle and consider ourselves synced.
-            if effectiveLastSynced == nil {
-                logger.info("No valid lastSynced - adopting server's merkle tree")
-                merkle = remoteMerkleTree
-                // Advance lastSynced only to what we actually reconciled this pass:
-                // the download baseline plus the messages we sent and received. Using
-                // this instead of the raw clock high-water mark avoids skipping a
-                // local write that interleaved during the awaits above without being
-                // included in `localMessages` — such a write sorts above this mark
-                // (HLC timestamps order lexicographically) and is resent next sync
-                // (actios-4k4). Fall back to the clock only for a truly empty budget
-                // with nothing reconciled, so we still record that a sync happened.
-                let reconciled = ([downloadBaselineTimestamp]
-                    + localMessages.map { $0.timestamp.toString() }
-                    + remoteMessages.map { $0.timestamp.toString() })
-                    .compactMap { $0 }
-                    .filter { !$0.isEmpty }
-                    .max()
-                if let reconciled {
-                    lastSyncedTimestamp = reconciled
-                } else {
-                    lastSyncedTimestamp = (await clock.current).toString()
-                }
-                logger.debug("Set lastSyncedTimestamp to: \(self.lastSyncedTimestamp ?? "nil", privacy: .public)")
-                try saveClock()
-                return
-            }
 
             guard attemptCount < 10 else {
                 logger.error("Too many sync attempts, giving up")

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -606,7 +606,7 @@ struct SettingsView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("Discards the local sync marker and re-adopts the server's view of your budget. Any transactions or edits made since the last successful sync may need to be re-entered.")
+                Text("Discards the local sync marker and re-checks your budget against the server, pulling down anything missing. Local edits are re-sent rather than discarded, but a large budget can take a moment to reconcile.")
             }
             .confirmationDialog(
                 "Select a Budget",

--- a/Actuali/ActualiTests/BudgetStoreInitialSyncTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreInitialSyncTests.swift
@@ -175,6 +175,31 @@ struct BudgetStoreInitialSyncTests {
         #expect(store.isInitialSyncing == false)
     }
 
+    /// The initial sync's catch-up can span weeks of history, and the downloaded
+    /// file's messages_crdt rowids restart from whatever the uploading client
+    /// had. A watermark left behind by a previous copy of this budget therefore
+    /// points at unrelated messages — high enough to pass the detector's
+    /// `watermark <= maxId` guard, low enough to announce that whole catch-up as
+    /// new transactions. Opening the file has to drop it.
+    @Test func freshDownloadDoesNotKeepAPreviousCopysNotificationWatermark() async throws {
+        let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
+        let root = try makeRootDirectory()
+        let budgetId = "test-initial-sync-\(UUID().uuidString)"
+        defer { cleanUp(root: root, budgetId: budgetId, savedBudgetId: savedBudgetId) }
+        let key = "transactionNotificationWatermark.\(budgetId)"
+        UserDefaults.standard.set(NSNumber(value: Int64(500)), forKey: key)
+        let store = try await makeStore(zip: try makeBudgetZip(budgetId: budgetId), root: root)
+
+        await store.downloadBudget(Self.remoteBudget)
+
+        #expect(store.error == nil)
+        // Either removed, or re-baselined against the new file by the detector
+        // that ran during the initial sync. What matters is that the stale value
+        // is gone.
+        let watermark = (UserDefaults.standard.object(forKey: key) as? NSNumber)?.int64Value
+        #expect(watermark != 500)
+    }
+
     // MARK: - Upstream schema
 
     /// The tables `loadLocalBudget` reads and `SyncClient.configure` needs,

--- a/Actuali/ActualiTests/SyncClientMerkleRepairTests.swift
+++ b/Actuali/ActualiTests/SyncClientMerkleRepairTests.swift
@@ -1,0 +1,286 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// One message in the fake server's log.
+private struct StubMessage {
+    let timestamp: String
+    let dataset: String
+    let row: String
+    let column: String
+    let value: String
+}
+
+/// A minimal stand-in for actual-server's `/sync/sync`: absorbs the messages the
+/// client sends, answers with everything in its log newer than the requested
+/// `since`, and reports an HONEST merkle over everything it holds. That last
+/// part is the whole point — the client's tree is the one under test.
+private final class FakeSyncServer: URLProtocol {
+    nonisolated(unsafe) static var log: [StubMessage] = []
+    nonisolated(unsafe) static var requestedSince: [String] = []
+
+    static func reset(log: [StubMessage]) {
+        self.log = log
+        requestedSince = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var response = SyncResponse()
+
+        if let decoded = try? SyncRequest(serializedData: Self.readBody(request)),
+           !decoded.fileID.isEmpty {
+            Self.requestedSince.append(decoded.since)
+            Self.absorb(decoded.messages)
+            for message in Self.log where message.timestamp > decoded.since {
+                response.messages.append(Self.envelope(for: message))
+            }
+        }
+        response.merkle = Self.merkleJSON()
+
+        let data = (try? response.serializedData()) ?? Data()
+        let httpResponse = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/actual-sync"]
+        )!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    /// URLSession hands POST bodies to URLProtocol as a stream, not httpBody.
+    private static func readBody(_ request: URLRequest) -> Data {
+        guard let stream = request.httpBodyStream else { return request.httpBody ?? Data() }
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        let bufferSize = 16 * 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            guard read > 0 else { break }
+            body.append(buffer, count: read)
+        }
+        return body
+    }
+
+    private static func absorb(_ envelopes: [MessageEnvelope]) {
+        for envelope in envelopes {
+            guard let inner = try? Message(serializedData: envelope.content),
+                  !log.contains(where: { $0.timestamp == envelope.timestamp })
+            else { continue }
+            log.append(StubMessage(
+                timestamp: envelope.timestamp,
+                dataset: inner.dataset,
+                row: inner.row,
+                column: inner.column,
+                value: inner.value
+            ))
+        }
+    }
+
+    private static func envelope(for message: StubMessage) -> MessageEnvelope {
+        var inner = Message()
+        inner.dataset = message.dataset
+        inner.row = message.row
+        inner.column = message.column
+        inner.value = message.value
+
+        var envelope = MessageEnvelope()
+        envelope.timestamp = message.timestamp
+        envelope.isEncrypted = false
+        envelope.content = (try? inner.serializedData()) ?? Data()
+        return envelope
+    }
+
+    static func merkle(over messages: [StubMessage]) -> MerkleTree {
+        var tree = MerkleTree()
+        for message in messages {
+            guard let parsed = HLCTimestamp.parse(message.timestamp) else { continue }
+            tree = tree.inserting(parsed)
+        }
+        return tree.pruned()
+    }
+
+    private static func merkleJSON() -> String {
+        guard let data = try? JSONEncoder().encode(merkle(over: log).root),
+              let json = String(data: data, encoding: .utf8)
+        else { return #"{"hash":0}"# }
+        return json
+    }
+}
+
+/// Issue #121: an install that synced under the pre-#182 fresh-install logic
+/// carries a merkle tree it never earned — the old code overwrote the local tree
+/// with the server's and recorded parity, so the window of messages that sync
+/// skipped became unreachable. The lie is self-consistent (both sides then fold
+/// in the same new messages), so every later diff matched and the gap survived
+/// re-syncs, "Reset Sync State", and app updates. Missed tombstones and amount
+/// edits in that window leave account balances reading high forever.
+///
+/// The tree must be derived from the local message log, never adopted, so the
+/// diff can see the gap and the server can resend it.
+@Suite(.serialized)
+struct SyncClientMerkleRepairTests {
+
+    // Canonical HLC strings: <ISO8601 with millis>-<4 hex counter>-<16 hex node>
+    private static let oldMessage = "2026-07-01T09:15:22.000Z-0000-a1b2c3d4e5f60718"
+    /// The message the old sync skipped: a $30k transaction deleted on another
+    /// client. Never applied locally, so the row still counts toward the balance.
+    private static let missedTombstone = "2026-07-18T11:42:07.000Z-0000-a1b2c3d4e5f60718"
+    private static let recentMessage = "2026-08-09T08:03:11.000Z-0000-a1b2c3d4e5f60718"
+
+    private static var serverLog: [StubMessage] {
+        [
+            StubMessage(timestamp: oldMessage, dataset: "transactions", row: "t1", column: "amount", value: "N:1000"),
+            StubMessage(timestamp: missedTombstone, dataset: "transactions", row: "t2", column: "tombstone", value: "N:1"),
+            StubMessage(timestamp: recentMessage, dataset: "transactions", row: "t2", column: "notes", value: "S:rent"),
+        ]
+    }
+
+    /// A budget in the poisoned state: one account whose $30k transaction was
+    /// deleted upstream, a message log missing that deletion, and a persisted
+    /// merkle equal to the server's (what the old adopt path wrote).
+    private func makePoisonedDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    notes TEXT,
+                    amount INTEGER,
+                    date INTEGER,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    parent_id TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                CREATE TABLE messages_clock (id INTEGER PRIMARY KEY, clock TEXT);
+
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+
+                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
+                    ('t1', 'acct-1',    1000, 20260701, 0),
+                    ('t2', 'acct-1', 3000000, 20260718, 0);
+            """)
+
+            // The local log is missing `missedTombstone` — exactly the window the
+            // old 24h `since` window skipped.
+            for timestamp in [Self.oldMessage, Self.recentMessage] {
+                try db.execute(
+                    sql: """
+                        INSERT INTO messages_crdt (timestamp, dataset, row, column, value)
+                        VALUES (?, 'transactions', 't1', 'amount', 'N:1000')
+                        """,
+                    arguments: [timestamp]
+                )
+            }
+
+            // ...but the persisted merkle claims the server's full log, and
+            // lastSynced claims everything through the newest message.
+            let adopted = BudgetDatabase.ClockRecord(
+                timestamp: Self.recentMessage,
+                merkle: FakeSyncServer.merkle(over: Self.serverLog).root
+            )
+            let json = String(data: try JSONEncoder().encode(adopted), encoding: .utf8)!
+            try db.execute(
+                sql: "INSERT INTO messages_clock (id, clock) VALUES (1, ?)",
+                arguments: [json]
+            )
+        }
+
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeSyncClient(database: BudgetDatabase) async throws -> SyncClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FakeSyncServer.self]
+        let serverClient = ActualServerClient(session: URLSession(configuration: config))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("test-token")
+
+        let syncClient = SyncClient(serverClient: serverClient, nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        return syncClient
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func syncRecoversTheWindowAnAdoptedMerkleHid() async throws {
+        FakeSyncServer.reset(log: Self.serverLog)
+        let (database, path) = try makePoisonedDatabase()
+        defer { cleanup(path) }
+
+        // The symptom the reporter saw: $30k of deleted transaction still counted.
+        let before = try await database.fetchAccounts().first { $0.id == "acct-1" }
+        #expect(before?.balance == 3001000)
+
+        let syncClient = try await makeSyncClient(database: database)
+        await syncClient.syncNow()
+
+        // The merkle no longer claims messages sync never fetched, so the diff
+        // exposes the gap and the server resends it.
+        let after = try await database.fetchAccounts().first { $0.id == "acct-1" }
+        #expect(after?.balance == 1000)
+
+        // Reaching back past the poisoned high-water mark is the mechanism: the
+        // first request asks from lastSynced, a later one from the divergence.
+        #expect(FakeSyncServer.requestedSince.count > 1)
+        #expect(FakeSyncServer.requestedSince.contains { $0 < Self.missedTombstone })
+    }
+
+    @Test func derivedMerkleReplacesAPersistedTreeThatDisagreesWithTheLog() async throws {
+        FakeSyncServer.reset(log: Self.serverLog)
+        let (database, path) = try makePoisonedDatabase()
+        defer { cleanup(path) }
+
+        // Derived from messages_crdt: the two messages actually held, and
+        // nothing else.
+        var expected = MerkleTree()
+        for timestamp in [Self.oldMessage, Self.recentMessage] {
+            expected = expected.inserting(try #require(HLCTimestamp.parse(timestamp)))
+        }
+
+        let derived = try database.deriveMerkleFromMessageLog()
+        #expect(derived.root.hash == expected.pruned().root.hash)
+        #expect(derived.root.hash != FakeSyncServer.merkle(over: Self.serverLog).root.hash)
+    }
+}

--- a/Actuali/ActualiTests/SyncEngineFixtureTests.swift
+++ b/Actuali/ActualiTests/SyncEngineFixtureTests.swift
@@ -331,6 +331,63 @@ struct MerkleTreeFixtureTests {
         #expect(node.children.isEmpty)
         #expect(node.hash == 1983295247)
     }
+
+    // deriveMerkleFromMessageLog reads the trie's minute straight off the
+    // ISO-8601 prefix instead of parsing a Date, so it must agree with `parse`
+    // exactly — including across leap days, century boundaries and month ends,
+    // where hand-rolled calendar math goes wrong.
+    @Test(arguments: [
+        "1970-01-01T00:00:00.000Z-0000-0123456789ABCDEF",
+        "1970-01-01T00:00:59.999Z-FFFF-0123456789ABCDEF",
+        "1999-12-31T23:59:00.000Z-0000-0123456789ABCDEF",
+        "2000-02-29T12:34:56.789Z-0000-0123456789ABCDEF",  // leap day, century leap year
+        "2018-11-01T00:45:00.000Z-0000-0123456789ABCDEF",
+        "2024-02-29T23:59:59.999Z-0000-0123456789ABCDEF",
+        "2026-03-01T00:00:00.000Z-0000-0123456789ABCDEF",  // day after a non-leap February
+        "2026-07-22T10:00:00.000Z-0000-a1b2c3d4e5f60718",
+        "2026-12-31T23:59:59.999Z-0000-0123456789ABCDEF",
+        "2100-03-01T00:00:00.000Z-0000-0123456789ABCDEF",  // century non-leap year
+    ])
+    func minuteArithmeticMatchesDateParsing(_ string: String) throws {
+        let parsed = try #require(HLCTimestamp.parse(string))
+        #expect(HLCTimestamp.minutesSinceEpoch(of: string) == parsed.millis / 1000 / 60)
+    }
+
+    @Test func minuteArithmeticRejectsMalformedTimestamps() {
+        #expect(HLCTimestamp.minutesSinceEpoch(of: "") == nil)
+        #expect(HLCTimestamp.minutesSinceEpoch(of: "2026-07-22") == nil)
+        #expect(HLCTimestamp.minutesSinceEpoch(of: "not-a-timestamp-at-all") == nil)
+        #expect(HLCTimestamp.minutesSinceEpoch(of: "2026-13-22T10:00:00.000Z-0000-0") == nil)
+        #expect(HLCTimestamp.minutesSinceEpoch(of: "2026-07-22T99:00:00.000Z-0000-0") == nil)
+    }
+
+    // `building(from:)` folds one XOR per active minute instead of one insert
+    // per message, so a whole message log can be re-derived cheaply
+    // (BudgetDatabase.deriveMerkleFromMessageLog). It must produce the identical
+    // trie — including for several messages sharing a minute, where the folding
+    // relies on XOR being associative along one shared path.
+    @Test func bulkBuildMatchesPerMessageInsertion() {
+        let timestamps = [
+            "2018-11-01T00:47:12.000Z-0000-0123456789ABCDEF",
+            "2018-11-01T00:47:39.000Z-0001-0123456789ABCDEF",  // same minute
+            "2018-11-01T00:47:39.500Z-0000-FEDCBA9876543210",  // same minute
+            "2018-11-01T01:15:00.000Z-0000-0123456789ABCDEF",
+            "2018-11-12T13:21:40.122Z-0000-0123456789ABCDEF",
+        ].map(ts)
+
+        var incremental = MerkleTree()
+        var buckets: [Int64: Int32] = [:]
+        for timestamp in timestamps {
+            incremental = incremental.inserting(timestamp)
+            // One bucket per minute, keyed by any millis inside it.
+            let minute = timestamp.millis / 60_000 * 60_000
+            buckets[minute, default: 0] ^= timestamp.hash()
+        }
+
+        let bulk = MerkleTree.building(from: buckets)
+        #expect(bulk.root == incremental.root)
+        #expect(bulk.diff(with: incremental) == nil)
+    }
 }
 
 // MARK: - SyncEncoder / protobuf

--- a/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
+++ b/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
@@ -8,6 +8,16 @@ import Testing
 /// and an unreachable server.
 private final class SyncOutcomeTransport: URLProtocol {
     nonisolated(unsafe) static var failWithOffline = false
+    /// Timestamps the client has pushed. A real server folds the messages it
+    /// receives into its own tree before answering, so answering with a merkle
+    /// over these is what lets the client see itself as in sync — a stub that
+    /// always claimed an empty tree would leave every sync out of sync.
+    nonisolated(unsafe) static var absorbed: Set<String> = []
+
+    static func reset(failWithOffline: Bool) {
+        self.failWithOffline = failWithOffline
+        absorbed = []
+    }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -20,7 +30,10 @@ private final class SyncOutcomeTransport: URLProtocol {
         }
 
         var response = SyncResponse()
-        response.merkle = #"{"hash":0}"#
+        if let decoded = try? SyncRequest(serializedData: Self.readBody(request)) {
+            Self.absorbed.formUnion(decoded.messages.map(\.timestamp))
+        }
+        response.merkle = Self.merkleJSON()
         let data = (try? response.serializedData()) ?? Data()
         let httpResponse = HTTPURLResponse(
             url: request.url!,
@@ -34,6 +47,35 @@ private final class SyncOutcomeTransport: URLProtocol {
     }
 
     override func stopLoading() {}
+
+    /// URLSession hands POST bodies to URLProtocol as a stream, not httpBody.
+    private static func readBody(_ request: URLRequest) -> Data {
+        guard let stream = request.httpBodyStream else { return request.httpBody ?? Data() }
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        let bufferSize = 16 * 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            guard read > 0 else { break }
+            body.append(buffer, count: read)
+        }
+        return body
+    }
+
+    private static func merkleJSON() -> String {
+        var tree = MerkleTree()
+        for timestamp in absorbed.sorted() {
+            guard let parsed = HLCTimestamp.parse(timestamp) else { continue }
+            tree = tree.inserting(parsed)
+        }
+        guard let data = try? JSONEncoder().encode(tree.pruned().root),
+              let json = String(data: data, encoding: .utf8)
+        else { return #"{"hash":0}"# }
+        return json
+    }
 }
 
 /// Issue #139: the Shortcut used to report a plain success even when the row
@@ -98,7 +140,7 @@ struct TransactionLoggerSyncOutcomeTests {
     }
 
     private func makeStore(database: BudgetDatabase, serverReachable: Bool) async throws -> BudgetStore {
-        SyncOutcomeTransport.failWithOffline = !serverReachable
+        SyncOutcomeTransport.reset(failWithOffline: !serverReachable)
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [SyncOutcomeTransport.self]
         let serverClient = ActualServerClient(session: URLSession(configuration: config))


### PR DESCRIPTION
## What was wrong

`fullSync` had a special case: when the first sync of a budget had no `lastSyncedTimestamp`, a merkle mismatch was resolved by overwriting the local tree with the server's and recording the pass as fully synced.

That records parity the client never earned. The adopted root already contains the timestamps of messages the pass had skipped, so the divergence signal is gone — and the lie is *self-consistent*: from then on both sides fold in the same new messages, so `merkle.diff` matches on every later sync, forever. The window sync missed becomes permanently unreachable.

The pre-#182 fresh-install path put installs into exactly that state (it asked for a 24h window, then adopted). #182 fixed the `since` computation, but did nothing for installs already carrying an adopted tree:

- `since` comes from `lastSyncedTimestamp`, which is recent, so it never reaches back into the gap
- "Reset Sync State" nils that and falls through to `downloadBaselineTimestamp`, which `configure()` derives from `getMaxMessageTimestamp()` over the *current* log — also recent
- the adopted tree keeps reporting parity, so recursion never triggers

A missed `tombstone = 1` or a missed downward `amount` edit therefore stays applied-never, and the account keeps counting money Actual has already removed — the symptom in #121 (one account reading ~$30k high while the transaction list looks broadly right).

## Why this fixes it

The tree is nothing but the XOR of the timestamps in `messages_crdt`, so that log — not the copy cached in `messages_clock` — is its source of truth. `SyncClient` now derives it from the log once per session, before the first comparison against the server, and the adoption branch is gone. An honest tree diverges from the server's exactly where the gap is, and the existing diff recursion pulls it down. Same invariant upstream relies on; upstream has no adoption escape hatch either.

Two consequences worth calling out:

- The same derivation repairs a tree left behind when the app is killed between `receiveMessages` committing to `messages_crdt` and the end-of-pass `saveClock` — previously also a permanent phantom divergence.
- `resetSyncState()` no longer blanks the tree (it's re-derived anyway, and blanking it is what used to invite the adoption). Its confirmation copy no longer warns about orphaning local edits, since honest diffing re-sends them.

Deriving deliberately avoids `HLCTimestamp.parse`, whose per-call `ISO8601DateFormatter` dominated a full-log pass. `HLCTimestamp.minutesSinceEpoch(of:)` reads the trie's minute off the ISO-8601 prefix arithmetically, and `MerkleTree.building(from:)` folds one XOR per active minute instead of one insert per message.

## Verification

New `SyncClientMerkleRepairTests` drives `SyncClient` against a stub server that holds a message log and reports an honest merkle over it. The local budget is assembled in the poisoned state: an account whose \$30k transaction was deleted upstream, a `messages_crdt` missing that deletion, and a persisted merkle equal to the server's.

On `main` (source fix reverted, tests kept):

```
✘ Test syncRecoversTheWindowAnAdoptedMerkleHid() recorded an issue at SyncClientMerkleRepairTests.swift:262:9: Expectation failed: (after?.balance → 3001000) == 1000
✘ Test syncRecoversTheWindowAnAdoptedMerkleHid() recorded an issue at SyncClientMerkleRepairTests.swift:266:9: Expectation failed: (FakeSyncServer.requestedSince.count → 1) > 1
✘ Test syncRecoversTheWindowAnAdoptedMerkleHid() recorded an issue at SyncClientMerkleRepairTests.swift:267:9: Expectation failed: FakeSyncServer.requestedSince.contains { $0 < Self.missedTombstone }
✘ Test run with 2 tests in 1 suite failed after 0.080 seconds with 3 issues.
```

One request, parity declared, the \$30k stays. With the fix the balance drops to the correct 1000 and a second request reaches back past the poisoned high-water mark.

Also added: `minutesSinceEpoch` pinned against `HLCTimestamp.parse` across leap days, century boundaries and month ends plus malformed input, and `MerkleTree.building(from:)` pinned to produce a trie identical to per-message insertion (including several messages sharing a minute, where the folding relies on XOR associativity).

Full unit suite on iPhone 17 / iOS 26.5 simulator, rebased on `main`:

```
✔ Test run with 766 tests in 110 suites passed after 3.594 seconds.
** TEST SUCCEEDED **
```

## Second commit: forget the notification watermark on download

Found while testing this against a real budget: reconnecting a budget now syncs immediately (#186), and that first sync can pull weeks of history. The downloaded file's `messages_crdt` rowids start from whatever the uploading client had, so a notification watermark left by a previous copy of the same budget points at unrelated messages — high enough to pass `NewTransactionDetector`'s `watermark <= maxId` guard, low enough to announce the whole catch-up as new transactions. `downloadBudget` now drops it so the next detection re-baselines.

Derivation cost, measured on a throwaway 250k-message log (Debug build, so shipping builds are faster): 3.8s before the arithmetic minute path, 1.4s after, of which 0.5s is hashing. Runs once per session, inside the async sync.

## Notes / not addressed

- I could not reproduce #121 from the issue itself — it has no repro steps and the reporter never followed up, so this fixes the mechanism I could prove rather than one confirmed against their data. Worth asking them whether the balance corrects itself after updating.
- With adoption gone, an unresolvable divergence surfaces as `SyncError.outOfSync` after 10 attempts instead of being silently papered over. That's the honest outcome, and each pass also pushes local messages the server turned out to be missing, so convergence works in both directions.
- `TransactionLoggerSyncOutcomeTests` (from #184, landed while this was open) needed a one-line change: its stub answered every request with an empty merkle, which only ever settled because the client adopted it. The stub now folds the messages it receives into its answer, like the real server does — that CI failure was the adoption removal doing exactly what it says.
- Adjacent, not touched: `getMessagesSince` parses every row with `HLCTimestamp.parse`, so it carries the same per-call formatter cost this PR avoided in the derive path. Want me to file that?

Fixes #121
