### PR TITLE
Tighten add-transaction section spacing; autofocus the amount field

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -261,7 +261,11 @@ struct AddTransactionView: View {
                     HStack {
                         Text(amountSignSymbol)
                             .foregroundStyle(amountSignColor)
-                        AmountInputField(text: $amount)
+                        // The amount is the first thing entered in a fresh
+                        // form, so the add flow opens with the keyboard ready.
+                        // Edits and prefilled amounts already have one and
+                        // start with the keyboard down.
+                        AmountInputField(text: $amount, autofocus: !isEditing && amount.isEmpty)
                     }
                 }
 
@@ -445,6 +449,7 @@ struct AddTransactionView: View {
                 }
             }
             .navigationTitle(isEditing ? "Edit Transaction" : "Add Transaction")
+            .listSectionSpacing(.compact)
             .scrollDismissesKeyboard(.interactively)
             .toolbar {
                 // Any presented flow (edit, account-detail "+", notification
@@ -732,9 +737,28 @@ struct AmountInputField: UIViewRepresentable {
     var alignment: NSTextAlignment = .natural
     var allowsNegative = false
     var weight: UIFont.Weight = .regular
+    /// Bring up the keyboard as soon as the field lands on screen. For
+    /// sheets whose whole purpose is entering an amount.
+    var autofocus = false
+
+    /// becomeFirstResponder is a no-op until the view joins a window, and
+    /// during a sheet presentation that happens well after makeUIView —
+    /// didMoveToWindow is the earliest reliable moment.
+    final class AutofocusTextField: UITextField {
+        var wantsAutofocus = false
+        private var hasAutofocused = false
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            guard wantsAutofocus, !hasAutofocused, window != nil else { return }
+            hasAutofocused = true
+            becomeFirstResponder()
+        }
+    }
 
     func makeUIView(context: Context) -> UITextField {
-        let field = UITextField()
+        let field = AutofocusTextField()
+        field.wantsAutofocus = autofocus
         field.keyboardType = .decimalPad
         field.placeholder = "0.00"
         field.textAlignment = alignment

--- a/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
@@ -44,6 +44,28 @@ final class AddTransactionKeyboardUITests: XCTestCase {
                       "tab bar not reachable after dismissing the keyboard")
     }
 
+    /// The add flow autofocuses the amount field — the first thing anyone
+    /// enters — so the keyboard must come up without a tap and keypad input
+    /// must land in that field.
+    @MainActor
+    func testAddTabAutofocusesAmountField() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "2"]
+        app.launch()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
+                      "keyboard did not come up on its own for the amount field")
+
+        let amountField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == '0.00'")
+        ).firstMatch
+        XCTAssertTrue(amountField.exists, "amount field not found")
+
+        app.keys["5"].tap()
+        XCTAssertEqual(amountField.value as? String, "0.05",
+                       "keypad input did not land in the amount field")
+    }
+
     @MainActor
     func testSheetPresentedAddFlowShowsCancel() throws {
         let app = XCUIApplication()


### PR DESCRIPTION
Two polish fixes for the add-transaction form:

- **Section spacing**: the form used the default inset-grouped section spacing, leaving oversized gaps between the boxes. `.listSectionSpacing(.compact)` pulls it together.
- **Amount autofocus**: the amount is the first thing anyone enters in a fresh form, so the add flow (tab-hosted and sheet-presented) now opens with the keyboard ready on the amount field. Edits and prefilled amounts (Shortcuts / notification prefill) already carry one and start with the keyboard down.

Notes:
- The `AmountInputField` autofocus support is byte-identical to the hunk on `ci-improvements` (#173, edit-budget sheet), so the two branches merge cleanly in either order.
- Related to #163 in that it touches the same screen, but deliberately does not touch the entry model — the sign-based / account-as-payee redesign discussed there stays its own effort.

Testing: new UI test asserts the keyboard comes up on the Add tab without a tap and keypad input lands in the amount field; existing AddTransactionKeyboard and AddTransactionPostSave suites pass locally (iPhone 17 / iOS 26.5). Spacing verified by screenshot on the simulator.