### PR TITLE
Show Saved / Projected savings for tracking budgets

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -51,6 +51,26 @@ struct BudgetMonth: Identifiable, Hashable {
     var totalIncome: Int {
         incomeCategories.reduce(0) { $0 + $1.received }
     }
+
+    /// Sum of budgeted amounts on income categories. Only meaningful for
+    /// tracking budgets, which can budget income. Mirrors loot-core
+    /// tracking.ts `total-budget-income`.
+    var totalBudgetedIncome: Int {
+        incomeCategories.reduce(0) { $0 + $1.budgeted }
+    }
+
+    /// Actual money kept this month: income received minus what actually went
+    /// out. Mirrors loot-core tracking.ts `real-saved`
+    /// (`total-income - -total-spent`); `totalSpent` is negative, so this adds.
+    var savedActual: Int {
+        totalIncome + totalSpent
+    }
+
+    /// What the budget projects will be kept: budgeted income minus budgeted
+    /// expenses. Mirrors loot-core tracking.ts `total-saved`.
+    var projectedSavings: Int {
+        totalBudgetedIncome - totalBudgeted
+    }
 }
 
 struct IncomeCategory: Identifiable, Hashable {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -585,6 +585,24 @@ struct CleanCategoryBudgetRow: View {
     }
 }
 
+/// Whether `month` ("YYYY-MM") is before the current calendar month. The
+/// strings are zero-padded, so a plain lexicographic compare is exact.
+private func isPastMonth(_ month: String) -> Bool {
+    month < BudgetView.currentMonthString()
+}
+
+/// The tracking-budget result figure for the summary bar: actual savings once
+/// a month is finished, projected savings while it's still current or ahead.
+/// Mirrors the Actual webapp, which flips "Projected savings" to "Saved" when
+/// the month rolls over.
+private func trackingSavings(_ budget: BudgetMonth) -> Int {
+    isPastMonth(budget.month) ? budget.savedActual : budget.projectedSavings
+}
+
+private func trackingSavingsLabel(_ budget: BudgetMonth) -> String {
+    isPastMonth(budget.month) ? "Saved" : "Projected"
+}
+
 /// Clean-style summary card: a 2x2 grid whose reading order follows the
 /// money — came in, allocated, went out, left over. Two rows because four
 /// currency amounts don't fit across narrow devices.
@@ -613,8 +631,8 @@ struct CleanBudgetSummary: View {
                 )
                 Spacer()
                 // Envelope budgets lead with unallocated funds; tracking
-                // budgets have no to-budget concept, so fall back to the
-                // total of category balances.
+                // budgets report savings instead — actual for a finished month,
+                // projected for the current/future month.
                 if let toBudget = budget.toBudget {
                     SummaryStat(
                         label: "To Budget",
@@ -623,10 +641,11 @@ struct CleanBudgetSummary: View {
                         alignment: .trailing
                     )
                 } else {
+                    let value = trackingSavings(budget)
                     SummaryStat(
-                        label: "Available",
-                        value: budgetStore.displayBalance(budget.totalAvailable),
-                        valueColor: budget.totalAvailable >= 0 ? .green : .red,
+                        label: trackingSavingsLabel(budget),
+                        value: budgetStore.displayBalance(value),
+                        valueColor: value >= 0 ? .green : .red,
                         alignment: .trailing
                     )
                 }
@@ -668,11 +687,23 @@ struct TableBudgetSummary: View {
                 label: "Spent",
                 value: budgetStore.displayBudgetCell(budget.totalOutflow)
             )
-            SummaryColumn(
-                label: "Balance",
-                value: budgetStore.displayBudgetCell(budget.totalAvailable),
-                valueColor: budget.totalAvailable >= 0 ? .green : .red
-            )
+            // Envelope budgets total the category balances; tracking budgets
+            // report savings instead — actual for a finished month, projected
+            // for the current/future month.
+            if budget.toBudget != nil {
+                SummaryColumn(
+                    label: "Balance",
+                    value: budgetStore.displayBudgetCell(budget.totalAvailable),
+                    valueColor: budget.totalAvailable >= 0 ? .green : .red
+                )
+            } else {
+                let value = trackingSavings(budget)
+                SummaryColumn(
+                    label: trackingSavingsLabel(budget),
+                    value: budgetStore.displayBudgetCell(value),
+                    valueColor: value >= 0 ? .green : .red
+                )
+            }
         }
     }
 }

--- a/Actuali/ActualiTests/BudgetMonthTrackingSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthTrackingSummaryTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The tracking-budget summary figures on `BudgetMonth`. These mirror upstream
+/// loot-core `tracking.ts`: `real-saved` (actual income + actual spent) and
+/// `total-saved` (budgeted income - budgeted expenses).
+struct BudgetMonthTrackingSummaryTests {
+
+    private func expense(id: String, budgeted: Int, spent: Int) -> CategoryBudget {
+        CategoryBudget(
+            month: "2026-07",
+            categoryId: id,
+            categoryName: "Category \(id)",
+            groupId: "g1",
+            groupName: "Everyday",
+            groupSortOrder: 0,
+            categorySortOrder: 0,
+            budgeted: budgeted,
+            spent: spent,
+            available: budgeted + spent,
+            carryover: 0
+        )
+    }
+
+    private func income(id: String, budgeted: Int, received: Int) -> IncomeCategory {
+        IncomeCategory(
+            month: "2026-07",
+            categoryId: id,
+            categoryName: "Income \(id)",
+            groupName: "Income",
+            sortOrder: 0,
+            budgeted: budgeted,
+            received: received
+        )
+    }
+
+    /// The exact figures from the Actual webapp's tracking summary (cents):
+    /// income 11,635.00 of budgeted 11,008.90; expenses -7,629.42 of budgeted
+    /// 4,952.66 → Saved 4,005.58, Projected 6,056.24.
+    @Test func matchesWebappSummaryFixture() {
+        let month = BudgetMonth(
+            month: "2026-07",
+            categoryBudgets: [expense(id: "e", budgeted: 495_266, spent: -762_942)],
+            incomeCategories: [income(id: "i", budgeted: 1_100_890, received: 1_163_500)]
+        )
+
+        #expect(month.totalBudgetedIncome == 1_100_890)
+        #expect(month.savedActual == 400_558)
+        #expect(month.projectedSavings == 605_624)
+    }
+
+    @Test func totalBudgetedIncomeSumsAllIncomeCategories() {
+        let month = BudgetMonth(
+            month: "2026-07",
+            categoryBudgets: [],
+            incomeCategories: [
+                income(id: "a", budgeted: 300_000, received: 0),
+                income(id: "b", budgeted: 150_000, received: 0)
+            ]
+        )
+        #expect(month.totalBudgetedIncome == 450_000)
+    }
+
+    @Test func savedActualIsNegativeWhenSpendingOutrunsIncome() {
+        let month = BudgetMonth(
+            month: "2026-07",
+            categoryBudgets: [expense(id: "e", budgeted: 100_000, spent: -250_000)],
+            incomeCategories: [income(id: "i", budgeted: 200_000, received: 200_000)]
+        )
+        // 200,000 received + (-250,000) spent = -50,000
+        #expect(month.savedActual == -50_000)
+    }
+
+    @Test func projectedSavingsIsNegativeWhenBudgetedExpensesExceedIncome() {
+        let month = BudgetMonth(
+            month: "2026-07",
+            categoryBudgets: [expense(id: "e", budgeted: 300_000, spent: 0)],
+            incomeCategories: [income(id: "i", budgeted: 200_000, received: 0)]
+        )
+        // 200,000 budgeted income - 300,000 budgeted expenses = -100,000
+        #expect(month.projectedSavings == -100_000)
+    }
+}


### PR DESCRIPTION
Tracking budgets were falling back to "Available" in the summary bar, which isn't the headline figure a tracking budgeter looks for. This surfaces what the Actual webapp shows instead:

- **Past month** → **Saved** = actual income + actual spent
- **Current/future month** → **Projected** = budgeted income − budgeted expenses

Mirrors loot-core `tracking.ts` (`real-saved` / `total-saved`). Adds three pure computed properties to `BudgetMonth` (`totalBudgetedIncome`, `savedActual`, `projectedSavings`) — no DB/sync changes — and swaps the tracking-only slot in both the clean and table summary styles. Envelope budgets are untouched.

Note: in the table (PWA) style this repurposes the trailing column's caption to Saved/Projected for tracking, mirroring how the clean style repurposes its Available stat.

Tests: new `BudgetMonthTrackingSummaryTests` (incl. the webapp's exact fixture). Ran the full unit suite locally — green. (UI tests are excluded from CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #235