### PR TITLE
Allow negative budgeted amounts on the Budget screen

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2824,11 +2824,14 @@ final class BudgetStore: ObservableObject {
 
     // MARK: - Budget Amounts
 
-    /// Parse the budget edit field ("25.50") into non-negative cents.
-    static func budgetAmountCents(from string: String) throws -> Int {
+    /// Parse the budget edit field ("25.50") into cents. Negative amounts
+    /// (intentional overdraw, as Actual's web client allows) are only valid
+    /// where the caller opts in — a transfer, for instance, must stay
+    /// non-negative or it would silently reverse direction.
+    static func budgetAmountCents(from string: String, allowNegative: Bool = false) throws -> Int {
         guard let dollars = Double(string),
               let cents = Transaction.cents(fromDollars: dollars),
-              cents >= 0 else {
+              allowNegative || cents >= 0 else {
             throw BudgetStoreError.invalidAmount
         }
         return cents

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -878,7 +878,7 @@ struct EditBudgetAmountSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    AmountInputField(text: $amountText, autofocus: true)
+                    AmountInputField(text: $amountText, allowsNegative: true, autofocus: true)
                 } header: {
                     Text("Budgeted in \(MonthPicker.title(for: category.month))")
                 } footer: {
@@ -911,7 +911,8 @@ struct EditBudgetAmountSheet: View {
             do {
                 // An emptied field means "no longer budgeted", i.e. zero.
                 let cents = try BudgetStore.budgetAmountCents(
-                    from: amountText.isEmpty ? "0" : amountText
+                    from: amountText.isEmpty ? "0" : amountText,
+                    allowNegative: true
                 )
                 try await budgetStore.setBudgetAmount(
                     month: category.month,

--- a/Actuali/ActualiTests/BudgetStoreSetBudgetAmountTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSetBudgetAmountTests.swift
@@ -121,6 +121,10 @@ struct BudgetStoreSetBudgetAmountTests {
         }
     }
 
+    @Test func parsesNegativeAmountWhenAllowed() throws {
+        #expect(try BudgetStore.budgetAmountCents(from: "-100", allowNegative: true) == -10000)
+    }
+
     // MARK: - End-to-end save
 
     @Test func settingBudgetPersistsAndRefreshesMonth() async throws {
@@ -144,6 +148,24 @@ struct BudgetStoreSetBudgetAmountTests {
         #expect(month.month == "2026-07")
         let groceries = try #require(month.categoryBudgets.first { $0.categoryId == "cat-groceries" })
         #expect(groceries.budgeted == 2550)
+    }
+
+    @Test func settingNegativeBudgetPersists() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.setBudgetAmount(month: "2026-07", categoryId: "cat-groceries", amountCents: -10000)
+
+        let queue = try DatabaseQueue(path: path.path)
+        let amount = try await queue.read { db in
+            try Int.fetchOne(db, sql: "SELECT amount FROM zero_budgets WHERE id = '202607-cat-groceries'")
+        }
+        #expect(amount == -10000)
+
+        let month = try #require(store.currentBudgetMonth)
+        let groceries = try #require(month.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(groceries.budgeted == -10000)
     }
 
     @Test func withoutSyncClientThrowsSyncNotConfigured() async throws {


### PR DESCRIPTION
Entering a negative budgeted amount (intentional overdraw, which Actual's web client allows) clamped to 0. Two things stripped the sign on the edit path: the budget edit sheet's `AmountInputField` wasn't opted into `allowsNegative` (so the field abs'd the value and hid the ± button), and `BudgetStore.budgetAmountCents` rejected negative cents outright.

Now `budgetAmountCents` takes an `allowNegative` flag (default false) and the budget edit sheet opts in on both the field and the parser. The transfer sheet keeps the non-negative default — a negative transfer would silently reverse direction. Nothing downstream needed changes; SyncClient passes the amount straight through to CRDT messages.

Tests: new parse test for `-100` → `-10000` with the flag, existing rejects-negative test still covers the default, and an end-to-end test that a negative budget persists to `zero_budgets` and the published month. Full unit suite run locally (`-skip-testing:ActualiUITests`): **TEST SUCCEEDED**.

Fixes #217