### PR TITLE
Add a tracking option to the demo budget

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1267,13 +1267,13 @@ final class BudgetStore: ObservableObject {
     /// Populate a local "demo" budget with curated data, for screenshots and for
     /// letting users (and App Review) explore the app without configuring a server.
     /// Logs out any active server session so sync cannot fire against a real server.
-    func loadDemoData() async {
+    func loadDemoData(tracking: Bool = false) async {
         // Log out any active session so sync doesn't try to fire against a
         // real server — but keep local budget files: trying the demo must
         // never destroy a user's synced data.
         logout(clearLocalData: false)
         do {
-            try DemoDataSeeder.seed()
+            try DemoDataSeeder.seed(tracking: tracking)
             currentBudgetId = DemoDataSeeder.budgetId
             await loadLocalBudget(DemoDataSeeder.budgetId)
             // The seeder recreates the budget directory mid-launch, so any

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -12,8 +12,9 @@ enum DemoDataSeeder {
 
     /// Creates a local "demo" budget directory with a populated SQLite DB.
     /// Overwrites any existing demo budget. Does NOT connect to a server or
-    /// start sync.
-    static func seed() throws {
+    /// start sync. `tracking` seeds a tracking (`reflect_budgets`) budget rather
+    /// than the default envelope (`zero_budgets`) one.
+    static func seed(tracking: Bool = false) throws {
         let fileManager = BudgetFileManager.shared
         let budgetDir = fileManager.budgetDirectory(for: budgetId)
 
@@ -26,7 +27,7 @@ enum DemoDataSeeder {
         // Write metadata.json
         let metadata = BudgetMetadata(
             id: budgetId,
-            budgetName: "Demo Budget",
+            budgetName: tracking ? "Demo Budget (Tracking)" : "Demo Budget",
             cloudFileId: nil,
             groupId: nil,
             resetClock: nil,
@@ -41,8 +42,8 @@ enum DemoDataSeeder {
         let dbQueue = try DatabaseQueue(path: dbPath.path)
 
         try dbQueue.write { db in
-            try createSchema(db)
-            try insertSeedData(db)
+            try createSchema(db, tracking: tracking)
+            try insertSeedData(db, tracking: tracking)
         }
 
         logger.info("Demo data seeded successfully at \(dbPath.path, privacy: .public)")
@@ -50,7 +51,7 @@ enum DemoDataSeeder {
 
     // MARK: - Schema
 
-    private static func createSchema(_ db: Database) throws {
+    private static func createSchema(_ db: Database, tracking: Bool) throws {
         try db.execute(sql: """
             CREATE TABLE accounts (
                 id TEXT PRIMARY KEY,
@@ -145,8 +146,11 @@ enum DemoDataSeeder {
             )
             """)
 
+        // Envelope budgets live in zero_budgets, tracking budgets in
+        // reflect_budgets. The columns are identical; only one table exists so
+        // BudgetDatabase.budgetTable picks it without needing the preference.
         try db.execute(sql: """
-            CREATE TABLE zero_budgets (
+            CREATE TABLE \(tracking ? "reflect_budgets" : "zero_budgets") (
                 id TEXT PRIMARY KEY,
                 month INTEGER,
                 category TEXT,
@@ -229,7 +233,7 @@ enum DemoDataSeeder {
 
     // MARK: - Seed Data
 
-    private static func insertSeedData(_ db: Database) throws {
+    private static func insertSeedData(_ db: Database, tracking: Bool) throws {
         let cal = Calendar(identifier: .gregorian)
         let now = Date()
         let comps = cal.dateComponents([.year, .month, .day], from: now)
@@ -483,8 +487,8 @@ enum DemoDataSeeder {
             sortOrder -= 1
         }
 
-        // --- Zero budgets (current month) ---
-        let budgets: [(String, Int)] = [
+        // --- Budgets (current month) ---
+        var budgets: [(String, Int)] = [
             (groceriesId, 60_000),
             (rentId, 185_000),
             (utilitiesId, 10_000),
@@ -499,9 +503,16 @@ enum DemoDataSeeder {
             (gymId, 3_500),
             (pharmacyId, 3_000)
         ]
+        // Tracking budgets also budget income (unlike envelope), so the Saved /
+        // Projected savings summary has a budgeted-income figure to work with.
+        // Matches the two 320,000 monthly paychecks.
+        if tracking {
+            budgets.append((salaryId, 640_000))
+        }
+        let budgetsTable = tracking ? "reflect_budgets" : "zero_budgets"
         for (catId, amount) in budgets {
             try db.execute(sql: """
-                INSERT INTO zero_budgets (id, month, category, amount, carryover)
+                INSERT INTO \(budgetsTable) (id, month, category, amount, carryover)
                 VALUES (?, ?, ?, ?, 0)
                 """, arguments: [UUID().uuidString, yyyymm, catId, amount])
         }
@@ -510,6 +521,13 @@ enum DemoDataSeeder {
         try db.execute(sql: """
             INSERT INTO preferences (id, value) VALUES ('defaultCurrencyCode', 'USD')
             """)
+        // Mirror a real tracking file: budgetType drives which budget table is
+        // live when both exist (harmless here where only one does).
+        if tracking {
+            try db.execute(sql: """
+                INSERT INTO preferences (id, value) VALUES ('budgetType', 'tracking')
+                """)
+        }
 
         // --- Reports dashboards ---
         // Two pages so the demo exercises the dashboard switcher (GH #120);

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -219,8 +219,13 @@ struct SettingsView: View {
                                 || (budgetStore.requiresServerPassword && password.isEmpty))
                         }
 
-                        Button("Try the demo budget") {
-                            Task { await budgetStore.loadDemoData() }
+                        Menu("Try the demo budget") {
+                            Button("Envelope budget") {
+                                Task { await budgetStore.loadDemoData() }
+                            }
+                            Button("Tracking budget") {
+                                Task { await budgetStore.loadDemoData(tracking: true) }
+                            }
                         }
                         .disabled(budgetStore.isLoading)
 

--- a/Actuali/ActualiTests/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/DemoDataSeederTests.swift
@@ -11,10 +11,39 @@ import Testing
 @MainActor
 struct DemoDataSeederTests {
 
-    private func seedAndOpen() throws -> BudgetDatabase {
-        try DemoDataSeeder.seed()
+    private func seedAndOpen(tracking: Bool = false) throws -> BudgetDatabase {
+        try DemoDataSeeder.seed(tracking: tracking)
         let dbPath = BudgetFileManager.shared.databasePath(for: DemoDataSeeder.budgetId)
         return try BudgetDatabase(path: dbPath)
+    }
+
+    /// The current month as "YYYY-MM", matching the demo seeder's budget month.
+    private var currentMonth: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM"
+        return formatter.string(from: Date())
+    }
+
+    /// The tracking demo seeds `reflect_budgets` and budgets income, so the
+    /// budget reads as tracking (no envelope "To Budget") and the new
+    /// Saved / Projected savings summary has real figures to show.
+    @Test func trackingSeedProducesATrackingBudget() async throws {
+        let database = try seedAndOpen(tracking: true)
+        let month = try await database.fetchBudgetMonth(month: currentMonth)
+
+        #expect(month.toBudget == nil)
+        // Tracking budgets can budget income; the seeder does, so the summary
+        // has a budgeted-income figure to work with.
+        #expect(month.incomeCategories.contains { $0.budgeted > 0 })
+    }
+
+    /// The default (envelope) demo keeps its "To Budget" unallocated-funds
+    /// figure — the tracking flag must not leak into the normal path.
+    @Test func envelopeSeedKeepsToBudget() async throws {
+        let database = try seedAndOpen()
+        let month = try await database.fetchBudgetMonth(month: currentMonth)
+
+        #expect(month.toBudget != nil)
     }
 
     // Two pages so the demo exercises the dashboard switcher (GH #120);


### PR DESCRIPTION
The demo only ever seeded an envelope budget, so there was no way to try the app's tracking-budget behaviour without a real server file set to tracking.

Settings' "Try the demo budget" is now a menu offering **Envelope** or **Tracking**. The tracking demo seeds `reflect_budgets` (including budgeted income) and sets the `budgetType` preference. Default stays envelope, so App Store screenshots and the `-loadDemoData` launch arg are unaffected.

Pairs nicely with the Saved/Projected tracking-summary PR, but is independent of it.

Tests: extends `DemoDataSeederTests` to cover the tracking seed (tracking table + budgeted income) and an envelope regression. Ran the full unit suite locally — green. (UI tests are excluded from CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #235