### PR TITLE
Send Discord PR notifications for fork PRs too

### DIFF
--- a/.github/workflows/discord-log.yml
+++ b/.github/workflows/discord-log.yml
@@ -14,7 +14,7 @@ name: Discord activity log
 on:
   issues:
     types: [opened, closed, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened]
   release:
     types: [published]


### PR DESCRIPTION
## Summary
- The Discord activity-log workflow used `pull_request`, which GitHub Actions runs without repo secrets when the PR head is a fork. `DISCORD_WEBHOOK_URL` came through empty for those runs, so the job failed for external-contributor PRs (e.g. #207, #208).
- Switches the trigger to `pull_request_target`, which runs in the base repo's context and has secret access.
- Safe here: the job never checks out the PR ref or runs any fork-controlled code — it only reads `github.event.*` metadata (passed through env vars and `jq --arg`, so no injection risk) and posts to Discord.

## Test plan
- [x] Open a PR from a fork and confirm the Discord notification fires and the job succeeds
- [x] Open/close/reopen a same-repo PR and confirm notifications still work as before