### PR TITLE
Show inflow vs outflow lines in split transactions

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1952,23 +1952,27 @@ final class BudgetStore: ObservableObject {
     }
 
     /// One line of a split entered in the form. `amount` is raw field text,
-    /// unsigned like `TransactionForm.amount`. An empty `payeeName` means
-    /// the line inherits the transaction's payee (Actual's makeChild rule).
-    /// `childId` links the line to an existing child row when editing a
-    /// split parent; nil means the line is new.
+    /// unsigned like `TransactionForm.amount`; `isOpposite` runs the line
+    /// against the transaction's direction — a refund inside a spend split
+    /// (GH #216). An empty `payeeName` means the line inherits the
+    /// transaction's payee (Actual's makeChild rule). `childId` links the
+    /// line to an existing child row when editing a split parent; nil means
+    /// the line is new.
     struct SplitLineForm: Identifiable, Equatable {
         let id: UUID
         var childId: String?
         var categoryId: String?
         var amount: String
+        var isOpposite: Bool
         var notes: String
         var payeeName: String
 
-        init(id: UUID = UUID(), childId: String? = nil, categoryId: String? = nil, amount: String = "", notes: String = "", payeeName: String = "") {
+        init(id: UUID = UUID(), childId: String? = nil, categoryId: String? = nil, amount: String = "", isOpposite: Bool = false, notes: String = "", payeeName: String = "") {
             self.id = id
             self.childId = childId
             self.categoryId = categoryId
             self.amount = amount
+            self.isOpposite = isOpposite
             self.notes = notes
             self.payeeName = payeeName
         }
@@ -2011,9 +2015,10 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Resolve an expense/income form to `.standard`, or `.split` when split
-    /// lines are present: every line must parse to a non-zero amount and the
-    /// lines must add up exactly to the total. Negative lines run opposite
-    /// to the transaction's direction — a refund inside a spend (GH #216).
+    /// lines are present: every line must parse to a positive amount and the
+    /// lines must add up exactly to the total. An `isOpposite` line runs
+    /// against the transaction's direction — a refund inside a spend
+    /// (GH #216).
     private static func planStandardOrSplit(
         _ form: TransactionForm,
         amountCents: Int,
@@ -2028,13 +2033,13 @@ final class BudgetStore: ObservableObject {
         let lines = try form.splits.map { line in
             guard let dollars = Double(line.amount),
                   let cents = Transaction.cents(fromDollars: dollars),
-                  cents != 0 else {
+                  cents > 0 else {
                 throw BudgetStoreError.invalidAmount
             }
             let payeeName = line.payeeName.trimmingCharacters(in: .whitespacesAndNewlines)
             return SplitPlanLine(
                 categoryId: line.categoryId,
-                amountCents: sign * cents,
+                amountCents: sign * (line.isOpposite ? -cents : cents),
                 notes: line.notes.isEmpty ? nil : line.notes,
                 payeeName: payeeName.isEmpty ? nil : payeeName,
                 childId: line.childId

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2011,8 +2011,9 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Resolve an expense/income form to `.standard`, or `.split` when split
-    /// lines are present: every line must parse to a positive amount and the
-    /// lines must add up exactly to the total.
+    /// lines are present: every line must parse to a non-zero amount and the
+    /// lines must add up exactly to the total. Negative lines run opposite
+    /// to the transaction's direction — a refund inside a spend (GH #216).
     private static func planStandardOrSplit(
         _ form: TransactionForm,
         amountCents: Int,
@@ -2027,7 +2028,7 @@ final class BudgetStore: ObservableObject {
         let lines = try form.splits.map { line in
             guard let dollars = Double(line.amount),
                   let cents = Transaction.cents(fromDollars: dollars),
-                  cents > 0 else {
+                  cents != 0 else {
                 throw BudgetStoreError.invalidAmount
             }
             let payeeName = line.payeeName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -769,7 +769,7 @@ private struct SplitLineRow: View {
                 .buttonStyle(.borderless)
                 .accessibilityLabel(isOutflow ? "Outflow" : "Inflow")
                 .accessibilityHint("Flips this line's direction")
-                AmountInputField(text: $line.amount)
+                AmountInputField(text: $line.amount, onToggleSign: { line.isOpposite.toggle() })
                     .frame(width: 110)
             }
             // No fill offer on a flipped line: the remainder is stated in the
@@ -813,8 +813,11 @@ private struct SplitLineRow: View {
 /// decimal entry where prior digits are reinterpreted as the integer part —
 /// so 1, ., 0 produces 1.0.
 ///
-/// With `allowsNegative`, a ± button joins the keyboard toolbar; sign is
-/// otherwise handled outside the field (e.g. the expense/income toggle).
+/// With `allowsNegative`, a ± button joins the keyboard toolbar and flips
+/// the text's own sign. With `onToggleSign`, the same button appears but the
+/// sign lives outside the field (a split line's direction flip) and the text
+/// stays unsigned. Neither set means sign is handled elsewhere entirely
+/// (e.g. the expense/income toggle).
 ///
 /// The toolbar also carries +, −, × and ÷ for quick math: typing 12.50, then
 /// +, then 6.00 shows "12.50 + 6.00" in the field and collapses to "18.50"
@@ -831,6 +834,9 @@ struct AmountInputField: UIViewRepresentable {
     /// Bring up the keyboard as soon as the field lands on screen. For
     /// sheets whose whole purpose is entering an amount.
     var autofocus = false
+    /// Shows the ± toolbar button and delegates it here instead of signing
+    /// the text — for callers whose sign is separate state.
+    var onToggleSign: (() -> Void)? = nil
 
     /// becomeFirstResponder is a no-op until the view joins a window, and
     /// during a sheet presentation that happens well after makeUIView —
@@ -871,9 +877,9 @@ struct AmountInputField: UIViewRepresentable {
         // field, or to do arithmetic in it.
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
         var items: [UIBarButtonItem] = []
-        if allowsNegative {
+        if allowsNegative || onToggleSign != nil {
             // The decimal pad has no minus key, so this button is the only
-            // touchscreen affordance for entering a negative amount.
+            // keyboard affordance for flipping an amount's sign.
             items.append(UIBarButtonItem(
                 image: UIImage(systemName: "plus.forwardslash.minus"),
                 style: .plain,
@@ -1052,6 +1058,12 @@ struct AmountInputField: UIViewRepresentable {
         }
 
         @objc func toggleSign() {
+            // Delegated sign lives outside the text (a split line's flip);
+            // the field's own text stays unsigned.
+            if let onToggleSign = parent.onToggleSign {
+                onToggleSign()
+                return
+            }
             guard parent.allowsNegative else { return }
             isNegative.toggle()
             if let textField {

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -128,7 +128,11 @@ struct AddTransactionView: View {
     /// doesn't parse yet. Blank lines count as zero so the remainder stays
     /// visible while the user is still filling lines in.
     private var splitRemainingCents: Int? {
-        SplitEntryMath.remainingCents(total: amount, lineAmounts: splitLines.map(\.amount))
+        // Opposite-direction lines hand their amount back to the remainder
+        // instead of consuming it (GH #216).
+        SplitEntryMath.remainingCents(total: amount, lineAmounts: splitLines.map { line in
+            line.isOpposite && !line.amount.isEmpty ? "-\(line.amount)" : line.amount
+        })
     }
 
     private var hasBlankSplitLine: Bool {
@@ -501,10 +505,10 @@ struct AddTransactionView: View {
             BudgetStore.SplitLineForm(
                 childId: child.id,
                 categoryId: child.categoryId,
-                // Signed relative to the parent so a refund line inside a
-                // spend split loads (and saves back) as negative (GH #216).
-                amount: SplitEntryMath.relativeAmountString(
-                    childCents: child.amount, parentCents: editing.amount),
+                amount: SplitEntryMath.amountString(fromCents: abs(child.amount)),
+                // A child running against the parent's direction — a refund
+                // inside a spend split — keeps its flip on reload (GH #216).
+                isOpposite: (child.amount < 0) != (editing.amount < 0),
                 notes: child.notes ?? "",
                 payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
             )
@@ -516,7 +520,7 @@ struct AddTransactionView: View {
     private var splitEntrySection: some View {
         Section {
             ForEach($splitLines) { $line in
-                SplitLineRow(line: $line, remainingCents: splitRemainingCents)
+                SplitLineRow(line: $line, txType: txType, remainingCents: splitRemainingCents)
             }
             .onDelete { offsets in
                 if isEditingSplitParent {
@@ -708,15 +712,6 @@ enum SplitEntryMath {
     static func amountString(fromCents cents: Int) -> String {
         "\(cents / 100).\(String(format: "%02d", cents % 100))"
     }
-
-    /// Form-relative amount text for an existing child. The form keeps line
-    /// amounts unsigned and applies the expense/income sign on save, so a
-    /// child running opposite to its parent (a refund inside a spend split,
-    /// GH #216) must load as negative to round-trip through that flip.
-    static func relativeAmountString(childCents: Int, parentCents: Int) -> String {
-        let relative = parentCents < 0 ? -childCents : childCents
-        return String(format: "%.2f", Double(relative) / 100.0)
-    }
 }
 
 /// One editable split line: a category picked through a sheet and an amount.
@@ -724,6 +719,9 @@ enum SplitEntryMath {
 private struct SplitLineRow: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Binding var line: BudgetStore.SplitLineForm
+    /// The transaction's direction, so the line's sign glyph can show its
+    /// effective direction relative to it.
+    var txType: TransactionType
     /// The section-wide unassigned remainder; a positive value on a line with
     /// no amount yet offers one-tap fill instead of mental arithmetic.
     var remainingCents: Int?
@@ -739,6 +737,12 @@ private struct SplitLineRow: View {
         return "Category"
     }
 
+    /// Whether the line runs as an outflow once the transaction's direction
+    /// and the line's flip are combined.
+    private var isOutflow: Bool {
+        (txType == .expense) != line.isOpposite
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
@@ -750,12 +754,28 @@ private struct SplitLineRow: View {
                 }
                 .buttonStyle(.borderless)
                 Spacer()
-                // Negative flips the line against the expense/income toggle:
-                // the only way to put a refund inside a spend split (GH #216).
-                AmountInputField(text: $line.amount, allowsNegative: true)
+                // Every line carries a sign like the total's, so direction is
+                // never implicit; tapping it flips the line — how a refund
+                // goes inside a spend split (GH #216).
+                Button {
+                    line.isOpposite.toggle()
+                } label: {
+                    Text(isOutflow ? "-" : "+")
+                        .foregroundStyle(isOutflow ? Color.red : Color.green)
+                        // Grow the tap target beyond the one-character glyph.
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(isOutflow ? "Outflow" : "Inflow")
+                .accessibilityHint("Flips this line's direction")
+                AmountInputField(text: $line.amount)
                     .frame(width: 110)
             }
-            if line.amount.isEmpty, let remaining = remainingCents, remaining > 0 {
+            // No fill offer on a flipped line: the remainder is stated in the
+            // transaction's direction, and filling it here would double the
+            // gap instead of closing it.
+            if line.amount.isEmpty, !line.isOpposite, let remaining = remainingCents, remaining > 0 {
                 HStack {
                     Spacer()
                     Button {

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -501,7 +501,10 @@ struct AddTransactionView: View {
             BudgetStore.SplitLineForm(
                 childId: child.id,
                 categoryId: child.categoryId,
-                amount: String(format: "%.2f", Double(abs(child.amount)) / 100.0),
+                // Signed relative to the parent so a refund line inside a
+                // spend split loads (and saves back) as negative (GH #216).
+                amount: SplitEntryMath.relativeAmountString(
+                    childCents: child.amount, parentCents: editing.amount),
                 notes: child.notes ?? "",
                 payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
             )
@@ -705,6 +708,15 @@ enum SplitEntryMath {
     static func amountString(fromCents cents: Int) -> String {
         "\(cents / 100).\(String(format: "%02d", cents % 100))"
     }
+
+    /// Form-relative amount text for an existing child. The form keeps line
+    /// amounts unsigned and applies the expense/income sign on save, so a
+    /// child running opposite to its parent (a refund inside a spend split,
+    /// GH #216) must load as negative to round-trip through that flip.
+    static func relativeAmountString(childCents: Int, parentCents: Int) -> String {
+        let relative = parentCents < 0 ? -childCents : childCents
+        return String(format: "%.2f", Double(relative) / 100.0)
+    }
 }
 
 /// One editable split line: a category picked through a sheet and an amount.
@@ -738,7 +750,9 @@ private struct SplitLineRow: View {
                 }
                 .buttonStyle(.borderless)
                 Spacer()
-                AmountInputField(text: $line.amount)
+                // Negative flips the line against the expense/income toggle:
+                // the only way to put a refund inside a spend split (GH #216).
+                AmountInputField(text: $line.amount, allowsNegative: true)
                     .frame(width: 110)
             }
             if line.amount.isEmpty, let remaining = remainingCents, remaining > 0 {

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -159,9 +159,10 @@ struct TransactionRow: View {
 
     /// Caption under the payee. Off-budget accounts aren't categorized at all
     /// ("Off budget", GH #123); split parents show their children's breakdown
-    /// ("Food $6.00, Fun $4.00" — amounts unsigned because the row's total
-    /// already carries the sign); transfers that can't take a category show
-    /// "Transfer" instead of nagging "Uncategorized" (GH #104).
+    /// ("Food $6.00, Refund +$4.00" — outflows unsigned, inflows keep a "+"
+    /// so a credit line inside a spend split stays distinguishable, GH #216);
+    /// transfers that can't take a category show "Transfer" instead of
+    /// nagging "Uncategorized" (GH #104).
     private var categoryLabel: String {
         if isInOffBudgetAccount {
             return "Off budget"
@@ -169,7 +170,7 @@ struct TransactionRow: View {
         if let portions = transaction.splitPortions, !portions.isEmpty {
             return portions.map { portion in
                 let name = portion.categoryName ?? "Uncategorized"
-                return "\(name) \(budgetStore.displayBalance(abs(portion.amount)))"
+                return "\(name) \(budgetStore.displaySpentCaption(portion.amount))"
             }.joined(separator: ", ")
         }
         if transaction.categoryName == nil, isTransfer,

--- a/Actuali/ActualiTests/BudgetStoreSplitPlanTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitPlanTests.swift
@@ -80,11 +80,33 @@ struct BudgetStoreSplitPlanTests {
         }
     }
 
-    @Test func splitLineWithNonPositiveAmountIsRejected() {
+    @Test func splitLineWithZeroAmountIsRejected() {
         #expect(throws: BudgetStoreError.invalidAmount) {
             try BudgetStore.plan(for: form(
                 amount: "10.00",
                 splits: [line("cat-a", "0"), line("cat-b", "10.00")]
+            ))
+        }
+    }
+
+    @Test func splitAllowsOppositeSignLines() throws {
+        // A refund/credit line alongside spend lines (GH #216): the negative
+        // form amount flips against the expense sign into a positive child.
+        let plan = try BudgetStore.plan(for: form(
+            type: .expense, amount: "20.00",
+            splits: [line("cat-a", "30.00"), line("cat-b", "-10.00")]
+        ))
+        #expect(plan == .split(amountCents: -2000, lines: [
+            .init(categoryId: "cat-a", amountCents: -3000, notes: nil),
+            .init(categoryId: "cat-b", amountCents: 1000, notes: nil)
+        ]))
+    }
+
+    @Test func mixedSignLinesMustStillSumToTotal() {
+        #expect(throws: BudgetStoreError.splitAmountMismatch) {
+            try BudgetStore.plan(for: form(
+                amount: "20.00",
+                splits: [line("cat-a", "30.00"), line("cat-b", "-5.00")]
             ))
         }
     }

--- a/Actuali/ActualiTests/BudgetStoreSplitPlanTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitPlanTests.swift
@@ -27,8 +27,8 @@ struct BudgetStoreSplitPlanTests {
         )
     }
 
-    private func line(_ categoryId: String?, _ amount: String, notes: String = "") -> BudgetStore.SplitLineForm {
-        BudgetStore.SplitLineForm(categoryId: categoryId, amount: amount, notes: notes)
+    private func line(_ categoryId: String?, _ amount: String, isOpposite: Bool = false, notes: String = "") -> BudgetStore.SplitLineForm {
+        BudgetStore.SplitLineForm(categoryId: categoryId, amount: amount, isOpposite: isOpposite, notes: notes)
     }
 
     @Test func splitExpenseSignsParentAndLines() throws {
@@ -80,21 +80,24 @@ struct BudgetStoreSplitPlanTests {
         }
     }
 
-    @Test func splitLineWithZeroAmountIsRejected() {
-        #expect(throws: BudgetStoreError.invalidAmount) {
-            try BudgetStore.plan(for: form(
-                amount: "10.00",
-                splits: [line("cat-a", "0"), line("cat-b", "10.00")]
-            ))
+    @Test func splitLineWithNonPositiveAmountIsRejected() {
+        // Direction is the line's flip, never a sign typed into the amount.
+        for bad in ["0", "-10.00"] {
+            #expect(throws: BudgetStoreError.invalidAmount) {
+                try BudgetStore.plan(for: form(
+                    amount: "10.00",
+                    splits: [line("cat-a", bad), line("cat-b", "10.00")]
+                ))
+            }
         }
     }
 
-    @Test func splitAllowsOppositeSignLines() throws {
-        // A refund/credit line alongside spend lines (GH #216): the negative
-        // form amount flips against the expense sign into a positive child.
+    @Test func splitAllowsOppositeDirectionLines() throws {
+        // A refund/credit line alongside spend lines (GH #216): the flipped
+        // line runs against the expense sign into a positive child.
         let plan = try BudgetStore.plan(for: form(
             type: .expense, amount: "20.00",
-            splits: [line("cat-a", "30.00"), line("cat-b", "-10.00")]
+            splits: [line("cat-a", "30.00"), line("cat-b", "10.00", isOpposite: true)]
         ))
         #expect(plan == .split(amountCents: -2000, lines: [
             .init(categoryId: "cat-a", amountCents: -3000, notes: nil),
@@ -102,11 +105,11 @@ struct BudgetStoreSplitPlanTests {
         ]))
     }
 
-    @Test func mixedSignLinesMustStillSumToTotal() {
+    @Test func oppositeDirectionLinesMustStillSumToTotal() {
         #expect(throws: BudgetStoreError.splitAmountMismatch) {
             try BudgetStore.plan(for: form(
                 amount: "20.00",
-                splits: [line("cat-a", "30.00"), line("cat-b", "-5.00")]
+                splits: [line("cat-a", "30.00"), line("cat-b", "5.00", isOpposite: true)]
             ))
         }
     }

--- a/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSplitSaveTests.swift
@@ -173,6 +173,29 @@ struct BudgetStoreSplitSaveTests {
         #expect(messageRows == 3)
     }
 
+    @Test func savingAMixedDirectionSplitPersistsSignedChildren() async throws {
+        // A refund/credit line inside a spend split (GH #216): the flipped
+        // line lands positive while the rest stay negative, netting the
+        // parent's total.
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await store.saveTransaction(form(
+            type: .expense, amount: "20.00", payeeName: "Hardware Store",
+            splits: [
+                .init(categoryId: "cat-home", amount: "30.00"),
+                .init(categoryId: "cat-home", amount: "10.00", isOpposite: true)
+            ]
+        ))
+
+        let all = try rows(path: path)
+        #expect(all.count == 3)
+        #expect(all[0]["amount"] == -2000)  // parent
+        #expect(all[1]["amount"] == -3000)  // spend line
+        #expect(all[2]["amount"] == 1000)   // refund line
+    }
+
     @Test func splitLinePayeeOverrideCreatesDistinctChildPayee() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }

--- a/Actuali/ActualiTests/SplitEntryMathTests.swift
+++ b/Actuali/ActualiTests/SplitEntryMathTests.swift
@@ -27,6 +27,21 @@ struct SplitEntryMathTests {
         #expect(SplitEntryMath.remainingCents(total: "100", lineAmounts: ["1.2.3"]) == nil)
     }
 
+    @Test func negativeLinesGiveBackTheirAmount() {
+        // A refund line inside an expense split enlarges the remainder
+        // instead of consuming it (GH #216).
+        #expect(SplitEntryMath.remainingCents(total: "20", lineAmounts: ["30", "-10"]) == 0)
+    }
+
+    @Test func relativeAmountStringSignsAgainstParentDirection() {
+        // Children matching the parent's direction load unsigned; opposite
+        // ones load negative so plan()'s sign flip round-trips them (GH #216).
+        #expect(SplitEntryMath.relativeAmountString(childCents: -3000, parentCents: -2000) == "30.00")
+        #expect(SplitEntryMath.relativeAmountString(childCents: 1000, parentCents: -2000) == "-10.00")
+        #expect(SplitEntryMath.relativeAmountString(childCents: 600, parentCents: 1000) == "6.00")
+        #expect(SplitEntryMath.relativeAmountString(childCents: -400, parentCents: 1000) == "-4.00")
+    }
+
     @Test func amountStringMatchesFieldFormat() {
         #expect(SplitEntryMath.amountString(fromCents: 4950) == "49.50")
         #expect(SplitEntryMath.amountString(fromCents: 5) == "0.05")

--- a/Actuali/ActualiTests/SplitEntryMathTests.swift
+++ b/Actuali/ActualiTests/SplitEntryMathTests.swift
@@ -28,18 +28,10 @@ struct SplitEntryMathTests {
     }
 
     @Test func negativeLinesGiveBackTheirAmount() {
-        // A refund line inside an expense split enlarges the remainder
-        // instead of consuming it (GH #216).
+        // A flipped (refund) line inside an expense split enlarges the
+        // remainder instead of consuming it — the view maps `isOpposite`
+        // lines to negative strings before calling this (GH #216).
         #expect(SplitEntryMath.remainingCents(total: "20", lineAmounts: ["30", "-10"]) == 0)
-    }
-
-    @Test func relativeAmountStringSignsAgainstParentDirection() {
-        // Children matching the parent's direction load unsigned; opposite
-        // ones load negative so plan()'s sign flip round-trips them (GH #216).
-        #expect(SplitEntryMath.relativeAmountString(childCents: -3000, parentCents: -2000) == "30.00")
-        #expect(SplitEntryMath.relativeAmountString(childCents: 1000, parentCents: -2000) == "-10.00")
-        #expect(SplitEntryMath.relativeAmountString(childCents: 600, parentCents: 1000) == "6.00")
-        #expect(SplitEntryMath.relativeAmountString(childCents: -400, parentCents: 1000) == "-4.00")
     }
 
     @Test func amountStringMatchesFieldFormat() {


### PR DESCRIPTION
A split with both spend and refund/credit lines (store credit, gift cards) showed every line the same way — and worse, couldn't be edited at all: the edit sheet loaded children as `abs()`, so the remainder math never balanced and Save stayed disabled, while `plan()` rejected any mixed split outright.

What changed:
- The list row's split breakdown now signs each portion like the spent captions from #102: outflows stay unsigned, inflows get a `+` ("Food $6.00, Refund +$4.00")
- Every split line in the add/edit sheet now shows a colored sign glyph (red `-` / green `+`) matching the total row's treatment, so a line's direction is never implicit; tapping the glyph flips the line — that's how a refund goes inside a spend split
- Sign lives in `SplitLineForm.isOpposite`, not the amount text — amounts stay unsigned everywhere, and typed negative amounts are still rejected
- Lines must still sum to the total; a flipped line hands its amount back to the remainder
- Editing a mixed split loads each child's flip from its stored sign and round-trips it on save

Verified: failing tests first, then full unit suite — 815 tests in 116 suites passed on iPhone 17 Pro sim. Covers plan validation/signing (`splitAllowsOppositeDirectionLines`, `oppositeDirectionLinesMustStillSumToTotal`), remainder math, and an end-to-end save (`savingAMixedDirectionSplitPersistsSignedChildren`).

Fixes #216