### PR TITLE
Add account notes

### DIFF
--- a/Actuali/Actuali/Models/Category.swift
+++ b/Actuali/Actuali/Models/Category.swift
@@ -9,31 +9,6 @@ struct Category: Identifiable, Hashable {
     var sortOrder: Int
 }
 
-/// A category's note, as stored in Actual's `notes` table (GH #131).
-///
-/// `supported` is false when the open budget file has no `notes` table at all
-/// — an older snapshot, or one whose migrations haven't caught up. The UI hides
-/// the note section in that case rather than offering an edit that could never
-/// save. Empty `text` means "no note": Actual stores a cleared note as an empty
-/// string rather than removing the row, so absent and cleared read the same.
-struct CategoryNote: Equatable {
-    var supported: Bool
-    var text: String
-
-    static let unsupported = CategoryNote(supported: false, text: "")
-
-    var isEmpty: Bool { text.isEmpty }
-
-    /// What to persist for text the user typed. Whitespace-only input clears
-    /// the note instead of storing blanks that would render as an empty-looking
-    /// note nobody can tell apart from none. Anything else is stored verbatim —
-    /// leading indentation and blank lines inside a multi-line note are
-    /// deliberate and must survive the round trip.
-    static func normalizedForSave(_ text: String) -> String {
-        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "" : text
-    }
-}
-
 struct CategoryGroup: Identifiable, Hashable {
     let id: String
     var name: String

--- a/Actuali/Actuali/Models/EntityNote.swift
+++ b/Actuali/Actuali/Models/EntityNote.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The note attached to one row of the budget, as stored in Actual's `notes`
+/// table — categories (GH #131) and accounts (GH #198) alike. The table is
+/// keyed by the annotated row's own id, so one model covers both rather than a
+/// per-entity copy that could drift.
+///
+/// `supported` is false when the open budget file has no `notes` table at all
+/// — an older snapshot, or one whose migrations haven't caught up. The UI hides
+/// the note affordance in that case rather than offering an edit that could
+/// never save. Empty `text` means "no note": Actual stores a cleared note as an
+/// empty string rather than removing the row, so absent and cleared read the
+/// same.
+struct EntityNote: Equatable {
+    var supported: Bool
+    var text: String
+
+    static let unsupported = EntityNote(supported: false, text: "")
+
+    var isEmpty: Bool { text.isEmpty }
+
+    /// What to persist for text the user typed. Whitespace-only input clears
+    /// the note instead of storing blanks that would render as an empty-looking
+    /// note nobody can tell apart from none. Anything else is stored verbatim —
+    /// leading indentation and blank lines inside a multi-line note are
+    /// deliberate and must survive the round trip.
+    static func normalizedForSave(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "" : text
+    }
+
+    /// The `notes.id` an account's note lives at.
+    ///
+    /// Accounts are the exception to "keyed by the row's own id": Actual
+    /// prefixes them (`account-${account.id}` in desktop-client's account
+    /// Header, sidebar Account, AccountMenuModal and mobile AccountPage), while
+    /// categories and category groups use the bare id. Reading or writing the
+    /// unprefixed id would put Actuali's account notes somewhere Actual never
+    /// looks — invisible in both directions.
+    static func accountNoteId(_ accountId: String) -> String {
+        "account-\(accountId)"
+    }
+}

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2868,30 +2868,31 @@ final class BudgetStore: ObservableObject {
         await fetchBudgetMonth(month)
     }
 
-    // MARK: - Category Notes
+    // MARK: - Notes
 
-    /// Load a category's note (GH #131). Reported as `.unsupported` when no
-    /// budget file is open, the file has no `notes` table, or the read fails —
-    /// the note section hides itself in all three cases, which is the right
-    /// outcome for each and beats surfacing a banner over a secondary field.
-    func fetchCategoryNote(categoryId: String) async -> CategoryNote {
+    /// Load the note for a category (GH #131) or account (GH #198), keyed by
+    /// that row's id. Reported as `.unsupported` when no budget file is open,
+    /// the file has no `notes` table, or the read fails — the note affordance
+    /// hides itself in all three cases, which is the right outcome for each and
+    /// beats surfacing a banner over a secondary field.
+    func fetchNote(id: String) async -> EntityNote {
         guard let database else { return .unsupported }
         do {
-            return try await database.fetchCategoryNote(categoryId: categoryId)
+            return try await database.fetchNote(id: id)
         } catch {
-            logger.error("Failed to read category note: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to read note: \(error.localizedDescription, privacy: .public)")
             return .unsupported
         }
     }
 
-    /// Save a category's note, syncing back to Actual (GH #131). An empty
-    /// string clears it. Throws so the caller can keep the editor open and show
-    /// the failure rather than silently dropping what the user typed.
-    func saveCategoryNote(categoryId: String, note: String) async throws {
+    /// Save a note, syncing back to Actual (GH #131, #198). An empty string
+    /// clears it. Throws so the caller can keep the editor open and show the
+    /// failure rather than silently dropping what the user typed.
+    func saveNote(id: String, note: String) async throws {
         guard let syncClient else {
             throw BudgetStoreError.syncNotConfigured
         }
-        try await syncClient.setNote(id: categoryId, note: note)
+        try await syncClient.setNote(id: id, note: note)
     }
 
     // MARK: - Currency Formatting

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1339,22 +1339,23 @@ class BudgetDatabase {
 
     // MARK: - Notes
 
-    /// The note stored for a category (GH #131). Actual's `notes` table is
-    /// keyed by the annotated row's own id, so a category's note lives at
-    /// `notes.id = <categoryId>`.
+    /// The note stored for one row of the budget — a category (GH #131) or an
+    /// account (GH #198). Actual's `notes` table is keyed by the annotated
+    /// row's own id, so the note lives at `notes.id = <the row's id>` whatever
+    /// kind of row it is.
     ///
     /// One read reports both whether the file has the table and what it holds,
     /// so the caller can distinguish "this file can't store notes" from "this
-    /// category has none" without a second round trip or a cached capability
-    /// flag that could go stale when the open file changes.
-    func fetchCategoryNote(categoryId: String) async throws -> CategoryNote {
+    /// row has none" without a second round trip or a cached capability flag
+    /// that could go stale when the open file changes.
+    func fetchNote(id: String) async throws -> EntityNote {
         try await dbQueue.read { db in
             guard try db.tableExists("notes") else { return .unsupported }
             // A row can exist with a NULL note (another client cleared it that
             // way); that reads as empty, same as no row at all.
             let note = try String.fetchOne(
-                db, sql: "SELECT note FROM notes WHERE id = ?", arguments: [categoryId])
-            return CategoryNote(supported: true, text: note ?? "")
+                db, sql: "SELECT note FROM notes WHERE id = ?", arguments: [id])
+            return EntityNote(supported: true, text: note ?? "")
         }
     }
 

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -318,6 +318,13 @@ enum DemoDataSeeder {
             Cap $250/mo.
             [Rewards portal](https://example.com/rewards)
             """)
+        // One account arrives annotated so the account note (GH #198) shows in
+        // the demo budget, same reasoning. Note the "account-" prefix: that's
+        // the key Actual itself uses for account notes.
+        try insertNote(db, id: EntityNote.accountNoteId(chaseId), note: """
+            Direct deposit lands here on the 15th; \
+            keep a $500 buffer for the card autopay.
+            """)
 
         // --- Payees ---
         let wholeFoodsId = UUID().uuidString

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -16,6 +16,10 @@ struct AccountDetailView: View {
     @State private var showingReconcile = false
     @State private var showingWalletImport = false
     @State private var editingTransaction: Transaction?
+    /// The account's note (GH #198). Starts `.unsupported` so the menu item
+    /// stays hidden until the read confirms this file can store notes.
+    @State private var note: EntityNote = .unsupported
+    @State private var editingNote = false
 
     private var currentBalance: Int {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
@@ -47,7 +51,57 @@ struct AccountDetailView: View {
 
     private func reload() async {
         breakdown = await budgetStore.balanceBreakdown(accountId: account.id)
+        await reloadNote()
         await currentPager().loadFirstPage(search: searchQuery)
+    }
+
+    private func reloadNote() async {
+        note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
+    }
+
+    /// The account's note (GH #198), presented exactly as a category's is (see
+    /// CategoryTransactionsView): visible without digging, tap to edit. Hidden
+    /// while searching — a search is about finding transactions, not reading
+    /// guidance — and on files with no `notes` table, where an edit could never
+    /// save.
+    private var noteSection: some View {
+        Section("Note") {
+            if note.isEmpty {
+                Button {
+                    editingNote = true
+                } label: {
+                    // Tinted: an empty note row is an invitation to act, where
+                    // an existing note is content to read.
+                    Label("Add Note", systemImage: "note.text.badge.plus")
+                        .foregroundStyle(Color.accentColor)
+                }
+                // Plain: a tinted List button would tint the label twice over.
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("accountNoteRow")
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    // Attributed so markdown links and bare URLs in the note
+                    // are tappable (GH #190). That's also why this row is a
+                    // tap gesture rather than the Button the empty state uses:
+                    // a Button label swallows link taps, where links inside a
+                    // gesture-carrying row take precedence over the gesture.
+                    Text(NoteLinkText.attributed(note.text))
+                        .multilineTextAlignment(.leading)
+                        // Multi-line notes are the point — let the row grow
+                        // instead of truncating the guidance to one line.
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "pencil")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { editingNote = true }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityIdentifier("accountNoteRow")
+            }
+        }
     }
 
     private func breakdownRow(_ title: String, amount: Int) -> some View {
@@ -93,6 +147,10 @@ struct AccountDetailView: View {
                     breakdownRow("Uncleared", amount: breakdown.uncleared)
                     breakdownRow("Reconciled", amount: breakdown.reconciled)
                 }
+            }
+
+            if note.supported && searchQuery == nil {
+                noteSection
             }
 
             Section("Recent Transactions") {
@@ -188,6 +246,18 @@ struct AccountDetailView: View {
         .sheet(item: $editingTransaction) { transaction in
             AddTransactionView(editing: transaction)
                 .environmentObject(budgetStore)
+        }
+        .sheet(isPresented: $editingNote, onDismiss: {
+            // Only the note needs re-reading — a note save doesn't touch
+            // transactions or the balance.
+            Task { await reloadNote() }
+        }) {
+            NoteEditorView(
+                noteId: EntityNote.accountNoteId(account.id),
+                title: account.name,
+                note: note.text
+            )
+            .environmentObject(budgetStore)
         }
         // Keyed on the account as well as the search: selecting another
         // account in the iPad split layout reuses this view, and without the

--- a/Actuali/Actuali/Views/Components/NoteEditorView.swift
+++ b/Actuali/Actuali/Views/Components/NoteEditorView.swift
@@ -1,23 +1,30 @@
 import SwiftUI
 
-/// Editor for one category's note (GH #131), presented as a sheet from the
-/// category detail view. Saving writes through to Actual; a failure keeps the
-/// sheet open with the text intact so nothing the user typed is lost.
-struct CategoryNoteEditorView: View {
+/// Editor for one row's note — a category (GH #131) or an account (GH #198) —
+/// presented as a sheet from that row's detail view. Saving writes through to
+/// Actual; a failure keeps the sheet open with the text intact so nothing the
+/// user typed is lost.
+///
+/// One editor serves every annotated entity because Actual's `notes` table is
+/// keyed by the annotated row's id: the only things that differ per entity are
+/// the id to write and the name to put in the title.
+struct NoteEditorView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
 
-    let categoryId: String
-    let categoryName: String
+    /// The annotated row's id — a category id or an account id.
+    let noteId: String
+    /// Shown as the sheet's title, so the user can see what they're annotating.
+    let title: String
 
     @State private var text: String
     @State private var isSaving = false
     @State private var saveError: String?
     @FocusState private var editorFocused: Bool
 
-    init(categoryId: String, categoryName: String, note: String) {
-        self.categoryId = categoryId
-        self.categoryName = categoryName
+    init(noteId: String, title: String, note: String) {
+        self.noteId = noteId
+        self.title = title
         _text = State(initialValue: note)
     }
 
@@ -28,7 +35,7 @@ struct CategoryNoteEditorView: View {
                     TextEditor(text: $text)
                         .frame(minHeight: 160)
                         .focused($editorFocused)
-                        .accessibilityIdentifier("categoryNoteEditor")
+                        .accessibilityIdentifier("noteEditor")
                     // Links stay openable mid-edit (GH #190); the editor text
                     // itself has to remain plain to stay editable.
                     NoteLinkRows(text: text)
@@ -41,7 +48,7 @@ struct CategoryNoteEditorView: View {
                     }
                 }
             }
-            .navigationTitle(categoryName)
+            .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -55,7 +62,7 @@ struct CategoryNoteEditorView: View {
                         Button("Save") {
                             Task { await save() }
                         }
-                        .accessibilityIdentifier("saveCategoryNote")
+                        .accessibilityIdentifier("saveNote")
                     }
                 }
             }
@@ -69,9 +76,9 @@ struct CategoryNoteEditorView: View {
         isSaving = true
         saveError = nil
         do {
-            try await budgetStore.saveCategoryNote(
-                categoryId: categoryId,
-                note: CategoryNote.normalizedForSave(text)
+            try await budgetStore.saveNote(
+                id: noteId,
+                note: EntityNote.normalizedForSave(text)
             )
             dismiss()
         } catch {
@@ -82,9 +89,9 @@ struct CategoryNoteEditorView: View {
 }
 
 #Preview {
-    CategoryNoteEditorView(
-        categoryId: "cat-1",
-        categoryName: "Food",
+    NoteEditorView(
+        noteId: "cat-1",
+        title: "Food",
         note: "Cap at $400/mo — fuel comes out of Transport."
     )
     .environmentObject(BudgetStore.previewInstance())

--- a/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
@@ -24,7 +24,7 @@ struct CategoryTransactionsView: View {
     @State private var editingTransaction: Transaction?
     /// Starts `.unsupported` so the section stays hidden until the read
     /// confirms this file can store notes (GH #131).
-    @State private var note: CategoryNote = .unsupported
+    @State private var note: EntityNote = .unsupported
     @State private var editingNote = false
 
     private var scopeTitle: String {
@@ -181,9 +181,9 @@ struct CategoryTransactionsView: View {
         .sheet(isPresented: $editingNote, onDismiss: {
             Task { await reloadNote() }
         }) {
-            CategoryNoteEditorView(
-                categoryId: destination.categoryId,
-                categoryName: destination.categoryName,
+            NoteEditorView(
+                noteId: destination.categoryId,
+                title: destination.categoryName,
                 note: note.text
             )
             .environmentObject(budgetStore)
@@ -200,7 +200,7 @@ struct CategoryTransactionsView: View {
     }
 
     private func reloadNote() async {
-        note = await budgetStore.fetchCategoryNote(categoryId: destination.categoryId)
+        note = await budgetStore.fetchNote(id: destination.categoryId)
     }
 }
 

--- a/Actuali/ActualiTests/BudgetDatabaseNoteTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseNoteTests.swift
@@ -3,10 +3,10 @@ import GRDB
 import Testing
 @testable import Actuali
 
-/// Reading category notes out of Actual's `notes` table (GH #131). The table
-/// is keyed by the annotated row's own id, so a category's note lives at
-/// `notes.id = <categoryId>`.
-struct BudgetDatabaseCategoryNoteTests {
+/// Reading notes out of Actual's `notes` table — categories (GH #131) and
+/// accounts (GH #198). The table is keyed by the annotated row's own id, so a
+/// note lives at `notes.id = <that row's id>` whatever kind of row it is.
+struct BudgetDatabaseNoteTests {
 
     /// A budget file with (or deliberately without) the `notes` table.
     /// `seedSQL` inserts rows once the schema is in place.
@@ -38,7 +38,7 @@ struct BudgetDatabaseCategoryNoteTests {
             """)
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(note.supported)
         #expect(note.text == "Cap at $400/mo")
@@ -54,7 +54,7 @@ struct BudgetDatabaseCategoryNoteTests {
             """)
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(note.text.contains("\n"))
     }
@@ -65,7 +65,7 @@ struct BudgetDatabaseCategoryNoteTests {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(note.supported)
         #expect(note.text.isEmpty)
@@ -80,7 +80,7 @@ struct BudgetDatabaseCategoryNoteTests {
             """)
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(note.supported)
         #expect(note.text.isEmpty)
@@ -94,7 +94,7 @@ struct BudgetDatabaseCategoryNoteTests {
             """)
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(note.text.isEmpty)
     }
@@ -106,7 +106,7 @@ struct BudgetDatabaseCategoryNoteTests {
         let (database, path) = try makeDatabase(includeNotesTable: false)
         defer { cleanup(path) }
 
-        let note = try await database.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = try await database.fetchNote(id: "cat-groceries")
 
         #expect(!note.supported)
         #expect(note.text.isEmpty)

--- a/Actuali/ActualiTests/BudgetStoreNoteTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreNoteTests.swift
@@ -3,10 +3,11 @@ import GRDB
 import Testing
 @testable import Actuali
 
-/// Saving category notes back to Actual (GH #131): the local row is written
-/// optimistically and a `notes`/`note` CRDT message is queued for the server.
+/// Saving notes back to Actual — categories (GH #131) and accounts (GH #198):
+/// the local row is written optimistically and a `notes`/`note` CRDT message is
+/// queued for the server.
 @MainActor
-struct BudgetStoreCategoryNoteTests {
+struct BudgetStoreNoteTests {
 
     /// The `notes` table plus messages_crdt for the sync write path. Both
     /// normally come from the downloaded budget file.
@@ -70,14 +71,14 @@ struct BudgetStoreCategoryNoteTests {
     // MARK: - Save normalization (pure)
 
     @Test func whitespaceOnlyNoteNormalizesToCleared() {
-        #expect(CategoryNote.normalizedForSave("   \n  ") == "")
-        #expect(CategoryNote.normalizedForSave("") == "")
+        #expect(EntityNote.normalizedForSave("   \n  ") == "")
+        #expect(EntityNote.normalizedForSave("") == "")
     }
 
     /// Indentation and blank lines inside a real note are deliberate — only
     /// entirely-blank input is treated as a clear.
     @Test func realNoteIsStoredVerbatim() {
-        #expect(CategoryNote.normalizedForSave("  Cap at $400\n\n    - fuel separate  ")
+        #expect(EntityNote.normalizedForSave("  Cap at $400\n\n    - fuel separate  ")
                 == "  Cap at $400\n\n    - fuel separate  ")
     }
 
@@ -90,7 +91,7 @@ struct BudgetStoreCategoryNoteTests {
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Cap at $400/mo")
+        try await store.saveNote(id: "cat-groceries", note: "Cap at $400/mo")
 
         let rows = try noteRows(path)
         #expect(rows.count == 1)
@@ -112,9 +113,9 @@ struct BudgetStoreCategoryNoteTests {
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Weekly shop only")
+        try await store.saveNote(id: "cat-groceries", note: "Weekly shop only")
 
-        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = await store.fetchNote(id: "cat-groceries")
         #expect(note.supported)
         #expect(note.text == "Weekly shop only")
     }
@@ -128,7 +129,7 @@ struct BudgetStoreCategoryNoteTests {
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "new note")
+        try await store.saveNote(id: "cat-groceries", note: "new note")
 
         let rows = try noteRows(path)
         #expect(rows.count == 1)
@@ -140,9 +141,9 @@ struct BudgetStoreCategoryNoteTests {
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "Line one\nLine two")
+        try await store.saveNote(id: "cat-groceries", note: "Line one\nLine two")
 
-        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = await store.fetchNote(id: "cat-groceries")
         #expect(note.text == "Line one\nLine two")
     }
 
@@ -156,7 +157,7 @@ struct BudgetStoreCategoryNoteTests {
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        try await store.saveCategoryNote(categoryId: "cat-groceries", note: "")
+        try await store.saveNote(id: "cat-groceries", note: "")
 
         let rows = try noteRows(path)
         #expect(rows.count == 1)
@@ -166,8 +167,75 @@ struct BudgetStoreCategoryNoteTests {
         #expect(messages.count == 1)
         #expect(messages.first?["value"] == "S:")
 
-        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = await store.fetchNote(id: "cat-groceries")
         #expect(note.isEmpty)
+    }
+
+    // MARK: - Account notes
+
+    /// Account notes are keyed `account-<id>`, not the bare account id — that's
+    /// the key Actual's own clients read and write (GH #198). Get this wrong and
+    /// the note is invisible in both directions: Actual's notes never show in
+    /// Actuali, and Actuali's never show in Actual.
+    @Test func accountNoteIdCarriesActualsAccountPrefix() {
+        #expect(EntityNote.accountNoteId("abc-123") == "account-abc-123")
+    }
+
+    /// An account's note goes through the same table and the same write path as
+    /// a category's, at the prefixed key — nothing about the save is
+    /// category-specific, and this pins the key down end to end.
+    @Test func savingAccountNoteWritesRowKeyedByPrefixedAccountId() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        let noteId = EntityNote.accountNoteId("acct-chase")
+        try await store.saveNote(id: noteId, note: "Direct deposit on the 15th")
+
+        let rows = try noteRows(path)
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
+        #expect(row["id"] == "account-acct-chase")
+        #expect(row["note"] == "Direct deposit on the 15th")
+
+        let messages = try noteMessages(path)
+        #expect(messages.count == 1)
+        #expect(messages.first?["row"] == "account-acct-chase")
+
+        let note = await store.fetchNote(id: noteId)
+        #expect(note.supported)
+        #expect(note.text == "Direct deposit on the 15th")
+    }
+
+    /// An account note written by Actual's web/desktop UI reads back in
+    /// Actuali — the case the feature request was actually about.
+    @Test func readsAccountNoteWrittenByActual() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('account-acct-chase', 'Buffer $500');
+            """)
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        let note = await store.fetchNote(id: EntityNote.accountNoteId("acct-chase"))
+        #expect(note.supported)
+        #expect(note.text == "Buffer $500")
+    }
+
+    /// A category and an account annotated in the same file keep separate
+    /// rows — ids are the only key, so neither edit can clobber the other.
+    /// Actual's prefix also means an account and a category can never collide
+    /// even if a file somehow reused an id.
+    @Test func accountAndCategoryNotesAreIndependent() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO notes (id, note) VALUES ('cat-groceries', 'Cap at $400/mo');
+            """)
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveNote(id: EntityNote.accountNoteId("acct-chase"), note: "Buffer $500")
+
+        #expect(await store.fetchNote(id: "cat-groceries").text == "Cap at $400/mo")
+        #expect(await store.fetchNote(id: EntityNote.accountNoteId("acct-chase")).text == "Buffer $500")
     }
 
     // MARK: - Unsupported files and misconfiguration
@@ -180,7 +248,7 @@ struct BudgetStoreCategoryNoteTests {
         let store = try await makeStore(database: database)
 
         await #expect(throws: SyncError.notesTableMissing) {
-            try await store.saveCategoryNote(categoryId: "cat-groceries", note: "nope")
+            try await store.saveNote(id: "cat-groceries", note: "nope")
         }
 
         #expect(try noteMessages(path).isEmpty)
@@ -190,14 +258,14 @@ struct BudgetStoreCategoryNoteTests {
         let store = BudgetStore.previewInstance()
 
         await #expect(throws: BudgetStoreError.syncNotConfigured) {
-            try await store.saveCategoryNote(categoryId: "cat-groceries", note: "nope")
+            try await store.saveNote(id: "cat-groceries", note: "nope")
         }
     }
 
     @Test func fetchWithoutDatabaseIsUnsupported() async throws {
         let store = BudgetStore.previewInstance()
 
-        let note = await store.fetchCategoryNote(categoryId: "cat-groceries")
+        let note = await store.fetchNote(id: "cat-groceries")
         #expect(!note.supported)
     }
 }

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -112,7 +112,7 @@ struct DemoDataSeederTests {
 
         let groceries = try #require(
             groups.flatMap(\.categories).first { $0.name == "Groceries" })
-        let note = try await database.fetchCategoryNote(categoryId: groceries.id)
+        let note = try await database.fetchNote(id: groceries.id)
 
         #expect(note.supported)
         #expect(note.text.contains("Target $650/mo"))
@@ -125,7 +125,36 @@ struct DemoDataSeederTests {
         let groups = try await database.fetchCategoryGroups()
 
         let rent = try #require(groups.flatMap(\.categories).first { $0.name == "Rent" })
-        let note = try await database.fetchCategoryNote(categoryId: rent.id)
+        let note = try await database.fetchNote(id: rent.id)
+
+        #expect(note.supported)
+        #expect(note.isEmpty)
+    }
+
+    /// One demo account ships annotated too (GH #198), so the account note
+    /// menu item opens onto something in demo mode rather than an empty sheet.
+    @Test func seededBudgetShipsAnAnnotatedAccount() async throws {
+        let database = try seedAndOpen()
+        let accounts = try await database.fetchAccounts()
+
+        let checking = try #require(accounts.first { $0.name == "Chase Checking" })
+        let note = try await database.fetchNote(id: EntityNote.accountNoteId(checking.id))
+
+        #expect(note.supported)
+        #expect(note.text.contains("Direct deposit"))
+        // Seeded at Actual's key, so the bare id holds nothing — the demo
+        // budget mirrors a real file rather than papering over the prefix.
+        #expect(try await database.fetchNote(id: checking.id).isEmpty)
+    }
+
+    /// Accounts nobody has annotated read as empty-but-supported, so the menu
+    /// offers "Add Note" instead of hiding.
+    @Test func unannotatedAccountsSupportNotes() async throws {
+        let database = try seedAndOpen()
+        let accounts = try await database.fetchAccounts()
+
+        let savings = try #require(accounts.first { $0.name == "Ally Savings" })
+        let note = try await database.fetchNote(id: EntityNote.accountNoteId(savings.id))
 
         #expect(note.supported)
         #expect(note.isEmpty)

--- a/Actuali/ActualiUITests/AccountNotesUITests.swift
+++ b/Actuali/ActualiUITests/AccountNotesUITests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+/// End-to-end check for account notes (GH #198).
+///
+/// The demo budget's seeded Chase Checking note must be visible on the account
+/// detail view without any digging — the same treatment a category's note gets
+/// — and an edit typed into the app must come back on the row after saving,
+/// proving the read, the write and the refresh are wired together.
+final class AccountNotesUITests: XCTestCase {
+
+    @MainActor
+    private func openAccount(_ name: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        app.tabBars.buttons["Accounts"].tap()
+        let account = app.staticTexts[name].firstMatch
+        XCTAssertTrue(account.waitForExistence(timeout: 10), "\(name) row not found")
+        account.tap()
+        return app
+    }
+
+    @MainActor
+    func testViewsAndEditsAccountNote() throws {
+        let app = openAccount("Chase Checking")
+
+        // The note shows on the detail view, above the transactions.
+        let noteRow = app.buttons["accountNoteRow"]
+        XCTAssertTrue(noteRow.waitForExistence(timeout: 10), "note row not shown")
+        XCTAssertTrue(noteRow.label.contains("Direct deposit"),
+                      "seeded note not displayed, row read: \(noteRow.label)")
+        attachScreenshot(app, name: "1-account-note")
+
+        // Tapping opens the editor, already focused so typing lands in it.
+        noteRow.tap()
+        let editor = app.textViews["noteEditor"]
+        XCTAssertTrue(editor.waitForExistence(timeout: 10), "note editor not shown")
+        attachScreenshot(app, name: "2-account-note-editor")
+
+        editor.typeText("checked")
+
+        let save = app.buttons["saveNote"]
+        XCTAssertTrue(save.waitForExistence(timeout: 10), "Save button not shown")
+        save.tap()
+        XCTAssertTrue(editor.waitForNonExistence(timeout: 10), "note editor did not dismiss")
+
+        // The edit is reflected on the row, and the original text survives —
+        // this is an edit, not a replacement (cursor position is the
+        // keyboard's business, so only containment is asserted).
+        let updated = app.buttons["accountNoteRow"]
+        XCTAssertTrue(updated.waitForExistence(timeout: 10), "note row gone after save")
+        XCTAssertTrue(updated.label.contains("checked"),
+                      "typed text missing after save, row read: \(updated.label)")
+        XCTAssertTrue(updated.label.contains("Direct deposit"),
+                      "original note lost on save, row read: \(updated.label)")
+        attachScreenshot(app, name: "3-account-note-edited")
+    }
+
+    /// An account nobody has annotated offers "Add Note" rather than a blank
+    /// row — and rather than hiding, which is reserved for files whose schema
+    /// can't store notes at all.
+    @MainActor
+    func testUnannotatedAccountOffersAddNote() throws {
+        let app = openAccount("Ally Savings")
+
+        let noteRow = app.buttons["accountNoteRow"]
+        XCTAssertTrue(noteRow.waitForExistence(timeout: 10), "note row not shown")
+        XCTAssertTrue(noteRow.label.contains("Add Note"),
+                      "empty note did not offer Add Note, row read: \(noteRow.label)")
+        attachScreenshot(app, name: "4-account-add-note")
+    }
+
+    @MainActor
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Actuali/ActualiUITests/CategoryNotesUITests.swift
+++ b/Actuali/ActualiUITests/CategoryNotesUITests.swift
@@ -38,13 +38,13 @@ final class CategoryNotesUITests: XCTestCase {
 
         // Tapping opens the editor, already focused so typing lands in it.
         noteRow.tap()
-        let editor = app.textViews["categoryNoteEditor"]
+        let editor = app.textViews["noteEditor"]
         XCTAssertTrue(editor.waitForExistence(timeout: 5), "note editor not shown")
         attachScreenshot(app, name: "2-note-editor")
 
         editor.typeText("checked")
 
-        let save = app.buttons["saveCategoryNote"]
+        let save = app.buttons["saveNote"]
         XCTAssertTrue(save.waitForExistence(timeout: 5), "Save button not shown")
         save.tap()
         XCTAssertTrue(editor.waitForNonExistence(timeout: 5), "note editor did not dismiss")

--- a/Actuali/ActualiUITests/NoteLinksUITests.swift
+++ b/Actuali/ActualiUITests/NoteLinksUITests.swift
@@ -40,7 +40,7 @@ final class NoteLinksUITests: XCTestCase {
         // line 2) still opens the editor: links must not cost the row its
         // tap-to-edit.
         noteRow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
-        let editor = app.textViews["categoryNoteEditor"]
+        let editor = app.textViews["noteEditor"]
         XCTAssertTrue(editor.waitForExistence(timeout: 5), "note editor did not open")
 
         // The editor surfaces the draft's link as a tappable row beneath the


### PR DESCRIPTION
Accounts in Actual can carry notes; Actuali had no way to see or edit them.

## What changed

Actual's `notes` table is keyed by the annotated row's own id, so the category-note stack (GH #131) already did everything account notes need except be named for categories. Generalized rather than duplicated:

- `CategoryNote` → `EntityNote` (new `Models/EntityNote.swift`)
- `BudgetDatabase.fetchCategoryNote(categoryId:)` → `fetchNote(id:)`
- `BudgetStore.fetchCategoryNote/saveCategoryNote` → `fetchNote(id:)` / `saveNote(id:note:)`
- `CategoryNoteEditorView` → shared `Views/Components/NoteEditorView.swift` (accessibility ids `noteEditor` / `saveNote`)

**Account notes are keyed differently in Actual**, which this handles: accounts live at `notes.id = "account-<accountId>"` (`desktop-client`'s account `Header.tsx`, sidebar `Account.tsx`, `AccountMenuModal.tsx` and mobile `AccountPage.tsx` all agree), where categories and groups use the bare id. `EntityNote.accountNoteId(_:)` builds that key, so a note written in Actual's web/desktop UI shows up here and an edit made here shows up there. Reading the unprefixed id would have made the note invisible in both directions.

On top of that, `AccountDetailView` shows the account's note the same way `CategoryTransactionsView` shows a category's: a **Note** section above the transactions, tap to edit, "Add Note" when there isn't one. The issue suggested the ⋯ menu, but matching the category treatment keeps one pattern for notes across the app and makes the note visible without digging — which was the actual complaint. Markdown links and bare URLs in the note stay tappable (GH #190). The section hides while searching, and on budget files with no `notes` table, where an edit could never save. Saving goes out as a `notes`/`note` CRDT message, so it syncs back to Actual like any other write.

The demo budget now ships an annotated account (Chase Checking), matching the seeded Groceries category note, so the feature is visible in demo mode and UI-testable.

## How it was verified

Unit suite (`-only-testing:ActualiTests`, iPhone 17 / iOS 26.5):

```
✔ Test run with 811 tests in 116 suites passed after 3.989 seconds.
** TEST SUCCEEDED **
```

New coverage, all passing:

```
✔ Test accountNoteIdCarriesActualsAccountPrefix() passed after 3.120 seconds.
✔ Test savingAccountNoteWritesRowKeyedByPrefixedAccountId() passed after 3.187 seconds.
✔ Test readsAccountNoteWrittenByActual() passed after 2.904 seconds.
✔ Test accountAndCategoryNotesAreIndependent() passed after 3.360 seconds.
✔ Test seededBudgetShipsAnAnnotatedAccount() passed after 0.018 seconds.
✔ Test unannotatedAccountsSupportNotes() passed after 0.018 seconds.
```

Red check — with the seeded account note removed, the new seeder test fails as intended:

```
✘ Test seededBudgetShipsAnAnnotatedAccount() recorded an issue at DemoDataSeederTests.swift:144:9:
  Expectation failed: (note.text → "").contains("Direct deposit")
```

UI tests (skipped in CI, run locally — the new account tests, the existing category tests with the renamed identifiers, and the reconciliation tests that exercise the same account detail view):

```
Test Case '-[ActualiUITests.AccountNotesUITests testUnannotatedAccountOffersAddNote]' passed (10.528 seconds).
Test Case '-[ActualiUITests.AccountNotesUITests testViewsAndEditsAccountNote]' passed (17.565 seconds).
Test Case '-[ActualiUITests.CategoryNotesUITests testUnannotatedCategoryOffersAddNote]' passed (9.849 seconds).
Test Case '-[ActualiUITests.CategoryNotesUITests testViewsAndEditsCategoryNote]' passed (18.509 seconds).
	 Executed 4 tests, with 0 failures (0 unexpected) in 56.450 seconds

Test Case '-[ActualiUITests.NoteLinksUITests testCategoryNoteRendersTappableLink]' passed (21.455 seconds).
Test Case '-[ActualiUITests.ReconciliationUITests testReconcileLocksClearedTransactions]' passed (19.590 seconds).
Test Case '-[ActualiUITests.ReconciliationUITests testTappingBalanceRevealsBreakdown]' passed (13.890 seconds).
Test Case '-[ActualiUITests.ReconciliationUITests testTappingDotTogglesClearedStatus]' passed (11.762 seconds).
	 Executed 4 tests, with 0 failures (0 unexpected) in 66.698 seconds
```

## Intentionally out of scope

- A note indicator on the accounts list rows (the note shows on the account's own screen only, as with categories).
- Notes on payees, schedules, or rules (same table, different surfaces).

Fixes #198
