### PR TITLE
Fix Spending widget calculations and category_group report filters

### DIFF
--- a/Actuali/Actuali/Services/Reports/ConditionsFilter.swift
+++ b/Actuali/Actuali/Services/Reports/ConditionsFilter.swift
@@ -7,6 +7,8 @@ enum ConditionsFilter {
     struct Context {
         var offBudgetAccountIds: Set<String> = []
         var accountNames: [String: String] = [:]  // account id -> name
+        var categoryGroupIds: [String: String] = [:]  // category id -> group id
+        var categoryGroupNames: [String: String] = [:]  // group id -> name
 
         static let empty = Context()
     }
@@ -45,7 +47,7 @@ enum ConditionsFilter {
 
     private static func fieldType(_ field: String) -> FieldType? {
         switch field {
-        case "category", "account", "payee", "description": return .id
+        case "category", "category_group", "account", "payee", "description": return .id
         case "notes", "imported_payee": return .string
         case "amount", "amount-inflow", "amount-outflow": return .number
         case "date": return .date
@@ -165,6 +167,8 @@ enum ConditionsFilter {
         let txId: String?
         switch c.field {
         case "category": txId = tx.categoryId
+        // Upstream rewrites category_group to category.group (transaction-rules.ts).
+        case "category_group": txId = tx.categoryId.flatMap { context.categoryGroupIds[$0] }
         case "account": txId = tx.accountId
         default: txId = tx.payeeId  // "payee" / legacy "description"
         }
@@ -204,6 +208,7 @@ enum ConditionsFilter {
             let name: String?
             switch c.field {
             case "category": name = tx.categoryName
+            case "category_group": name = txId.flatMap { context.categoryGroupNames[$0] }
             case "account": name = context.accountNames[tx.accountId]
             default: name = tx.payeeName
             }

--- a/Actuali/Actuali/Services/Reports/DashboardWidget.swift
+++ b/Actuali/Actuali/Services/Reports/DashboardWidget.swift
@@ -185,12 +185,20 @@ struct SpendingMeta: Codable, Equatable {
     let compareTo: String?
     let isLive: Bool?
     let mode: Mode?
+    let averageRange: SpendingAverageRange?
 
     enum Mode: String, Codable {
         case singleMonth = "single-month"
         case budget
         case average
     }
+}
+
+/// Window the spending widget's average mode averages over. Mirrors upstream
+/// SpendingAverageRange: `last-n-months` (3/6/12), `year-to-date`, `all-time`.
+struct SpendingAverageRange: Codable, Equatable {
+    let mode: String?
+    let months: Int?
 }
 
 struct MarkdownMeta: Codable, Equatable {

--- a/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
@@ -5,6 +5,12 @@ struct SpendingData: Equatable {
     let comparisonCents: Int      // positive
 }
 
+/// Port of the webapp's spending-spreadsheet.ts + SpendingCard.tsx. The card
+/// shows the compare month's cumulative spending at "today's day" against a
+/// comparison: another month (single-month), an average over a configurable
+/// window (average), or the month's budget (budget). Spending is the NET of
+/// all matching transactions (refunds count), with income categories and
+/// off-budget accounts already removed by the caller (spendingScope).
 enum SpendingEngine {
 
     static func compute(
@@ -16,45 +22,94 @@ enum SpendingEngine {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "UTC")!
 
+        let live = transactions.filter { !$0.tombstone }
+        let filtered = live
+            .filter { ConditionsFilter.matches(transaction: $0, conditions: meta?.conditions, op: meta?.conditionsOp, context: context) }
+
         let monthComponents = cal.dateComponents([.year, .month], from: today)
-        guard let monthStart = cal.date(from: DateComponents(
+        guard let currentMonthStart = cal.date(from: DateComponents(
             year: monthComponents.year, month: monthComponents.month, day: 1
         )) else { return SpendingData(currentSpentCents: 0, comparisonCents: 0) }
 
-        let filtered = transactions
-            .filter { !$0.tombstone }
-            .filter { ConditionsFilter.matches(transaction: $0, conditions: meta?.conditions, op: meta?.conditionsOp, context: context) }
-
-        let current = monthSpending(transactions: filtered, monthStart: monthStart, calendar: cal)
+        let (compareStart, compareToStart) = resolveMonths(
+            meta: meta, currentMonthStart: currentMonthStart, calendar: cal
+        )
 
         let todayDay = cal.component(.day, from: today)
+        let isCurrentCompare = compareStart == currentMonthStart
+
+        // Upstream's card reads the cumulative at today's day of the compare
+        // month; a past compare month reads the day-28 bucket, i.e. the full
+        // month (SpendingCard.tsx todayDay). Comparison values use the same
+        // day so current-vs-past is month-to-date against month-to-same-date,
+        // except past day 28 where prior months use their full totals.
+        let current = monthSpending(transactions: filtered,
+                                    monthStart: compareStart,
+                                    calendar: cal,
+                                    throughDay: isCurrentCompare ? todayDay : nil)
+        let sameDayCutoff: Int? = (isCurrentCompare && todayDay < 28) ? todayDay : nil
 
         let comparison: Int
-        switch meta?.mode {
-        case .singleMonth?:
-            if let compareTo = meta?.compareTo,
-               let compareMonth = parseMonthStart(from: compareTo, calendar: cal) {
-                comparison = monthSpending(transactions: filtered, monthStart: compareMonth, calendar: cal)
-            } else {
-                comparison = averageOfPriorMonths(transactions: filtered,
-                                                  currentMonthStart: monthStart,
-                                                  count: 3,
-                                                  throughDay: todayDay,
-                                                  calendar: cal)
-            }
-        case .budget?:
+        switch meta?.mode ?? .singleMonth {
+        case .singleMonth:
+            comparison = monthSpending(transactions: filtered,
+                                       monthStart: compareToStart,
+                                       calendar: cal,
+                                       throughDay: sameDayCutoff)
+        case .budget:
+            // Budget-mode target needs zero_budgets/reflect_budgets data that
+            // isn't plumbed into the engine yet; the widget shows spending only.
             comparison = 0
-        case .average?, .none:
-            comparison = averageOfPriorMonths(transactions: filtered,
-                                              currentMonthStart: monthStart,
-                                              count: 3,
-                                              throughDay: todayDay,
-                                              calendar: cal)
+        case .average:
+            comparison = averageSpending(transactions: filtered,
+                                         allTransactions: live,
+                                         compareStart: compareStart,
+                                         range: meta?.averageRange,
+                                         throughDay: sameDayCutoff,
+                                         calendar: cal)
         }
 
         return SpendingData(currentSpentCents: current, comparisonCents: comparison)
     }
 
+    /// Port of calculateSpendingReportTimeRange (reportRanges.ts): live
+    /// budget/average pin to the stored compare month or the current one;
+    /// live single-month with a stored compare uses it (and compareTo, else
+    /// the month before); otherwise a live window slides to end at the
+    /// current month while a static one keeps its stored months verbatim.
+    private static func resolveMonths(
+        meta: SpendingMeta?,
+        currentMonthStart: Date,
+        calendar: Calendar
+    ) -> (compare: Date, compareTo: Date) {
+        let isLive = meta?.isLive ?? true
+        let mode = meta?.mode ?? .singleMonth
+        let stored = parseMonthStart(from: meta?.compare, calendar: calendar)
+        let storedTo = parseMonthStart(from: meta?.compareTo, calendar: calendar)
+
+        func prevMonth(_ d: Date) -> Date {
+            calendar.date(byAdding: .month, value: -1, to: d) ?? d
+        }
+
+        if (mode == .budget || mode == .average) && isLive {
+            let compare = stored ?? currentMonthStart
+            return (compare, prevMonth(compare))
+        }
+        if mode == .singleMonth, isLive, let stored {
+            return (stored, storedTo ?? prevMonth(stored))
+        }
+        if isLive {
+            // Sliding window: compare is the current month; compareTo keeps
+            // its stored month (clamped), defaulting to the previous month.
+            let to = storedTo ?? prevMonth(currentMonthStart)
+            return (currentMonthStart, min(to, currentMonthStart))
+        }
+        let compare = stored ?? currentMonthStart
+        return (compare, storedTo ?? prevMonth(compare))
+    }
+
+    /// Net spending for one month as positive cents. `throughDay` limits to a
+    /// month-to-date cumulative; nil sums the whole month.
     private static func monthSpending(
         transactions: [Transaction],
         monthStart: Date,
@@ -68,37 +123,65 @@ enum SpendingEngine {
         guard let cutoff = calendar.date(byAdding: .day, value: endDay - 1, to: monthStart) else { return 0 }
         let startYMD = ymdInt(from: monthStart, calendar: calendar)
         let endYMD = ymdInt(from: cutoff, calendar: calendar)
-        let totalNegative = transactions
-            .filter { $0.date >= startYMD && $0.date <= endYMD && $0.amount < 0 }
+        let net = transactions
+            .filter { $0.date >= startYMD && $0.date <= endYMD }
             .reduce(0) { $0 + $1.amount }
-        return -totalNegative
+        return -net
     }
 
-    private static func averageOfPriorMonths(
+    /// Average cumulative spending across the months of the configured range
+    /// (resolveSpendingAverageRange upstream): the range ends the month
+    /// before `compareStart`; months with no transactions still count in the
+    /// divisor.
+    private static func averageSpending(
         transactions: [Transaction],
-        currentMonthStart: Date,
-        count: Int,
+        allTransactions: [Transaction],
+        compareStart: Date,
+        range: SpendingAverageRange?,
         throughDay: Int?,
         calendar: Calendar
     ) -> Int {
-        // Matches WebUI behavior: average cumulative spending through `throughDay`
-        // across the `count` prior months. When throughDay >= 28, the WebUI buckets
-        // days 28+ together and uses full-month totals for prior months — we pass
-        // nil to monthSpending in that case.
-        let dayParam: Int? = (throughDay ?? 0) >= 28 ? nil : throughDay
-        var sum = 0
-        for i in 1...count {
-            guard let priorStart = calendar.date(byAdding: .month, value: -i, to: currentMonthStart) else { continue }
-            sum += monthSpending(transactions: transactions,
-                                 monthStart: priorStart,
-                                 calendar: calendar,
-                                 throughDay: dayParam)
+        guard let endMonth = calendar.date(byAdding: .month, value: -1, to: compareStart) else { return 0 }
+
+        // Unsupported last-n values normalize to the 3-month default upstream.
+        let supportedMonths: Set<Int> = [3, 6, 12]
+        let startMonth: Date?
+        switch range?.mode {
+        case "year-to-date":
+            startMonth = calendar.date(from: DateComponents(
+                year: calendar.component(.year, from: compareStart), month: 1, day: 1))
+        case "all-time":
+            // ponytail: earliest month derived from the transactions given to
+            // the engine; upstream queries the globally earliest transaction.
+            startMonth = allTransactions.map(\.date).min().flatMap { ymd in
+                calendar.date(from: DateComponents(year: ymd / 10000, month: (ymd % 10000) / 100, day: 1))
+            }
+        default:
+            let n = range?.months.flatMap { supportedMonths.contains($0) ? $0 : nil } ?? 3
+            startMonth = calendar.date(byAdding: .month, value: -n, to: compareStart)
         }
-        return sum / count
+
+        guard let startMonth, startMonth <= endMonth else { return 0 }
+
+        var sum = 0
+        var count = 0
+        var month = startMonth
+        while month <= endMonth {
+            sum += monthSpending(transactions: transactions,
+                                 monthStart: month,
+                                 calendar: calendar,
+                                 throughDay: throughDay)
+            count += 1
+            guard let next = calendar.date(byAdding: .month, value: 1, to: month) else { break }
+            month = next
+        }
+        guard count > 0 else { return 0 }
+        return Int((Double(sum) / Double(count)).rounded())
     }
 
-    private static func parseMonthStart(from string: String, calendar: Calendar) -> Date? {
+    private static func parseMonthStart(from string: String?, calendar: Calendar) -> Date? {
         // Accept "YYYY-MM" or "YYYY-MM-DD"
+        guard let string else { return nil }
         let isoMonth = DateFormatter()
         isoMonth.dateFormat = "yyyy-MM"
         isoMonth.timeZone = TimeZone(identifier: "UTC")

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -104,6 +104,14 @@ struct DashboardView: View {
             accountNames: Dictionary(
                 budgetStore.accounts.map { ($0.id, $0.name) },
                 uniquingKeysWith: { first, _ in first }
+            ),
+            categoryGroupIds: Dictionary(
+                budgetStore.categoryGroups.flatMap(\.categories).map { ($0.id, $0.groupId) },
+                uniquingKeysWith: { first, _ in first }
+            ),
+            categoryGroupNames: Dictionary(
+                budgetStore.categoryGroups.map { ($0.id, $0.name) },
+                uniquingKeysWith: { first, _ in first }
             )
         )
     }
@@ -196,10 +204,11 @@ struct DashboardView: View {
     }
 
     private func comparisonLabel(for meta: SpendingMeta?) -> String {
-        switch meta?.mode {
-        case .budget?: return "vs budget"
-        case .singleMonth?: return "vs \(meta?.compareTo ?? "prior")"
-        case .average?, .none: return "vs avg"
+        // nil mode defaults to single-month upstream (SpendingCard.tsx).
+        switch meta?.mode ?? .singleMonth {
+        case .budget: return "vs budget"
+        case .singleMonth: return "vs \(meta?.compareTo ?? "prior")"
+        case .average: return "vs avg"
         }
     }
 }

--- a/Actuali/ActualiTests/ConditionsFilterTests.swift
+++ b/Actuali/ActualiTests/ConditionsFilterTests.swift
@@ -263,6 +263,42 @@ struct ConditionsFilterTests {
         let miss = WidgetRuleCondition.makeMock(op: "hasTags", field: "notes", stringValue: "#travel")
         #expect(!ConditionsFilter.matches(transaction: tx, conditions: [miss], op: "and"))
     }
+
+    // MARK: - category_group (upstream maps the field to category.group)
+
+    private var groupContext: ConditionsFilter.Context {
+        ConditionsFilter.Context(
+            categoryGroupIds: ["groceries": "g-food", "dining": "g-food", "rent": "g-home"],
+            categoryGroupNames: ["g-food": "Food", "g-home": "Home"]
+        )
+    }
+
+    @Test func categoryGroupIs() {
+        let cond = WidgetRuleCondition.makeMock(op: "is", field: "category_group", stringValue: "g-food")
+        let inGroup = makeTransaction(category: "groceries")
+        let outOfGroup = makeTransaction(category: "rent")
+        #expect(ConditionsFilter.matches(transaction: inGroup, conditions: [cond], op: "and", context: groupContext))
+        #expect(!ConditionsFilter.matches(transaction: outOfGroup, conditions: [cond], op: "and", context: groupContext))
+    }
+
+    @Test func categoryGroupIsNot() {
+        let cond = WidgetRuleCondition.makeMock(op: "isNot", field: "category_group", stringValue: "g-food")
+        #expect(!ConditionsFilter.matches(transaction: makeTransaction(category: "dining"), conditions: [cond], op: "and", context: groupContext))
+        #expect(ConditionsFilter.matches(transaction: makeTransaction(category: "rent"), conditions: [cond], op: "and", context: groupContext))
+    }
+
+    @Test func categoryGroupOneOf() {
+        let cond = WidgetRuleCondition.makeMock(op: "oneOf", field: "category_group", stringArrayValue: ["g-home"])
+        #expect(ConditionsFilter.matches(transaction: makeTransaction(category: "rent"), conditions: [cond], op: "and", context: groupContext))
+        #expect(!ConditionsFilter.matches(transaction: makeTransaction(category: "groceries"), conditions: [cond], op: "and", context: groupContext))
+        #expect(!ConditionsFilter.matches(transaction: makeTransaction(category: nil), conditions: [cond], op: "and", context: groupContext))
+    }
+
+    @Test func categoryGroupContainsMatchesGroupName() {
+        let cond = WidgetRuleCondition.makeMock(op: "contains", field: "category_group", stringValue: "foo")
+        #expect(ConditionsFilter.matches(transaction: makeTransaction(category: "groceries"), conditions: [cond], op: "and", context: groupContext))
+        #expect(!ConditionsFilter.matches(transaction: makeTransaction(category: "rent"), conditions: [cond], op: "and", context: groupContext))
+    }
 }
 
 /// Test helper to build WidgetRuleCondition values from primitives.

--- a/Actuali/ActualiTests/SpendingEngineTests.swift
+++ b/Actuali/ActualiTests/SpendingEngineTests.swift
@@ -22,16 +22,78 @@ struct SpendingEngineTests {
         )
     }
 
-    @Test func currentMonthSpendingExcludesIncome() {
+    private func meta(
+        compare: String? = nil,
+        compareTo: String? = nil,
+        isLive: Bool? = true,
+        mode: SpendingMeta.Mode? = nil,
+        averageRange: SpendingAverageRange? = nil
+    ) -> SpendingMeta {
+        SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
+                     compare: compare, compareTo: compareTo, isLive: isLive,
+                     mode: mode, averageRange: averageRange)
+    }
+
+    // Upstream nets positive amounts (refunds) into spending; income
+    // exclusion happens by category upstream (categoryIncome), mirrored by
+    // DashboardView.spendingScope(), not by dropping positive amounts.
+    @Test func currentMonthNetsRefunds() {
         let transactions = [
             tx(date: 20260501, amount: -10000),
-            tx(date: 20260502, amount: 50000),   // income — excluded
-            tx(date: 20260503, amount: -2000)
+            tx(date: 20260503, amount: 3000),   // refund — nets against spending
+            tx(date: 20260504, amount: -2000)
         ]
-        let meta = SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
-                                compare: nil, compareTo: nil, isLive: true, mode: .average)
-        let result = SpendingEngine.compute(meta: meta, transactions: transactions, today: asOf)
-        #expect(result.currentSpentCents == 12000)
+        let result = SpendingEngine.compute(meta: meta(mode: .average), transactions: transactions, today: asOf)
+        #expect(result.currentSpentCents == 9000)
+    }
+
+    // Upstream's card reads the cumulative at today's day, so transactions
+    // dated later in the current month (scheduled/entered ahead) don't count.
+    @Test func currentMonthExcludesFutureDatedTransactions() {
+        let transactions = [
+            tx(date: 20260510, amount: -10000),
+            tx(date: 20260520, amount: -5000)   // after asOf (May 14) — excluded
+        ]
+        let result = SpendingEngine.compute(meta: meta(mode: .average), transactions: transactions, today: asOf)
+        #expect(result.currentSpentCents == 10000)
+    }
+
+    // Upstream defaults mode to 'single-month' compared against the previous
+    // month through the same day of month — not a 3-month average.
+    @Test func defaultModeIsSingleMonthVsPreviousMonth() {
+        let transactions = [
+            tx(date: 20260410, amount: -8000),
+            tx(date: 20260420, amount: -9000),  // past day 14 — excluded from comparison
+            tx(date: 20260505, amount: -100)
+        ]
+        let result = SpendingEngine.compute(meta: meta(mode: nil), transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 8000)
+    }
+
+    @Test func singleMonthWithoutCompareToUsesPreviousMonth() {
+        let transactions = [
+            tx(date: 20260410, amount: -8000),
+            tx(date: 20260505, amount: -100)
+        ]
+        let result = SpendingEngine.compute(meta: meta(mode: .singleMonth), transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 8000)
+    }
+
+    // A non-live widget keeps its stored compare/compareTo months verbatim,
+    // and past months always use their full-month totals (day-28 bucket).
+    @Test func pinnedCompareMonthIsHonored() {
+        let transactions = [
+            tx(date: 20260305, amount: -4000),
+            tx(date: 20260320, amount: -1000),  // past day 14, still counts: full month
+            tx(date: 20260210, amount: -2500),
+            tx(date: 20260505, amount: -999)    // current month — not the compare month
+        ]
+        let result = SpendingEngine.compute(
+            meta: meta(compare: "2026-03", compareTo: "2026-02", isLive: false, mode: .singleMonth),
+            transactions: transactions, today: asOf
+        )
+        #expect(result.currentSpentCents == 5000)
+        #expect(result.comparisonCents == 2500)
     }
 
     @Test func averageOfPriorMonths() {
@@ -44,12 +106,64 @@ struct SpendingEngineTests {
             tx(date: 20260420, amount: -50000),  // Apr, after day 14 — excluded by MTD cutoff
             tx(date: 20260505, amount: -5000)    // current month
         ]
-        let meta = SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
-                                compare: nil, compareTo: nil, isLive: true, mode: .average)
-        let result = SpendingEngine.compute(meta: meta, transactions: transactions, today: asOf)
+        let result = SpendingEngine.compute(meta: meta(mode: .average), transactions: transactions, today: asOf)
         #expect(result.currentSpentCents == 5000)
         // 3 prior months MTD: 10000 each (the 20260420 tx is past day 14), sum 30000, avg 30000/3 = 10000
         #expect(result.comparisonCents == 10000)
+    }
+
+    @Test func averageRangeSixMonths() {
+        let transactions = [
+            tx(date: 20251110, amount: -12000),
+            tx(date: 20251210, amount: -12000),
+            tx(date: 20260110, amount: -12000),
+            tx(date: 20260210, amount: -6000),
+            tx(date: 20260310, amount: -6000),
+            tx(date: 20260410, amount: -6000)
+        ]
+        let range = SpendingAverageRange(mode: "last-n-months", months: 6)
+        let result = SpendingEngine.compute(meta: meta(mode: .average, averageRange: range),
+                                            transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 9000)  // (3×12000 + 3×6000) / 6
+    }
+
+    @Test func averageRangeUnsupportedMonthsFallsBackToThree() {
+        let transactions = [
+            tx(date: 20251110, amount: -12000),
+            tx(date: 20260210, amount: -6000),
+            tx(date: 20260310, amount: -6000),
+            tx(date: 20260410, amount: -6000)
+        ]
+        let range = SpendingAverageRange(mode: "last-n-months", months: 5)
+        let result = SpendingEngine.compute(meta: meta(mode: .average, averageRange: range),
+                                            transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 6000)
+    }
+
+    @Test func averageRangeYearToDate() {
+        let transactions = [
+            tx(date: 20251210, amount: -99000),  // prior year — outside YTD
+            tx(date: 20260110, amount: -8000),
+            tx(date: 20260210, amount: -4000),
+            tx(date: 20260310, amount: -4000),
+            tx(date: 20260410, amount: -4000)
+        ]
+        let range = SpendingAverageRange(mode: "year-to-date", months: nil)
+        let result = SpendingEngine.compute(meta: meta(mode: .average, averageRange: range),
+                                            transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 5000)  // (8000 + 4000×3) / 4 (Jan–Apr)
+    }
+
+    @Test func averageRangeAllTime() {
+        // Earliest transaction is Dec 2025 → window Dec–Apr, 5 months.
+        let transactions = [
+            tx(date: 20251210, amount: -10000),
+            tx(date: 20260505, amount: -100)
+        ]
+        let range = SpendingAverageRange(mode: "all-time", months: nil)
+        let result = SpendingEngine.compute(meta: meta(mode: .average, averageRange: range),
+                                            transactions: transactions, today: asOf)
+        #expect(result.comparisonCents == 2000)  // 10000 / 5
     }
 
     @Test func singleMonthCompareTo() {
@@ -57,16 +171,15 @@ struct SpendingEngineTests {
             tx(date: 20260301, amount: -7777),   // March
             tx(date: 20260501, amount: -100)     // current
         ]
-        let meta = SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
-                                compare: nil, compareTo: "2026-03", isLive: true, mode: .singleMonth)
-        let result = SpendingEngine.compute(meta: meta, transactions: transactions, today: asOf)
+        let result = SpendingEngine.compute(
+            meta: meta(compareTo: "2026-03", mode: .singleMonth),
+            transactions: transactions, today: asOf
+        )
         #expect(result.comparisonCents == 7777)
     }
 
     @Test func budgetModeReturnsZeroComparison() {
-        let meta = SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
-                                compare: nil, compareTo: nil, isLive: true, mode: .budget)
-        let result = SpendingEngine.compute(meta: meta, transactions: [], today: asOf)
+        let result = SpendingEngine.compute(meta: meta(mode: .budget), transactions: [], today: asOf)
         #expect(result.comparisonCents == 0)
     }
 }


### PR DESCRIPTION
Follow-up to #102/#120 for the remaining report mismatches in #226. Each fix was checked against the upstream source in `packages/desktop-client` / `packages/loot-core`.

## What was wrong

**Filters (affects Summary, Spending, and every other widget engine):**
- `category_group` conditions were silently ignored — `ConditionsFilter` didn't know the field, so the condition matched *every* transaction. Upstream rewrites it to `category.group` (`transaction-rules.ts`). A Summary widget filtered by a category group would show the unfiltered total, which fits the "off by a significant amount" report.

**Spending widget (vs `spending-spreadsheet.ts` + `SpendingCard.tsx`):**
- `compare`/`isLive` were ignored — the widget always used the current month, even when pinned to a specific month.
- A missing `mode` was treated as `average`; upstream defaults to single-month vs the previous month.
- Single-month comparison used the full comparison month; upstream compares month-to-date against the same day of that month (full month only from day 28, or when comparing a past month).
- `averageRange` (last 3/6/12 months, YTD, all-time) wasn't decoded; 3 months was hardcoded.
- Refunds weren't netted (only negative amounts counted) and the live month included future-dated transactions; upstream nets everything and stops the cumulative at today.

SummaryEngine itself matched upstream; it picks up the `category_group` fix through the shared filter.

## Test notes

- New failing-first tests: 8 SpendingEngine cases fail on the old engine with exactly the diverging values; 4 new `category_group` ConditionsFilter cases (the old `Context` couldn't represent groups at all).
- `currentMonthSpendingExcludesIncome` was replaced by `currentMonthNetsRefunds`: it pinned the sign-based exclusion of positive amounts, which is what broke refund netting. Income exclusion is category-based upstream and already handled by `spendingScope()` in `DashboardView`.

## Out of scope

Budget-mode comparison still shows 0 (needs `zero_budgets`/`reflect_budgets` plumbing into the engine) — tracked as a follow-up. Exact repro configs from the Reddit reporter are still unconfirmed; if their widgets use other setups we can iterate.

## Verification

`xcodebuild test -skip-testing:ActualiUITests` on iPhone 17 Pro (iOS 26.2): **823 tests in 116 suites passed**, 0 failures.

Fixes #226