### PR TITLE
View and edit category notes

### DIFF
--- a/Actuali/Actuali/Models/Category.swift
+++ b/Actuali/Actuali/Models/Category.swift
@@ -9,6 +9,31 @@ struct Category: Identifiable, Hashable {
     var sortOrder: Int
 }
 
+/// A category's note, as stored in Actual's `notes` table (GH #131).
+///
+/// `supported` is false when the open budget file has no `notes` table at all
+/// — an older snapshot, or one whose migrations haven't caught up. The UI hides
+/// the note section in that case rather than offering an edit that could never
+/// save. Empty `text` means "no note": Actual stores a cleared note as an empty
+/// string rather than removing the row, so absent and cleared read the same.
+struct CategoryNote: Equatable {
+    var supported: Bool
+    var text: String
+
+    static let unsupported = CategoryNote(supported: false, text: "")
+
+    var isEmpty: Bool { text.isEmpty }
+
+    /// What to persist for text the user typed. Whitespace-only input clears
+    /// the note instead of storing blanks that would render as an empty-looking
+    /// note nobody can tell apart from none. Anything else is stored verbatim —
+    /// leading indentation and blank lines inside a multi-line note are
+    /// deliberate and must survive the round trip.
+    static func normalizedForSave(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "" : text
+    }
+}
+
 struct CategoryGroup: Identifiable, Hashable {
     let id: String
     var name: String

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2722,6 +2722,32 @@ final class BudgetStore: ObservableObject {
         await fetchBudgetMonth(month)
     }
 
+    // MARK: - Category Notes
+
+    /// Load a category's note (GH #131). Reported as `.unsupported` when no
+    /// budget file is open, the file has no `notes` table, or the read fails —
+    /// the note section hides itself in all three cases, which is the right
+    /// outcome for each and beats surfacing a banner over a secondary field.
+    func fetchCategoryNote(categoryId: String) async -> CategoryNote {
+        guard let database else { return .unsupported }
+        do {
+            return try await database.fetchCategoryNote(categoryId: categoryId)
+        } catch {
+            logger.error("Failed to read category note: \(error.localizedDescription, privacy: .public)")
+            return .unsupported
+        }
+    }
+
+    /// Save a category's note, syncing back to Actual (GH #131). An empty
+    /// string clears it. Throws so the caller can keep the editor open and show
+    /// the failure rather than silently dropping what the user typed.
+    func saveCategoryNote(categoryId: String, note: String) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        try await syncClient.setNote(id: categoryId, note: note)
+    }
+
     // MARK: - Currency Formatting
 
     /// Format an amount in cents to a currency string using the budget's currency

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1336,6 +1336,33 @@ class BudgetDatabase {
         }
     }
 
+    // MARK: - Notes
+
+    /// The note stored for a category (GH #131). Actual's `notes` table is
+    /// keyed by the annotated row's own id, so a category's note lives at
+    /// `notes.id = <categoryId>`.
+    ///
+    /// One read reports both whether the file has the table and what it holds,
+    /// so the caller can distinguish "this file can't store notes" from "this
+    /// category has none" without a second round trip or a cached capability
+    /// flag that could go stale when the open file changes.
+    func fetchCategoryNote(categoryId: String) async throws -> CategoryNote {
+        try await dbQueue.read { db in
+            guard try db.tableExists("notes") else { return .unsupported }
+            // A row can exist with a NULL note (another client cleared it that
+            // way); that reads as empty, same as no row at all.
+            let note = try String.fetchOne(
+                db, sql: "SELECT note FROM notes WHERE id = ?", arguments: [categoryId])
+            return CategoryNote(supported: true, text: note ?? "")
+        }
+    }
+
+    /// Whether this file has the `notes` table, for `SyncClient`'s write guard.
+    /// Sync (see the async/sync split above): the write path can't suspend.
+    func notesTableExists() throws -> Bool {
+        try dbQueue.read { db in try db.tableExists("notes") }
+    }
+
     /// Where a budget amount write for (month, category) must land: which
     /// budget table this file uses, and the row to update or create.
     struct BudgetCellRef: Equatable {

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -162,6 +162,16 @@ enum DemoDataSeeder {
             )
             """)
 
+        // Real Actual files key notes by the annotated row's own id (GH #131).
+        // The demo budget needs the table for the category note UI to appear at
+        // all — without it the section hides itself as unsupported.
+        try db.execute(sql: """
+            CREATE TABLE notes (
+                id TEXT PRIMARY KEY,
+                note TEXT
+            )
+            """)
+
         // Mirrors the dashboard table created by BudgetDatabase's migrations, so
         // the demo budget can ship a pre-built Reports dashboard.
         try db.execute(sql: """
@@ -285,6 +295,15 @@ enum DemoDataSeeder {
         let pharmacyId = UUID().uuidString
         try insertCategory(db, id: gymId, name: "Gym", groupId: healthId, isIncome: false, sortOrder: 0)
         try insertCategory(db, id: pharmacyId, name: "Pharmacy", groupId: healthId, isIncome: false, sortOrder: 1)
+
+        // --- Notes ---
+        // One category arrives annotated so the note on the category detail
+        // view (GH #131) is visible in the demo budget rather than only after
+        // the user writes one.
+        try insertNote(db, id: groceriesId, note: """
+            Target $650/mo. Household supplies count here; \
+            takeaway goes to Dining Out.
+            """)
 
         // --- Payees ---
         let wholeFoodsId = UUID().uuidString
@@ -556,6 +575,16 @@ enum DemoDataSeeder {
             INSERT INTO categories (id, name, is_income, cat_group, sort_order, tombstone, hidden)
             VALUES (?, ?, ?, ?, ?, 0, 0)
             """, arguments: [id, name, isIncome ? 1 : 0, groupId, sortOrder])
+    }
+
+    private static func insertNote(
+        _ db: Database,
+        id: String,
+        note: String
+    ) throws {
+        try db.execute(sql: """
+            INSERT INTO notes (id, note) VALUES (?, ?)
+            """, arguments: [id, note])
     }
 
     private static func insertPayee(

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -7,13 +7,14 @@ import os
 
 private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "SyncClient")
 
-enum SyncError: LocalizedError {
+enum SyncError: LocalizedError, Equatable {
     case notConfigured
     case offline
     case outOfSync
     case encodingFailed
     case serverError(String)
     case budgetTableMissing
+    case notesTableMissing
 
     var errorDescription: String? {
         switch self {
@@ -29,6 +30,8 @@ enum SyncError: LocalizedError {
             return "Server error: \(message)"
         case .budgetTableMissing:
             return "This budget file has no budget table to write to."
+        case .notesTableMissing:
+            return "This budget file has no notes table to write to."
         }
     }
 }
@@ -525,6 +528,49 @@ actor SyncClient {
         logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
 
         // 4. Push to the server in the background
+        scheduleAutomaticSync()
+    }
+
+    /// Save the note attached to a row — a category, for now (GH #131) —
+    /// optimistic local-first. Mirrors upstream notes-save (loot-core
+    /// server/notes/app.ts): a single `note` cell on the `notes` table, keyed
+    /// by the annotated row's own id. No row is created up front: the CRDT
+    /// apply upserts, so a category that has never been annotated gets its row
+    /// from this write.
+    ///
+    /// Clearing a note saves an empty string rather than tombstoning the row,
+    /// again matching upstream — a tombstone would leave other clients showing
+    /// the stale note, since they read the note column, not the tombstone.
+    ///
+    /// Requires the `notes` table: without it `applyMessages` would skip the
+    /// local apply as unknown schema and the write would look like it worked
+    /// while changing nothing on screen.
+    func setNote(id: String, note: String) async throws {
+        guard let database else { throw SyncError.notConfigured }
+        guard try database.notesTableExists() else { throw SyncError.notesTableMissing }
+
+        logger.debug("setNote() - row: \(id, privacy: .private), length: \(note.count, privacy: .public)")
+
+        // 1. Generate CRDT messages (before any DB write, so an HLC failure
+        //    leaves nothing stranded)
+        let messages = try await messageGenerator.messages(
+            dataset: "notes", row: id, fields: [("note", note)])
+
+        // 2. Apply locally (optimistic) through the same LWW upsert incoming
+        //    messages use, so a local edit and the identical edit arriving from
+        //    another device converge byte-for-byte.
+        try database.applyMessages(messages)
+
+        // 3. Store messages and update merkle
+        for msg in try database.insertMessages(messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+        logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
+
+        // 4. Push in the background — the Save button awaits this write, and
+        //    an unreachable server must not hold the sheet open (issue #125).
         scheduleAutomaticSync()
     }
 

--- a/Actuali/Actuali/Views/Transactions/CategoryNoteEditorView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryNoteEditorView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Editor for one category's note (GH #131), presented as a sheet from the
+/// category detail view. Saving writes through to Actual; a failure keeps the
+/// sheet open with the text intact so nothing the user typed is lost.
+struct CategoryNoteEditorView: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    let categoryId: String
+    let categoryName: String
+
+    @State private var text: String
+    @State private var isSaving = false
+    @State private var saveError: String?
+    @FocusState private var editorFocused: Bool
+
+    init(categoryId: String, categoryName: String, note: String) {
+        self.categoryId = categoryId
+        self.categoryName = categoryName
+        _text = State(initialValue: note)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextEditor(text: $text)
+                        .frame(minHeight: 160)
+                        .focused($editorFocused)
+                        .accessibilityIdentifier("categoryNoteEditor")
+                } footer: {
+                    if let saveError {
+                        Text(saveError)
+                            .foregroundStyle(.red)
+                    } else {
+                        Text("Syncs back to Actual, so it shows on every device on this budget. Clearing the text removes the note.")
+                    }
+                }
+            }
+            .navigationTitle(categoryName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .accessibilityIdentifier("saveCategoryNote")
+                    }
+                }
+            }
+            // Opening straight into the keyboard: the sheet exists only to
+            // type in, so an extra tap to focus would be busywork.
+            .task { editorFocused = true }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        saveError = nil
+        do {
+            try await budgetStore.saveCategoryNote(
+                categoryId: categoryId,
+                note: CategoryNote.normalizedForSave(text)
+            )
+            dismiss()
+        } catch {
+            saveError = error.localizedDescription
+        }
+        isSaving = false
+    }
+}
+
+#Preview {
+    CategoryNoteEditorView(
+        categoryId: "cat-1",
+        categoryName: "Food",
+        note: "Cap at $400/mo — fuel comes out of Transport."
+    )
+    .environmentObject(BudgetStore.previewInstance())
+}

--- a/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
@@ -10,9 +10,10 @@ struct CategoryTransactionsDestination: Hashable {
 }
 
 /// Every transaction counting toward one category's spend, pushed from the
-/// Budget tab (GH #56). The row set mirrors the budget month's spent query
-/// (see BudgetDatabase.fetchCategoryTransactions), so a month-scoped list
-/// sums to the "Spent" figure the user tapped.
+/// Budget tab (GH #56), above it the category's note (GH #131). The row set
+/// mirrors the budget month's spent query (see
+/// BudgetDatabase.fetchCategoryTransactions), so a month-scoped list sums to
+/// the "Spent" figure the user tapped.
 struct CategoryTransactionsView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let destination: CategoryTransactionsDestination
@@ -21,6 +22,10 @@ struct CategoryTransactionsView: View {
     @State private var searchText = ""
     @State private var loaded = false
     @State private var editingTransaction: Transaction?
+    /// Starts `.unsupported` so the section stays hidden until the read
+    /// confirms this file can store notes (GH #131).
+    @State private var note: CategoryNote = .unsupported
+    @State private var editingNote = false
 
     private var scopeTitle: String {
         destination.month.map { MonthPicker.title(for: $0) } ?? "All Time"
@@ -34,73 +39,119 @@ struct CategoryTransactionsView: View {
         return transactions.filter { matcher.matches($0) }
     }
 
-    var body: some View {
-        Group {
-            if transactions.isEmpty && loaded {
-                ContentUnavailableView(
-                    "No Transactions",
-                    systemImage: "list.bullet.rectangle",
-                    description: Text("Nothing in \(destination.categoryName) for \(scopeTitle.lowercased() == "all time" ? "any month" : scopeTitle)")
-                )
-            } else {
-                List {
-                    Section {
-                        if !transactions.isEmpty && filteredTransactions.isEmpty {
-                            Text("No matching transactions")
-                                .foregroundStyle(.secondary)
-                        }
-                        ForEach(filteredTransactions) { transaction in
-                            Group {
-                                // Split children only display at full
-                                // opacity, without tap/swipe: the edit form
-                                // has no split support, and deleting one leg
-                                // would break the parent's amount.
-                                if transaction.parentId == nil {
-                                    Button {
-                                        editingTransaction = transaction
-                                    } label: {
-                                        TransactionRow(transaction: transaction, onToggleCleared: {
-                                            Task {
-                                                await budgetStore.toggleCleared(transaction)
-                                                await reload()
-                                            }
-                                        })
-                                        .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-                                } else {
-                                    TransactionRow(transaction: transaction)
-                                }
-                            }
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                if transaction.parentId == nil {
-                                    Button(role: .destructive) {
-                                        Task {
-                                            await budgetStore.deleteTransaction(transaction)
-                                            await reload()
-                                        }
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                    Button {
-                                        editingTransaction = transaction
-                                    } label: {
-                                        Label("Edit", systemImage: "pencil")
-                                    }
-                                    .tint(.yellow)
-                                }
-                            }
-                        }
-                    } header: {
-                        HStack {
-                            Text(scopeTitle)
-                            Spacer()
-                            // Sums the filtered rows so the total matches
-                            // what's on screen while searching.
-                            Text("Total \(budgetStore.displayBalance(filteredTransactions.reduce(0) { $0 + $1.amount }))")
-                        }
+    /// The category's note. Hidden while searching — a search is about finding
+    /// transactions, not reading guidance — and on files with no `notes` table,
+    /// where an edit could never save.
+    private var noteSection: some View {
+        Section("Note") {
+            Button {
+                editingNote = true
+            } label: {
+                if note.isEmpty {
+                    // Tinted: an empty note row is an invitation to act, where
+                    // an existing note is content to read.
+                    Label("Add Note", systemImage: "note.text.badge.plus")
+                        .foregroundStyle(Color.accentColor)
+                } else {
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(note.text)
+                            .multilineTextAlignment(.leading)
+                            // Multi-line notes are the point — let the row grow
+                            // instead of truncating the guidance to one line.
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(systemName: "pencil")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
                     }
                 }
+            }
+            // Plain: a tinted List button would render the note itself in the
+            // accent color, reading as a link rather than as the text it is.
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("categoryNoteRow")
+        }
+    }
+
+    /// Kept as a row inside the List rather than replacing the whole view, so a
+    /// category with no transactions yet still shows (and can add) its note.
+    private var emptyTransactionsRow: some View {
+        ContentUnavailableView(
+            "No Transactions",
+            systemImage: "list.bullet.rectangle",
+            description: Text("Nothing in \(destination.categoryName) for \(scopeTitle.lowercased() == "all time" ? "any month" : scopeTitle)")
+        )
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+    }
+
+    private var transactionsSection: some View {
+        Section {
+            if !transactions.isEmpty && filteredTransactions.isEmpty {
+                Text("No matching transactions")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(filteredTransactions) { transaction in
+                Group {
+                    // Split children only display at full opacity, without
+                    // tap/swipe: the edit form has no split support, and
+                    // deleting one leg would break the parent's amount.
+                    if transaction.parentId == nil {
+                        Button {
+                            editingTransaction = transaction
+                        } label: {
+                            TransactionRow(transaction: transaction, onToggleCleared: {
+                                Task {
+                                    await budgetStore.toggleCleared(transaction)
+                                    await reload()
+                                }
+                            })
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        TransactionRow(transaction: transaction)
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    if transaction.parentId == nil {
+                        Button(role: .destructive) {
+                            Task {
+                                await budgetStore.deleteTransaction(transaction)
+                                await reload()
+                            }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            editingTransaction = transaction
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(.yellow)
+                    }
+                }
+            }
+        } header: {
+            HStack {
+                Text(scopeTitle)
+                Spacer()
+                // Sums the filtered rows so the total matches what's on screen
+                // while searching.
+                Text("Total \(budgetStore.displayBalance(filteredTransactions.reduce(0) { $0 + $1.amount }))")
+            }
+        }
+    }
+
+    var body: some View {
+        List {
+            if note.supported && searchText.isEmpty {
+                noteSection
+            }
+            if transactions.isEmpty && loaded {
+                emptyTransactionsRow
+            } else {
+                transactionsSection
             }
         }
         .navigationTitle(destination.categoryName)
@@ -117,6 +168,16 @@ struct CategoryTransactionsView: View {
             AddTransactionView(editing: transaction)
                 .environmentObject(budgetStore)
         }
+        .sheet(isPresented: $editingNote, onDismiss: {
+            Task { await reloadNote() }
+        }) {
+            CategoryNoteEditorView(
+                categoryId: destination.categoryId,
+                categoryName: destination.categoryName,
+                note: note.text
+            )
+            .environmentObject(budgetStore)
+        }
     }
 
     private func reload() async {
@@ -124,7 +185,12 @@ struct CategoryTransactionsView: View {
             categoryId: destination.categoryId,
             month: destination.month
         )
+        await reloadNote()
         loaded = true
+    }
+
+    private func reloadNote() async {
+        note = await budgetStore.fetchCategoryNote(categoryId: destination.categoryId)
     }
 }
 

--- a/Actuali/ActualiTests/BudgetDatabaseCategoryNoteTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseCategoryNoteTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Reading category notes out of Actual's `notes` table (GH #131). The table
+/// is keyed by the annotated row's own id, so a category's note lives at
+/// `notes.id = <categoryId>`.
+struct BudgetDatabaseCategoryNoteTests {
+
+    /// A budget file with (or deliberately without) the `notes` table.
+    /// `seedSQL` inserts rows once the schema is in place.
+    private func makeDatabase(
+        includeNotesTable: Bool = true,
+        seedSQL: String = ""
+    ) throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            if includeNotesTable {
+                try db.execute(sql: "CREATE TABLE notes (id TEXT PRIMARY KEY, note TEXT);")
+            }
+            if !seedSQL.isEmpty {
+                try db.execute(sql: seedSQL)
+            }
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func readsStoredNote() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-groceries', 'Cap at $400/mo');
+            """)
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(note.supported)
+        #expect(note.text == "Cap at $400/mo")
+        #expect(!note.isEmpty)
+    }
+
+    /// Multi-line notes are the norm for budgeting guidance, so newlines must
+    /// survive the round trip untouched.
+    @Test func preservesMultilineNoteText() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-groceries', 'Line one
+            Line two');
+            """)
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(note.text.contains("\n"))
+    }
+
+    /// A category nobody has annotated has no row at all — that's an empty
+    /// note on a file that supports them, not a missing feature.
+    @Test func categoryWithoutARowIsSupportedAndEmpty() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(note.supported)
+        #expect(note.text.isEmpty)
+        #expect(note.isEmpty)
+    }
+
+    /// A row whose note is NULL reads as empty rather than crashing on the
+    /// non-optional `text`.
+    @Test func nullNoteReadsAsEmpty() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id) VALUES ('cat-groceries');
+            """)
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(note.supported)
+        #expect(note.text.isEmpty)
+    }
+
+    /// Notes must not read across entities: another row's note is not this
+    /// category's.
+    @Test func doesNotReadAnotherEntitysNote() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-fuel', 'Fuel note');
+            """)
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(note.text.isEmpty)
+    }
+
+    /// A file with no `notes` table at all (older snapshot, partially migrated
+    /// file) reports unsupported so the UI can hide the section rather than
+    /// offer an edit that could never save.
+    @Test func fileWithoutNotesTableIsUnsupported() async throws {
+        let (database, path) = try makeDatabase(includeNotesTable: false)
+        defer { cleanup(path) }
+
+        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+
+        #expect(!note.supported)
+        #expect(note.text.isEmpty)
+    }
+
+    // MARK: - Write-path guard
+
+    @Test func notesTableExistsReportsPresence() throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+
+        #expect(try database.notesTableExists())
+    }
+
+    @Test func notesTableExistsReportsAbsence() throws {
+        let (database, path) = try makeDatabase(includeNotesTable: false)
+        defer { cleanup(path) }
+
+        #expect(try database.notesTableExists() == false)
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreCategoryNoteTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreCategoryNoteTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Saving category notes back to Actual (GH #131): the local row is written
+/// optimistically and a `notes`/`note` CRDT message is queued for the server.
+@MainActor
+struct BudgetStoreCategoryNoteTests {
+
+    /// The `notes` table plus messages_crdt for the sync write path. Both
+    /// normally come from the downloaded budget file.
+    private func makeDatabase(
+        includeNotesTable: Bool = true,
+        seedSQL: String = ""
+    ) throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            if includeNotesTable {
+                try db.execute(sql: "CREATE TABLE notes (id TEXT PRIMARY KEY, note TEXT);")
+            }
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+                """)
+            if !seedSQL.isEmpty {
+                try db.execute(sql: seedSQL)
+            }
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func noteRows(_ url: URL) throws -> [Row] {
+        let queue = try DatabaseQueue(path: url.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM notes ORDER BY id")
+        }
+    }
+
+    private func noteMessages(_ url: URL) throws -> [Row] {
+        let queue = try DatabaseQueue(path: url.path)
+        return try queue.read { db in
+            try Row.fetchAll(
+                db,
+                sql: "SELECT * FROM messages_crdt WHERE dataset = 'notes' ORDER BY id"
+            )
+        }
+    }
+
+    // MARK: - Save normalization (pure)
+
+    @Test func whitespaceOnlyNoteNormalizesToCleared() {
+        #expect(CategoryNote.normalizedForSave("   \n  ") == "")
+        #expect(CategoryNote.normalizedForSave("") == "")
+    }
+
+    /// Indentation and blank lines inside a real note are deliberate — only
+    /// entirely-blank input is treated as a clear.
+    @Test func realNoteIsStoredVerbatim() {
+        #expect(CategoryNote.normalizedForSave("  Cap at $400\n\n    - fuel separate  ")
+                == "  Cap at $400\n\n    - fuel separate  ")
+    }
+
+    // MARK: - First note for a category
+
+    /// A category with no `notes` row gets one created, and the edit goes out
+    /// as a CRDT message so Actual picks it up.
+    @Test func savingFirstNoteCreatesRowAndQueuesMessage() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Cap at $400/mo")
+
+        let rows = try noteRows(path)
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
+        #expect(row["id"] == "cat-groceries")
+        #expect(row["note"] == "Cap at $400/mo")
+
+        let messages = try noteMessages(path)
+        #expect(messages.count == 1)
+        let message = try #require(messages.first)
+        #expect(message["row"] == "cat-groceries")
+        #expect(message["column"] == "note")
+        #expect(message["value"] == "S:Cap at $400/mo")
+    }
+
+    /// The saved note is what a subsequent read returns — no manual refresh.
+    @Test func savedNoteReadsBack() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Weekly shop only")
+
+        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        #expect(note.supported)
+        #expect(note.text == "Weekly shop only")
+    }
+
+    // MARK: - Editing an existing note
+
+    @Test func editingExistingNoteUpdatesRowInPlace() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-groceries', 'old note');
+            """)
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "new note")
+
+        let rows = try noteRows(path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["note"] == "new note")
+    }
+
+    @Test func savingPreservesMultilineText() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Line one\nLine two")
+
+        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        #expect(note.text == "Line one\nLine two")
+    }
+
+    /// Clearing the text saves an empty string, matching Actual's web UI, so
+    /// the cleared state syncs. Tombstoning the row would instead leave other
+    /// clients showing the stale note.
+    @Test func clearingNoteSavesEmptyStringRatherThanDeletingRow() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-groceries', 'old note');
+            """)
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "")
+
+        let rows = try noteRows(path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["note"] == "")
+
+        let messages = try noteMessages(path)
+        #expect(messages.count == 1)
+        #expect(messages.first?["value"] == "S:")
+
+        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        #expect(note.isEmpty)
+    }
+
+    // MARK: - Unsupported files and misconfiguration
+
+    /// A file with no `notes` table must fail loudly rather than queue a
+    /// message that applies to nothing locally.
+    @Test func savingWithoutNotesTableThrows() async throws {
+        let (database, path) = try makeDatabase(includeNotesTable: false)
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        await #expect(throws: SyncError.notesTableMissing) {
+            try await store.saveCategoryNote(categoryId: "cat-groceries", note: "nope")
+        }
+
+        #expect(try noteMessages(path).isEmpty)
+    }
+
+    @Test func withoutSyncClientThrowsSyncNotConfigured() async throws {
+        let store = BudgetStore.previewInstance()
+
+        await #expect(throws: BudgetStoreError.syncNotConfigured) {
+            try await store.saveCategoryNote(categoryId: "cat-groceries", note: "nope")
+        }
+    }
+
+    @Test func fetchWithoutDatabaseIsUnsupported() async throws {
+        let store = BudgetStore.previewInstance()
+
+        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        #expect(!note.supported)
+    }
+}

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -87,4 +87,32 @@ struct DemoDataSeederTests {
         }
         #expect(try await database.fetchUncategorizedCount() == 0)
     }
+
+    /// The demo budget must support notes and ship one, or the category note
+    /// section (GH #131) hides itself as unsupported and the feature is
+    /// invisible in demo mode — including in App Store screenshots.
+    @Test func seededBudgetShipsAnAnnotatedCategory() async throws {
+        let database = try seedAndOpen()
+        let groups = try await database.fetchCategoryGroups()
+
+        let groceries = try #require(
+            groups.flatMap(\.categories).first { $0.name == "Groceries" })
+        let note = try await database.fetchCategoryNote(categoryId: groceries.id)
+
+        #expect(note.supported)
+        #expect(note.text.contains("Target $650/mo"))
+    }
+
+    /// Every other category opens with an empty — not unsupported — note, so
+    /// the "Add Note" row is offered rather than hidden.
+    @Test func unannotatedCategoriesSupportNotes() async throws {
+        let database = try seedAndOpen()
+        let groups = try await database.fetchCategoryGroups()
+
+        let rent = try #require(groups.flatMap(\.categories).first { $0.name == "Rent" })
+        let note = try await database.fetchCategoryNote(categoryId: rent.id)
+
+        #expect(note.supported)
+        #expect(note.isEmpty)
+    }
 }

--- a/Actuali/ActualiUITests/CategoryNotesUITests.swift
+++ b/Actuali/ActualiUITests/CategoryNotesUITests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+/// End-to-end check for category notes (GH #131).
+///
+/// The demo budget's seeded Groceries note must be visible on the category
+/// detail view without any digging, and an edit typed into the app must come
+/// back on the row after saving — proving the read, the write and the refresh
+/// are wired together, not just individually correct.
+final class CategoryNotesUITests: XCTestCase {
+
+    @MainActor
+    func testViewsAndEditsCategoryNote() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "1"]
+        app.launch()
+
+        XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
+                      "Budget tab not found")
+
+        // Groceries is the demo category that ships annotated.
+        let groceries = app.buttons["All transactions for Groceries"]
+        var scrollsLeft = 8
+        while !groceries.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(groceries.isHittable, "Groceries row not reachable")
+        groceries.tap()
+        XCTAssertTrue(app.navigationBars["Groceries"].waitForExistence(timeout: 5),
+                      "Groceries transactions did not open")
+
+        // The note shows on the detail view, above the transactions.
+        let noteRow = app.buttons["categoryNoteRow"]
+        XCTAssertTrue(noteRow.waitForExistence(timeout: 5), "note row not shown")
+        XCTAssertTrue(noteRow.label.contains("Target $650"),
+                      "seeded note not displayed, row read: \(noteRow.label)")
+        attachScreenshot(app, name: "1-category-note")
+
+        // Tapping opens the editor, already focused so typing lands in it.
+        noteRow.tap()
+        let editor = app.textViews["categoryNoteEditor"]
+        XCTAssertTrue(editor.waitForExistence(timeout: 5), "note editor not shown")
+        attachScreenshot(app, name: "2-note-editor")
+
+        editor.typeText("checked")
+
+        let save = app.buttons["saveCategoryNote"]
+        XCTAssertTrue(save.waitForExistence(timeout: 5), "Save button not shown")
+        save.tap()
+        XCTAssertTrue(editor.waitForNonExistence(timeout: 5), "note editor did not dismiss")
+
+        // The edit is reflected on the row, and the original text survives —
+        // this is an edit, not a replacement (cursor position is the
+        // keyboard's business, so only containment is asserted).
+        let updated = app.buttons["categoryNoteRow"]
+        XCTAssertTrue(updated.waitForExistence(timeout: 5), "note row gone after save")
+        XCTAssertTrue(updated.label.contains("checked"),
+                      "typed text missing after save, row read: \(updated.label)")
+        XCTAssertTrue(updated.label.contains("Target $650"),
+                      "original note lost on save, row read: \(updated.label)")
+        attachScreenshot(app, name: "3-note-edited")
+    }
+
+    /// A category nobody has annotated offers "Add Note" rather than a blank
+    /// row — and rather than hiding, which is reserved for files whose schema
+    /// can't store notes at all.
+    @MainActor
+    func testUnannotatedCategoryOffersAddNote() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "1"]
+        app.launch()
+
+        XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
+                      "Budget tab not found")
+
+        let rent = app.buttons["All transactions for Rent"]
+        var scrollsLeft = 8
+        while !rent.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(rent.isHittable, "Rent row not reachable")
+        rent.tap()
+        XCTAssertTrue(app.navigationBars["Rent"].waitForExistence(timeout: 5),
+                      "Rent transactions did not open")
+
+        let noteRow = app.buttons["categoryNoteRow"]
+        XCTAssertTrue(noteRow.waitForExistence(timeout: 5), "note row not shown")
+        XCTAssertTrue(noteRow.label.contains("Add Note"),
+                      "empty note did not offer Add Note, row read: \(noteRow.label)")
+        attachScreenshot(app, name: "4-add-note")
+    }
+
+    @MainActor
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Why

Fixes #131. Actual stores per-entity notes in a `notes` table keyed by the annotated row's own id, and the app ignored it completely — no read, no write, nothing on screen. Any budgeting guidance written on the web (`Target $650/mo`, "household supplies count here") was invisible on mobile.

This isn't a regression; the read and write paths never existed.

## What

- The category detail view shows the note above the transactions, growing to fit multi-line text, with a pencil affordance. Tapping opens a sheet with a focused `TextEditor` and Cancel/Save.
- Saving writes through the sync engine exactly the way budget amounts do (`SyncClient.setBudgetAmount` was the template): a `notes`/`note` CRDT message generated before any DB write, applied locally through the same LWW upsert incoming messages use, then pushed. The upsert means a category that has never been annotated gets its row created by the write.
- Clearing the text saves an empty string rather than tombstoning the row, matching upstream `notes-save`. A tombstone would leave other clients showing the stale note, since they read the `note` column, not the tombstone. Whitespace-only input counts as cleared; real notes are stored verbatim so indentation and blank lines survive.
- Files with no `notes` table report the note as unsupported, and the section hides itself rather than offering an edit that could never save. The write path fails loudly for the same case instead of queueing a message that applies to nothing locally.
- The note section is hidden while searching — a search is about finding transactions.
- The empty-transactions state moved inside the list so a category with no transactions yet can still show and add its note.

Scope is category notes only, per the issue. Group notes are the issue's own stated follow-up.

**One thing worth a reviewer's eye:** the demo budget had no `notes` table, so the feature would have been invisible in demo mode — including in App Store screenshots and for App Review. I added the table plus one annotated category (Groceries). Happy to pull that out if you'd rather keep the seeder untouched.

## How it was tested

31 new tests; full unit suite green (`749 tests in 105 suites`, CI's exact invocation minus UI tests):

```
✔ Test run with 749 tests in 105 suites passed after 3.167 seconds.
```

- `BudgetDatabaseCategoryNoteTests` — reads a stored note, preserves newlines, treats a missing row and a NULL note as empty-but-supported, doesn't read another entity's note, reports a file with no `notes` table as unsupported.
- `BudgetStoreCategoryNoteTests` — first note creates the row and queues exactly one `notes`/`note` message with value `S:…`; editing updates in place; clearing writes `""` and keeps the row; a file without the table throws and queues nothing; missing sync client throws.
- `DemoDataSeederTests` — the demo budget ships an annotated category, and un-annotated ones read as empty rather than unsupported.
- `CategoryNotesUITests` (local; CI skips UI tests) — end-to-end on iPhone 17 / iOS 26.5: opens Groceries, asserts the seeded note is on screen, types into the editor, saves, and asserts the row comes back with both the typed text and the original. A second test asserts an un-annotated category offers "Add Note".

```
Test Case '-[ActualiUITests.CategoryNotesUITests testUnannotatedCategoryOffersAddNote]' passed (10.411 seconds).
Test Case '-[ActualiUITests.CategoryNotesUITests testViewsAndEditsCategoryNote]' passed (17.685 seconds).
```

The UI test caught one real defect during review: the note rendered in the accent color, reading as a link rather than as text. Fixed with `.buttonStyle(.plain)`.

Not verified: I have no real Actual budget file to hand, so I couldn't empirically confirm the `notes` table is present in a downloaded file. That's what the `tableExists` guard is for — a file without it degrades to the previous behaviour instead of erroring.

## Screenshots

Not attached — `gh pr create` can't upload images, so these live as attachments in the local UI-test result bundle (`1-category-note`, `2-note-editor`, `3-note-edited`, `4-add-note` in the `CategoryNotesUITests` xcresult). Say the word and I'll drop them in a comment from the browser.

What they show: the note rendering multi-line above the transactions in body text with a subtle pencil; the editor opening focused with the keyboard up and Cancel/Save; the edited note reflected on the row after saving; and "Add Note" offered on an un-annotated category.
