### PR TITLE
Add a Shortcuts action that opens the add-transaction form prefilled

### DIFF
--- a/Actuali/Actuali/AppIntents/ActualiShortcutsProvider.swift
+++ b/Actuali/Actuali/AppIntents/ActualiShortcutsProvider.swift
@@ -17,6 +17,17 @@ struct ActualiShortcutsProvider: AppShortcutsProvider {
         )
 
         AppShortcut(
+            intent: AddTransactionWithReviewIntent(),
+            phrases: [
+                "Add transaction with review in \(.applicationName)",
+                "Enter transaction in \(.applicationName)",
+                "Review a transaction in \(.applicationName)",
+            ],
+            shortTitle: "Add with Review",
+            systemImageName: "square.and.pencil"
+        )
+
+        AppShortcut(
             intent: GetAccountBalanceIntent(),
             phrases: [
                 "Check \(\.$account) balance in \(.applicationName)",

--- a/Actuali/Actuali/AppIntents/AddTransactionWithReviewIntent.swift
+++ b/Actuali/Actuali/AppIntents/AddTransactionWithReviewIntent.swift
@@ -1,0 +1,122 @@
+import AppIntents
+import Foundation
+
+/// Opens the app on the add-transaction form with any provided fields
+/// pre-filled, instead of logging silently like `LogTransactionIntent` —
+/// for automations where details (notes, category) are decided at purchase
+/// time and the user wants to review before saving (GH #91).
+struct AddTransactionWithReviewIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add Transaction with Review"
+    static let description = IntentDescription(
+        "Open the add-transaction screen with fields pre-filled so you can review and save.",
+        categoryName: "Transactions"
+    )
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Account")
+    var account: AccountEntity?
+
+    @Parameter(title: "Card or Account Hint", default: "")
+    var cardHint: String
+
+    // String, not Double, for the same reason as LogTransactionIntent:
+    // Wallet's amount coerces to 0 as a Number for some cards (issue #41).
+    @Parameter(title: "Amount", default: "")
+    var amount: String
+
+    @Parameter(title: "Payee", default: "")
+    var payee: String
+
+    @Parameter(title: "Notes", default: "")
+    var notes: String
+
+    @Parameter(title: "Category")
+    var category: CategoryEntity?
+
+    @Parameter(title: "Date")
+    var date: Date?
+
+    @Parameter(title: "Is Income", default: false)
+    var isIncome: Bool
+
+    @Parameter(title: "Cleared", default: false)
+    var cleared: Bool
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$amount) at \(\.$payee) in \(\.$account)") {
+            \.$cardHint
+            \.$notes
+            \.$category
+            \.$date
+            \.$isIncome
+            \.$cleared
+        }
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let store = BudgetStore.shared
+        // Wait for the budget so account/category resolution below sees data
+        // even when the intent cold-starts the app.
+        await store.ensureBudgetReady()
+
+        // Resolve the account like LogTransactionIntent: explicit parameter,
+        // else card hint. No default-account fallback here — ContentView
+        // applies it when presenting the form, and nil degrades gracefully.
+        var resolvedAccountId = account?.id
+        if resolvedAccountId == nil, !cardHint.isEmpty {
+            resolvedAccountId = await store.resolveAccountId(hint: cardHint)
+        }
+
+        // Drop a category that no longer exists (deleted since the shortcut
+        // was configured) rather than pre-selecting a dangling id the form
+        // would happily save.
+        var resolvedCategoryId = category?.id
+        if let id = resolvedCategoryId {
+            let categories = await store.categoriesForIntent()
+            if !categories.contains(where: { $0.id == id }) {
+                resolvedCategoryId = nil
+            }
+        }
+
+        NotificationRouter.shared.pendingPrefill = Self.prefill(
+            accountId: resolvedAccountId,
+            amount: amount,
+            payee: payee,
+            notes: notes,
+            categoryId: resolvedCategoryId,
+            date: date ?? Date(),
+            isIncome: isIncome,
+            cleared: cleared
+        )
+        return .result()
+    }
+
+    /// Pure mapping from intent parameters to the form prefill. The amount is
+    /// parsed leniently — the user is about to review the form, so an
+    /// unparsable value just leaves the field empty instead of erroring.
+    static func prefill(
+        accountId: String?,
+        amount: String,
+        payee: String,
+        notes: String,
+        categoryId: String?,
+        date: Date,
+        isIncome: Bool,
+        cleared: Bool
+    ) -> TransactionPrefill {
+        let amountCents = AmountParser.parse(amount).flatMap { parsed in
+            parsed.isFinite && parsed > 0 ? Transaction.cents(fromDollars: parsed) : nil
+        }
+        return TransactionPrefill(
+            accountId: accountId,
+            payee: payee,
+            amountCents: amountCents,
+            date: date,
+            notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
+            categoryId: categoryId,
+            isIncome: isIncome,
+            cleared: cleared
+        )
+    }
+}

--- a/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
+++ b/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
@@ -165,7 +165,10 @@ struct LogTransactionIntent: AppIntent {
                 accountId: account?.id ?? store.defaultAccountId,
                 payee: payee,
                 amountCents: amountCents,
-                date: date ?? Date()
+                date: date ?? Date(),
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
+                isIncome: isIncome,
+                cleared: cleared
             )
         )
     }

--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -33,7 +33,11 @@ struct ContentView: View {
                         accountId: accountId,
                         payee: prefill.payee,
                         amountCents: prefill.amountCents,
-                        date: prefill.date
+                        date: prefill.date,
+                        notes: prefill.notes,
+                        categoryId: prefill.categoryId,
+                        isIncome: prefill.isIncome,
+                        cleared: prefill.cleared
                     )
                 } else {
                     ContentUnavailableView(

--- a/Actuali/Actuali/Models/TransactionPrefill.swift
+++ b/Actuali/Actuali/Models/TransactionPrefill.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Details carried on a failed log-transaction notification so tapping it can
-/// open the add-transaction form with whatever the automation did receive.
+/// Details carried into the add-transaction form by an automation: a failed
+/// log-transaction notification tap, or the Add Transaction with Review
+/// intent, which opens the form pre-filled for the user to finish (GH #91).
 struct TransactionPrefill: Identifiable, Equatable {
     /// Marker key distinguishing our payload from other notifications.
     private static let kind = "com.mfazz.Actuali.transactionPrefill"
@@ -10,14 +11,31 @@ struct TransactionPrefill: Identifiable, Equatable {
     let payee: String
     let amountCents: Int?
     let date: Date
+    let notes: String
+    let categoryId: String?
+    let isIncome: Bool
+    let cleared: Bool
 
     var id: Date { date }
 
-    init(accountId: String?, payee: String, amountCents: Int?, date: Date) {
+    init(
+        accountId: String?,
+        payee: String,
+        amountCents: Int?,
+        date: Date,
+        notes: String = "",
+        categoryId: String? = nil,
+        isIncome: Bool = false,
+        cleared: Bool = false
+    ) {
         self.accountId = accountId
         self.payee = payee
         self.amountCents = amountCents
         self.date = date
+        self.notes = notes
+        self.categoryId = categoryId
+        self.isIncome = isIncome
+        self.cleared = cleared
     }
 
     init?(userInfo: [AnyHashable: Any]) {
@@ -27,6 +45,12 @@ struct TransactionPrefill: Identifiable, Equatable {
         self.payee = userInfo["payee"] as? String ?? ""
         self.amountCents = userInfo["amountCents"] as? Int
         self.date = Date(timeIntervalSince1970: timestamp)
+        // Absent on payloads scheduled by older builds; the defaults match
+        // what the form used before these fields were carried.
+        self.notes = userInfo["notes"] as? String ?? ""
+        self.categoryId = userInfo["categoryId"] as? String
+        self.isIncome = userInfo["isIncome"] as? Bool ?? false
+        self.cleared = userInfo["cleared"] as? Bool ?? false
     }
 
     var userInfo: [AnyHashable: Any] {
@@ -34,9 +58,13 @@ struct TransactionPrefill: Identifiable, Equatable {
             "kind": Self.kind,
             "payee": payee,
             "date": date.timeIntervalSince1970,
+            "isIncome": isIncome,
+            "cleared": cleared,
         ]
         if let accountId { info["accountId"] = accountId }
         if let amountCents { info["amountCents"] = amountCents }
+        if !notes.isEmpty { info["notes"] = notes }
+        if let categoryId { info["categoryId"] = categoryId }
         return info
     }
 }

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -34,23 +34,31 @@ struct AddTransactionView: View {
     @FocusState private var payeeFocused: Bool
 
     /// Initializer for the "Add" flow. The optional prefill parameters carry
-    /// whatever a failed Wallet automation received (see TransactionPrefill).
+    /// whatever an automation passed along — a failed Wallet log or the Add
+    /// Transaction with Review intent (see TransactionPrefill).
     init(
         accountId: String,
         payee: String = "",
         amountCents: Int? = nil,
-        date: Date = Date()
+        date: Date = Date(),
+        notes: String = "",
+        categoryId: String? = nil,
+        isIncome: Bool = false,
+        cleared: Bool = false
     ) {
         self.editing = nil
         _selectedAccountId = State(initialValue: accountId)
         _amount = State(initialValue: amountCents.map { String(format: "%.2f", Double(abs($0)) / 100.0) } ?? "")
-        _txType = State(initialValue: .expense)
+        _txType = State(initialValue: isIncome ? .income : .expense)
         _payeeName = State(initialValue: payee)
         _transferToAccountId = State(initialValue: nil)
-        _selectedCategoryId = State(initialValue: nil)
-        _notes = State(initialValue: "")
+        _selectedCategoryId = State(initialValue: categoryId)
+        _notes = State(initialValue: notes)
         _date = State(initialValue: date)
-        _cleared = State(initialValue: false)
+        _cleared = State(initialValue: cleared)
+        // A prefilled category is the automation's explicit choice — don't
+        // let the payee-history suggestion overwrite it.
+        _userPickedCategory = State(initialValue: categoryId != nil)
     }
 
     /// Initializer for the "Edit" flow. Transfer legs load as transfers —

--- a/Actuali/ActualiTests/AddTransactionWithReviewIntentTests.swift
+++ b/Actuali/ActualiTests/AddTransactionWithReviewIntentTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct AddTransactionWithReviewIntentTests {
+
+    @Test func buildsPrefillWithParsedAmount() {
+        let date = Date(timeIntervalSince1970: 1_750_000_000)
+        let prefill = AddTransactionWithReviewIntent.prefill(
+            accountId: "acct-1",
+            amount: "$4.50",
+            payee: "Blue Bottle",
+            notes: "  Team coffee  ",
+            categoryId: "cat-7",
+            date: date,
+            isIncome: false,
+            cleared: true
+        )
+        #expect(prefill.accountId == "acct-1")
+        #expect(prefill.amountCents == 450)
+        #expect(prefill.payee == "Blue Bottle")
+        #expect(prefill.notes == "Team coffee")
+        #expect(prefill.categoryId == "cat-7")
+        #expect(prefill.date == date)
+        #expect(prefill.isIncome == false)
+        #expect(prefill.cleared == true)
+    }
+
+    @Test(arguments: ["", "   ", "abc", "0", "-3"])
+    func unparsableAmountLeavesAmountUnset(amount: String) {
+        let prefill = AddTransactionWithReviewIntent.prefill(
+            accountId: nil,
+            amount: amount,
+            payee: "",
+            notes: "",
+            categoryId: nil,
+            date: Date(timeIntervalSince1970: 1_750_000_000),
+            isIncome: false,
+            cleared: false
+        )
+        #expect(prefill.amountCents == nil)
+    }
+}

--- a/Actuali/ActualiTests/TransactionPrefillTests.swift
+++ b/Actuali/ActualiTests/TransactionPrefillTests.swift
@@ -6,12 +6,25 @@ struct TransactionPrefillTests {
 
     @Test func roundTripsAllFields() {
         let date = Date(timeIntervalSince1970: 1_750_000_000)
-        let prefill = TransactionPrefill(accountId: "acct-1", payee: "Blue Bottle", amountCents: 450, date: date)
+        let prefill = TransactionPrefill(
+            accountId: "acct-1",
+            payee: "Blue Bottle",
+            amountCents: 450,
+            date: date,
+            notes: "Team coffee",
+            categoryId: "cat-7",
+            isIncome: true,
+            cleared: true
+        )
         let decoded = TransactionPrefill(userInfo: prefill.userInfo)
         #expect(decoded?.accountId == "acct-1")
         #expect(decoded?.payee == "Blue Bottle")
         #expect(decoded?.amountCents == 450)
         #expect(decoded?.date == date)
+        #expect(decoded?.notes == "Team coffee")
+        #expect(decoded?.categoryId == "cat-7")
+        #expect(decoded?.isIncome == true)
+        #expect(decoded?.cleared == true)
     }
 
     @Test func roundTripsOptionalFieldsAsNil() {
@@ -22,6 +35,24 @@ struct TransactionPrefillTests {
         #expect(decoded?.accountId == nil)
         #expect(decoded?.payee == "")
         #expect(decoded?.amountCents == nil)
+        #expect(decoded?.categoryId == nil)
+    }
+
+    @Test func decodesLegacyPayloadWithoutNewKeys() {
+        // A notification scheduled by an older build carries none of the
+        // notes/category/type keys; decoding must fall back to the same
+        // defaults the old form used.
+        let userInfo: [AnyHashable: Any] = [
+            "kind": "com.mfazz.Actuali.transactionPrefill",
+            "payee": "Blue Bottle",
+            "date": 1_750_000_000.0,
+        ]
+        let decoded = TransactionPrefill(userInfo: userInfo)
+        #expect(decoded != nil)
+        #expect(decoded?.notes == "")
+        #expect(decoded?.categoryId == nil)
+        #expect(decoded?.isIncome == false)
+        #expect(decoded?.cleared == false)
     }
 
     @Test func returnsNilForForeignUserInfo() {

--- a/website/src/pages/guides/shortcuts.astro
+++ b/website/src/pages/guides/shortcuts.astro
@@ -43,6 +43,11 @@ import Layout from "../../layouts/Layout.astro";
           <a href="/guides/wallet-automation" class="underline hover:text-neutral-900">Apple Wallet automation</a> to log
           tap-to-pay purchases automatically.
         </li>
+        <li>
+          <strong>Add Transaction with Review</strong> — open the app on the add-transaction screen with any fields you
+          pass (amount, payee, account, category, notes, date) already filled in, so you can review and save. Handy for
+          Wallet automations where you want to pick a category or add notes at purchase time.
+        </li>
         <li><strong>Get Account Balance</strong> — the current balance of an account (or your default account).</li>
         <li><strong>Get Category Balance</strong> — how much is left in a category this month.</li>
         <li>


### PR DESCRIPTION
## What
Adds a new App Intent, **Add Transaction with Review**, that opens the app on the add-transaction screen with fields pre-populated from a Shortcut or Wallet automation: account (or card hint), amount, payee, notes, category, date, income flag, and cleared state. The user reviews and saves, instead of the transaction being logged silently.

Fixes #91

## Why / How
The app already had an "open the add form prefilled" pathway: `NotificationRouter.pendingPrefill` drives a sheet in `ContentView` when a background log fails. The new intent (`openAppWhenRun = true`) reuses it:

- `AddTransactionWithReviewIntent` waits for the budget, resolves the account like `LogTransactionIntent` (explicit parameter → card hint; the default-account fallback stays in `ContentView`), drops a category id that no longer exists, parses the amount leniently (String parameter for the Wallet number-coercion quirk, #41 — an unparsable amount just leaves the field empty since the user is about to review), and sets `pendingPrefill`.
- `TransactionPrefill` gains `notes`, `categoryId`, `isIncome`, `cleared` with backward-compatible userInfo decoding (payloads from older builds fall back to the previous form defaults).
- `AddTransactionView`'s add-flow init accepts the new fields; a prefilled category sets `userPickedCategory` so the payee-history suggestion doesn't overwrite the automation's explicit choice.
- Side benefit: the failed-log notification prefill now carries notes/type/cleared instead of dropping them.
- Registered in `ActualiShortcutsProvider` ("Add with Review") and documented in the website shortcuts guide.

## Verification
TDD: extended `TransactionPrefillTests` (round-trip of new fields, legacy payload defaults) and added `AddTransactionWithReviewIntentTests` (prefill mapping, lenient amount parsing) — confirmed failing first, then implemented.

Full unit suite on iPhone 17 / iOS 26.5 simulator:
```
xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -skip-testing:ActualiUITests
** TEST SUCCEEDED **  — 759 tests passed, 0 failed
```