### PR TITLE
Show the split remainder while entering lines; one-tap fill from the remainder

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -124,18 +124,15 @@ struct AddTransactionView: View {
         editing?.transferId == nil && (!isEditingSplitParent || unsplitRequested)
     }
 
-    /// Cents still unassigned across the split lines, nil while the total or
-    /// any line doesn't parse yet.
+    /// Cents still unassigned across the split lines, nil while the total
+    /// doesn't parse yet. Blank lines count as zero so the remainder stays
+    /// visible while the user is still filling lines in.
     private var splitRemainingCents: Int? {
-        guard let dollars = Double(amount),
-              let total = Transaction.cents(fromDollars: dollars) else { return nil }
-        var assigned = 0
-        for line in splitLines {
-            guard let lineDollars = Double(line.amount),
-                  let cents = Transaction.cents(fromDollars: lineDollars) else { return nil }
-            assigned += cents
-        }
-        return total - assigned
+        SplitEntryMath.remainingCents(total: amount, lineAmounts: splitLines.map(\.amount))
+    }
+
+    private var hasBlankSplitLine: Bool {
+        splitLines.contains { $0.amount.isEmpty }
     }
 
     /// Open accounts ordered to match the webapp's AccountAutocomplete:
@@ -516,7 +513,7 @@ struct AddTransactionView: View {
     private var splitEntrySection: some View {
         Section {
             ForEach($splitLines) { $line in
-                SplitLineRow(line: $line)
+                SplitLineRow(line: $line, remainingCents: splitRemainingCents)
             }
             .onDelete { offsets in
                 if isEditingSplitParent {
@@ -565,6 +562,11 @@ struct AddTransactionView: View {
         } footer: {
             if let remaining = splitRemainingCents, remaining != 0 {
                 Text("\(budgetStore.formatCurrency(remaining)) left to assign")
+                    .foregroundStyle(.red)
+            } else if splitRemainingCents == 0 && hasBlankSplitLine {
+                // Nothing left to assign but a line is still blank — say why
+                // Save stays disabled instead of leaving it a mystery.
+                Text("Fill in or remove the empty line")
                     .foregroundStyle(.red)
             }
         }
@@ -621,7 +623,9 @@ struct AddTransactionView: View {
     private var saveDisabled: Bool {
         if isLoading || amount.isEmpty { return true }
         if isTransfer && transferToAccountId == nil { return true }
-        if isSplitting && !isTransfer && splitRemainingCents != 0 { return true }
+        // A blank line reads as zero for the remainder display, but the store
+        // rejects zero-amount children — keep save blocked until it's filled.
+        if isSplitting && !isTransfer && (splitRemainingCents != 0 || hasBlankSplitLine) { return true }
         return false
     }
 
@@ -679,11 +683,38 @@ struct AddTransactionView: View {
     }
 }
 
+/// Math for the split entry section, kept off the view for testability.
+enum SplitEntryMath {
+    /// Cents still unassigned across the split lines. Blank lines count as
+    /// zero so the remainder stays visible mid-entry; nil while the total or
+    /// a non-blank line doesn't parse.
+    static func remainingCents(total: String, lineAmounts: [String]) -> Int? {
+        guard let dollars = Double(total),
+              let totalCents = Transaction.cents(fromDollars: dollars) else { return nil }
+        var assigned = 0
+        for amount in lineAmounts where !amount.isEmpty {
+            guard let lineDollars = Double(amount),
+                  let cents = Transaction.cents(fromDollars: lineDollars) else { return nil }
+            assigned += cents
+        }
+        return totalCents - assigned
+    }
+
+    /// Plain dot-decimal string for non-negative cents, the format
+    /// AmountInputField keeps in its binding.
+    static func amountString(fromCents cents: Int) -> String {
+        "\(cents / 100).\(String(format: "%02d", cents % 100))"
+    }
+}
+
 /// One editable split line: a category picked through a sheet and an amount.
 /// Borderless button so the amount field keeps its own tap target in the row.
 private struct SplitLineRow: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Binding var line: BudgetStore.SplitLineForm
+    /// The section-wide unassigned remainder; a positive value on a line with
+    /// no amount yet offers one-tap fill instead of mental arithmetic.
+    var remainingCents: Int?
     @State private var showCategoryPicker = false
 
     private var categoryName: String {
@@ -709,6 +740,18 @@ private struct SplitLineRow: View {
                 Spacer()
                 AmountInputField(text: $line.amount)
                     .frame(width: 110)
+            }
+            if line.amount.isEmpty, let remaining = remainingCents, remaining > 0 {
+                HStack {
+                    Spacer()
+                    Button {
+                        line.amount = SplitEntryMath.amountString(fromCents: remaining)
+                    } label: {
+                        Text("Use remaining \(budgetStore.formatCurrency(remaining))")
+                            .font(.subheadline)
+                    }
+                    .buttonStyle(.borderless)
+                }
             }
             // Empty payee inherits the transaction's payee
             TextField("Payee (optional)", text: $line.payeeName)

--- a/Actuali/ActualiTests/SplitEntryMathTests.swift
+++ b/Actuali/ActualiTests/SplitEntryMathTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import Actuali
+
+struct SplitEntryMathTests {
+    @Test func blankLinesCountAsZero() {
+        #expect(SplitEntryMath.remainingCents(total: "100", lineAmounts: ["20", "", "30.50"]) == 4950)
+    }
+
+    @Test func allBlankLinesLeaveFullTotal() {
+        #expect(SplitEntryMath.remainingCents(total: "62.18", lineAmounts: ["", ""]) == 6218)
+    }
+
+    @Test func zeroWhenFullyAssigned() {
+        #expect(SplitEntryMath.remainingCents(total: "50", lineAmounts: ["20", "30"]) == 0)
+    }
+
+    @Test func negativeWhenOverAssigned() {
+        #expect(SplitEntryMath.remainingCents(total: "50", lineAmounts: ["60"]) == -1000)
+    }
+
+    @Test func nilWhileTotalDoesNotParse() {
+        #expect(SplitEntryMath.remainingCents(total: "", lineAmounts: ["20"]) == nil)
+        #expect(SplitEntryMath.remainingCents(total: "abc", lineAmounts: ["20"]) == nil)
+    }
+
+    @Test func nilWhenNonBlankLineDoesNotParse() {
+        #expect(SplitEntryMath.remainingCents(total: "100", lineAmounts: ["1.2.3"]) == nil)
+    }
+
+    @Test func amountStringMatchesFieldFormat() {
+        #expect(SplitEntryMath.amountString(fromCents: 4950) == "49.50")
+        #expect(SplitEntryMath.amountString(fromCents: 5) == "0.05")
+        #expect(SplitEntryMath.amountString(fromCents: 100) == "1.00")
+        #expect(SplitEntryMath.amountString(fromCents: 1234) == "12.34")
+    }
+}


### PR DESCRIPTION
## What

Feedback from a TestFlight user: when splitting a transaction you can't see the remainder or assign it to a category, so the last line of a shopping trip takes hand arithmetic.

Two changes to the split entry section of the add/edit form:

- **The "left to assign" footer now stays visible mid-entry.** It previously disappeared whenever any line's amount was blank — exactly when you need it — because the remainder computation returned nil on the first unparseable line. Blank lines now count as zero.
- **One-tap remainder fill.** Any line with no amount yet shows a "Use remaining $X" button (when the remainder is positive) that fills that line with the unassigned remainder. Enter the small categories, add a line, pick Groceries, tap the button, save.

Save behavior is unchanged: it stays disabled while a line is blank (the store rejects zero-amount children), and the footer now says "Fill in or remove the empty line" when that's the only thing left, instead of silently disabling Save.

## How

The remainder math moved out of the view into `SplitEntryMath` (`remainingCents` + `amountString`), which also gives it unit coverage. `SplitLineRow` takes the section-wide remainder and offers the fill button on empty-amount lines.

## Testing

- New `SplitEntryMathTests` (7 tests): blank-line handling, over-assignment, unparseable totals/lines, cent→string formatting.
- Full `ActualiTests` suite: 797 tests in 115 suites, all passing on iPhone 17 / iOS 26.5 sim.