### PR TITLE
Center the budget month stepper

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -293,25 +293,30 @@ struct BudgetView: View {
             }
             .navigationTitle("Budget")
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        selectedMonth = Self.shiftMonth(selectedMonth, by: -1)
-                    } label: {
-                        Image(systemName: "chevron.left")
-                    }
-                    .accessibilityLabel("Previous month")
-                }
+                // Both arrows flank the month in the center, so nothing sits in
+                // the leading "back button" position where the previous-month
+                // chevron used to be mistaken for one (it steps the month, not
+                // the navigation stack).
                 ToolbarItem(placement: .principal) {
-                    MonthPicker(selectedMonth: $selectedMonth)
-                }
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    Button {
-                        selectedMonth = Self.shiftMonth(selectedMonth, by: 1)
-                    } label: {
-                        Image(systemName: "chevron.right")
-                    }
-                    .accessibilityLabel("Next month")
+                    HStack(spacing: 8) {
+                        Button {
+                            selectedMonth = Self.shiftMonth(selectedMonth, by: -1)
+                        } label: {
+                            Image(systemName: "chevron.left")
+                        }
+                        .accessibilityLabel("Previous month")
 
+                        MonthPicker(selectedMonth: $selectedMonth)
+
+                        Button {
+                            selectedMonth = Self.shiftMonth(selectedMonth, by: 1)
+                        } label: {
+                            Image(systemName: "chevron.right")
+                        }
+                        .accessibilityLabel("Next month")
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     // Every "how should this look" control lives here (GH
                     // #157). Whole-table expand/collapse is a menu rather
                     // than a long-press on the group headers: SwiftUI context


### PR DESCRIPTION
On the Budget tab the previous-month chevron sat in the top-leading slot — the same place every pushed screen (e.g. Accounts) shows a Back button — so it read as "go back" when it actually steps the month back.

This groups both arrows around the month in the center (`‹ September 2026 ›`), freeing the leading edge so nothing looks like a back button (matches iOS Calendar/Health). The `⋯` options menu stays trailing and the swipe-to-change-month gesture is unchanged.

Tests: view-layout only. Ran the full unit suite locally — green. (UI tests are excluded from CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #236