### PR TITLE
Add iPad support

### DIFF
--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -454,6 +454,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -468,7 +469,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -493,6 +494,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -507,7 +509,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -11,6 +11,14 @@ struct ContentView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
 
+    /// Window width, measured here rather than deeper in the hierarchy so it
+    /// doesn't move when a sidebar expands. Feeds `\.isWideLayout`.
+    @State private var windowWidth: CGFloat = 0
+
+    /// Below this the iPad's split views can't lay out real columns and the
+    /// sidebar becomes an overlay drawer instead; see `\.isWideLayout`.
+    private static let wideLayoutThreshold: CGFloat = 1000
+
     /// Presents whenever the store publishes an error; dismissing clears it
     /// so the next failure can present again.
     private var errorAlertBinding: Binding<Bool> {
@@ -22,6 +30,8 @@ struct ContentView: View {
 
     var body: some View {
         MainTabView()
+            .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { windowWidth = $0 }
+            .environment(\.isWideLayout, windowWidth >= Self.wideLayoutThreshold)
             .alert("Something Went Wrong", isPresented: errorAlertBinding) {
                 Button("OK") {}
             } message: {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -5,6 +5,10 @@ struct AccountDetailView: View {
     let account: Account
 
     @State private var pager: TransactionPager?
+    /// Which account `pager` was built for. The iPad split layout reuses one
+    /// instance of this view across selections, so the account can change
+    /// under state that was scoped to the previous one.
+    @State private var pagerAccountId: String?
     @State private var breakdown: AccountBalanceBreakdown?
     @State private var showingBreakdown = false
     @State private var searchText = ""
@@ -24,9 +28,10 @@ struct AccountDetailView: View {
 
     /// The pager is created on first use rather than in init because its
     /// fetch closure needs the environment store, which isn't available
-    /// until body/task time.
+    /// until body/task time. Rebuilt when the account changes: the closure
+    /// captures the id, so a reused pager would keep paging the old account.
     private func currentPager() -> TransactionPager {
-        if let pager { return pager }
+        if let pager, pagerAccountId == account.id { return pager }
         let store = budgetStore
         let accountId = account.id
         let created = TransactionPager { offset, limit, search in
@@ -36,6 +41,7 @@ struct AccountDetailView: View {
             )
         }
         pager = created
+        pagerAccountId = accountId
         return created
     }
 
@@ -136,6 +142,7 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
+        .readableWidth()
         .navigationTitle(account.name)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
         .toolbar {
@@ -182,9 +189,19 @@ struct AccountDetailView: View {
             AddTransactionView(editing: transaction)
                 .environmentObject(budgetStore)
         }
-        .task(id: searchText) {
-            // Debounce keystrokes; the initial (empty) load runs immediately.
-            if searchQuery != nil {
+        // Keyed on the account as well as the search: selecting another
+        // account in the iPad split layout reuses this view, and without the
+        // account in the key nothing would reload — the previous account's
+        // rows would sit under the new one's name and balance.
+        .task(id: [account.id, searchText]) {
+            if pagerAccountId != account.id {
+                // Drop the previous account's page and balance split rather
+                // than showing them while the new ones load.
+                pager = nil
+                breakdown = nil
+            } else if searchQuery != nil {
+                // Debounce keystrokes; the initial (empty) load and account
+                // switches run immediately.
                 try? await Task.sleep(for: .milliseconds(250))
                 if Task.isCancelled { return }
             }

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -4,10 +4,31 @@ import SwiftUI
 /// notification tap can programmatically reset the stack onto it.
 struct AllAccountsRoute: Hashable {}
 
+/// Which detail the iPad's split layout is showing. Accounts are held by id,
+/// not by value: the `Account` struct changes on every sync (balances move),
+/// and a stored value would stop matching its row the moment it did.
+private enum AccountSelection: Hashable {
+    case allAccounts
+    case account(String)
+}
+
 struct AccountsListView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.isWideLayout) private var isWideLayout
     @State private var path = NavigationPath()
+    /// Split layout only. Starts on All Accounts so the detail column has
+    /// something in it at launch instead of an empty pane.
+    @State private var selection: AccountSelection? = .allAccounts
+
+    /// Two real columns, or tap-and-push? Width, not just size class: in a
+    /// window too narrow for a second column the split view hides the sidebar
+    /// behind a drawer that opens over the content and under the floating tab
+    /// bar, which is worse than the phone's push navigation.
+    private var usesSplitLayout: Bool {
+        horizontalSizeClass == .regular && isWideLayout
+    }
 
     var totalBalance: Int {
         budgetStore.accounts.reduce(0) { $0 + $1.balance }
@@ -22,42 +43,29 @@ struct AccountsListView: View {
     }
 
     var body: some View {
+        Group {
+            // A wide iPad window puts the account list beside its transactions
+            // instead of pushing to them.
+            if usesSplitLayout {
+                splitLayout
+            } else {
+                stackLayout
+            }
+        }
+        .initialSyncBanner()
+    }
+
+    /// The phone layout: tap an account, push its transactions.
+    private var stackLayout: some View {
         NavigationStack(path: $path) {
-            Group {
-                if budgetStore.accounts.isEmpty && !budgetStore.isLoading {
-                    if budgetStore.currentBudgetId != nil {
-                        // A budget is loaded, it just has no accounts (yet) —
-                        // "go connect a server" would be wrong advice here (GH #122).
-                        ContentUnavailableView(
-                            "No Accounts",
-                            systemImage: "dollarsign.circle",
-                            description: Text("This budget doesn't have any accounts yet. Create one in Actual Budget, then sync.")
-                        )
-                    } else if budgetStore.isConnected {
-                        ContentUnavailableView(
-                            "Select a Budget",
-                            systemImage: "dollarsign.circle",
-                            description: Text("You're connected. Choose a budget in Settings to load it here.")
-                        )
-                    } else {
-                        ContentUnavailableView(
-                            "No Budget Loaded",
-                            systemImage: "dollarsign.circle",
-                            description: Text("Go to Settings to connect to your Actual Budget server")
-                        )
-                    }
+            withChrome {
+                if hasNoAccounts {
+                    emptyState
                 } else {
                     List {
                         Section {
                             NavigationLink(value: AllAccountsRoute()) {
-                                HStack {
-                                    Text("All Accounts")
-                                        .font(.headline)
-                                    Spacer()
-                                    Text(budgetStore.displayBalance(totalBalance))
-                                        .font(.headline)
-                                        .foregroundColor(totalBalance > 0 ? .green : (totalBalance < 0 ? .red : .primary))
-                                }
+                                allAccountsRow
                             }
                         }
 
@@ -81,13 +89,11 @@ struct AccountsListView: View {
                             }
                         }
                     }
-                }
-            }
-            .contentMargins(.horizontal, 6, for: .scrollContent)
-            .navigationTitle("Accounts")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    SyncStatusView(state: budgetStore.syncState)
+                    // Capped like the transactions this pushes to, so a
+                    // narrow-iPad account list doesn't stretch a row's balance
+                    // an inch away from its name. Only here: the split
+                    // layout's copy is a sidebar and sizes itself.
+                    .readableWidth()
                 }
             }
             .navigationDestination(for: Account.self) { account in
@@ -95,6 +101,123 @@ struct AccountsListView: View {
             }
             .navigationDestination(for: AllAccountsRoute.self) { _ in
                 TransactionsListView()
+            }
+        }
+    }
+
+    /// The iPad layout: the same list as a sidebar, transactions alongside.
+    private var splitLayout: some View {
+        NavigationSplitView {
+            withChrome {
+                if hasNoAccounts {
+                    emptyState
+                } else {
+                    List(selection: $selection) {
+                        Section {
+                            allAccountsRow
+                                .tag(AccountSelection.allAccounts)
+                        }
+
+                        if !onBudgetAccounts.isEmpty {
+                            Section("On Budget") {
+                                ForEach(onBudgetAccounts) { account in
+                                    AccountRow(account: account)
+                                        .tag(AccountSelection.account(account.id))
+                                }
+                            }
+                        }
+
+                        if !offBudgetAccounts.isEmpty {
+                            Section("Off Budget") {
+                                ForEach(offBudgetAccounts) { account in
+                                    AccountRow(account: account)
+                                        .tag(AccountSelection.account(account.id))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } detail: {
+            NavigationStack {
+                switch selection {
+                case .account(let id):
+                    // Resolved fresh from the store so the detail follows
+                    // balance changes, and degrades gracefully if the account
+                    // is closed or removed out from under the selection.
+                    if let account = budgetStore.accounts.first(where: { $0.id == id }) {
+                        AccountDetailView(account: account)
+                    } else {
+                        ContentUnavailableView(
+                            "Account Unavailable",
+                            systemImage: "banknote",
+                            description: Text("Pick another account from the list.")
+                        )
+                    }
+                case .allAccounts:
+                    TransactionsListView()
+                case nil:
+                    ContentUnavailableView(
+                        "No Account Selected",
+                        systemImage: "banknote",
+                        description: Text("Pick an account from the list.")
+                    )
+                }
+            }
+        }
+    }
+
+    private var hasNoAccounts: Bool {
+        budgetStore.accounts.isEmpty && !budgetStore.isLoading
+    }
+
+    private var allAccountsRow: some View {
+        HStack {
+            Text("All Accounts")
+                .font(.headline)
+            Spacer()
+            Text(budgetStore.displayBalance(totalBalance))
+                .font(.headline)
+                .foregroundColor(totalBalance > 0 ? .green : (totalBalance < 0 ? .red : .primary))
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if budgetStore.currentBudgetId != nil {
+            // A budget is loaded, it just has no accounts (yet) —
+            // "go connect a server" would be wrong advice here (GH #122).
+            ContentUnavailableView(
+                "No Accounts",
+                systemImage: "dollarsign.circle",
+                description: Text("This budget doesn't have any accounts yet. Create one in Actual Budget, then sync.")
+            )
+        } else if budgetStore.isConnected {
+            ContentUnavailableView(
+                "Select a Budget",
+                systemImage: "dollarsign.circle",
+                description: Text("You're connected. Choose a budget in Settings to load it here.")
+            )
+        } else {
+            ContentUnavailableView(
+                "No Budget Loaded",
+                systemImage: "dollarsign.circle",
+                description: Text("Go to Settings to connect to your Actual Budget server")
+            )
+        }
+    }
+
+    /// Everything both layouts hang off their account list: title, sync
+    /// status, notification routing, pull-to-refresh, loading overlay. Shared
+    /// so the two layouts can't drift apart.
+    private func withChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        Group(content: content)
+            .contentMargins(.horizontal, 6, for: .scrollContent)
+            .navigationTitle("Accounts")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    SyncStatusView(state: budgetStore.syncState)
+                }
             }
             .onAppear {
                 consumePendingAllAccountsNavigation()
@@ -114,8 +237,6 @@ struct AccountsListView: View {
                     ProgressView()
                 }
             }
-        }
-        .initialSyncBanner()
     }
 
     /// Tapping a success notification lands here: jump the stack straight to
@@ -124,7 +245,11 @@ struct AccountsListView: View {
     /// taps while this tab is already showing.
     private func consumePendingAllAccountsNavigation() {
         guard notificationRouter.pendingAllAccountsNavigation else { return }
-        path = NavigationPath([AllAccountsRoute()])
+        if usesSplitLayout {
+            selection = .allAccounts
+        } else {
+            path = NavigationPath([AllAccountsRoute()])
+        }
         notificationRouter.pendingAllAccountsNavigation = false
     }
 
@@ -137,7 +262,11 @@ struct AccountsListView: View {
         guard let accountId = notificationRouter.pendingAccountNavigation else { return }
         notificationRouter.pendingAccountNavigation = nil
         guard let account = budgetStore.accounts.first(where: { $0.id == accountId }) else { return }
-        path = NavigationPath([account])
+        if usesSplitLayout {
+            selection = .account(account.id)
+        } else {
+            path = NavigationPath([account])
+        }
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -268,6 +268,10 @@ struct BudgetView: View {
                                 }
                         )
                     }
+                    // The budget table is a fixed grid of narrow amount
+                    // columns; stretched to iPad width it becomes a category
+                    // name and its numbers separated by a foot of nothing.
+                    .readableWidth()
                     // The pinned summary sits outside the List, so paint the
                     // grouped background behind it to match.
                     .background(Color(.systemGroupedBackground).ignoresSafeArea())

--- a/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
+++ b/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
@@ -43,6 +43,7 @@ struct OverspentCategoriesView: View {
                 )
             }
         }
+        .readableWidth()
         .navigationTitle("Overspent Categories")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Actuali/Actuali/Views/Components/ReadableWidth.swift
+++ b/Actuali/Actuali/Views/Components/ReadableWidth.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// iPad width adaptations. Every one of these is gated on the horizontal size
+/// class being `.regular`, which is never true on iPhone — the app is
+/// portrait-locked there, so the phone layout is the reference and must not
+/// shift by a pixel. A narrow iPad window (Slide Over, a thin Split View
+/// pane) reports `.compact` too, and correctly gets the phone layout.
+extension EnvironmentValues {
+    /// Whether the window is wide enough for genuine side-by-side columns.
+    ///
+    /// Regular width isn't enough on its own: an 11-inch iPad in portrait
+    /// (834 pt) is regular, but a `NavigationSplitView` there collapses its
+    /// sidebar into an overlay drawer that slides out under the floating tab
+    /// bar — the header ends up behind it, and the tab-sidebar toggle has
+    /// nowhere useful to go. At 1024 pt (13-inch portrait) and up the columns
+    /// are real and both behave. Set once from the window in `ContentView`,
+    /// never from tab content, whose width shrinks when a sidebar expands —
+    /// measuring that would let the layout oscillate.
+    @Entry var isWideLayout = false
+}
+
+extension View {
+    /// Caps content width so a phone-shaped list doesn't stretch across 13
+    /// inches, centering what's left. `background` paints the gutters either
+    /// side: pass the colour the screen's own scroll content sits on, else
+    /// the clamped card region floats on the wrong shade.
+    ///
+    /// A no-op in compact width, and a no-op whenever the container is
+    /// already narrower than `maxWidth` (a sidebar-squeezed detail column,
+    /// an iPad page sheet), because `maxWidth` only ever shrinks.
+    func readableWidth(
+        _ maxWidth: CGFloat = 700,
+        background: Color = Color(.systemGroupedBackground)
+    ) -> some View {
+        modifier(ReadableWidth(maxWidth: maxWidth, background: background))
+    }
+}
+
+private struct ReadableWidth: ViewModifier {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    let maxWidth: CGFloat
+    let background: Color
+
+    func body(content: Content) -> some View {
+        if horizontalSizeClass == .regular {
+            content
+                .frame(maxWidth: maxWidth)
+                .frame(maxWidth: .infinity)
+                .background(background.ignoresSafeArea())
+        } else {
+            content
+        }
+    }
+}

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -4,6 +4,8 @@ struct MainTabView: View {
     @State private var selectedTab = initialTab()
     @StateObject private var notificationRouter = NotificationRouter.shared
     @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.isWideLayout) private var isWideLayout
 
     private static func initialTab() -> Int {
         #if DEBUG
@@ -31,38 +33,18 @@ struct MainTabView: View {
     }
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            AccountsListView()
-                .tabItem {
-                    Label("Accounts", systemImage: "banknote")
-                }
-                .tag(0)
-
-            BudgetView()
-                .tabItem {
-                    Label("Budget", systemImage: "wallet.bifold")
-                        .accessibilityValue(overspentBadgeValue)
-                }
-                .badge(overspentCount)
-                .tag(1)
-
-            AddTransactionTabView()
-                .tabItem {
-                    Label("Add", systemImage: "plus.circle.fill")
-                }
-                .tag(2)
-
-            ReportsTabView()
-                .tabItem {
-                    Label("Reports", systemImage: "chart.bar.xaxis")
-                }
-                .tag(3)
-
-            SettingsView()
-                .tabItem {
-                    Label("Settings", systemImage: "gear")
-                }
-                .tag(4)
+        Group {
+            // A wide iPad window (never iPhone) offers the sidebar as an
+            // alternative to the floating tab bar. Gated on width, not just on
+            // regular size class: in an 11-inch portrait window the sidebar
+            // has no room to sit beside the content, so the toggle only ever
+            // swaps the tab bar for a drawer over the top of it. Narrower
+            // windows — and every phone — keep the plain tab bar.
+            if horizontalSizeClass == .regular, isWideLayout {
+                tabs.tabViewStyle(.sidebarAdaptable)
+            } else {
+                tabs
+            }
         }
         .onChange(of: notificationRouter.pendingAllAccountsNavigation) { _, pending in
             if pending { selectedTab = 0 }
@@ -71,6 +53,49 @@ struct MainTabView: View {
         // transaction list, which lives on the Accounts tab.
         .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
             if accountId != nil { selectedTab = 0 }
+        }
+    }
+
+    /// The `Tab` value API rather than `tabItem`: `sidebarAdaptable` above only
+    /// takes effect for tabs declared this way. Renders identically to the
+    /// `tabItem` form in compact width.
+    private var tabs: some View {
+        TabView(selection: $selectedTab) {
+            Tab(value: 0) {
+                AccountsListView()
+            } label: {
+                Label("Accounts", systemImage: "banknote")
+            }
+
+            Tab(value: 1) {
+                BudgetView()
+            } label: {
+                Label("Budget", systemImage: "wallet.bifold")
+            }
+            .badge(overspentCount)
+            // On the tab, not its label: under the Tab API the tab's own
+            // modifiers are what reach the tab bar item. (Neither placement
+            // surfaces the value to XCUITest on iOS 26 — BudgetTabBadgeUITests
+            // fails on main for that reason, unrelated to this.)
+            .accessibilityValue(Text(overspentBadgeValue))
+
+            Tab(value: 2) {
+                AddTransactionTabView()
+            } label: {
+                Label("Add", systemImage: "plus.circle.fill")
+            }
+
+            Tab(value: 3) {
+                ReportsTabView()
+            } label: {
+                Label("Reports", systemImage: "chart.bar.xaxis")
+            }
+
+            Tab(value: 4) {
+                SettingsView()
+            } label: {
+                Label("Settings", systemImage: "gear")
+            }
         }
     }
 }

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DashboardView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     let widgets: [DashboardWidget]
 
     /// Report transactions fetched once per dashboard load and shared by all
@@ -30,6 +31,13 @@ struct DashboardView: View {
         }
     }
 
+    @ViewBuilder
+    private var widgetCards: some View {
+        ForEach(visibleWidgets, id: \.id) { widget in
+            widgetView(for: widget)
+        }
+    }
+
     var body: some View {
         if widgets.isEmpty {
             ContentUnavailableView(
@@ -39,12 +47,26 @@ struct DashboardView: View {
             )
         } else {
             ScrollView {
+                // Regular width (iPad, never iPhone) tiles the cards two-up
+                // rather than running one column down the middle. Adaptive
+                // rather than a fixed pair, so a card never gets squeezed
+                // below phone width in a narrow window or beside a sidebar —
+                // below ~660 pt of content the grid falls back to one column.
                 LazyVStack(spacing: 12) {
+                    // Full width above the cards rather than taking a grid
+                    // cell of its own — it describes the whole dashboard.
                     if hasUnsupportedWidgets {
                         UnsupportedTypesNotice()
                     }
-                    ForEach(visibleWidgets, id: \.id) { widget in
-                        widgetView(for: widget)
+                    if horizontalSizeClass == .regular {
+                        LazyVGrid(
+                            columns: [GridItem(.adaptive(minimum: 320), spacing: 12)],
+                            spacing: 12
+                        ) {
+                            widgetCards
+                        }
+                    } else {
+                        widgetCards
                     }
                 }
                 .padding(.horizontal, 6)

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -568,6 +568,7 @@ struct SettingsView: View {
                     Text("About")
                 }
             }
+            .readableWidth()
             .navigationTitle("Settings")
             .contentMargins(.horizontal, 6, for: .scrollContent)
             .task {

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -450,8 +450,14 @@ struct AddTransactionView: View {
                         }
                     }
                     .disabled(saveDisabled)
+                    // Hardware-keyboard commit, for the iPad case where the
+                    // form is filled without ever leaving the keys. Return on
+                    // its own belongs to the focused field; ⌘Return is the
+                    // whole form. Inert while the save is disabled.
+                    .keyboardShortcut(.return, modifiers: .command)
                 }
             }
+            .readableWidth()
             .navigationTitle(isEditing ? "Edit Transaction" : "Add Transaction")
             .listSectionSpacing(.compact)
             .scrollDismissesKeyboard(.interactively)
@@ -461,7 +467,9 @@ struct AddTransactionView: View {
                 // to dismiss to, so it shows none.
                 if isEditing || isPresented {
                     ToolbarItem(placement: .cancellationAction) {
+                        // Esc closes the form on a hardware keyboard.
                         Button("Cancel") { dismiss() }
+                            .keyboardShortcut(.cancelAction)
                     }
                 }
                 ToolbarItemGroup(placement: .keyboard) {

--- a/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
@@ -163,6 +163,7 @@ struct CategoryTransactionsView: View {
                 transactionsSection
             }
         }
+        .readableWidth()
         .navigationTitle(destination.categoryName)
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -89,6 +89,7 @@ struct TransactionsListView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
+        .readableWidth()
         .navigationTitle("All Accounts")
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
         .toolbar {

--- a/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
@@ -80,6 +80,7 @@ struct UncategorizedTransactionsView: View {
                 }
             }
         }
+        .readableWidth()
         .navigationTitle("Uncategorized")
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")

--- a/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
+++ b/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+/// Coverage for the iPad-only layouts. Skipped on iPhone, which keeps the
+/// compact tab-bar-and-push layout these assertions would contradict.
+final class IPadSplitLayoutUITests: XCTestCase {
+
+    /// Matches `ContentView.wideLayoutThreshold`: below it the iPad falls back
+    /// to the phone's push navigation, so an 11-inch portrait simulator skips
+    /// the split-view tests. Run them on a 13-inch, or in landscape.
+    private let wideLayoutThreshold: CGFloat = 1000
+
+    @MainActor
+    private func launch(initialTab: Int) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", String(initialTab)]
+        app.launch()
+        return app
+    }
+
+    @MainActor
+    private func launchWide(initialTab: Int) throws -> XCUIApplication {
+        let app = launch(initialTab: initialTab)
+        try XCTSkipUnless(
+            app.windows.firstMatch.frame.width >= wideLayoutThreshold,
+            "split layouts only; this window is too narrow for side-by-side columns"
+        )
+        return app
+    }
+
+    /// The Accounts tab shows its list beside the transactions rather than
+    /// pushing to them, and All Accounts is selected out of the gate so the
+    /// detail column is never empty.
+    @MainActor
+    func testAccountsOpenBesideTheListInsteadOfPushing() throws {
+        let app = try launchWide(initialTab: 0)
+
+        XCTAssertTrue(app.navigationBars["All Accounts"].waitForExistence(timeout: 15),
+                      "detail column should start on All Accounts")
+        // Both columns on screen at once: the sidebar's own title survives
+        // alongside the detail's.
+        XCTAssertTrue(app.navigationBars["Accounts"].exists,
+                      "sidebar should stay visible beside the detail")
+
+        // Selecting an account swaps the detail column in place.
+        let account = app.staticTexts["Chase Checking"].firstMatch
+        XCTAssertTrue(account.waitForExistence(timeout: 10))
+        account.tap()
+
+        XCTAssertTrue(app.navigationBars["Chase Checking"].waitForExistence(timeout: 10),
+                      "tapping an account should load it into the detail column")
+        XCTAssertTrue(app.navigationBars["Accounts"].exists,
+                      "the sidebar should still be there after selecting")
+    }
+
+    /// The detail column's rows follow the selection, not just its title: the
+    /// split layout reuses one `AccountDetailView`, and its paged transactions
+    /// used to be keyed to the account it was first built for — leaving the
+    /// previous account's rows under the new one's name and balance.
+    @MainActor
+    func testSelectingAnotherAccountReloadsItsTransactions() throws {
+        let app = try launchWide(initialTab: 0)
+
+        let chase = app.staticTexts["Chase Checking"].firstMatch
+        XCTAssertTrue(chase.waitForExistence(timeout: 15))
+        chase.tap()
+
+        // Payees unique to each account's demo transactions.
+        let chasePayee = app.staticTexts["Whole Foods"].firstMatch
+        XCTAssertTrue(chasePayee.waitForExistence(timeout: 10),
+                      "Chase's own transactions should load")
+
+        app.staticTexts["Apple Card"].firstMatch.tap()
+
+        let cardPayee = app.staticTexts["Blue Bottle Coffee"].firstMatch
+        XCTAssertTrue(cardPayee.waitForExistence(timeout: 10),
+                      "the newly selected account's transactions should load")
+        // The sidebar keeps both account names on screen, so assert on a payee
+        // that only the previous account had.
+        XCTAssertFalse(app.staticTexts["Whole Foods"].exists,
+                       "the previous account's rows should be gone")
+    }
+
+    /// The layout follows the window, not the device: an 11-inch iPad is too
+    /// narrow for columns in portrait and wide enough in landscape, and gets
+    /// the phone's push navigation in the former (where the split view's
+    /// sidebar would otherwise open as a drawer under the floating tab bar).
+    @MainActor
+    func testRotatingIntoLandscapeBringsUpTheSplitLayout() throws {
+        let app = launch(initialTab: 0)
+
+        XCTAssertTrue(app.staticTexts["Chase Checking"].waitForExistence(timeout: 15))
+        let portraitWidth = app.windows.firstMatch.frame.width
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        addTeardownBlock { XCUIDevice.shared.orientation = .portrait }
+
+        let landscapeWidth = app.windows.firstMatch.frame.width
+        try XCTSkipUnless(landscapeWidth > portraitWidth,
+                          "orientation is locked here; nothing to check")
+        try XCTSkipUnless(landscapeWidth >= wideLayoutThreshold,
+                          "still too narrow for side-by-side columns in landscape")
+
+        XCTAssertTrue(app.navigationBars["All Accounts"].waitForExistence(timeout: 10),
+                      "landscape should put the detail column beside the list")
+        XCTAssertTrue(app.navigationBars["Accounts"].exists,
+                      "the account list should stay on screen as a sidebar")
+    }
+
+    /// Regular width caps content width rather than stretching phone-shaped
+    /// rows edge to edge: the budget table stays narrower than the window.
+    @MainActor
+    func testBudgetTableIsWidthCapped() throws {
+        // Launched straight onto the tab: in the sidebar layout the tab
+        // controls aren't the tab-bar buttons the phone tests tap.
+        let app = launch(initialTab: 1)
+        // Capping applies at any regular width, not just wide enough for
+        // columns — it just needs a window wider than the 700 pt cap.
+        try XCTSkipUnless(app.windows.firstMatch.frame.width > 760,
+                          "nothing to cap; this window is narrower than the cap")
+
+        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        XCTAssertTrue(groceries.waitForExistence(timeout: 15), "budget rows should load")
+
+        let windowWidth = app.windows.firstMatch.frame.width
+        // The row's amount button sits at the table's trailing edge; if the
+        // table were full-bleed it would land within a hair of the window's.
+        let amount = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Edit budgeted amount for Groceries'")
+        ).firstMatch
+        XCTAssertTrue(amount.waitForExistence(timeout: 10))
+        XCTAssertLessThan(amount.frame.maxX, windowWidth - 40,
+                          "budget table should be capped, not stretched to the window edge")
+    }
+}


### PR DESCRIPTION
Makes the app universal. iPhone is untouched: every layout change here is gated on window width, which never gets wide on a portrait-locked phone.

## Build settings
- `TARGETED_DEVICE_FAMILY` → `1,2`
- All four orientations on iPad; iPhone stays portrait-only

## iPad layout
- **Readable width** — new `readableWidth()` modifier caps content instead of stretching phone-shaped rows across 13 inches, applied to the budget table, transaction lists, settings and the add form.
- **Dashboard grid** — report cards tile adaptively rather than running one column down the middle.
- **Accounts split view** — the account list sits beside its transactions.
- **Sidebar tab bar** — `.tabViewStyle(.sidebarAdaptable)`, which needed the tabs migrated to the `Tab` value API.
- **Keyboard** — ⌘↩ saves and Esc cancels in the add-transaction form.

The split view and the sidebar tab bar require a window ≥ 1000 pt, not just a regular size class. At 834 pt (11-inch portrait) there is no room for a second column, so the split view opens its sidebar as a drawer that slides under the floating tab bar — covering the sidebar's own header — and the sidebar toggle has nowhere useful to put it. Those windows keep the phone's tab bar and push navigation with width-capped content. Landscape and 13-inch portrait get the columns.

## Fix: stale rows in the split layout
`AccountDetailView` built its `TransactionPager` once, with the account id captured in the fetch closure, and reloaded only when the search text changed. One instance is reused across selections in the split layout, so the name and balance followed the selection while the transaction rows stayed on the account the view was first built for. It now tracks which account the pager belongs to and reloads on the account as well as the search.

## Verification
- 786 unit tests pass.
- Full iPhone UI suite: only the two pre-existing iOS 26 accessibility-value failures (`BudgetTabBadgeUITests`, `OverspentCategoriesUITests`), both of which fail on `main` too.
- New `IPadSplitLayoutUITests` (4 tests) pass on iPad Pro 13-inch, behave correctly on 11-inch portrait/landscape, and skip on iPhone. The stale-rows test was confirmed to fail against the unfixed code.
- iPhone screenshots for Accounts, Budget, Reports and Settings are byte-identical to a clean-`HEAD` build.

App Store screenshots for the iPad size classes still need capturing before submission.