### PR TITLE
Budget summary Spent shows net activity, matching the server

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -33,15 +33,11 @@ struct BudgetMonth: Identifiable, Hashable {
         categoryBudgets.reduce(0) { $0 + $1.budgeted }
     }
 
+    /// Net activity across expense categories — inflows (refunds,
+    /// reimbursements) offset outflows, matching the Spent total in Actual's
+    /// web UI (GH #212).
     var totalSpent: Int {
         categoryBudgets.reduce(0) { $0 + $1.spent }
-    }
-
-    /// Money that actually left the budget this month — inflows (refunds,
-    /// reimbursements) are excluded so a positive-heavy month doesn't show
-    /// a misleading "Spent" total.
-    var totalOutflow: Int {
-        categoryBudgets.reduce(0) { $0 + $1.outflow }
     }
 
     var totalAvailable: Int {
@@ -75,7 +71,6 @@ struct CategoryBudget: Identifiable, Hashable {
     var categorySortOrder: Double
     var budgeted: Int // In cents
     var spent: Int // In cents (negative value, net of inflows)
-    var outflow: Int = 0 // In cents (negative transactions only)
     var available: Int // In cents (budgeted + spent + carryover)
     var carryover: Int
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1124,8 +1124,7 @@ class BudgetDatabase {
                 SELECT
                     (t.date / 100) AS month,
                     COALESCE(cm.transferId, t.category) AS category_id,
-                    SUM(t.amount) AS spent,
-                    SUM(CASE WHEN t.amount < 0 THEN t.amount ELSE 0 END) AS outflow
+                    SUM(t.amount) AS spent
                 FROM transactions t
                 LEFT JOIN category_mapping cm ON cm.id = t.category
                 LEFT JOIN accounts a ON a.id = t.acct
@@ -1139,18 +1138,11 @@ class BudgetDatabase {
                 GROUP BY (t.date / 100), COALESCE(cm.transferId, t.category)
                 """, arguments: [targetMonthInt])
             var spentByMonthCat: [Int: [String: Int]] = [:]
-            // Outflow-only spending (inflows like refunds excluded) for the
-            // target month. The leftover chain needs the net, but the summary
-            // "Spent" total shows money that actually went out.
-            var targetOutflowByCat: [String: Int] = [:]
             for row in spentRows {
                 let m: Int = row["month"] ?? 0
                 guard m > 0, let categoryId: String = row["category_id"] else { continue }
                 let spent: Int = row["spent"] ?? 0
                 spentByMonthCat[m, default: [:]][categoryId] = spent
-                if m == targetMonthInt {
-                    targetOutflowByCat[categoryId] = row["outflow"] ?? 0
-                }
             }
 
             // "Hold for next month" amounts, keyed by YYYYMM. Upstream writes
@@ -1301,7 +1293,6 @@ class BudgetDatabase {
                     categorySortOrder: cat.sortOrder ?? .greatestFiniteMagnitude,
                     budgeted: budgeted,
                     spent: spent,
-                    outflow: targetOutflowByCat[cat.id] ?? 0,
                     available: available,
                     carryover: priorContribution
                 )

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -609,7 +609,7 @@ struct CleanBudgetSummary: View {
             HStack(alignment: .top) {
                 SummaryStat(
                     label: "Spent",
-                    value: budgetStore.displayBalance(abs(budget.totalOutflow))
+                    value: budgetStore.displayBalance(-budget.totalSpent)
                 )
                 Spacer()
                 // Envelope budgets lead with unallocated funds; tracking
@@ -666,7 +666,7 @@ struct TableBudgetSummary: View {
             )
             SummaryColumn(
                 label: "Spent",
-                value: budgetStore.displayBudgetCell(budget.totalOutflow)
+                value: budgetStore.displayBudgetCell(budget.totalSpent)
             )
             SummaryColumn(
                 label: "Balance",

--- a/Actuali/ActualiTests/BudgetDatabaseRolloverTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseRolloverTests.swift
@@ -417,10 +417,11 @@ struct BudgetDatabaseRolloverTests {
         #expect(groceries?.available == 7000)
     }
 
-    @Test func outflowExcludesInflowsWhileNetSpentDrivesAvailable() async throws {
-        // May: budget 5000, spend -2000, refund +500.
-        // Net spent (-1500) drives Available; outflow (-2000) is what the
-        // summary "Spent" shows — refunds must not shrink it.
+    @Test func totalSpentNetsInflowsToMatchServer() async throws {
+        // GH #212: the summary "Spent" must be net category activity, the
+        // same figure Actual's web UI totals — a gross outflow-only sum
+        // disagrees with the server whenever a refund lands.
+        // May: budget 5000, spend -2000, refund +500 -> net -1500.
         let (db, url) = try makeDatabase(envelope: true)
         defer { cleanup(url) }
 
@@ -431,13 +432,12 @@ struct BudgetDatabaseRolloverTests {
         let may = try await db.fetchBudgetMonth(month: "2026-05")
         let groceries = may.categoryBudgets.first { $0.categoryId == "cat-groceries" }
         #expect(groceries?.spent == -1500)
-        #expect(groceries?.outflow == -2000)
         #expect(groceries?.available == 3500)
-        #expect(may.totalOutflow == -2000)
+        #expect(may.totalSpent == -1500)
     }
 
-    @Test func outflowOnlyCountsTargetMonth() async throws {
-        // April outflows must not bleed into May's summary Spent.
+    @Test func totalSpentOnlyCountsTargetMonth() async throws {
+        // April activity must not bleed into May's summary Spent.
         let (db, url) = try makeDatabase(envelope: true)
         defer { cleanup(url) }
 
@@ -446,8 +446,8 @@ struct BudgetDatabaseRolloverTests {
 
         let may = try await db.fetchBudgetMonth(month: "2026-05")
         let groceries = may.categoryBudgets.first { $0.categoryId == "cat-groceries" }
-        #expect(groceries?.outflow == -1000)
-        #expect(may.totalOutflow == -1000)
+        #expect(groceries?.spent == -1000)
+        #expect(may.totalSpent == -1000)
     }
 
     @Test func splitChildrenOfTombstonedParentAreNotCounted() async throws {


### PR DESCRIPTION
The Budget tab's summary "Spent" was summing only negative transactions (gross outflow), so any refund or reimbursement in an expense category made it larger than the server's number — the mismatch in #212 (app -22.330,05 vs server -12.731,80 for the same month, with Budgeted and Balance agreeing exactly).

Upstream computes `total-spent` as the sum of net category activity (`loot-core/src/server/budget/tracking.ts:103` and `envelope.ts:211`, both summing `group-sum-amount`), which is also what already drives this app's category rows, group totals, and Balance. So the header now shows `totalSpent` (net) in both summary styles, and the outflow-only plumbing (`CategoryBudget.outflow`, `totalOutflow`, the extra SQL column) is removed.

Note: this deliberately reverses the display choice from #48 ("Spent excludes inflows"). That choice made the header disagree with both the server and the app's own table whenever an inflow landed, which users read as a wrong number. The two tests from #48 that pinned outflow behavior were replaced with tests pinning the net behavior — they no longer described desired behavior.

Verified: full unit suite on iPhone 17 Pro sim — 811 tests in 116 suites, all passed, including the two new `BudgetDatabaseRolloverTests` cases (`totalSpentNetsInflowsToMatchServer`, `totalSpentOnlyCountsTargetMonth`).

Fixes #212