### PR TITLE
Show each report dashboard separately with a dashboard switcher

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -228,7 +228,8 @@ class BudgetDatabase {
         // "Main" page and moves widgets onto it, but that half generates no
         // CRDT messages and forks a fresh page id on every client that runs
         // it, so doing it here would add yet another divergent page. Pageless
-        // widgets still render via the fallback in fetchWidgets().
+        // widgets still render via the nil-page fallback (ReportsTabView's
+        // resolvePageId → fetchWidgets(pageId: nil)).
         (1765518577215, """
             CREATE TABLE IF NOT EXISTS dashboard_pages (
                 id TEXT PRIMARY KEY,
@@ -1592,34 +1593,46 @@ class BudgetDatabase {
         }
     }
 
-    func fetchWidgets() async throws -> [DashboardWidget] {
+    /// Live dashboard pages in table order — the same order the web app's
+    /// unordered AQL select (`q('dashboard_pages').select('*')`) yields and
+    /// its router indexes into for the default dashboard
+    /// (ReportsDashboardRouter → dashboardPages[0]).
+    func fetchDashboardPages() async throws -> [DashboardPage] {
         try await dbQueue.read { db in
-            // The web app treats pages as separate dashboards and opens the
-            // first live one (ReportsDashboardRouter → dashboardPages[0]), so
-            // widgets on other, deleted, or unknown pages must not render.
-            // Upstream's migration mints a fresh "Main" page id on every
-            // client that runs it, so a synced budget can carry full
-            // duplicate widget sets under orphaned page ids (GH: Reports
-            // showed every widget twice).
-            let firstLivePageId = try String.fetchOne(db, sql: """
-                SELECT id FROM dashboard_pages
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, name FROM dashboard_pages
                 WHERE (tombstone = 0 OR tombstone IS NULL)
                 ORDER BY rowid ASC
-                LIMIT 1
                 """)
+            return rows.compactMap { row -> DashboardPage? in
+                guard let id = row["id"] as String? else { return nil }
+                return DashboardPage(id: id, name: (row["name"] as String?) ?? "")
+            }
+        }
+    }
 
+    /// Live widgets on one dashboard page, in reading order (y, then x).
+    /// The web app treats pages as separate dashboards (GH #120: rendering
+    /// only one merged view scrambled multi-dashboard budgets), so widgets
+    /// on other, deleted, or unknown pages must not render for a given page.
+    /// Upstream's migration mints a fresh "Main" page id on every client
+    /// that runs it, so a synced budget can carry full duplicate widget sets
+    /// under orphaned page ids (GH: Reports showed every widget twice).
+    ///
+    /// A nil `pageId` selects pageless widgets — budgets from servers that
+    /// predate multiple dashboards carry no page rows or ids.
+    func fetchWidgets(pageId: String?) async throws -> [DashboardWidget] {
+        try await dbQueue.read { db in
             let rows: [Row]
-            if let firstLivePageId {
+            if let pageId {
                 rows = try Row.fetchAll(db, sql: """
                     SELECT id, type, meta
                     FROM dashboard
                     WHERE (tombstone = 0 OR tombstone IS NULL)
                       AND dashboard_page_id = ?
                     ORDER BY y ASC, x ASC
-                    """, arguments: [firstLivePageId])
+                    """, arguments: [pageId])
             } else {
-                // Pre-pages budget (or every page deleted): widgets carry no
-                // page id.
                 rows = try Row.fetchAll(db, sql: """
                     SELECT id, type, meta
                     FROM dashboard

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -172,8 +172,8 @@ enum DemoDataSeeder {
             )
             """)
 
-        // Mirrors the dashboard table created by BudgetDatabase's migrations, so
-        // the demo budget can ship a pre-built Reports dashboard.
+        // Mirrors the dashboard tables created by BudgetDatabase's migrations, so
+        // the demo budget can ship pre-built Reports dashboards.
         try db.execute(sql: """
             CREATE TABLE dashboard (
                 id TEXT PRIMARY KEY,
@@ -185,6 +185,14 @@ enum DemoDataSeeder {
                 height INTEGER DEFAULT 2,
                 meta TEXT,
                 tombstone INTEGER NOT NULL DEFAULT 0
+            )
+            """)
+
+        try db.execute(sql: """
+            CREATE TABLE dashboard_pages (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                tombstone INTEGER DEFAULT 0
             )
             """)
 
@@ -490,31 +498,51 @@ enum DemoDataSeeder {
             INSERT INTO preferences (id, value) VALUES ('defaultCurrencyCode', 'USD')
             """)
 
-        // --- Reports dashboard ---
+        // --- Reports dashboards ---
+        // Two pages so the demo exercises the dashboard switcher (GH #120);
+        // "Main" is inserted first so it's the default dashboard on open.
+        let mainPageId = UUID().uuidString
+        let trendsPageId = UUID().uuidString
+        try db.execute(sql: """
+            INSERT INTO dashboard_pages (id, name, tombstone)
+            VALUES (?, 'Main', 0), (?, 'Trends', 0)
+            """, arguments: [mainPageId, trendsPageId])
+
         // A curated set of widgets so the Reports tab is populated in the demo.
         // Sliding-window time frames slide their stored range forward to end at
         // the current month, so the net-worth/cash-flow trends always cover the
         // seeded data regardless of when the demo is loaded. Ordered by `y`.
-        try insertWidget(db, type: "markdown-card", y: 0, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "markdown-card", y: 0, width: 12, height: 2, meta: """
             {"content":"**Welcome to the demo** 👋\\n\\nThis is sample data stored only on this device \u{2014} nothing you do here can touch a server or a real budget. When you\u{2019}re ready, connect your own Actual Budget server in **Settings**."}
             """)
-        try insertWidget(db, type: "net-worth-card", y: 1, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "net-worth-card", y: 1, width: 12, height: 2, meta: """
             {"name":"Net Worth","timeFrame":{"start":"2024-01","end":"2024-06","mode":"sliding-window"},"interval":"Monthly"}
             """)
-        try insertWidget(db, type: "cash-flow-card", y: 2, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "cash-flow-card", y: 2, width: 12, height: 2, meta: """
             {"name":"Cash Flow","timeFrame":{"start":"2024-01","end":"2024-06","mode":"sliding-window"},"showBalance":false}
             """)
-        try insertWidget(db, type: "summary-card", y: 3, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "summary-card", y: 3, width: 12, height: 2, meta: """
             {"name":"Spent This Month","content":"{\\"type\\":\\"sum\\"}","conditions":[{"field":"amount","op":"lt","value":0}],"conditionsOp":"and"}
             """)
-        try insertWidget(db, type: "spending-card", y: 4, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "spending-card", y: 4, width: 12, height: 2, meta: """
             {"name":"This Month","mode":"single-month"}
             """)
-        try insertWidget(db, type: "spending-card", y: 5, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "spending-card", y: 5, width: 12, height: 2, meta: """
             {"name":"Budget Overview","mode":"budget"}
             """)
-        try insertWidget(db, type: "spending-card", y: 6, width: 12, height: 2, meta: """
+        try insertWidget(db, pageId: mainPageId, type: "spending-card", y: 6, width: 12, height: 2, meta: """
             {"name":"3-Month Average","mode":"average"}
+            """)
+
+        // The second dashboard: a small page that shows off switching.
+        try insertWidget(db, pageId: trendsPageId, type: "markdown-card", y: 0, width: 12, height: 2, meta: """
+            {"content":"**A second dashboard** 📊\\n\\nBudgets can have several report dashboards \u{2014} switch between them with the menu in the top corner. Create and arrange dashboards in the Actual Budget webapp."}
+            """)
+        try insertWidget(db, pageId: trendsPageId, type: "age-of-money-card", y: 1, width: 12, height: 2, meta: """
+            {"name":"Age of Money"}
+            """)
+        try insertWidget(db, pageId: trendsPageId, type: "summary-card", y: 2, width: 12, height: 2, meta: """
+            {"name":"Income This Month","content":"{\\"type\\":\\"sum\\"}","conditions":[{"field":"amount","op":"gt","value":0}],"conditionsOp":"and"}
             """)
 
         logger.info("Inserted \(transactions.count) demo transactions for month \(yyyymm)")
@@ -522,6 +550,7 @@ enum DemoDataSeeder {
 
     private static func insertWidget(
         _ db: Database,
+        pageId: String,
         type: String,
         y: Int,
         width: Int,
@@ -530,8 +559,8 @@ enum DemoDataSeeder {
     ) throws {
         try db.execute(sql: """
             INSERT INTO dashboard (id, type, dashboard_page_id, x, y, width, height, meta, tombstone)
-            VALUES (?, ?, NULL, 0, ?, ?, ?, ?, 0)
-            """, arguments: [UUID().uuidString, type, y, width, height, meta])
+            VALUES (?, ?, ?, 0, ?, ?, ?, ?, 0)
+            """, arguments: [UUID().uuidString, type, pageId, y, width, height, meta])
     }
 
     // MARK: - Insert helpers

--- a/Actuali/Actuali/Services/Reports/DashboardWidget.swift
+++ b/Actuali/Actuali/Services/Reports/DashboardWidget.swift
@@ -233,6 +233,16 @@ struct CustomReportMeta: Codable, Equatable {
     let name: String?
 }
 
+// MARK: - DashboardPage
+
+/// A live row in `dashboard_pages`. The web app treats each page as a
+/// separate dashboard (upstream migration 1765518577215); a null name
+/// renders as an empty string upstream.
+struct DashboardPage: Identifiable, Equatable {
+    let id: String
+    let name: String
+}
+
 // MARK: - DashboardWidget enum
 
 enum DashboardWidget: Equatable {

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct ReportsTabView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+    @State private var pages: [DashboardPage] = []
+    @State private var selectedPageId: String?
     @State private var widgets: [DashboardWidget] = []
     @State private var loadError: String?
     @State private var hasLoaded = false
@@ -25,10 +27,21 @@ struct ReportsTabView: View {
                         description: Text("Open or sync a budget to see reports.")
                     )
                 } else {
+                    // Keyed so per-widget @State (computed card values) resets
+                    // when switching dashboards instead of showing the
+                    // previous dashboard's numbers.
                     DashboardView(widgets: widgets)
+                        .id(selectedPageId)
                 }
             }
             .navigationTitle("Reports")
+            .toolbar {
+                if pages.count > 1 {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        dashboardPicker
+                    }
+                }
+            }
             // Keyed to the open database so the initial load re-runs when
             // the budget finishes opening (launching straight onto this tab
             // races loadLocalBudget) and when the budget is switched.
@@ -41,13 +54,57 @@ struct ReportsTabView: View {
         .initialSyncBanner()
     }
 
+    /// Menu listing every live dashboard page, shown only when the budget
+    /// actually has more than one (the web app's sidebar equivalent).
+    private var dashboardPicker: some View {
+        Menu {
+            Picker("Dashboard", selection: Binding(
+                get: { selectedPageId ?? "" },
+                set: { newId in
+                    selectedPageId = newId
+                    Task { await reload() }
+                }
+            )) {
+                ForEach(pages) { page in
+                    Text(displayName(for: page)).tag(page.id)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(pages.first { $0.id == selectedPageId }.map(displayName(for:)) ?? "Dashboard")
+                Image(systemName: "chevron.up.chevron.down")
+                    .imageScale(.small)
+            }
+        }
+        .accessibilityLabel("Switch dashboard")
+    }
+
+    private func displayName(for page: DashboardPage) -> String {
+        page.name.isEmpty ? "Untitled" : page.name
+    }
+
+    /// Which page to show: a still-live explicit selection wins, otherwise
+    /// the first live page (the web's ReportsDashboardRouter redirects to
+    /// dashboardPages[0]), otherwise nil so the pre-pages pageless fallback
+    /// applies.
+    static func resolvePageId(selected: String?, pages: [DashboardPage]) -> String? {
+        if let selected, pages.contains(where: { $0.id == selected }) {
+            return selected
+        }
+        return pages.first?.id
+    }
+
     private func reload() async {
         guard let database = budgetStore.databaseForLogger else {
             self.hasLoaded = true
             return
         }
         do {
-            let fetched = try await database.fetchWidgets()
+            let fetchedPages = try await database.fetchDashboardPages()
+            let pageId = Self.resolvePageId(selected: selectedPageId, pages: fetchedPages)
+            let fetched = try await database.fetchWidgets(pageId: pageId)
+            self.pages = fetchedPages
+            self.selectedPageId = pageId
             self.widgets = fetched
             self.loadError = nil
         } catch is CancellationError {

--- a/Actuali/ActualiTests/BudgetDatabaseDashboardTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseDashboardTests.swift
@@ -49,7 +49,7 @@ struct BudgetDatabaseDashboardTests {
 
     @Test func returnsEmptyForFreshDatabase() async throws {
         let (database, _) = try makeDatabase()
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.isEmpty)
     }
 
@@ -60,7 +60,7 @@ struct BudgetDatabaseDashboardTests {
         try insertWidget(path: path, id: "b", type: "net-worth-card",
                          meta: #"{"name":"Net Worth"}"#)
 
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.count == 2)
         #expect(widgets.contains { $0.displayName == "Spent" })
         #expect(widgets.contains { $0.displayName == "Net Worth" })
@@ -72,7 +72,7 @@ struct BudgetDatabaseDashboardTests {
         try insertWidget(path: path, id: "dead", type: "summary-card", meta: "{}",
                          tombstone: 1)
 
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.count == 1)
         #expect(widgets.first?.id == "alive")
     }
@@ -83,17 +83,36 @@ struct BudgetDatabaseDashboardTests {
         try insertWidget(path: path, id: "top-right", type: "summary-card", x: 4, y: 0, meta: "{}")
         try insertWidget(path: path, id: "top-left", type: "summary-card", x: 0, y: 0, meta: "{}")
 
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.map(\.id) == ["top-left", "top-right", "bottom"])
     }
 
-    // The web app treats dashboard pages as separate dashboards and renders
-    // only the first live page (ReportsDashboardRouter redirects to
-    // dashboardPages[0]). Upstream's multiple-dashboards migration runs
-    // per-client and mints a fresh "Main" page id each time, so a synced
-    // budget can carry orphaned page ids and full duplicate widget sets
-    // (GH: Reports showed every widget twice).
-    @Test func showsOnlyFirstLivePageWhenPagesExist() async throws {
+    // The web app lists dashboard pages in table order with tombstoned rows
+    // filtered (AQL `q('dashboard_pages').select('*')`); a null name renders
+    // as an empty string upstream.
+    @Test func fetchDashboardPagesReturnsLivePagesInInsertionOrder() async throws {
+        let (database, path) = try makeDatabase()
+        try insertPage(path: path, id: "page-main", name: "Main")
+        try insertPage(path: path, id: "page-deleted", name: "Old", tombstone: 1)
+        try insertPage(path: path, id: "page-second", name: "Second")
+
+        let pages = try await database.fetchDashboardPages()
+        #expect(pages.map(\.id) == ["page-main", "page-second"])
+        #expect(pages.map(\.name) == ["Main", "Second"])
+    }
+
+    @Test func fetchDashboardPagesIsEmptyForFreshDatabase() async throws {
+        let (database, _) = try makeDatabase()
+        let pages = try await database.fetchDashboardPages()
+        #expect(pages.isEmpty)
+    }
+
+    // Each dashboard page is a separate dashboard (GH #120: multiple
+    // dashboards were merged into one). Fetching a page must return only
+    // that page's live widgets, in reading order (y, then x) — never
+    // widgets from other pages, deleted pages, orphaned page ids, or
+    // pageless rows.
+    @Test func fetchWidgetsForPageFiltersToThatPageInYXOrder() async throws {
         let (database, path) = try makeDatabase()
         try insertPage(path: path, id: "page-main", name: "Main")
         try insertPage(path: path, id: "page-second", name: "Second")
@@ -112,14 +131,17 @@ struct BudgetDatabaseDashboardTests {
         try insertWidget(path: path, id: "pageless", type: "summary-card",
                          meta: "{}")
 
-        let widgets = try await database.fetchWidgets()
-        #expect(widgets.map(\.id) == ["main-0", "main-1"])
+        let mainWidgets = try await database.fetchWidgets(pageId: "page-main")
+        #expect(mainWidgets.map(\.id) == ["main-0", "main-1"])
+
+        let secondWidgets = try await database.fetchWidgets(pageId: "page-second")
+        #expect(secondWidgets.map(\.id) == ["second-page"])
     }
 
     // Budgets from servers that predate multiple dashboards have no page
     // rows; their widgets carry no page id and must still render. Widgets
     // pointing at a page that no longer exists stay hidden, matching the web.
-    @Test func fallsBackToPagelessWidgetsWhenNoLivePages() async throws {
+    @Test func nilPageIdReturnsOnlyPagelessWidgets() async throws {
         let (database, path) = try makeDatabase()
         try insertPage(path: path, id: "page-deleted", name: "Old", tombstone: 1)
 
@@ -127,7 +149,7 @@ struct BudgetDatabaseDashboardTests {
         try insertWidget(path: path, id: "orphan", type: "summary-card",
                          meta: "{}", pageId: "page-ghost")
 
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.map(\.id) == ["pageless"])
     }
 
@@ -135,7 +157,7 @@ struct BudgetDatabaseDashboardTests {
         let (database, path) = try makeDatabase()
         try insertWidget(path: path, id: "x", type: "sankey-card", meta: "{}")
 
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.count == 1)
         if case .unsupported(let id, let type) = widgets.first {
             #expect(id == "x")
@@ -143,5 +165,33 @@ struct BudgetDatabaseDashboardTests {
         } else {
             Issue.record("Expected .unsupported")
         }
+    }
+}
+
+// Resolution of which dashboard page the Reports tab shows: a still-live
+// explicit selection wins, otherwise the first live page (matching the web's
+// ReportsDashboardRouter redirect to dashboardPages[0]), otherwise nil so the
+// pre-pages pageless fallback applies.
+struct ReportsPageSelectionTests {
+
+    private let pages = [
+        DashboardPage(id: "page-main", name: "Main"),
+        DashboardPage(id: "page-second", name: "Second")
+    ]
+
+    @Test func keepsSelectionWhenStillLive() {
+        #expect(ReportsTabView.resolvePageId(selected: "page-second", pages: pages) == "page-second")
+    }
+
+    @Test func fallsBackToFirstPageWhenSelectionGone() {
+        #expect(ReportsTabView.resolvePageId(selected: "page-deleted", pages: pages) == "page-main")
+    }
+
+    @Test func defaultsToFirstPageWhenNothingSelected() {
+        #expect(ReportsTabView.resolvePageId(selected: nil, pages: pages) == "page-main")
+    }
+
+    @Test func isNilWhenNoLivePages() {
+        #expect(ReportsTabView.resolvePageId(selected: "anything", pages: []) == nil)
     }
 }

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -17,24 +17,39 @@ struct DemoDataSeederTests {
         return try BudgetDatabase(path: dbPath)
     }
 
+    // Two pages so the demo exercises the dashboard switcher (GH #120);
+    // "Main" is first so it's the default dashboard on open.
+    @Test func seedsTwoDashboardPages() async throws {
+        let database = try seedAndOpen()
+        let pages = try await database.fetchDashboardPages()
+        #expect(pages.map(\.name) == ["Main", "Trends"])
+    }
+
     @Test func seededDashboardWidgetsAllParseToSupportedTypes() async throws {
         let database = try seedAndOpen()
-        let widgets = try await database.fetchWidgets(pageId: nil)
+        let pages = try await database.fetchDashboardPages()
+        let mainPage = try #require(pages.first { $0.name == "Main" })
+        let trendsPage = try #require(pages.first { $0.name == "Trends" })
 
-        #expect(widgets.count == 7)
-        for widget in widgets {
+        let mainWidgets = try await database.fetchWidgets(pageId: mainPage.id)
+        let trendsWidgets = try await database.fetchWidgets(pageId: trendsPage.id)
+
+        for widget in mainWidgets + trendsWidgets {
             if case .unsupported(_, let type) = widget {
                 Issue.record("Seeded widget did not parse to a supported type: \(type)")
             }
         }
 
-        // The exact curated set, in dashboard order (y ASC).
-        #expect(widgets.map(\.typeLabel) == ["Notes", "Net Worth", "Cash Flow", "Summary", "Spending", "Spending", "Spending"])
+        // The exact curated sets, in dashboard order (y ASC).
+        #expect(mainWidgets.map(\.typeLabel) == ["Notes", "Net Worth", "Cash Flow", "Summary", "Spending", "Spending", "Spending"])
+        #expect(trendsWidgets.map(\.typeLabel) == ["Notes", "Age of Money", "Summary"])
     }
 
     @Test func seededWidgetsProduceDataFromDemoTransactions() async throws {
         let database = try seedAndOpen()
-        let widgets = try await database.fetchWidgets(pageId: nil)
+        let pages = try await database.fetchDashboardPages()
+        let mainPage = try #require(pages.first { $0.name == "Main" })
+        let widgets = try await database.fetchWidgets(pageId: mainPage.id)
         let transactions = try await database.fetchTransactionsForReports()
         let today = Date()
 

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -19,7 +19,7 @@ struct DemoDataSeederTests {
 
     @Test func seededDashboardWidgetsAllParseToSupportedTypes() async throws {
         let database = try seedAndOpen()
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
 
         #expect(widgets.count == 7)
         for widget in widgets {
@@ -34,7 +34,7 @@ struct DemoDataSeederTests {
 
     @Test func seededWidgetsProduceDataFromDemoTransactions() async throws {
         let database = try seedAndOpen()
-        let widgets = try await database.fetchWidgets()
+        let widgets = try await database.fetchWidgets(pageId: nil)
         let transactions = try await database.fetchTransactionsForReports()
         let today = Date()
 


### PR DESCRIPTION
## What was wrong

Actuali collapsed Actual's multiple-dashboards feature into a single view. `fetchWidgets()` silently picked the first live `dashboard_pages` row **by local rowid** and rendered only that page, with no UI to reach the others. So:

- Users with several dashboards saw exactly one dashboard in the app — perceived as "merged into one".
- Which page is "first" by rowid depends on CRDT message-application order, not on what the web shows, so after creating dashboards or deleting the default "Main" page the app could render a *different* page than the one the user compared against — read as "scrambled ordering".

The v1.0.7 fix (#57) stopped duplicate rendering but kept the single-page model, which is why the report persisted.

## Why this fixes it

Mirrors the web app's model (verified against upstream `loot-core` migration `1765518577215`, `dashboard/app.ts`, and `ReportsDashboardRouter`/`dashboardQueries`):

- `fetchDashboardPages()` lists live pages in table order — the same order the web's unordered AQL select yields and its router indexes into for the default dashboard.
- `fetchWidgets(pageId:)` returns exactly one page's live widgets in reading order (y, then x); widgets on other, deleted, or orphaned pages never leak in. A nil page keeps the pageless fallback for budgets predating multiple dashboards.
- The Reports tab shows a dashboard menu when more than one page exists; a still-live selection is kept across reloads, otherwise it falls back to the first live page (matching `dashboardPages[0]`). `DashboardView` is keyed by page id so widget state resets on switch.

Upstream tombstones a deleted page's widgets and forbids deleting the last page, so per-live-page filtering also handles the "deleted the default dashboard" case: the next live page renders.

## How it was verified

TDD — new tests failed first (missing API), then:

- `xcodebuild test … -only-testing:ActualiTests`: **772 tests in 111 suites passed** (includes new `fetchDashboardPages` ordering/tombstone tests, per-page widget filtering in y,x order, pageless-fallback tests, and `ReportsTabView.resolvePageId` selection tests).
- Real-app checks on an iPhone 17 / iOS 26.5 simulator:
  - Demo budget (pageless): Reports renders as before, no switcher.
  - Demo DB split into `Main` + `Savings` pages: switcher appears, only Main's widgets render (Net Worth, moved to Savings, correctly absent).
  - `Main` tombstoned (deleted default dashboard): app falls back to Savings and renders only its widget.

## Notes / out of scope

- Excel-style formula limitations mentioned in the same Reddit comment are a known gap (report types not all implemented); numeric total bugs are tracked in #102.
- The demo budget now seeds two dashboards ("Main" and "Trends"), so the switcher is testable out of the box with demo data. Still no XCUITest for the menu itself; can add one as a follow-up if wanted.

Fixes #120
