### PR TITLE
Post due schedules after any successful sync, not only the foreground attempt

### DIFF
--- a/Actuali/Actuali/Models/Schedule.swift
+++ b/Actuali/Actuali/Models/Schedule.swift
@@ -17,10 +17,16 @@ enum ScheduledAmount: Equatable {
     }
 }
 
-/// The rule's date condition: either a one-off day or a recurrence.
+/// The rule's date condition: a one-off day, a recurrence, or a shape the
+/// port can't advance. Upstream posting never consults this — getStatus works
+/// off the stored next_date, and only the ADVANCE needs the recurrence
+/// (setNextDate throws on shapes it can't handle and the schedule service
+/// swallows it) — so `.unsupported` posts the stored due occurrence once and
+/// never advances, exactly like `.fixed`.
 enum ScheduleDateCondition {
     case fixed(DayDate)
     case recurring(RecurConfig)
+    case unsupported
 }
 
 /// A schedule eligible for auto-posting, read from the synced Actual tables
@@ -35,8 +41,11 @@ struct Schedule {
     /// `schedules_next_date.id` — target row for the advance write after posting.
     let nextDateRowId: String
     /// `schedules_next_date.base_next_date_ts` (ms epoch); the advance write
-    /// sets `local_next_date_ts` to this value (loot-core setNextDate).
-    let baseNextDateTs: Int64
+    /// sets `local_next_date_ts` to this value (loot-core setNextDate). NULL
+    /// in the row stays nil here — the web posts such schedules (its
+    /// v_schedules CASE falls through to base_next_date) and its advance
+    /// writes a NULL local_next_date_ts, so ours must too.
+    let baseNextDateTs: Int64?
     let accountId: String
     let payeeId: String?
     /// From the linked rule's `set category` action, when present. Surfaced

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -669,6 +669,7 @@ final class BudgetStore: ObservableObject {
     func configureForTesting(database: BudgetDatabase, syncClient: SyncClient) {
         self.database = database
         self.syncClient = syncClient
+        subscribeToSyncState()
     }
 
     /// Test-only: install an already-completed load task that produced no
@@ -1214,12 +1215,7 @@ final class BudgetStore: ObservableObject {
                 logger.error("Database is nil, cannot configure sync")
             }
 
-            // Subscribe to sync state
-            syncStateCancellable = syncClient?.statePublisher
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] state in
-                    self?.syncState = state
-                }
+            subscribeToSyncState()
 
             refreshPayeeLocationSupport()
 
@@ -2634,11 +2630,44 @@ final class BudgetStore: ObservableObject {
         "Posted \(count) scheduled transaction\(count == 1 ? "" : "s")"
     }
 
-    private func postDueSchedulesIfNeeded() async {
+    /// Mirror sync state into the published property, and post due schedules
+    /// whenever a sync completes successfully (.syncing → .idle; performSync
+    /// is the only sender of that transition). loot-core runs its schedule
+    /// service on every sync completion event, so posting must not depend on
+    /// WHICH sync succeeded: before this hook existed the only trigger was
+    /// inline in syncOnForeground(), and a foreground attempt that failed
+    /// (network not up yet at wake) with the retry ladder succeeding seconds
+    /// later — or a pull-to-refresh / background-push sync — never posted
+    /// anything (GH #97).
+    private func subscribeToSyncState() {
+        syncStateCancellable = syncClient?.statePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                let wasSyncing = syncState == .syncing
+                syncState = state
+                if wasSyncing, state == .idle {
+                    Task { await self.postDueSchedulesAfterSync() }
+                }
+            }
+    }
+
+    /// Sink-triggered posting for syncs that finish outside
+    /// syncOnForeground() — that path refreshes after posting itself; here
+    /// nothing else would republish the register, so refresh when anything
+    /// posted.
+    private func postDueSchedulesAfterSync() async {
+        if await postDueSchedulesIfNeeded() > 0 {
+            await refreshDataOnly()
+        }
+    }
+
+    @discardableResult
+    private func postDueSchedulesIfNeeded() async -> Int {
         guard postScheduledTransactions,
               let client = syncClient,
               let database,
-              let budgetId = currentBudgetId else { return }
+              let budgetId = currentBudgetId else { return 0 }
         // Lazy-create; no suspension between this check and the cache write,
         // so two MainActor-interleaved calls still share one instance.
         let poster: SchedulePoster
@@ -2649,7 +2678,7 @@ final class BudgetStore: ObservableObject {
             schedulePoster = poster
         }
         let count = await poster.runIfNeeded(budgetId: budgetId)
-        guard count > 0 else { return }
+        guard count > 0 else { return 0 }
         schedulePostNotice = Self.schedulePostNoticeText(count: count)
         scheduleNoticeDismissTask?.cancel()
         scheduleNoticeDismissTask = Task { [weak self] in
@@ -2657,6 +2686,7 @@ final class BudgetStore: ObservableObject {
             guard !Task.isCancelled else { return }
             self?.schedulePostNotice = nil
         }
+        return count
     }
 
     // MARK: - Budget

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2079,9 +2079,11 @@ class BudgetDatabase {
     /// Fetch schedules eligible for auto-posting: alive, not completed, and
     /// flagged `posts_transaction = 1`, with their rule conditions extracted
     /// (port of loot-core `extractScheduleConds`). The poster writes to users'
-    /// real servers, so every doubt case is a logged skip — never a throw and
-    /// never a partially-understood schedule. Returns [] when the schedule
-    /// tables don't exist (older budget files).
+    /// real servers, so doubt about WHAT to post (conditions, account, next
+    /// date) is a logged skip — never a throw. Doubt about the recurrence
+    /// alone is `.unsupported`, not a skip: upstream posts the stored due
+    /// occurrence either way and only its advance fails. Returns [] when the
+    /// schedule tables don't exist (older budget files).
     func fetchPostableSchedules() throws -> [Schedule] {
         try dbQueue.read { db in
             guard try db.tableExists("schedules"),
@@ -2121,11 +2123,14 @@ class BudgetDatabase {
                     return nil
                 }
 
-                guard let nextDateRowId: String = row["nd_id"],
-                      let baseNextDateTs: Int64 = row["base_next_date_ts"] else {
+                guard let nextDateRowId: String = row["nd_id"] else {
                     logger.notice("Skipping schedule \(id, privacy: .public): incomplete schedules_next_date row")
                     return nil
                 }
+                // NULL is postable: the web's v_schedules CASE falls through
+                // to base_next_date for NULL timestamps, and its advance
+                // writes local_next_date_ts = NULL — so must ours.
+                let baseNextDateTs: Int64? = row["base_next_date_ts"]
 
                 guard let conditions = Self.parseConditionsArray(row["conditions"]) else {
                     logger.notice("Skipping schedule \(id, privacy: .public): unparseable rule conditions")
@@ -2144,11 +2149,14 @@ class BudgetDatabase {
                     return nil
                 }
 
-                // Date: required; unsupported recurrences mean we can't advance
-                // the schedule correctly after posting, so skip.
-                guard let dateCondition = Self.parseDateCondition(in: conditions) else {
-                    logger.notice("Skipping schedule \(id, privacy: .public): missing or unsupported date condition")
-                    return nil
+                // Date: informs only the ADVANCE. Upstream posting works off
+                // the stored next_date regardless of this condition (its
+                // setNextDate throws on unsupported shapes after posting and
+                // the service swallows it), so a missing or unparseable date
+                // condition still posts — once, without advancing.
+                let dateCondition = Self.parseDateCondition(in: conditions)
+                if case .unsupported = dateCondition {
+                    logger.notice("Schedule \(id, privacy: .public): date condition missing or unsupported - due occurrence will post without advancing")
                 }
 
                 // Effective next date, per loot-core's v_schedules view:
@@ -2259,10 +2267,10 @@ class BudgetDatabase {
         return nil
     }
 
-    private static func parseDateCondition(in conditions: [[String: Any]]) -> ScheduleDateCondition? {
+    private static func parseDateCondition(in conditions: [[String: Any]]) -> ScheduleDateCondition {
         guard let cond = firstCondition(
             in: conditions, ops: ["is", "isapprox"], fields: ["date"]
-        ) else { return nil }
+        ) else { return .unsupported }
         // Fixed dates inside conditions JSON are "YYYY-MM-DD" strings
         // (unlike the schedules_next_date columns, which are YYYYMMDD ints).
         if let iso = cond["value"] as? String, let day = DayDate(iso: iso) {
@@ -2271,7 +2279,7 @@ class BudgetDatabase {
         if let recur = cond["value"] as? [String: Any], let config = RecurConfig(json: recur) {
             return .recurring(config)
         }
-        return nil
+        return .unsupported
     }
 
     // MARK: - Preferences

--- a/Actuali/Actuali/Services/Schedules/SchedulePoster.swift
+++ b/Actuali/Actuali/Services/Schedules/SchedulePoster.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "ScheduleP
 /// record them. `SyncClient` is the production conformance.
 protocol SchedulePostingActions {
     func createTransaction(_ transaction: Transaction) async throws
-    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64) async throws
+    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64?) async throws
 }
 
 /// Posts due automatic schedules and advances their next dates.
@@ -127,8 +127,10 @@ actor SchedulePoster {
                 posted += 1
             }
 
-            // One-off schedules post at most once and never advance;
-            // completion is left to the web app (loot-core parity).
+            // One-off and unsupported-recurrence schedules post at most once
+            // and never advance; completion (or the advance the port can't
+            // compute) is left to the web app (loot-core parity — its advance
+            // throws on such shapes and the service swallows it after posting).
             guard case .recurring(let config) = schedule.dateCondition else { break }
 
             guard let next = ScheduleRecurrence.nextOccurrence(config: config, onOrAfter: current.adding(days: 1)),

--- a/Actuali/Actuali/Services/Schedules/ScheduleRecurrence.swift
+++ b/Actuali/Actuali/Services/Schedules/ScheduleRecurrence.swift
@@ -21,7 +21,18 @@ struct RecurConfig {
         else { return nil }
         frequency = freq
         self.start = start
-        interval = max(1, json["interval"] as? Int ?? 1)
+        // Absent/null interval defaults to 1 (upstream `config.interval ?? 1`),
+        // but a present non-integer value (legacy picker state stored strings)
+        // makes rSchedule throw upstream — reject rather than silently posting
+        // on interval-1 cadence.
+        switch json["interval"] {
+        case nil, is NSNull:
+            interval = 1
+        case let n as Int:
+            interval = max(1, n)
+        default:
+            return nil
+        }
         if let raw = json["patterns"] as? [[String: Any]] {
             var parsed: [Pattern] = []
             for p in raw {

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -584,16 +584,18 @@ actor SyncClient {
     /// so the local override stays valid (per the v_schedules CASE rule) until
     /// another client resets the base. `base_next_date`/`base_next_date_ts`
     /// are never touched.
-    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64) async throws {
+    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64?) async throws {
         guard let database else { throw SyncError.notConfigured }
 
         logger.debug("advanceScheduleNextDate() - row: \(nextDateRowId, privacy: .private), newDate: \(newNextDate, privacy: .public)")
 
         // 1. Generate CRDT messages (before any DB write, so an HLC failure
         //    leaves nothing stranded)
+        // .map flattens Int64? into Any? so a NULL base ts serializes through
+        // CRDTValue's nil case ("0:"), the null loot-core's setNextDate writes.
         let fields: [(column: String, value: Any?)] = [
             ("local_next_date", newNextDate),
-            ("local_next_date_ts", baseNextDateTs),
+            ("local_next_date_ts", baseNextDateTs.map { $0 as Any }),
         ]
         let messages = try await messageGenerator.messages(dataset: "schedules_next_date", row: nextDateRowId, fields: fields)
         logger.debug("Generated \(messages.count, privacy: .public) CRDT messages")

--- a/Actuali/ActualiTests/BudgetStoreSchedulePostingTriggerTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSchedulePostingTriggerTests.swift
@@ -1,0 +1,187 @@
+import Combine
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// GH #97: due schedules must post after ANY successful sync, not only when
+/// `syncOnForeground()`'s first immediate attempt succeeds. Upstream loot-core
+/// runs its schedule service on every sync completion event; Actuali's only
+/// trigger was inline in `syncOnForeground()`, so a foreground sync that fails
+/// once (network not yet up at wake) and then succeeds via the retry ladder —
+/// or any pull-to-refresh / background-push sync — never posted anything.
+@MainActor
+struct BudgetStoreSchedulePostingTriggerTests {
+
+    /// Upstream-shaped schema for everything the fetch + post + local-apply
+    /// pipeline touches (matches SchedulePosterTests, plus messages_crdt so
+    /// the real SyncClient can store the CRDT messages it generates).
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    parent_id TEXT,
+                    schedule TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                CREATE TABLE rules (
+                    id TEXT PRIMARY KEY,
+                    stage TEXT,
+                    conditions_op TEXT DEFAULT 'and',
+                    conditions TEXT,
+                    actions TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE schedules (
+                    id TEXT PRIMARY KEY,
+                    rule TEXT,
+                    active INTEGER DEFAULT 0,
+                    completed INTEGER DEFAULT 0,
+                    posts_transaction INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0,
+                    name TEXT
+                );
+
+                CREATE TABLE schedules_next_date (
+                    id TEXT PRIMARY KEY,
+                    schedule_id TEXT,
+                    local_next_date INTEGER,
+                    local_next_date_ts INTEGER,
+                    base_next_date INTEGER,
+                    base_next_date_ts INTEGER
+                );
+            """)
+        }
+        let database = try BudgetDatabase(path: tempURL)
+        return (database, tempURL)
+    }
+
+    /// A postable monthly schedule whose next date is already in the past.
+    private func insertDueSchedule(_ db: BudgetDatabase, dueOn: Int) throws {
+        let conditionsJSON = """
+            [{"op":"is","field":"acct","value":"acct-1"},
+             {"op":"is","field":"date","value":{"frequency":"monthly","start":"2026-01-15","interval":1}},
+             {"op":"is","field":"amount","value":-1500}]
+            """
+        try db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: "INSERT INTO accounts (id, name) VALUES ('acct-1', 'Checking')")
+            try conn.execute(sql: """
+                INSERT INTO rules (id, stage, conditions_op, conditions, actions)
+                VALUES ('rule-1', NULL, 'and', ?, '[]')
+                """, arguments: [conditionsJSON])
+            try conn.execute(sql: """
+                INSERT INTO schedules (id, rule, completed, posts_transaction, tombstone, name)
+                VALUES ('sched-1', 'rule-1', 0, 1, 0, 'Rent')
+                """)
+            try conn.execute(sql: """
+                INSERT INTO schedules_next_date
+                    (id, schedule_id, local_next_date, local_next_date_ts, base_next_date, base_next_date_ts)
+                VALUES ('nd-1', 'sched-1', ?, 1000, ?, 1000)
+                """, arguments: [dueOn, dueOn])
+        }
+    }
+
+    private func postedTransactionCount(_ db: BudgetDatabase) throws -> Int {
+        try db.dbQueueForTesting.read { conn in
+            try Int.fetchOne(conn, sql: """
+                SELECT COUNT(*) FROM transactions
+                WHERE schedule = 'sched-1' AND (tombstone = 0 OR tombstone IS NULL)
+                """) ?? 0
+        }
+    }
+
+    /// A sync that succeeds through any path other than syncOnForeground()'s
+    /// inline attempt — retry ladder, pull-to-refresh, background push — is
+    /// visible only as the client's .syncing → .idle state transition. That
+    /// transition must trigger posting.
+    @Test func syncSuccessStateTransitionPostsDueSchedules() async throws {
+        let (database, url) = try makeDatabase()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let yesterday = DayDate.today().adding(days: -1)
+        try insertDueSchedule(database, dueOn: yesterday.yyyymmdd)
+
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+
+        // Unique budget id per run so the poster's once-per-day gate can't
+        // carry over between test runs; scrub both UserDefaults keys after.
+        let budgetId = "test-\(UUID().uuidString)"
+        let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
+        let savedToggle = UserDefaults.standard.object(forKey: "postScheduledTransactions")
+        defer {
+            UserDefaults.standard.set(savedBudgetId, forKey: "currentBudgetId")
+            UserDefaults.standard.set(savedToggle, forKey: "postScheduledTransactions")
+            UserDefaults.standard.removeObject(forKey: "lastScheduleRun-\(budgetId)")
+        }
+        store.currentBudgetId = budgetId
+        store.postScheduledTransactions = true
+
+        #expect(try postedTransactionCount(database) == 0)
+
+        // Simulate a successful sync completing outside syncOnForeground():
+        // performSync() is the only sender of .syncing followed by .idle.
+        syncClient.stateSubject.send(.syncing)
+        syncClient.stateSubject.send(.idle)
+
+        // The trigger hops through the main queue and the poster actor; poll
+        // rather than sleep a fixed amount.
+        var posted = 0
+        for _ in 0..<200 {
+            posted = try postedTransactionCount(database)
+            if posted > 0 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        #expect(posted == 1)
+    }
+}

--- a/Actuali/ActualiTests/ScheduleFetchTests.swift
+++ b/Actuali/ActualiTests/ScheduleFetchTests.swift
@@ -330,14 +330,21 @@ struct ScheduleFetchTests {
 
     /// The advance write needs base_next_date_ts; a NULL there is a skip,
     /// without poisoning other schedules in the same fetch.
-    @Test func skipsNullBaseNextDateTsWithoutAffectingOthers() async throws {
+    /// v_schedules' `local_next_date_ts = base_next_date_ts` CASE is NULL for
+    /// NULL timestamps, so the web falls through to base_next_date and still
+    /// posts — a NULL ts row must not be skipped (GH #97 follow-up).
+    @Test func nullBaseNextDateTsPostsUsingBaseNextDate() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
-        try insertSchedule(db, id: "s-nots", localNextDateTs: nil, baseNextDateTs: nil)
+        try insertSchedule(db, id: "s-nots", localNextDate: 20260715, localNextDateTs: nil,
+                           baseNextDate: 20260801, baseNextDateTs: nil)
         try insertSchedule(db, id: "s-ok")
 
         let schedules = try db.fetchPostableSchedules()
-        #expect(schedules.map(\.id) == ["s-ok"])
+        #expect(schedules.map(\.id) == ["s-nots", "s-ok"])
+        let noTs = schedules.first { $0.id == "s-nots" }
+        #expect(noTs?.nextDate == DayDate(yyyymmdd: 20260801))
+        #expect(noTs?.baseNextDateTs == nil)
     }
 
     /// loot-core's rules service only loads rules with tombstone = 0, so a
@@ -461,7 +468,12 @@ struct ScheduleFetchTests {
         #expect(schedules.isEmpty)
     }
 
-    @Test func skipsUnparseableRecurrenceAndMissingDateCondition() async throws {
+    /// Upstream posting never consults the date condition — getStatus works
+    /// off the stored next_date, and only the ADVANCE needs the recurrence
+    /// (setNextDate throws on shapes it can't handle and the service swallows
+    /// it). So an unparseable or missing date condition must still yield a
+    /// postable schedule, marked so the poster posts once and never advances.
+    @Test func unparseableRecurrenceAndMissingDateConditionStillPostable() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
         try insertSchedule(db, id: "s-badfreq", conditions: """
@@ -472,9 +484,21 @@ struct ScheduleFetchTests {
             [{"op":"is","field":"acct","value":"acct-1"},
              {"op":"is","field":"description","value":"payee-1"}]
             """)
+        // Legacy picker state could store interval as a string; rSchedule
+        // throws on it upstream, so it must not silently post on interval 1.
+        try insertSchedule(db, id: "s-strinterval", conditions: """
+            [{"op":"is","field":"acct","value":"acct-1"},
+             {"op":"is","field":"date","value":{"frequency":"monthly","start":"2026-01-15","interval":"2"}}]
+            """)
 
         let schedules = try db.fetchPostableSchedules()
-        #expect(schedules.isEmpty)
+        #expect(schedules.map(\.id) == ["s-badfreq", "s-nodate", "s-strinterval"])
+        for schedule in schedules {
+            guard case .unsupported = schedule.dateCondition else {
+                Issue.record("\(schedule.id) should carry .unsupported, got \(schedule.dateCondition)")
+                continue
+            }
+        }
     }
 
     @Test func skipsInvalidEffectiveNextDate() async throws {

--- a/Actuali/ActualiTests/SchedulePosterTests.swift
+++ b/Actuali/ActualiTests/SchedulePosterTests.swift
@@ -11,7 +11,7 @@ import GRDB
 private final class RecordingActions: SchedulePostingActions {
     let database: BudgetDatabase
     var created: [Transaction] = []
-    var advances: [(rowId: String, newNextDate: Int, baseTs: Int64)] = []
+    var advances: [(rowId: String, newNextDate: Int, baseTs: Int64?)] = []
     /// Schedule ids whose createTransaction should throw (schedule-level error).
     var failingScheduleIds: Set<String> = []
     /// Suspension before each create, simulating the network round-trip so
@@ -44,7 +44,7 @@ private final class RecordingActions: SchedulePostingActions {
         created.append(transaction)
     }
 
-    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64) async throws {
+    func advanceScheduleNextDate(nextDateRowId: String, newNextDate: Int, baseNextDateTs: Int64?) async throws {
         try await database.dbQueueForTesting.write { conn in
             try conn.execute(sql: """
                 UPDATE schedules_next_date
@@ -185,7 +185,8 @@ struct SchedulePosterTests {
         id: String = "sched-1",
         conditions: String? = nil,
         actions: String = "[]",
-        nextDate: Int
+        nextDate: Int,
+        nextDateTs: Int64? = 1000
     ) throws {
         let conditionsJSON = conditions ?? """
             [{"op":"is","field":"acct","value":"acct-1"},
@@ -205,8 +206,8 @@ struct SchedulePosterTests {
             try conn.execute(sql: """
                 INSERT INTO schedules_next_date
                     (id, schedule_id, local_next_date, local_next_date_ts, base_next_date, base_next_date_ts)
-                VALUES (?, ?, ?, 1000, ?, 1000)
-                """, arguments: ["nd-\(id)", id, nextDate, nextDate])
+                VALUES (?, ?, ?, ?, ?, ?)
+                """, arguments: ["nd-\(id)", id, nextDate, nextDateTs, nextDate, nextDateTs])
         }
     }
 
@@ -333,6 +334,52 @@ struct SchedulePosterTests {
         #expect(posted == 0)
         #expect(actions.created.isEmpty)
         #expect(actions.advances.isEmpty)
+    }
+
+    /// Web parity (GH #97 follow-up): a recurrence the port can't advance
+    /// still posts the stored due occurrence — upstream posts from the stored
+    /// next_date and only the advance throws (swallowed by the service). The
+    /// paid dedup then keeps every later pass from re-posting.
+    @Test func unsupportedDateConditionPostsStoredOccurrenceOnceAndNeverAdvances() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try insertSchedule(db, conditions: """
+            [{"op":"is","field":"acct","value":"acct-1"},
+             {"op":"is","field":"date","value":{"frequency":"fortnightly","start":"2026-01-15"}}]
+            """, nextDate: 20260710)
+        let (poster, actions, defaults, suite) = makePoster(db)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let posted = await poster.runIfNeeded(budgetId: Self.budgetId, today: Self.today)
+        #expect(posted == 1)
+        #expect(actions.created.map(\.date) == [20260710])
+        #expect(actions.advances.isEmpty)
+
+        // Next day: the posted transaction marks the occurrence paid, so
+        // nothing re-posts and the schedule still never advances.
+        let nextDay = await poster.runIfNeeded(budgetId: Self.budgetId, today: Self.today.adding(days: 1))
+        #expect(nextDay == 0)
+        #expect(actions.created.count == 1)
+        #expect(actions.advances.isEmpty)
+    }
+
+    /// Web parity (GH #97 follow-up): NULL next-date timestamps mean the
+    /// v_schedules CASE falls through to base_next_date; posting proceeds and
+    /// the advance writes local_next_date_ts = base_next_date_ts (NULL), the
+    /// same cell values loot-core's setNextDate writes.
+    @Test func nullBaseNextDateTsPostsAndAdvancesWithNullTs() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try insertSchedule(db, nextDate: 20260715, nextDateTs: nil)
+        let (poster, actions, defaults, suite) = makePoster(db)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let posted = await poster.runIfNeeded(budgetId: Self.budgetId, today: Self.today)
+
+        #expect(posted == 1)
+        #expect(actions.created.map(\.date) == [20260715])
+        #expect(actions.advances.map(\.newNextDate) == [20260815])
+        #expect(actions.advances.first?.baseTs == nil)
     }
 
     // MARK: - Gate

--- a/Actuali/ActualiTests/ScheduleRecurrenceTests.swift
+++ b/Actuali/ActualiTests/ScheduleRecurrenceTests.swift
@@ -59,6 +59,22 @@ struct ScheduleRecurrenceTests {
         #expect(RecurConfig(json: ["frequency": "daily", "start": "2026-13-01"]) == nil)
     }
 
+    /// Legacy picker state could persist interval as a string; rSchedule
+    /// throws on it upstream ("interval" expects a whole number), so the
+    /// config must be rejected — silently treating it as 1 would post on the
+    /// wrong cadence. Absent or null interval stays 1 (upstream default).
+    @Test func configRejectsNonIntegerInterval() {
+        #expect(RecurConfig(json: [
+            "frequency": "monthly", "start": "2026-01-01", "interval": "2",
+        ]) == nil)
+        #expect(RecurConfig(json: [
+            "frequency": "monthly", "start": "2026-01-01",
+        ])?.interval == 1)
+        #expect(RecurConfig(json: [
+            "frequency": "monthly", "start": "2026-01-01", "interval": NSNull(),
+        ])?.interval == 1)
+    }
+
     @Test func configRejectsMalformedPatterns() {
         let badType: [String: Any] = [
             "frequency": "monthly", "start": "2026-01-01",


### PR DESCRIPTION
## What changed and why

Auto-posting of due schedules (the **Post Scheduled Transactions** toggle) had exactly one trigger in the whole app: the inline call in `syncOnForeground()`, guarded by the success bool of that *single, immediate* `automaticSync()` attempt. Any sync that succeeded through another path never posted:

- the retry ladder (`scheduleRetry` → `performSync`) after a failed foreground attempt — common on device wake when Wi-Fi/VPN to a self-hosted server isn't up yet,
- pull-to-refresh / Settings "Sync Now" (`syncNow()`),
- background pushes after local writes,
- background app refresh.

Upstream loot-core instead runs `advanceSchedulesService` on **every** sync completion event and only marks the day done on success, so posting retries on subsequent successful syncs (`packages/loot-core/src/server/schedules/app.ts`). This PR restores that parity: the existing sync-state subscription in `BudgetStore` now detects the `.syncing → .idle` transition — sent only by a successful `performSync()` — and runs the poster, refreshing the register when anything posted. The poster's actor guard and once-per-day clean-pass gate make the overlap with the retained foreground call safe.

For the reporter specifically (1.0.7 build 88): that build also predates the merkle-divergence fixes (#99/#121/#188), under which `performSync()` could throw `outOfSync` on every pass while data still visibly synced — making `success` false on every open, so the poster literally never ran. Those sync fixes are already merged; this PR removes the remaining structural single point of failure so posting no longer depends on one attempt's outcome.

## Edge-shape parity with the web client (second commit)

Investigation surfaced three data shapes where the port skipped schedules the web still posts. Each was verified empirically by driving upstream via `@actual-app/api` and reading loot-core's actual behavior:

- **Missing/unparseable date conditions still post.** Upstream posting never consults the date condition — `getStatus` works off the stored `next_date`; only the *advance* needs the recurrence (`setNextDate` throws on shapes it can't handle and the service swallows it after posting). New `ScheduleDateCondition.unsupported`: post the stored due occurrence once, never advance, and the paid-dedup prevents re-posts.
- **NULL `base_next_date_ts` no longer skips.** The web's `v_schedules` CASE falls through to `base_next_date` for NULL timestamps and its advance writes a NULL `local_next_date_ts`; `baseNextDateTs` is now `Int64?` end to end and the CRDT write serializes the null (`"0:"`).
- **String-typed `interval` is rejected, not silently treated as 1.** rSchedule throws on it upstream (`"interval" expects a whole number` — confirmed by attempting `schedule/create` with legacy string-shaped configs), so such a config routes to `.unsupported` (post-once) instead of posting on the wrong cadence.

Not changed, deliberately: duplicate `schedules_next_date` rows keep deterministic first-row-wins and `nd.tombstone` stays unfiltered — the web defines no behavior for either (arbitrary `db.first`, no tombstone filter in `v_schedules`).

## How it was verified

- New test `BudgetStoreSchedulePostingTriggerTests.syncSuccessStateTransitionPostsDueSchedules` drives a due schedule through the real `BudgetStore` + `SyncClient` + `SchedulePoster` pipeline and simulates a sync succeeding outside `syncOnForeground()`. It failed before the fix (`posted → 0`) and passes after.
- Data-layer parity was verified against a **real budget file** generated by upstream `@actual-app/api` (schedule created with "Automatically add transaction", next date rewound past due): `fetchPostableSchedules` parsed it and `SchedulePoster` posted the missed occurrence and advanced the next date correctly — confirming the trigger, not the parser/poster, broke the reported case.
- Edge-shape semantics (post-once-never-advance, NULL-ts fallthrough, string-interval rejection) were established by running upstream loot-core directly, then pinned with new unit tests (poster, fetch, and recurrence suites).
- Full unit suite: **780 tests in 113 suites, all passed** (`xcodebuild test`, iPhone 17 / iOS 26.5 simulator).

Fixes #97