### PR TITLE
Add account creation

### DIFF
--- a/Actuali/Actuali/Models/Account.swift
+++ b/Actuali/Actuali/Models/Account.swift
@@ -29,3 +29,24 @@ enum AccountType: String, CaseIterable {
     case debt
     case other
 }
+
+// MARK: - CRDTSyncable
+
+extension Account: CRDTSyncable {
+    static var datasetName: String { "accounts" }
+
+    /// Only the fields a manually-created (non-bank-linked) account sets.
+    /// Bank-sync columns (account_id, balance_current, mask, official_name,
+    /// subtype, bank) stay untouched — matching how the PWA leaves them null
+    /// for a local account, same as `financial_id` on Transaction.
+    var syncableFields: [String: Any?] {
+        [
+            "name": name,
+            "type": type.rawValue,
+            "offbudget": offBudget ? 1 : 0,
+            "closed": closed ? 1 : 0,
+            "tombstone": 0,
+            "sort_order": sortOrder
+        ]
+    }
+}

--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -30,6 +30,10 @@ struct Transaction: Identifiable, Hashable {
     // Set at creation time by the Wallet import; not read back by the fetch
     // paths, so it is nil on fetched rows — dedup queries the column directly.
     var financialId: String? = nil
+    // Marks the special "opening balance" transaction created alongside a
+    // new account (Actual's starting_balance_flag). Only ever set at
+    // creation, matching financialId's write-only shape below.
+    var startingBalanceFlag: Bool = false
     // Payee's transfer_acct: the account on the other side when the payee is a
     // transfer payee, nil otherwise. Populated by the display and reports
     // fetches so rows can render transfers as transfers and engines can
@@ -137,6 +141,9 @@ extension Transaction: CRDTSyncable {
         // nil included).
         if let financialId {
             fields["financial_id"] = financialId
+        }
+        if startingBalanceFlag {
+            fields["starting_balance_flag"] = 1
         }
         return fields
     }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -20,6 +20,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case cannotConvertToSplit
     case splitNeedsTwoLines
     case splitAmountMismatch
+    case invalidAccountName
+    case accountCreationFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -49,6 +51,10 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "A split needs at least two lines"
         case .splitAmountMismatch:
             return "Split amounts must add up to the total"
+        case .invalidAccountName:
+            return "Enter an account name"
+        case .accountCreationFailed(let message):
+            return "Failed to create account: \(message)"
         }
     }
 }
@@ -1344,6 +1350,82 @@ final class BudgetStore: ObservableObject {
         payees.append(newPayee)
 
         return newPayee
+    }
+
+    // MARK: - Accounts
+
+    /// Create a new local (manually-added) account, matching the PWA's own
+    /// "Create local account" flow: an accounts row plus an opening-balance
+    /// transaction from the shared "Starting Balance" payee (Actual has no
+    /// separate stored-balance field — every account's balance is always the
+    /// sum of its transactions, so this transaction IS the starting balance,
+    /// not a display shortcut). Always creates the transaction, even for a
+    /// zero balance, matching the PWA so "Starting Balance" is editable later
+    /// the same way for every account.
+    @discardableResult
+    func createAccount(name: String, offBudget: Bool, startingBalanceCents: Int) async throws -> Account {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw BudgetStoreError.invalidAccountName
+        }
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+
+        // New accounts sort after existing ones, same convention as new
+        // transactions (Transaction.sortOrder) — a millisecond timestamp
+        // keeps concurrent creates from colliding.
+        let sortOrder = Int(Date().timeIntervalSince1970 * 1000)
+
+        let account = Account(
+            id: UUID().uuidString,
+            name: trimmedName,
+            type: .checking,
+            offBudget: offBudget,
+            closed: false,
+            sortOrder: sortOrder,
+            balance: startingBalanceCents
+        )
+
+        do {
+            let startingBalancePayee = try await findOrCreatePayee(name: "Starting Balance")
+
+            // Uncategorized, like the PWA: opening balances land as unassigned
+            // income the person allocates during budgeting, not a pre-picked
+            // category — matching how every other client represents it.
+            let startingBalanceTransaction = Transaction(
+                id: UUID().uuidString,
+                accountId: account.id,
+                date: Transaction.yyyymmdd(from: Date()),
+                amount: startingBalanceCents,
+                payeeId: startingBalancePayee.id,
+                payeeName: startingBalancePayee.name,
+                categoryId: nil,
+                categoryName: nil,
+                notes: nil,
+                cleared: true,
+                reconciled: false,
+                transferId: nil,
+                isParent: false,
+                parentId: nil,
+                tombstone: false,
+                sortOrder: nil,
+                importedPayee: nil,
+                startingBalanceFlag: true
+            )
+
+            try await syncClient.createAccount(account, startingBalanceTransaction: startingBalanceTransaction)
+        } catch let error as BudgetStoreError {
+            throw error
+        } catch {
+            throw BudgetStoreError.accountCreationFailed(error.localizedDescription)
+        }
+
+        // Refresh local data (without recreating SyncClient, which would
+        // cancel the scheduled sync) so the new account appears immediately.
+        await refreshDataOnly()
+
+        return account
     }
 
     // MARK: - Transactions

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1355,13 +1355,14 @@ final class BudgetStore: ObservableObject {
     // MARK: - Accounts
 
     /// Create a new local (manually-added) account, matching the PWA's own
-    /// "Create local account" flow: an accounts row plus an opening-balance
-    /// transaction from the shared "Starting Balance" payee (Actual has no
-    /// separate stored-balance field — every account's balance is always the
-    /// sum of its transactions, so this transaction IS the starting balance,
-    /// not a display shortcut). Always creates the transaction, even for a
-    /// zero balance, matching the PWA so "Starting Balance" is editable later
-    /// the same way for every account.
+    /// "Create local account" flow (loot-core `createAccount`): an accounts
+    /// row, the account's transfer payee (the empty-named payee carrying
+    /// `transfer_acct` that every transfer to or from this account resolves
+    /// through), and — only for a nonzero balance, like the PWA — an
+    /// opening-balance transaction from the shared "Starting Balance" payee
+    /// (Actual has no separate stored-balance field — every account's balance
+    /// is always the sum of its transactions, so this transaction IS the
+    /// starting balance, not a display shortcut).
     @discardableResult
     func createAccount(name: String, offBudget: Bool, startingBalanceCents: Int) async throws -> Account {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1387,34 +1388,51 @@ final class BudgetStore: ObservableObject {
             balance: startingBalanceCents
         )
 
+        let transferPayee = Payee(
+            id: UUID().uuidString,
+            name: "",
+            transferAccountId: account.id,
+            tombstone: false
+        )
+
         do {
-            let startingBalancePayee = try await findOrCreatePayee(name: "Starting Balance")
+            var startingBalanceTransaction: Transaction?
+            if startingBalanceCents != 0 {
+                let startingBalancePayee = try await findOrCreatePayee(name: "Starting Balance")
 
-            // Uncategorized, like the PWA: opening balances land as unassigned
-            // income the person allocates during budgeting, not a pre-picked
-            // category — matching how every other client represents it.
-            let startingBalanceTransaction = Transaction(
-                id: UUID().uuidString,
-                accountId: account.id,
-                date: Transaction.yyyymmdd(from: Date()),
-                amount: startingBalanceCents,
-                payeeId: startingBalancePayee.id,
-                payeeName: startingBalancePayee.name,
-                categoryId: nil,
-                categoryName: nil,
-                notes: nil,
-                cleared: true,
-                reconciled: false,
-                transferId: nil,
-                isParent: false,
-                parentId: nil,
-                tombstone: false,
-                sortOrder: nil,
-                importedPayee: nil,
-                startingBalanceFlag: true
+                // An on-budget opening balance is income the budget can
+                // allocate, so it takes the income category the PWA picks
+                // ("Starting Balances", else the first income category).
+                // Off-budget money never enters the budget, so no category.
+                let category = offBudget ? nil : startingBalanceCategory()
+
+                startingBalanceTransaction = Transaction(
+                    id: UUID().uuidString,
+                    accountId: account.id,
+                    date: Transaction.yyyymmdd(from: Date()),
+                    amount: startingBalanceCents,
+                    payeeId: startingBalancePayee.id,
+                    payeeName: startingBalancePayee.name,
+                    categoryId: category?.id,
+                    categoryName: category?.name,
+                    notes: nil,
+                    cleared: true,
+                    reconciled: false,
+                    transferId: nil,
+                    isParent: false,
+                    parentId: nil,
+                    tombstone: false,
+                    sortOrder: nil,
+                    importedPayee: nil,
+                    startingBalanceFlag: true
+                )
+            }
+
+            try await syncClient.createAccount(
+                account,
+                transferPayee: transferPayee,
+                startingBalanceTransaction: startingBalanceTransaction
             )
-
-            try await syncClient.createAccount(account, startingBalanceTransaction: startingBalanceTransaction)
         } catch let error as BudgetStoreError {
             throw error
         } catch {
@@ -1426,6 +1444,16 @@ final class BudgetStore: ObservableObject {
         await refreshDataOnly()
 
         return account
+    }
+
+    /// The category an on-budget opening balance lands in, mirroring the
+    /// PWA's `getStartingBalancePayee`: the income category named "Starting
+    /// Balances" when the budget has one, else any income category, else nil
+    /// (the transaction stays uncategorized, same as upstream).
+    private func startingBalanceCategory() -> Category? {
+        let incomeCategories = categoryGroups.flatMap(\.categories).filter(\.isIncome)
+        return incomeCategories.first { $0.name.lowercased() == "starting balances" }
+            ?? incomeCategories.first
     }
 
     // MARK: - Transactions

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1935,6 +1935,28 @@ class BudgetDatabase {
         }
     }
 
+    /// Inserts a newly-created account and its opening-balance transaction
+    /// (if any) in a single SQLite transaction, so a failure on either row
+    /// rolls back both — mirrors `insertTransfer`'s all-or-nothing shape.
+    func insertAccount(_ account: Account, startingBalanceTransaction: Transaction?) throws {
+        try dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
+                VALUES (?, ?, ?, ?, ?, 0, ?)
+                """, arguments: [
+                    account.id,
+                    account.name,
+                    account.type.rawValue,
+                    account.offBudget ? 1 : 0,
+                    account.closed ? 1 : 0,
+                    account.sortOrder
+                ])
+            if let startingBalanceTransaction {
+                try Self.insertTransactionRow(db, startingBalanceTransaction)
+            }
+        }
+    }
+
     /// Inserts both legs of a transfer and their CRDT messages in a single
     /// SQLite transaction, so a failure on either leg rolls back everything
     /// and no orphaned half-transfer can persist.
@@ -1975,8 +1997,8 @@ class BudgetDatabase {
         // children keep their entry order under the parent.
         let sortOrder = transaction.sortOrder ?? Date().timeIntervalSince1970 * 1000
         try db.execute(sql: """
-            INSERT INTO transactions (id, acct, date, description, category, amount, notes, cleared, reconciled, transferred_id, isParent, isChild, parent_id, tombstone, sort_order, imported_description, schedule, financial_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO transactions (id, acct, date, description, category, amount, notes, cleared, reconciled, transferred_id, isParent, isChild, parent_id, tombstone, sort_order, imported_description, schedule, financial_id, starting_balance_flag)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, arguments: [
                 transaction.id,
                 transaction.accountId,
@@ -1995,7 +2017,8 @@ class BudgetDatabase {
                 sortOrder,
                 transaction.importedPayee,
                 transaction.schedule,
-                transaction.financialId
+                transaction.financialId,
+                transaction.startingBalanceFlag ? 1 : 0
             ])
     }
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1935,10 +1935,16 @@ class BudgetDatabase {
         }
     }
 
-    /// Inserts a newly-created account and its opening-balance transaction
-    /// (if any) in a single SQLite transaction, so a failure on either row
-    /// rolls back both — mirrors `insertTransfer`'s all-or-nothing shape.
-    func insertAccount(_ account: Account, startingBalanceTransaction: Transaction?) throws {
+    /// Inserts a newly-created account, its transfer payee (plus the payee's
+    /// self-mapping row the transaction joins need), and its opening-balance
+    /// transaction (if any) in a single SQLite transaction, so a failure on
+    /// any row rolls back everything — mirrors `insertTransfer`'s
+    /// all-or-nothing shape.
+    func insertAccount(
+        _ account: Account,
+        transferPayee: Payee,
+        startingBalanceTransaction: Transaction?
+    ) throws {
         try dbQueue.write { db in
             try db.execute(sql: """
                 INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
@@ -1950,6 +1956,22 @@ class BudgetDatabase {
                     account.offBudget ? 1 : 0,
                     account.closed ? 1 : 0,
                     account.sortOrder
+                ])
+            try db.execute(sql: """
+                INSERT INTO payees (id, name, transfer_acct, tombstone)
+                VALUES (?, ?, ?, ?)
+                """, arguments: [
+                    transferPayee.id,
+                    transferPayee.name,
+                    transferPayee.transferAccountId,
+                    transferPayee.tombstone ? 1 : 0
+                ])
+            try db.execute(sql: """
+                INSERT INTO payee_mapping (id, targetId)
+                VALUES (?, ?)
+                """, arguments: [
+                    transferPayee.id,
+                    transferPayee.id
                 ])
             if let startingBalanceTransaction {
                 try Self.insertTransactionRow(db, startingBalanceTransaction)

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -366,37 +366,54 @@ actor SyncClient {
         // Note: Don't schedule sync here - let the transaction sync handle it
     }
 
-    /// Create a new account and, if given, its opening-balance transaction —
-    /// atomically, so a failure on either leaves nothing orphaned. Rules are
-    /// skipped, same as `createTransfer`/`createSplit`: the caller (account
-    /// creation) builds the transaction explicitly and it's never
-    /// user-editable rule input.
-    func createAccount(_ account: Account, startingBalanceTransaction: Transaction?) async throws {
+    /// Create a new account, its transfer payee (the empty-named payee every
+    /// transfer to or from the account resolves through — created here and
+    /// nowhere else, matching the PWA), and, if given, its opening-balance
+    /// transaction — atomically, so a failure on any row leaves nothing
+    /// orphaned. Rules are skipped, same as `createTransfer`/`createSplit`:
+    /// the caller (account creation) builds the transaction explicitly and
+    /// it's never user-editable rule input.
+    func createAccount(
+        _ account: Account,
+        transferPayee: Payee,
+        startingBalanceTransaction: Transaction?
+    ) async throws {
         guard let database else { throw SyncError.notConfigured }
 
         logger.debug("createAccount() - id: \(account.id, privacy: .private)")
 
         // 1. Insert locally (optimistic)
-        try database.insertAccount(account, startingBalanceTransaction: startingBalanceTransaction)
+        try database.insertAccount(
+            account,
+            transferPayee: transferPayee,
+            startingBalanceTransaction: startingBalanceTransaction
+        )
         logger.debug("Account inserted locally")
 
         // 2. Generate CRDT messages for the account row
         var messages = try await messageGenerator.messagesForInsert(account)
 
-        // 3. Generate CRDT messages for the opening-balance transaction, if any
+        // 3. Generate CRDT messages for the transfer payee and its mapping,
+        //    same pair `createPayee` emits.
+        messages += try await messageGenerator.messagesForInsert(transferPayee)
+        messages += try await messageGenerator.messagesForInsert(
+            PayeeMapping(id: transferPayee.id, targetId: transferPayee.id)
+        )
+
+        // 4. Generate CRDT messages for the opening-balance transaction, if any
         if let startingBalanceTransaction {
             messages += try await messageGenerator.messagesForInsert(startingBalanceTransaction)
         }
         logger.debug("Generated \(messages.count, privacy: .public) CRDT messages for new account")
 
-        // 4. Store messages and update merkle
+        // 5. Store messages and update merkle
         for msg in try database.insertMessages(messages) {
             merkle = merkle.inserting(msg.timestamp)
         }
         merkle = merkle.pruned()
         try saveClock()
 
-        // 5. Sync to push the new account to the server (rate-limited)
+        // 6. Sync to push the new account to the server (rate-limited)
         await automaticSync()
     }
 

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -366,6 +366,40 @@ actor SyncClient {
         // Note: Don't schedule sync here - let the transaction sync handle it
     }
 
+    /// Create a new account and, if given, its opening-balance transaction —
+    /// atomically, so a failure on either leaves nothing orphaned. Rules are
+    /// skipped, same as `createTransfer`/`createSplit`: the caller (account
+    /// creation) builds the transaction explicitly and it's never
+    /// user-editable rule input.
+    func createAccount(_ account: Account, startingBalanceTransaction: Transaction?) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        logger.debug("createAccount() - id: \(account.id, privacy: .private)")
+
+        // 1. Insert locally (optimistic)
+        try database.insertAccount(account, startingBalanceTransaction: startingBalanceTransaction)
+        logger.debug("Account inserted locally")
+
+        // 2. Generate CRDT messages for the account row
+        var messages = try await messageGenerator.messagesForInsert(account)
+
+        // 3. Generate CRDT messages for the opening-balance transaction, if any
+        if let startingBalanceTransaction {
+            messages += try await messageGenerator.messagesForInsert(startingBalanceTransaction)
+        }
+        logger.debug("Generated \(messages.count, privacy: .public) CRDT messages for new account")
+
+        // 4. Store messages and update merkle
+        for msg in try database.insertMessages(messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        // 5. Sync to push the new account to the server (rate-limited)
+        await automaticSync()
+    }
+
     /// Record a location for a payee (optimistic local-first). Callers are
     /// responsible for the server-version guard and 500 m dedupe — this
     /// method just writes.

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -18,6 +18,7 @@ struct AccountsListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.isWideLayout) private var isWideLayout
     @State private var path = NavigationPath()
+    @State private var showingAddAccount = false
     /// Split layout only. Starts on All Accounts so the detail column has
     /// something in it at launch instead of an empty pane.
     @State private var selection: AccountSelection? = .allAccounts
@@ -40,6 +41,10 @@ struct AccountsListView: View {
 
     var offBudgetAccounts: [Account] {
         budgetStore.accounts.filter { $0.offBudget && !$0.closed }
+    }
+
+    var closedAccounts: [Account] {
+        budgetStore.accounts.filter { $0.closed }
     }
 
     var body: some View {
@@ -88,6 +93,16 @@ struct AccountsListView: View {
                                 }
                             }
                         }
+
+                        if !closedAccounts.isEmpty {
+                            Section("Closed Accounts") {
+                                ForEach(closedAccounts) { account in
+                                    NavigationLink(value: account) {
+                                        AccountRow(account: account)
+                                    }
+                                }
+                            }
+                        }
                     }
                     // Capped like the transactions this pushes to, so a
                     // narrow-iPad account list doesn't stretch a row's balance
@@ -130,6 +145,15 @@ struct AccountsListView: View {
                         if !offBudgetAccounts.isEmpty {
                             Section("Off Budget") {
                                 ForEach(offBudgetAccounts) { account in
+                                    AccountRow(account: account)
+                                        .tag(AccountSelection.account(account.id))
+                                }
+                            }
+                        }
+
+                        if !closedAccounts.isEmpty {
+                            Section("Closed Accounts") {
+                                ForEach(closedAccounts) { account in
                                     AccountRow(account: account)
                                         .tag(AccountSelection.account(account.id))
                                 }
@@ -216,8 +240,20 @@ struct AccountsListView: View {
             .navigationTitle("Accounts")
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showingAddAccount = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("Add Account")
+                }
+                ToolbarItem(placement: .primaryAction) {
                     SyncStatusView(state: budgetStore.syncState)
                 }
+            }
+            .sheet(isPresented: $showingAddAccount) {
+                AddAccountView()
+                    .environmentObject(budgetStore)
             }
             .onAppear {
                 consumePendingAllAccountsNavigation()

--- a/Actuali/Actuali/Views/Accounts/AddAccountView.swift
+++ b/Actuali/Actuali/Views/Accounts/AddAccountView.swift
@@ -30,8 +30,8 @@ struct AddAccountView: View {
 
 /// The account creation form: name, on/off-budget, and starting balance.
 /// Submitting creates a real Actual account (synced via the normal CRDT
-/// path, same as every other write in the app) plus a "Starting Balance"
-/// transaction for the opening amount — Actual has no separate stored
+/// path, same as every other write in the app) plus, for a nonzero amount,
+/// a "Starting Balance" transaction — Actual has no separate stored
 /// balance field, so the transaction *is* the balance, not a shortcut.
 struct CreateLocalAccountView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
@@ -98,6 +98,9 @@ struct CreateLocalAccountView: View {
     }
 
     private func create() async {
+        // A second tap can race the button's .disabled(isSaving) re-render
+        // and enqueue a second Task — bail so one tap means one account.
+        guard !isSaving else { return }
         guard !trimmedName.isEmpty else {
             errorMessage = "Enter an account name"
             return

--- a/Actuali/Actuali/Views/Accounts/AddAccountView.swift
+++ b/Actuali/Actuali/Views/Accounts/AddAccountView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// Entry point for the Accounts tab's + button. A simple menu of account
+/// creation methods, matching the PWA's own "Add account" popup — currently
+/// just the local (manual) account, since bank-linked import (Plaid/
+/// SimpleFin) isn't implemented here.
+struct AddAccountView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink {
+                    CreateLocalAccountView(onCreated: { dismiss() })
+                } label: {
+                    Text("Create a local account")
+                }
+            }
+            .navigationTitle("Add Account")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}
+
+/// The account creation form: name, on/off-budget, and starting balance.
+/// Submitting creates a real Actual account (synced via the normal CRDT
+/// path, same as every other write in the app) plus a "Starting Balance"
+/// transaction for the opening amount — Actual has no separate stored
+/// balance field, so the transaction *is* the balance, not a shortcut.
+struct CreateLocalAccountView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    /// Called on success — dismisses the whole "Add Account" sheet (both
+    /// this pushed form and the popup underneath it), not just this screen,
+    /// so the person lands back on the Accounts tab in one step.
+    var onCreated: () -> Void = {}
+
+    @State private var name = ""
+    @State private var onBudget = true
+    @State private var balanceText = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Account Name", text: $name)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.words)
+            } footer: {
+                if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                Toggle("On Budget", isOn: $onBudget)
+            } footer: {
+                Text("Off-budget accounts (like investments or loans) aren't included in your budget's available funds.")
+            }
+
+            Section {
+                HStack {
+                    Text("Balance")
+                    Spacer()
+                    AmountInputField(
+                        text: $balanceText,
+                        alignment: .right,
+                        allowsNegative: true
+                    )
+                }
+            } footer: {
+                Text("The account's starting balance, as of today.")
+            }
+        }
+        .navigationTitle("Create Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Create") {
+                    Task { await create() }
+                }
+                .disabled(isSaving)
+            }
+        }
+        .disabled(isSaving)
+        .interactiveDismissDisabled(isSaving)
+    }
+
+    private func create() async {
+        guard !trimmedName.isEmpty else {
+            errorMessage = "Enter an account name"
+            return
+        }
+
+        let cents: Int
+        let trimmedBalance = balanceText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedBalance.isEmpty {
+            cents = 0
+        } else if let dollars = AmountParser.parse(balanceText),
+                  let parsedCents = Transaction.cents(fromDollars: dollars) {
+            cents = parsedCents
+        } else {
+            errorMessage = "Invalid balance"
+            return
+        }
+
+        isSaving = true
+        errorMessage = nil
+
+        do {
+            try await budgetStore.createAccount(
+                name: trimmedName,
+                offBudget: !onBudget,
+                startingBalanceCents: cents
+            )
+            onCreated()
+        } catch {
+            errorMessage = error.localizedDescription
+            isSaving = false
+        }
+    }
+}
+
+#Preview {
+    AddAccountView()
+        .environmentObject(BudgetStore.previewInstance())
+}

--- a/Actuali/ActualiTests/BudgetDatabaseSplitTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseSplitTests.swift
@@ -50,6 +50,7 @@ struct BudgetDatabaseSplitTests {
 
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
@@ -16,6 +16,7 @@ struct BudgetDatabaseTransferAtomicityTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreCreateAccountTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreCreateAccountTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Account creation (PR #199): the store must mirror the PWA's own
+/// `createAccount` — an accounts row, the account's transfer payee (the
+/// empty-named payee transfers resolve through), and an opening-balance
+/// transaction only when the balance is nonzero, categorized to the income
+/// category for on-budget accounts.
+@MainActor
+struct BudgetStoreCreateAccountTests {
+
+    /// Upstream schema, matching BudgetStoreWalletImportTests plus the
+    /// accounts table createAccount writes.
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    /// An "Income" group whose second category is Starting Balances, so a
+    /// test can tell "picked by name" apart from "picked because it's first".
+    private func incomeGroups() -> [CategoryGroup] {
+        [CategoryGroup(
+            id: "grp-income",
+            name: "Income",
+            isIncome: true,
+            hidden: false,
+            sortOrder: 0,
+            categories: [
+                Category(id: "cat-income", name: "Income", groupId: "grp-income",
+                         isIncome: true, hidden: false, sortOrder: 0),
+                Category(id: "cat-starting", name: "Starting Balances", groupId: "grp-income",
+                         isIncome: true, hidden: false, sortOrder: 1)
+            ]
+        )]
+    }
+
+    private func rows(path: URL, sql: String) throws -> [Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: sql)
+        }
+    }
+
+    private func count(path: URL, sql: String) throws -> Int {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Int.fetchOne(db, sql: sql) ?? 0
+        }
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func createPersistsAccountTransferPayeeAndOpeningBalance() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        let account = try await store.createAccount(
+            name: "  Savings  ", offBudget: false, startingBalanceCents: 12345)
+
+        let accountRows = try rows(path: url, sql: "SELECT * FROM accounts")
+        #expect(accountRows.count == 1)
+        #expect(accountRows[0]["id"] == account.id)
+        #expect(accountRows[0]["name"] == "Savings")
+        #expect(accountRows[0]["offbudget"] == 0)
+        #expect(accountRows[0]["closed"] == 0)
+        #expect(accountRows[0]["tombstone"] == 0)
+
+        // The transfer payee: empty name, carries transfer_acct, and has the
+        // self-mapping row the transaction joins resolve through.
+        let transferPayees = try rows(
+            path: url, sql: "SELECT * FROM payees WHERE transfer_acct IS NOT NULL")
+        #expect(transferPayees.count == 1)
+        #expect(transferPayees[0]["name"] == "")
+        #expect(transferPayees[0]["transfer_acct"] == account.id)
+        let transferPayeeId: String = transferPayees[0]["id"]
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM payee_mapping WHERE id = '\(transferPayeeId)' AND targetId = '\(transferPayeeId)'"
+        ) == 1)
+
+        // The opening balance: full amount, flagged, cleared, from the shared
+        // "Starting Balance" payee (a separate payee from the transfer one).
+        let txnRows = try rows(path: url, sql: "SELECT * FROM transactions")
+        #expect(txnRows.count == 1)
+        #expect(txnRows[0]["acct"] == account.id)
+        #expect(txnRows[0]["amount"] == 12345)
+        #expect(txnRows[0]["starting_balance_flag"] == 1)
+        #expect(txnRows[0]["cleared"] == 1)
+        let payeeId: String? = txnRows[0]["description"]
+        #expect(payeeId != nil)
+        #expect(payeeId != transferPayeeId)
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM payees WHERE name = 'Starting Balance'"
+        ) == 1)
+    }
+
+    @Test func createEmitsCRDTMessagesForEveryRow() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        let account = try await store.createAccount(
+            name: "Checking", offBudget: false, startingBalanceCents: 500)
+
+        let transferPayeeId: String = try rows(
+            path: url, sql: "SELECT id FROM payees WHERE transfer_acct IS NOT NULL")[0]["id"]
+
+        // One message per synced column, same shape as every other write.
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM messages_crdt WHERE dataset = 'accounts' AND row = '\(account.id)'"
+        ) == 6)
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM messages_crdt WHERE dataset = 'payees' AND row = '\(transferPayeeId)'"
+        ) == 3)
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM messages_crdt WHERE dataset = 'payee_mapping' AND row = '\(transferPayeeId)'"
+        ) == 1)
+        #expect(try count(
+            path: url,
+            sql: "SELECT COUNT(*) FROM messages_crdt WHERE dataset = 'transactions' AND column = 'starting_balance_flag'"
+        ) == 1)
+    }
+
+    @Test func onBudgetOpeningBalanceTakesTheStartingBalancesCategory() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+        store.categoryGroups = incomeGroups()
+
+        try await store.createAccount(
+            name: "Checking", offBudget: false, startingBalanceCents: 1000)
+
+        let txnRows = try rows(path: url, sql: "SELECT category FROM transactions")
+        #expect(txnRows.count == 1)
+        #expect(txnRows[0]["category"] == "cat-starting")
+    }
+
+    @Test func openingBalanceFallsBackToTheFirstIncomeCategory() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+        var groups = incomeGroups()
+        groups[0].categories.removeAll { $0.name == "Starting Balances" }
+        store.categoryGroups = groups
+
+        try await store.createAccount(
+            name: "Checking", offBudget: false, startingBalanceCents: 1000)
+
+        let txnRows = try rows(path: url, sql: "SELECT category FROM transactions")
+        #expect(txnRows.count == 1)
+        #expect(txnRows[0]["category"] == "cat-income")
+    }
+
+    @Test func offBudgetOpeningBalanceStaysUncategorized() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+        store.categoryGroups = incomeGroups()
+
+        try await store.createAccount(
+            name: "Brokerage", offBudget: true, startingBalanceCents: 99900)
+
+        let txnRows = try rows(path: url, sql: "SELECT category, amount FROM transactions")
+        #expect(txnRows.count == 1)
+        let category: String? = txnRows[0]["category"]
+        #expect(category == nil)
+        #expect(txnRows[0]["amount"] == 99900)
+    }
+
+    @Test func zeroBalanceSkipsTheOpeningTransaction() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        try await store.createAccount(
+            name: "Empty", offBudget: false, startingBalanceCents: 0)
+
+        // No transaction and no "Starting Balance" payee — only the account
+        // and its transfer payee, exactly like the PWA.
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM transactions") == 0)
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM accounts") == 1)
+        let payeeRows = try rows(path: url, sql: "SELECT name, transfer_acct FROM payees")
+        #expect(payeeRows.count == 1)
+        #expect(payeeRows[0]["name"] == "")
+        let transferAcct: String? = payeeRows[0]["transfer_acct"]
+        #expect(transferAcct != nil)
+    }
+
+    @Test func blankNameIsRejectedAndNothingPersists() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        await #expect(throws: BudgetStoreError.invalidAccountName) {
+            try await store.createAccount(
+                name: "   ", offBudget: false, startingBalanceCents: 100)
+        }
+
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM accounts") == 0)
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM payees") == 0)
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM messages_crdt") == 0)
+    }
+
+    @Test func openingBalanceFailureRollsBackAccountAndPayee() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        // Pre-insert a row so the opening-balance INSERT violates the primary
+        // key, simulating a persistence failure on the last row of the batch.
+        let collidingId = UUID().uuidString
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(
+                sql: "INSERT INTO transactions (id) VALUES (?)",
+                arguments: [collidingId])
+        }
+
+        let account = Account(
+            id: UUID().uuidString, name: "Doomed", type: .checking,
+            offBudget: false, closed: false, sortOrder: 1, balance: 100)
+        let transferPayee = Payee(
+            id: UUID().uuidString, name: "", transferAccountId: account.id, tombstone: false)
+        let openingBalance = Transaction(
+            id: collidingId,
+            accountId: account.id,
+            date: 20260812,
+            amount: 100,
+            payeeId: nil,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: nil,
+            cleared: true,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil,
+            startingBalanceFlag: true
+        )
+
+        #expect(throws: (any Error).self) {
+            try database.insertAccount(
+                account, transferPayee: transferPayee,
+                startingBalanceTransaction: openingBalance)
+        }
+
+        // Atomicity: the account and payee rolled back with the transaction.
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM accounts") == 0)
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM payees") == 0)
+        #expect(try count(path: url, sql: "SELECT COUNT(*) FROM payee_mapping") == 0)
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreReconciliationTests.swift
@@ -20,6 +20,7 @@ struct BudgetStoreReconciliationTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
@@ -17,6 +17,7 @@ struct BudgetStoreSaveTransactionTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreSchedulePostingTriggerTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSchedulePostingTriggerTests.swift
@@ -44,6 +44,7 @@ struct BudgetStoreSchedulePostingTriggerTests {
 
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
@@ -48,6 +48,7 @@ struct BudgetStoreSplitSaveTests {
 
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreUpdateTransferTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreUpdateTransferTests.swift
@@ -22,6 +22,7 @@ struct BudgetStoreUpdateTransferTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/BudgetStoreWalletImportTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreWalletImportTests.swift
@@ -16,6 +16,7 @@ struct BudgetStoreWalletImportTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/ScheduleFieldTests.swift
+++ b/Actuali/ActualiTests/ScheduleFieldTests.swift
@@ -51,6 +51,7 @@ struct ScheduleFieldTests {
 
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/SchedulePosterTests.swift
+++ b/Actuali/ActualiTests/SchedulePosterTests.swift
@@ -95,6 +95,7 @@ struct SchedulePosterTests {
 
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/SyncClientOfflineWriteTests.swift
+++ b/Actuali/ActualiTests/SyncClientOfflineWriteTests.swift
@@ -52,6 +52,7 @@ struct SyncClientOfflineWriteTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
+++ b/Actuali/ActualiTests/SyncClientPostWritePushTests.swift
@@ -69,6 +69,7 @@ struct SyncClientPostWritePushTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,

--- a/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
+++ b/Actuali/ActualiTests/TransactionLoggerSyncOutcomeTests.swift
@@ -93,6 +93,7 @@ struct TransactionLoggerSyncOutcomeTests {
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
                     isParent INTEGER DEFAULT 0,
                     isChild INTEGER DEFAULT 0,
                     acct TEXT,


### PR DESCRIPTION
## Why

Users currently don't have a way to create a new local account from the app. This adds the ability to create accounts directly from the Accounts section.

## What

* Added an **Add Account** flow from the Accounts screen.
* Added support for creating a local account with a name, starting balance, and on-budget/off-budget selection.
* Added validation and error handling for account creation.
* Starting balances are created using the existing transaction system.
* We can also view closed accounts

## How it was tested

* Manually tested account creation in the iOS SIMULATOR.
* Tested creating accounts with different starting balances and on-budget/off-budget settings.
* Verified the newly created account appears in the Accounts list.

