### PR TITLE
Stop claiming "no budget loaded" with a budget open; move Default Account under Budget

### DIFF
--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -25,7 +25,15 @@ struct AccountsListView: View {
         NavigationStack(path: $path) {
             Group {
                 if budgetStore.accounts.isEmpty && !budgetStore.isLoading {
-                    if budgetStore.isConnected && budgetStore.currentBudgetId == nil {
+                    if budgetStore.currentBudgetId != nil {
+                        // A budget is loaded, it just has no accounts (yet) —
+                        // "go connect a server" would be wrong advice here (GH #122).
+                        ContentUnavailableView(
+                            "No Accounts",
+                            systemImage: "dollarsign.circle",
+                            description: Text("This budget doesn't have any accounts yet. Create one in Actual Budget, then sync.")
+                        )
+                    } else if budgetStore.isConnected {
                         ContentUnavailableView(
                             "Select a Budget",
                             systemImage: "dollarsign.circle",

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -264,49 +264,67 @@ struct SettingsView: View {
                     }
                 }
 
-                if budgetStore.isConnected {
+                // Shown while connected OR while a budget is loaded without a
+                // session (demo, offline): the Default Account row below must
+                // stay reachable in both.
+                if budgetStore.isConnected || budgetStore.currentBudgetId != nil {
                     Section {
-                        Picker("Budget", selection: budgetPickerBinding) {
-                            // Placeholder until a budget is chosen — deliberately
-                            // not offered again afterwards, so "None" can't be
-                            // (re)selected.
-                            if budgetPickerBinding.wrappedValue == nil {
-                                Text("Select a Budget").tag(nil as String?)
-                            }
-                            // Render a placeholder tag for the current cloudFileId
-                            // when remoteBudgets hasn't loaded yet (or doesn't
-                            // include it), so SwiftUI can match the selection
-                            // and we don't get an "invalid selection" warning.
-                            if let currentId = budgetPickerBinding.wrappedValue,
-                               !budgetStore.remoteBudgets.contains(where: { $0.id == currentId }) {
-                                Text(budgetStore.remoteBudgets.isEmpty ? "Loading…" : "Unknown")
-                                    .tag(currentId as String?)
-                            }
-                            ForEach(budgetStore.remoteBudgets.filter { !$0.isEncrypted }) { budget in
-                                Text(budget.name).tag(budget.id as String?)
-                            }
-                        }
-                        .disabled(budgetStore.downloadingBudgetId != nil)
-
-                        ForEach(budgetStore.remoteBudgets.filter { $0.isEncrypted }) { budget in
-                            Button {
-                                openBudget(budget)
-                            } label: {
-                                HStack {
-                                    Image(systemName: "lock.fill").foregroundStyle(.secondary)
-                                    Text(budget.name)
-                                    Spacer()
-                                    if budgetStore.downloadingBudgetId == budget.id {
-                                        ProgressView()
-                                    }
+                        if budgetStore.isConnected {
+                            Picker("Budget", selection: budgetPickerBinding) {
+                                // Placeholder until a budget is chosen — deliberately
+                                // not offered again afterwards, so "None" can't be
+                                // (re)selected.
+                                if budgetPickerBinding.wrappedValue == nil {
+                                    Text("Select a Budget").tag(nil as String?)
+                                }
+                                // Render a placeholder tag for the current cloudFileId
+                                // when remoteBudgets hasn't loaded yet (or doesn't
+                                // include it), so SwiftUI can match the selection
+                                // and we don't get an "invalid selection" warning.
+                                if let currentId = budgetPickerBinding.wrappedValue,
+                                   !budgetStore.remoteBudgets.contains(where: { $0.id == currentId }) {
+                                    Text(budgetStore.remoteBudgets.isEmpty ? "Loading…" : "Unknown")
+                                        .tag(currentId as String?)
+                                }
+                                ForEach(budgetStore.remoteBudgets.filter { !$0.isEncrypted }) { budget in
+                                    Text(budget.name).tag(budget.id as String?)
                                 }
                             }
                             .disabled(budgetStore.downloadingBudgetId != nil)
+
+                            ForEach(budgetStore.remoteBudgets.filter { $0.isEncrypted }) { budget in
+                                Button {
+                                    openBudget(budget)
+                                } label: {
+                                    HStack {
+                                        Image(systemName: "lock.fill").foregroundStyle(.secondary)
+                                        Text(budget.name)
+                                        Spacer()
+                                        if budgetStore.downloadingBudgetId == budget.id {
+                                            ProgressView()
+                                        }
+                                    }
+                                }
+                                .disabled(budgetStore.downloadingBudgetId != nil)
+                            }
+
+                            if budgetStore.remoteBudgets.isEmpty && !budgetStore.isLoading {
+                                Button("Refresh Budgets") {
+                                    Task { await budgetStore.fetchRemoteBudgets() }
+                                }
+                            }
                         }
 
-                        if budgetStore.remoteBudgets.isEmpty && !budgetStore.isLoading {
-                            Button("Refresh Budgets") {
-                                Task { await budgetStore.fetchRemoteBudgets() }
+                        // Lives up here rather than under Preferences because
+                        // it's the natural next step after choosing a budget —
+                        // Shortcuts and Wallet automation can't post without
+                        // it (GH #122).
+                        if budgetStore.currentBudgetId != nil {
+                            Picker("Default Account", selection: $budgetStore.defaultAccountId) {
+                                Text("None").tag(nil as String?)
+                                ForEach(budgetStore.accounts.filter { !$0.closed }) { account in
+                                    Text(account.name).tag(account.id as String?)
+                                }
                             }
                         }
                     } header: {
@@ -318,6 +336,8 @@ struct SettingsView: View {
                             } else {
                                 Text("Select a budget to load it onto this device. The app stays empty until one is chosen.")
                             }
+                        } else {
+                            Text("New transactions, Siri Shortcuts, and Wallet automation use the Default Account when no account is chosen.")
                         }
                     }
                 }
@@ -371,13 +391,6 @@ struct SettingsView: View {
                     }
 
                     if budgetStore.currentBudgetId != nil {
-                        Picker("Default Account", selection: $budgetStore.defaultAccountId) {
-                            Text("None").tag(nil as String?)
-                            ForEach(budgetStore.accounts.filter { !$0.closed }) { account in
-                                Text(account.name).tag(account.id as String?)
-                            }
-                        }
-
                         NavigationLink {
                             CardAccountMappingsView()
                         } label: {


### PR DESCRIPTION
## What was wrong

Two leftovers from #122 (the data-loss half of that issue was fixed by #182/#186/#188):

- The Accounts tab's empty state told users to "Go to Settings to connect to your Actual Budget server" whenever the account list was empty — including when a server was connected and a budget selected. That's the exact wrong-advice message quoted in the report; it's still reachable on main whenever a loaded budget has no (open) accounts, e.g. mid-initial-sync or a genuinely account-less budget.
- The Default Account picker lived at the bottom of Preferences even though it's effectively mandatory for Shortcuts and Wallet automation — the thread asked for it to sit with the budget selection.

## What changed

- `AccountsListView`: the empty state now distinguishes three situations instead of two — budget loaded but no accounts ("No Accounts … create one in Actual Budget, then sync"), connected but no budget chosen ("Select a Budget", unchanged), and nothing configured ("No Budget Loaded", unchanged).
- `SettingsView`: the Default Account picker moved into the Budget section, directly under the budget picker, with a footer explaining what it drives. The section now also renders when a budget is loaded without a session (demo, offline) so the picker stays reachable there — previously that case was covered by the Preferences placement.

## Verification

Full unit suite plus the two Settings-navigating UI suites on an iPhone 17 / iOS 26.5 simulator:

```
✔ Test run with 766 tests in 110 suites passed after 4.000 seconds.
Test Suite 'BackgroundRefreshRowUITests' passed
Test Suite 'PayeeLocationsUITests' passed
** TEST SUCCEEDED **  (exit 0)
```

Both changes are declarative SwiftUI with no store/logic changes, and no existing tests reference the affected strings.

Follows up on #122.