### PR TITLE
Fix Discord notify case matching after pull_request_target switch

### DIFF
--- a/.github/workflows/discord-log.yml
+++ b/.github/workflows/discord-log.yml
@@ -60,10 +60,10 @@ jobs:
             issues:reopened)
               TITLE="♻️ Issue reopened: #$ISSUE_NUMBER $ISSUE_TITLE"
               URL="$ISSUE_URL" COLOR=$RED ;;
-            pull_request:opened)
+            pull_request_target:opened)
               TITLE="🔀 PR opened: #$PR_NUMBER $PR_TITLE"
               URL="$PR_URL" COLOR=$BLUE ;;
-            pull_request:closed)
+            pull_request_target:closed)
               if [ "$PR_MERGED" = "true" ]; then
                 TITLE="🟣 PR merged: #$PR_NUMBER $PR_TITLE"
                 URL="$PR_URL" COLOR=$PURPLE
@@ -71,7 +71,7 @@ jobs:
                 TITLE="❌ PR closed: #$PR_NUMBER $PR_TITLE"
                 URL="$PR_URL" COLOR=$RED
               fi ;;
-            pull_request:reopened)
+            pull_request_target:reopened)
               TITLE="♻️ PR reopened: #$PR_NUMBER $PR_TITLE"
               URL="$PR_URL" COLOR=$BLUE ;;
             release:published)


### PR DESCRIPTION
## Summary
- Follow-up to #210: switching the trigger to `pull_request_target` changed `$EVENT` from `pull_request` to `pull_request_target`, but the `case` statement's PR arms still matched the literal `pull_request:*` string.
- Every PR opened/closed/reopened event has been falling through to the unhandled-event catch-all since #210 merged — the job exits 0 (looks green) but sends nothing. Seen on run https://github.com/MattFaz/actuali/actions/runs/31668036755 (PR #208 merge).
- Updates the three `pull_request:opened|closed|reopened` case arms to `pull_request_target:opened|closed|reopened`.

## Test plan
- [ ] Open/close/reopen a same-repo PR and confirm the Discord embed is sent
- [ ] Open/close a fork PR and confirm the Discord embed is sent