### PR TITLE
Render clickable URLs in transaction/category notes

### DIFF
--- a/Actuali/Actuali/Models/NoteLinkText.swift
+++ b/Actuali/Actuali/Models/NoteLinkText.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One tappable link found in a note: the text the user reads and the URL it
+/// opens. `label` is the markdown link's title, or the URL text itself for
+/// bare URLs.
+struct NoteLink: Identifiable, Equatable {
+    let label: String
+    let url: URL
+    /// Position within the note, so repeated links stay distinct rows.
+    let position: Int
+
+    var id: Int { position }
+}
+
+/// Turns note text into tappable links (GH #190). Notes written in Actual
+/// commonly carry markdown links (e.g. a rule that links a transaction to its
+/// Amazon order page), and sometimes bare URLs pasted straight in.
+///
+/// Two passes: inline markdown first — the same parsing MarkdownWidgetView
+/// uses for dashboard widgets — then NSDataDetector over what markdown left
+/// unlinked, so `[label](url)` and pasted URLs both become links without
+/// double-linking the markdown ones.
+enum NoteLinkText {
+
+    /// The note rendered for display: markdown links become link runs, bare
+    /// URLs are linkified in place. Falls back to the raw text if markdown
+    /// parsing rejects the note — a note must never display as empty.
+    static func attributed(_ text: String) -> AttributedString {
+        var attributed = (try? AttributedString(
+            markdown: text,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        )) ?? AttributedString(text)
+        detectBareURLs(in: &attributed)
+        return attributed
+    }
+
+    /// Every link in the note, in note order — for edit surfaces, where the
+    /// text sits in a TextField/TextEditor and can't be tappable itself, so
+    /// links render as separate rows beneath it.
+    static func links(in text: String) -> [NoteLink] {
+        let attributed = attributed(text)
+        var links: [NoteLink] = []
+        // Consecutive runs can share one URL (markdown labels with styled
+        // spans), so coalesce by URL before splitting into rows.
+        for (url, range) in attributed.runs[\.link] {
+            guard let url else { continue }
+            let label = String(attributed[range].characters)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            links.append(NoteLink(label: label, url: url, position: links.count))
+        }
+        return links
+    }
+
+    /// Adds `.link` to detector matches that markdown didn't already link.
+    /// NSDataDetector also normalizes schemeless matches ("www.example.com")
+    /// to openable http URLs.
+    private static func detectBareURLs(in attributed: inout AttributedString) {
+        guard let detector = try? NSDataDetector(
+            types: NSTextCheckingResult.CheckingType.link.rawValue
+        ) else { return }
+        let plain = String(attributed.characters)
+        let matches = detector.matches(
+            in: plain,
+            range: NSRange(plain.startIndex..., in: plain)
+        )
+        for match in matches {
+            guard let url = match.url,
+                  let range = Range(match.range, in: attributed),
+                  attributed[range].runs.allSatisfy({ $0.link == nil })
+            else { continue }
+            attributed[range].link = url
+        }
+    }
+}

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -312,6 +312,12 @@ enum DemoDataSeeder {
             Target $650/mo. Household supplies count here; \
             takeaway goes to Dining Out.
             """)
+        // A second note carries a markdown link so tappable note links
+        // (GH #190) are demonstrable — and UI-testable — in the demo budget.
+        try insertNote(db, id: diningId, note: """
+            Cap $250/mo.
+            [Rewards portal](https://example.com/rewards)
+            """)
 
         // --- Payees ---
         let wholeFoodsId = UUID().uuidString

--- a/Actuali/Actuali/Views/Components/NoteLinkRows.swift
+++ b/Actuali/Actuali/Views/Components/NoteLinkRows.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Tappable rows for the links in a note being edited (GH #190). Edit
+/// surfaces keep the raw text editable — a TextField can't render tappable
+/// links — so any markdown links or bare URLs in the draft surface as rows
+/// beneath the field, updating live as the user types.
+struct NoteLinkRows: View {
+    let text: String
+
+    var body: some View {
+        ForEach(NoteLinkText.links(in: text)) { link in
+            Link(destination: link.url) {
+                Label(link.label, systemImage: "link")
+                    .lineLimit(1)
+            }
+            .accessibilityIdentifier("noteLinkRow")
+        }
+    }
+}
+
+#Preview {
+    Form {
+        Section {
+            Text("Groceries note")
+            NoteLinkRows(text: "See [Amazon order](https://amazon.com/gp/order/123) or https://example.com/r/9")
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -415,6 +415,10 @@ struct AddTransactionView: View {
                 Section {
                     TextField("Notes", text: $notes, axis: .vertical)
                         .lineLimit(3...6)
+                    // Links in the note stay openable while the text is a
+                    // TextField (GH #190) — this form doubles as the only
+                    // full view of a transaction's note.
+                    NoteLinkRows(text: notes)
                 }
 
                 Section {
@@ -704,6 +708,8 @@ private struct SplitLineRow: View {
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.words)
             TextField("Notes (optional)", text: $line.notes)
+                .font(.subheadline)
+            NoteLinkRows(text: line.notes)
                 .font(.subheadline)
         }
         .sheet(isPresented: $showCategoryPicker) {

--- a/Actuali/Actuali/Views/Transactions/CategoryNoteEditorView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryNoteEditorView.swift
@@ -29,6 +29,9 @@ struct CategoryNoteEditorView: View {
                         .frame(minHeight: 160)
                         .focused($editorFocused)
                         .accessibilityIdentifier("categoryNoteEditor")
+                    // Links stay openable mid-edit (GH #190); the editor text
+                    // itself has to remain plain to stay editable.
+                    NoteLinkRows(text: text)
                 } footer: {
                     if let saveError {
                         Text(saveError)

--- a/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
@@ -44,32 +44,41 @@ struct CategoryTransactionsView: View {
     /// where an edit could never save.
     private var noteSection: some View {
         Section("Note") {
-            Button {
-                editingNote = true
-            } label: {
-                if note.isEmpty {
+            if note.isEmpty {
+                Button {
+                    editingNote = true
+                } label: {
                     // Tinted: an empty note row is an invitation to act, where
                     // an existing note is content to read.
                     Label("Add Note", systemImage: "note.text.badge.plus")
                         .foregroundStyle(Color.accentColor)
-                } else {
-                    HStack(alignment: .top, spacing: 12) {
-                        Text(note.text)
-                            .multilineTextAlignment(.leading)
-                            // Multi-line notes are the point — let the row grow
-                            // instead of truncating the guidance to one line.
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Image(systemName: "pencil")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
                 }
+                // Plain: a tinted List button would tint the label twice over.
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("categoryNoteRow")
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    // Attributed so markdown links and bare URLs in the note
+                    // are tappable (GH #190). That's also why this row is a
+                    // tap gesture rather than the Button the empty state uses:
+                    // a Button label swallows link taps, where links inside a
+                    // gesture-carrying row take precedence over the gesture.
+                    Text(NoteLinkText.attributed(note.text))
+                        .multilineTextAlignment(.leading)
+                        // Multi-line notes are the point — let the row grow
+                        // instead of truncating the guidance to one line.
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "pencil")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { editingNote = true }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityIdentifier("categoryNoteRow")
             }
-            // Plain: a tinted List button would render the note itself in the
-            // accent color, reading as a link rather than as the text it is.
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("categoryNoteRow")
         }
     }
 

--- a/Actuali/ActualiTests/NoteLinkTextTests.swift
+++ b/Actuali/ActualiTests/NoteLinkTextTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct NoteLinkTextTests {
+
+    /// Every URL attached to a link run, in note order.
+    private func linkURLs(_ text: String) -> [URL] {
+        NoteLinkText.links(in: text).map(\.url)
+    }
+
+    // MARK: - attributed(_:)
+
+    @Test func markdownLinkBecomesTappableLabel() {
+        let attributed = NoteLinkText.attributed("Order: [Amazon](https://amazon.com/gp/order/123)")
+        #expect(String(attributed.characters) == "Order: Amazon")
+        let linkRun = attributed.runs.first { $0.link != nil }
+        #expect(linkRun?.link == URL(string: "https://amazon.com/gp/order/123"))
+    }
+
+    @Test func bareURLBecomesLink() {
+        let attributed = NoteLinkText.attributed("Receipt at https://example.com/r/9 filed")
+        // Bare URLs keep their text — nothing is rewritten, only linkified.
+        #expect(String(attributed.characters) == "Receipt at https://example.com/r/9 filed")
+        let linkRun = attributed.runs.first { $0.link != nil }
+        #expect(linkRun?.link == URL(string: "https://example.com/r/9"))
+    }
+
+    @Test func plainTextGetsNoLinks() {
+        let attributed = NoteLinkText.attributed("Cap at $400/mo — fuel comes out of Transport.")
+        #expect(attributed.runs.allSatisfy { $0.link == nil })
+    }
+
+    @Test func newlinesSurviveParsing() {
+        let attributed = NoteLinkText.attributed("Line one\nLine two")
+        #expect(String(attributed.characters) == "Line one\nLine two")
+    }
+
+    // MARK: - links(in:)
+
+    @Test func extractsMarkdownLabelAndURL() {
+        let links = NoteLinkText.links(in: "See [Amazon order](https://amazon.com/gp/order/123).")
+        #expect(links.count == 1)
+        #expect(links.first?.label == "Amazon order")
+        #expect(links.first?.url == URL(string: "https://amazon.com/gp/order/123"))
+    }
+
+    @Test func extractsBareURLWithItsTextAsLabel() {
+        let links = NoteLinkText.links(in: "Manual: https://example.com/manual.pdf")
+        #expect(links.count == 1)
+        #expect(links.first?.label == "https://example.com/manual.pdf")
+        #expect(links.first?.url == URL(string: "https://example.com/manual.pdf"))
+    }
+
+    @Test func schemelessURLGetsAScheme() {
+        let urls = linkURLs("see www.example.com for details")
+        #expect(urls.count == 1)
+        // NSDataDetector normalizes to an openable URL; without a scheme
+        // openURL would silently no-op.
+        #expect(urls.first?.scheme != nil)
+        #expect(urls.first?.host == "www.example.com")
+    }
+
+    @Test func mixedMarkdownAndBareURLsKeepNoteOrder() {
+        let links = NoteLinkText.links(
+            in: "[Rule](https://amazon.com/rule) and also https://example.com/x"
+        )
+        #expect(links.map(\.label) == ["Rule", "https://example.com/x"])
+        #expect(links.map(\.url) == [
+            URL(string: "https://amazon.com/rule"),
+            URL(string: "https://example.com/x"),
+        ].compactMap { $0 })
+    }
+
+    @Test func markdownURLIsNotDoubleDetected() {
+        // The detector pass must skip ranges the markdown pass already linked.
+        let links = NoteLinkText.links(in: "[https://example.com](https://example.com)")
+        #expect(links.count == 1)
+    }
+
+    @Test func noLinksMeansEmpty() {
+        #expect(NoteLinkText.links(in: "just words").isEmpty)
+        #expect(NoteLinkText.links(in: "").isEmpty)
+    }
+}

--- a/Actuali/ActualiUITests/NoteLinksUITests.swift
+++ b/Actuali/ActualiUITests/NoteLinksUITests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+/// End-to-end check for tappable links in notes (GH #190).
+///
+/// The demo budget seeds Dining Out with a markdown link. The category detail
+/// row must render the link's label (not raw markdown), tapping the link must
+/// leave the app for the URL, and a plain-text tap must still open the editor
+/// — proving links and the edit gesture coexist on one row.
+final class NoteLinksUITests: XCTestCase {
+
+    @MainActor
+    func testCategoryNoteRendersTappableLink() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "1"]
+        app.launch()
+
+        XCTAssertTrue(app.tabBars.buttons["Budget"].waitForExistence(timeout: 10),
+                      "Budget tab not found")
+
+        let dining = app.buttons["All transactions for Dining Out"]
+        var scrollsLeft = 8
+        while !dining.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(dining.isHittable, "Dining Out row not reachable")
+        dining.tap()
+        XCTAssertTrue(app.navigationBars["Dining Out"].waitForExistence(timeout: 5),
+                      "Dining Out transactions did not open")
+
+        let noteRow = app.buttons["categoryNoteRow"]
+        XCTAssertTrue(noteRow.waitForExistence(timeout: 5), "note row not shown")
+        // The markdown renders as its label, not as raw syntax.
+        XCTAssertTrue(noteRow.label.contains("Rewards portal"),
+                      "link label missing, row read: \(noteRow.label)")
+        XCTAssertFalse(noteRow.label.contains("https://"),
+                       "raw markdown leaked into the row: \(noteRow.label)")
+
+        // A tap on the plain-text part of the row (line 1 — the link sits on
+        // line 2) still opens the editor: links must not cost the row its
+        // tap-to-edit.
+        noteRow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+        let editor = app.textViews["categoryNoteEditor"]
+        XCTAssertTrue(editor.waitForExistence(timeout: 5), "note editor did not open")
+
+        // The editor surfaces the draft's link as a tappable row beneath the
+        // text, since the editable text itself can't be tapped as a link.
+        // (a SwiftUI Link in a Form row is exposed as a button, not a link)
+        XCTAssertTrue(app.buttons["noteLinkRow"].waitForExistence(timeout: 5),
+                      "link row missing from note editor")
+        app.buttons["Cancel"].tap()
+        XCTAssertTrue(editor.waitForNonExistence(timeout: 5), "editor did not dismiss")
+
+        // Tapping the link itself leaves the app for the URL instead of
+        // opening the editor.
+        let link = app.links["Rewards portal"]
+        XCTAssertTrue(link.waitForExistence(timeout: 5), "inline link not exposed")
+        link.tap()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        XCTAssertTrue(safari.wait(for: .runningForeground, timeout: 10),
+                      "tapping the note link did not open the URL")
+    }
+}


### PR DESCRIPTION
Fixes #190

## What changed

Notes commonly carry markdown links (e.g. Courtney's Amazon-order rule links) and pasted URLs, but rendered as plain text everywhere. Now:

- **`NoteLinkText`** (new, unit-tested): parses inline markdown the same way `MarkdownWidgetView` already does, then runs `NSDataDetector` over whatever markdown left unlinked — so both `[label](url)` and bare/schemeless URLs become links, without double-linking. Also extracts an ordered label+URL list for edit surfaces.
- **Category note row** (`CategoryTransactionsView`): renders the attributed note, so links are tappable in place. The row was a `Button` (which swallows link taps), so it's now a tap gesture — tapping a link opens the URL, tapping anywhere else still opens the editor. Accessibility identifier/traits preserved; the existing `CategoryNotesUITests` pass unchanged.
- **Edit surfaces** — transaction form notes, split-line notes, and the category note editor: editable text can't be tapped as a link, so a shared `NoteLinkRows` component shows each link as a tappable row beneath the field, updating live as you type. This matters most for transactions, where the edit form is the only full view of a note.
- **Demo budget**: Dining Out now seeds a note with a markdown link, so the feature is visible in demo mode and end-to-end testable.

## Out of scope (intentionally)

- The one-line notes caption in transaction list rows still shows raw text — a tappable link inside a truncated, dimmed caption inside a row button would fight the row tap. Can follow up if wanted.
- No link previews or URL validation.

## How it was verified

- New `NoteLinkTextTests` (10 tests): markdown links, bare URLs, schemeless URLs, mixed ordering, no double-detection, plain-text/newline preservation.
- New `NoteLinksUITests` end-to-end on the demo budget: row shows the rendered label (not raw markdown), tapping the link leaves the app for the URL (Safari foregrounds), tapping plain text still opens the editor, and the editor shows the link row.
- Full unit suite: **786 tests in 113 suites passed** (`xcodebuild test -skip-testing:ActualiUITests`, iPhone 17 / iOS 26.5 sim).
- `CategoryNotesUITests` (both tests) and `NoteLinksUITests` pass.