### PR TITLE
Cover all remaining dashboard report widget types

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1704,6 +1704,59 @@ class BudgetDatabase {
     }
 
     /// Synced pref controlling week bucketing (0 = Sunday … 6 = Saturday).
+    /// Budget rows for report engines from the live budgets table (see
+    /// budgetTable(_:)), plus whether that table is reflect_budgets so
+    /// callers can mirror upstream budgetType checks.
+    struct ReportBudgetData: Equatable {
+        var entries: [BudgetAnalysisBudgetEntry] = []
+        var isTracking = false
+    }
+
+    func fetchBudgetDataForReports() async throws -> ReportBudgetData {
+        try await dbQueue.read { db in
+            guard let table = try Self.budgetTable(db) else { return ReportBudgetData() }
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT b.month, COALESCE(cm.transferId, b.category) AS category, b.amount
+                FROM \(table) b
+                LEFT JOIN category_mapping cm ON cm.id = b.category
+                WHERE b.category IS NOT NULL
+                """)
+            let entries = rows.compactMap { row -> BudgetAnalysisBudgetEntry? in
+                guard let month: Int = row["month"], let category: String = row["category"] else { return nil }
+                return BudgetAnalysisBudgetEntry(month: month, categoryId: category, amountCents: row["amount"] ?? 0)
+            }
+            return ReportBudgetData(entries: entries, isTracking: table == "reflect_budgets")
+        }
+    }
+
+    /// Per-month tracking-budget totals for the balance-forecast engine
+    /// (upstream forecast-tracking-budget.ts: income = budgeted amounts across
+    /// income categories, expenses = across the rest). Always reads
+    /// reflect_budgets; callers gate on the budget type.
+    func fetchTrackingBudgetMonths() async throws -> [BalanceForecastBudgetMonth] {
+        try await dbQueue.read { db in
+            guard try db.tableExists("reflect_budgets") else { return [] }
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT b.month AS month,
+                       SUM(CASE WHEN c.is_income = 1 THEN b.amount ELSE 0 END) AS income,
+                       SUM(CASE WHEN c.is_income = 1 THEN 0 ELSE b.amount END) AS expenses
+                FROM reflect_budgets b
+                LEFT JOIN category_mapping cm ON cm.id = b.category
+                LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, b.category)
+                WHERE b.category IS NOT NULL
+                GROUP BY b.month
+                """)
+            return rows.compactMap { row in
+                guard let month: Int = row["month"] else { return nil }
+                return BalanceForecastBudgetMonth(
+                    month: month,
+                    budgetedIncomeCents: row["income"] ?? 0,
+                    budgetedExpensesCents: row["expenses"] ?? 0
+                )
+            }
+        }
+    }
+
     func fetchFirstDayOfWeekIdx() async throws -> Int {
         try await dbQueue.read { db in
             guard try db.tableExists("preferences") else { return 0 }
@@ -2122,7 +2175,17 @@ class BudgetDatabase {
     /// occurrence either way and only its advance fails. Returns [] when the
     /// schedule tables don't exist (older budget files).
     func fetchPostableSchedules() throws -> [Schedule] {
-        try dbQueue.read { db in
+        try dbQueue.read { db in try Self.schedules(db, postableOnly: true) }
+    }
+
+    /// Schedules for the balance-forecast engine: same parsing as the poster,
+    /// but manual (posts_transaction = 0) schedules forecast too, matching
+    /// upstream forecast-schedules.ts.
+    func fetchForecastSchedules() async throws -> [Schedule] {
+        try await dbQueue.read { db in try Self.schedules(db, postableOnly: false) }
+    }
+
+    private static func schedules(_ db: Database, postableOnly: Bool) throws -> [Schedule] {
             guard try db.tableExists("schedules"),
                   try db.tableExists("schedules_next_date"),
                   try db.tableExists("rules")
@@ -2142,7 +2205,7 @@ class BudgetDatabase {
                 JOIN rules r ON r.id = s.rule
                 WHERE (s.tombstone = 0 OR s.tombstone IS NULL)
                   AND (s.completed = 0 OR s.completed IS NULL)
-                  AND s.posts_transaction = 1
+                  AND (s.posts_transaction = 1 OR \(postableOnly ? 0 : 1))
                   AND (r.tombstone = 0 OR r.tombstone IS NULL)
                 ORDER BY s.id, nd.id
                 """)
@@ -2235,7 +2298,6 @@ class BudgetDatabase {
                     dateCondition: dateCondition
                 )
             }
-        }
     }
 
     /// Dedup guard for the poster: does an alive transaction linked to this

--- a/Actuali/Actuali/Services/Reports/DashboardWidget.swift
+++ b/Actuali/Actuali/Services/Reports/DashboardWidget.swift
@@ -262,6 +262,12 @@ enum DashboardWidget: Equatable {
     case ageOfMoney(id: String, meta: AgeOfMoneyMeta?)
     case formula(id: String, meta: FormulaMeta?)
     case customReport(id: String, meta: CustomReportMeta?)
+    case calendar(id: String, meta: CalendarMeta?)
+    case crossover(id: String, meta: CrossoverMeta?)
+    case budgetAnalysis(id: String, meta: BudgetAnalysisMeta?)
+    case sankey(id: String, meta: SankeyMeta?)
+    case balanceForecast(id: String, meta: BalanceForecastMeta?)
+    case monteCarlo(id: String, meta: MonteCarloMeta?)
     case unsupported(id: String, type: String)
 
     var id: String {
@@ -274,6 +280,12 @@ enum DashboardWidget: Equatable {
              .ageOfMoney(let id, _),
              .formula(let id, _),
              .customReport(let id, _),
+             .calendar(let id, _),
+             .crossover(let id, _),
+             .budgetAnalysis(let id, _),
+             .sankey(let id, _),
+             .balanceForecast(let id, _),
+             .monteCarlo(let id, _),
              .unsupported(let id, _):
             return id
         }
@@ -289,6 +301,12 @@ enum DashboardWidget: Equatable {
         case .ageOfMoney: return "Age of Money"
         case .formula: return "Formula"
         case .customReport: return "Custom Report"
+        case .calendar: return "Calendar"
+        case .crossover: return "Crossover"
+        case .budgetAnalysis: return "Budget Analysis"
+        case .sankey: return "Sankey"
+        case .balanceForecast: return "Balance Forecast"
+        case .monteCarlo: return "Monte Carlo"
         case .unsupported(_, let type): return type
         }
     }
@@ -303,6 +321,12 @@ enum DashboardWidget: Equatable {
         case .ageOfMoney(_, let meta): return meta?.name ?? typeLabel
         case .formula(_, let meta): return meta?.name ?? typeLabel
         case .customReport(_, let meta): return meta?.name ?? typeLabel
+        case .calendar(_, let meta): return meta?.name ?? typeLabel
+        case .crossover(_, let meta): return meta?.name ?? typeLabel
+        case .budgetAnalysis(_, let meta): return meta?.name ?? typeLabel
+        case .sankey(_, let meta): return meta?.name ?? typeLabel
+        case .balanceForecast(_, let meta): return meta?.name ?? typeLabel
+        case .monteCarlo(_, let meta): return meta?.name ?? typeLabel
         case .unsupported: return typeLabel
         }
     }
@@ -333,6 +357,18 @@ enum DashboardWidget: Equatable {
             return .formula(id: id, meta: decode(FormulaMeta.self))
         case "custom-report":
             return .customReport(id: id, meta: decode(CustomReportMeta.self))
+        case "calendar-card":
+            return .calendar(id: id, meta: decode(CalendarMeta.self))
+        case "crossover-card":
+            return .crossover(id: id, meta: decode(CrossoverMeta.self))
+        case "budget-analysis-card":
+            return .budgetAnalysis(id: id, meta: decode(BudgetAnalysisMeta.self))
+        case "sankey-card":
+            return .sankey(id: id, meta: decode(SankeyMeta.self))
+        case "balance-forecast-card":
+            return .balanceForecast(id: id, meta: decode(BalanceForecastMeta.self))
+        case "monte-carlo-card":
+            return .monteCarlo(id: id, meta: decode(MonteCarloMeta.self))
         default:
             return .unsupported(id: id, type: type)
         }

--- a/Actuali/Actuali/Services/Reports/Engines/BalanceForecastEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/BalanceForecastEngine.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+// MARK: - Meta
+
+/// Mirrors upstream `BalanceForecastWidget` meta (loot-core dashboard.ts).
+struct BalanceForecastMeta: Codable, Equatable {
+    let name: String?
+    let startDate: String?
+    let endDate: String?
+    let accounts: [String]?
+    let conditions: [WidgetRuleCondition]?
+    let conditionsOp: String?
+    let timeFrame: WidgetTimeFrame?
+    let granularity: Granularity?
+    let source: Source?
+
+    enum Granularity: String, Codable {
+        case daily = "Daily"
+        case monthly = "Monthly"
+    }
+
+    enum Source: String, Codable {
+        case schedules
+        case trackingBudget = "tracking-budget"
+    }
+}
+
+// MARK: - Inputs
+
+/// One month of tracking-budget totals, derived from `reflect_budgets`
+/// (month YYYYMM, category, amount — integer cents). Mirrors the upstream
+/// sheet cells (forecast-tracking-budget.ts): `budgetedIncomeCents` =
+/// 'total-budget-income' (sum of budgeted amounts across income categories),
+/// `budgetedExpensesCents` = 'total-budgeted' (sum across expense
+/// categories, positive). Months missing from the array count as zero.
+struct BalanceForecastBudgetMonth: Equatable {
+    let month: Int  // YYYYMM
+    let budgetedIncomeCents: Int
+    let budgetedExpensesCents: Int
+}
+
+// MARK: - Output
+
+struct BalanceForecastPoint: Equatable {
+    /// The sampled day: each day for Daily, the last day of the month for
+    /// Monthly (upstream keys monthly points by month; the balance is the
+    /// month-end balance either way).
+    let date: Date
+    let balanceCents: Int
+    /// True when the sampled day is after `today` — the projected segment.
+    let isForecast: Bool
+}
+
+struct BalanceForecastData: Equatable {
+    let points: [BalanceForecastPoint]
+}
+
+// MARK: - Engine
+
+/// Port of upstream's balance forecast at dashboard-card fidelity:
+/// loot-core `forecast/` (projection, schedules, tracking-budget) combined
+/// with desktop-client `balanceForecastChartData.ts`.
+///
+/// Integrator wiring:
+/// - `transactions`: all live transactions (the engine applies account
+///   selection and widget conditions itself).
+/// - `schedules`: alive, non-completed schedules regardless of
+///   `posts_transaction` (the forecast projects manual schedules too, so
+///   `fetchPostableSchedules` needs a variant without that flag filter).
+/// - `trackingBudgetMonths`: see `BalanceForecastBudgetMonth`; only needed
+///   for `source == .trackingBudget`, and the integrator must fall back to
+///   `.schedules` when the budget file isn't a tracking budget (card parity
+///   with the `budgetType` pref check in BalanceForecastCard.tsx).
+/// - `offBudgetAccountIds`: used by the tracking-budget starting balance.
+/// - `transferAccountsByPayeeId`: payee id → `payees.transfer_acct` (non-null
+///   rows only), so transfer schedules project both legs.
+///
+/// Deliberate cuts from upstream (card fidelity):
+/// - No rule-running on simulated occurrences (upstream `runRules`); the
+///   schedule's own account/payee/category feed the condition filter directly.
+/// - Posted-occurrence dedup always matches the exact occurrence date;
+///   upstream widens to a 2-day lookback for `isapprox` manual schedules.
+/// - Accountless schedules are excluded (the app's schedule model requires
+///   an account condition; upstream's `includeAccountlessSchedules`).
+enum BalanceForecastEngine {
+
+    static func compute(
+        meta: BalanceForecastMeta?,
+        transactions: [Transaction],
+        schedules: [Schedule] = [],
+        trackingBudgetMonths: [BalanceForecastBudgetMonth] = [],
+        offBudgetAccountIds: Set<String> = [],
+        transferAccountsByPayeeId: [String: String] = [:],
+        today: Date,
+        context: ConditionsFilter.Context = .empty
+    ) -> BalanceForecastData {
+        let todayDay = dayDate(from: today)
+        let (chartStart, chartEnd) = resolveRange(meta?.timeFrame, asOf: today)
+        guard chartStart <= chartEnd else { return BalanceForecastData(points: []) }
+
+        // The forecast query always covers whole months; the chart trims
+        // back to the requested bounds (BalanceForecastCard.tsx).
+        let forecastStart = DayDate(year: chartStart.year, month: chartStart.month, day: 1)
+        let forecastEnd = DayDate(
+            year: chartEnd.year, month: chartEnd.month,
+            day: DayDate.lastDay(year: chartEnd.year, month: chartEnd.month)
+        )
+
+        let combinedByDay: [Int: Int]
+        if meta?.source == .trackingBudget {
+            combinedByDay = trackingBudgetSeries(
+                transactions: transactions,
+                months: trackingBudgetMonths,
+                offBudgetAccountIds: offBudgetAccountIds,
+                forecastStart: forecastStart,
+                forecastEnd: forecastEnd
+            )
+        } else {
+            if let selected = meta?.accounts, selected.isEmpty {
+                return BalanceForecastData(points: [])
+            }
+            combinedByDay = schedulesSeries(
+                meta: meta,
+                transactions: transactions,
+                schedules: schedules,
+                transferAccountsByPayeeId: transferAccountsByPayeeId,
+                forecastStart: forecastStart,
+                forecastEnd: forecastEnd,
+                today: todayDay,
+                context: context
+            )
+        }
+
+        let granularity = meta?.granularity ?? .monthly
+        return BalanceForecastData(points: chartPoints(
+            combinedByDay: combinedByDay,
+            granularity: granularity,
+            chartStart: chartStart,
+            chartEnd: chartEnd,
+            today: todayDay
+        ))
+    }
+
+    // MARK: - Schedules source
+
+    /// Combined running balance per day over the whole forecast range:
+    /// posted history plus projected schedule occurrences from
+    /// `firstForecastDate` (= max(start, today)) onward. Port of
+    /// `projectForecastData` (forecast-projection.ts), collapsed to the
+    /// combined series the card renders.
+    private static func schedulesSeries(
+        meta: BalanceForecastMeta?,
+        transactions: [Transaction],
+        schedules: [Schedule],
+        transferAccountsByPayeeId: [String: String],
+        forecastStart: DayDate,
+        forecastEnd: DayDate,
+        today: DayDate,
+        context: ConditionsFilter.Context
+    ) -> [Int: Int] {
+        let selected = meta?.accounts.map { Set($0) }
+        func inSelection(_ accountId: String) -> Bool { selected?.contains(accountId) ?? true }
+
+        let filtered = transactions
+            .filter { !$0.tombstone }
+            .filter { inSelection($0.accountId) }
+            .filter { ConditionsFilter.matches(transaction: $0, conditions: meta?.conditions, op: meta?.conditionsOp, context: context) }
+
+        var startingBalance = 0
+        var deltaByDay: [Int: Int] = [:]
+        for tx in filtered {
+            if tx.date < forecastStart.yyyymmdd {
+                startingBalance += tx.amount
+            } else if tx.date <= forecastEnd.yyyymmdd {
+                deltaByDay[tx.date, default: 0] += tx.amount
+            }
+        }
+
+        // Posted-occurrence dedup index (shared/schedules
+        // indexPostedScheduleTransactions; upstream also builds it from the
+        // account+condition-filtered set).
+        var postedDatesBySchedule: [String: [Int]] = [:]
+        for tx in filtered {
+            if let scheduleId = tx.schedule {
+                postedDatesBySchedule[scheduleId, default: []].append(tx.date)
+            }
+        }
+
+        // Past-due occurrences before today never project (firstForecastDate
+        // in forecast-projection.ts).
+        let firstForecast = forecastEnd < today ? forecastStart : max(forecastStart, today)
+
+        func addOccurrenceLeg(accountId: String, amount: Int, payeeId: String?, categoryId: String?, date: DayDate) {
+            guard inSelection(accountId) else { return }
+            let simulated = Transaction(
+                id: "forecast", accountId: accountId, date: date.yyyymmdd, amount: amount,
+                payeeId: payeeId, payeeName: nil, categoryId: categoryId, categoryName: nil,
+                notes: nil, cleared: false, reconciled: false,
+                transferId: nil, isParent: false, parentId: nil,
+                tombstone: false, sortOrder: nil, importedPayee: nil
+            )
+            guard ConditionsFilter.matches(transaction: simulated, conditions: meta?.conditions, op: meta?.conditionsOp, context: context) else { return }
+            deltaByDay[date.yyyymmdd, default: 0] += amount
+        }
+
+        // Schedules are NOT pre-filtered by account: when only the transfer
+        // side is selected, its leg still projects (forecast-schedules.ts).
+        for schedule in schedules {
+            let amount = schedule.amount?.postAmount ?? 0
+            let posted = postedDatesBySchedule[schedule.id] ?? []
+            for date in occurrenceDates(for: schedule, endDate: forecastEnd) {
+                guard date >= firstForecast, date <= forecastEnd else { continue }
+                guard !posted.contains(date.yyyymmdd) else { continue }
+                addOccurrenceLeg(
+                    accountId: schedule.accountId, amount: amount,
+                    payeeId: schedule.payeeId, categoryId: schedule.categoryId, date: date
+                )
+                if let payeeId = schedule.payeeId,
+                   let transferAccountId = transferAccountsByPayeeId[payeeId],
+                   transferAccountId != schedule.accountId {
+                    addOccurrenceLeg(
+                        accountId: transferAccountId, amount: -amount,
+                        payeeId: nil, categoryId: nil, date: date
+                    )
+                }
+            }
+        }
+
+        var series: [Int: Int] = [:]
+        var running = startingBalance
+        var day = forecastStart
+        while day <= forecastEnd {
+            running += deltaByDay[day.yyyymmdd] ?? 0
+            series[day.yyyymmdd] = running
+            day = day.adding(days: 1)
+        }
+        return series
+    }
+
+    /// Port of `getFutureOccurrenceDates` (forecast-schedules.ts): the stored
+    /// next date, then recurrence expansion through `endDate`.
+    private static func occurrenceDates(for schedule: Schedule, endDate: DayDate) -> [DayDate] {
+        switch schedule.dateCondition {
+        case .fixed(let date):
+            return date <= endDate ? [date] : []
+        case .unsupported:
+            // Recurrence shape the port can't expand; the stored next_date is
+            // still a real upcoming occurrence, so project that one (mirrors
+            // the poster's post-once-without-advancing behavior).
+            return schedule.nextDate <= endDate ? [schedule.nextDate] : []
+        case .recurring(let config):
+            var dates = [schedule.nextDate]
+            var seen: Set<DayDate> = [schedule.nextDate]
+            var day = schedule.nextDate
+            var iterations = 0
+            while day <= endDate, iterations < 10_000 {
+                iterations += 1
+                guard let next = ScheduleRecurrence.nextOccurrence(config: config, onOrAfter: day),
+                      next <= endDate
+                else { break }
+                // getNextDate can return an already-seen date (ended schedule
+                // fallback, weekend solve); step a day forward like upstream.
+                if seen.contains(next) {
+                    day = day.adding(days: 1)
+                    continue
+                }
+                dates.append(next)
+                seen.insert(next)
+                day = next.adding(days: 1)
+            }
+            return dates
+        }
+    }
+
+    // MARK: - Tracking-budget source
+
+    /// Port of `projectTrackingBudgetForecast` (forecast-tracking-budget.ts):
+    /// current on-budget balance, then one month-end point per month adding
+    /// budgeted income minus budgeted expenses. Ignores account selection and
+    /// conditions, like upstream.
+    private static func trackingBudgetSeries(
+        transactions: [Transaction],
+        months: [BalanceForecastBudgetMonth],
+        offBudgetAccountIds: Set<String>,
+        forecastStart: DayDate,
+        forecastEnd: DayDate
+    ) -> [Int: Int] {
+        var running = transactions
+            .filter { !$0.tombstone && !offBudgetAccountIds.contains($0.accountId) }
+            .reduce(0) { $0 + $1.amount }
+
+        var byMonth: [Int: BalanceForecastBudgetMonth] = [:]
+        for month in months { byMonth[month.month] = month }
+
+        var series: [Int: Int] = [:]
+        for (year, month) in monthsInclusive(from: forecastStart, to: forecastEnd) {
+            let entry = byMonth[year * 100 + month]
+            running += (entry?.budgetedIncomeCents ?? 0) - (entry?.budgetedExpensesCents ?? 0)
+            let lastDay = DayDate(year: year, month: month, day: DayDate.lastDay(year: year, month: month))
+            series[lastDay.yyyymmdd] = running
+        }
+        return series
+    }
+
+    // MARK: - Chart data
+
+    /// Port of `buildBalanceForecastChartData` (balanceForecastChartData.ts).
+    private static func chartPoints(
+        combinedByDay: [Int: Int],
+        granularity: BalanceForecastMeta.Granularity,
+        chartStart: DayDate,
+        chartEnd: DayDate,
+        today: DayDate
+    ) -> [BalanceForecastPoint] {
+        guard !combinedByDay.isEmpty else { return [] }
+
+        switch granularity {
+        case .daily:
+            // Carry the balance forward from the latest point before the
+            // visible range, so a day-shaped start doesn't begin at zero.
+            var running = combinedByDay
+                .filter { $0.key < chartStart.yyyymmdd }
+                .max { $0.key < $1.key }?.value ?? 0
+            var points: [BalanceForecastPoint] = []
+            var day = chartStart
+            while day <= chartEnd {
+                if let balance = combinedByDay[day.yyyymmdd] { running = balance }
+                points.append(BalanceForecastPoint(date: date(from: day), balanceCents: running, isForecast: day > today))
+                day = day.adding(days: 1)
+            }
+            return points
+
+        case .monthly:
+            // Latest balance within each month; months with no data carry the
+            // running balance (which starts at zero — upstream monthly has no
+            // prior-range carry).
+            var latestKeyByMonth: [Int: Int] = [:]
+            for key in combinedByDay.keys {
+                let month = key / 100
+                if key > latestKeyByMonth[month] ?? 0 { latestKeyByMonth[month] = key }
+            }
+            var running = 0
+            return monthsInclusive(from: chartStart, to: chartEnd).map { year, month in
+                if let key = latestKeyByMonth[year * 100 + month], let balance = combinedByDay[key] {
+                    running = balance
+                }
+                let lastDay = DayDate(year: year, month: month, day: DayDate.lastDay(year: year, month: month))
+                return BalanceForecastPoint(date: date(from: lastDay), balanceCents: running, isForecast: lastDay > today)
+            }
+        }
+    }
+
+    // MARK: - Dates
+
+    private static func resolveRange(_ timeFrame: WidgetTimeFrame?, asOf today: Date) -> (DayDate, DayDate) {
+        if let timeFrame {
+            let (start, end) = TimeFrame.resolve(timeFrame, asOf: today)
+            return (dayDate(from: start), dayDate(from: end))
+        }
+        // Card default: current month through 11 months ahead
+        // (BalanceForecastCard.tsx defaultTimeFrame).
+        let now = dayDate(from: today)
+        let start = DayDate(year: now.year, month: now.month, day: 1)
+        let totalMonths = (now.month - 1) + 11
+        let endYear = now.year + totalMonths / 12
+        let endMonth = totalMonths % 12 + 1
+        let end = DayDate(year: endYear, month: endMonth, day: DayDate.lastDay(year: endYear, month: endMonth))
+        return (start, end)
+    }
+
+    private static func monthsInclusive(from start: DayDate, to end: DayDate) -> [(year: Int, month: Int)] {
+        var result: [(Int, Int)] = []
+        var year = start.year
+        var month = start.month
+        while year < end.year || (year == end.year && month <= end.month) {
+            result.append((year, month))
+            month += 1
+            if month > 12 { month = 1; year += 1 }
+        }
+        return result
+    }
+
+    private static var utcCalendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private static func dayDate(from date: Date) -> DayDate {
+        let c = utcCalendar.dateComponents([.year, .month, .day], from: date)
+        return DayDate(year: c.year!, month: c.month!, day: c.day!)
+    }
+
+    private static func date(from day: DayDate) -> Date {
+        utcCalendar.date(from: DateComponents(year: day.year, month: day.month, day: day.day))!
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
@@ -200,8 +200,9 @@ enum BudgetAnalysisEngine {
     /// Port of budgetDataQuery.ts filterCategoriesByConditions: only
     /// category / category_group conditions narrow the set, and if any of
     /// them can't be safely interpreted, no filtering happens at all (better
-    /// to be broad than to silently exclude data).
-    private static func filterCategoriesByConditions(
+    /// to be broad than to silently exclude data). Shared with SpendingEngine,
+    /// mirroring upstream's import into getSpendingBudgetFilters.
+    static func filterCategoriesByConditions(
         _ categories: [Category],
         groups: [CategoryGroup],
         conditions: [WidgetRuleCondition]?,
@@ -226,7 +227,7 @@ enum BudgetAnalysisEngine {
     }
 
     /// Port of budgetDataQuery.ts isSupportedCategoryCondition.
-    private static func isSupportedCategoryCondition(_ cond: WidgetRuleCondition) -> Bool {
+    static func isSupportedCategoryCondition(_ cond: WidgetRuleCondition) -> Bool {
         switch cond.op {
         case "is", "isNot", "contains", "doesNotContain", "matches":
             return decodeString(cond.value) != nil

--- a/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
@@ -1,0 +1,296 @@
+import Foundation
+
+/// Meta for the upstream `budget-analysis-card` widget (dashboard.ts
+/// BudgetAnalysisWidget). `interval` is declared upstream but the spreadsheet
+/// only ever computes monthly intervals; it is kept for round-tripping.
+struct BudgetAnalysisMeta: Codable, Equatable {
+    let name: String?
+    let conditions: [WidgetRuleCondition]?
+    let conditionsOp: String?
+    let timeFrame: WidgetTimeFrame?
+    let interval: String?   // "Daily" | "Weekly" | "Monthly" | "Yearly"
+    let graphType: String?  // "Line" | "Bar"
+    let showBalance: Bool?
+    let balanceOnly: Bool?
+    let showHiddenCategories: Bool?
+}
+
+/// One budget row. Integrator: fetch with
+/// `SELECT month, category, amount FROM <table>` where `<table>` is
+/// "zero_budgets" (envelope) or "reflect_budgets" (tracking), selected by the
+/// budgetType synced pref the way `BudgetDatabase.budgetTable(_:)` already
+/// does ('tracking' / legacy 'report' → reflect_budgets, else zero_budgets).
+/// `month` is YYYYMM and `amount` integer cents, both stored as such.
+struct BudgetAnalysisBudgetEntry: Equatable {
+    let month: Int  // YYYYMM
+    let categoryId: String
+    let amountCents: Int
+}
+
+struct BudgetAnalysisIntervalPoint: Equatable {
+    let month: Int                        // YYYYMM
+    let budgetedCents: Int
+    let spentCents: Int                   // negative for spending, as upstream
+    let balanceCents: Int
+    let overspendingAdjustmentCents: Int  // positive
+}
+
+struct BudgetAnalysisData: Equatable {
+    enum GraphType: Equatable {
+        case line, bar
+    }
+
+    let intervalData: [BudgetAnalysisIntervalPoint]
+    let totalBudgetedCents: Int
+    let totalSpentCents: Int
+    let graphType: GraphType
+    let showBalance: Bool
+    let balanceOnly: Bool
+}
+
+/// Port of the webapp's budget-analysis-spreadsheet.ts at card fidelity.
+/// Budget rows here carry no carryover flag, so the balance math uses
+/// upstream's default (carryover off): positive category balances roll
+/// forward, negative ones zero out and surface as the next month's
+/// overspending adjustment.
+enum BudgetAnalysisEngine {
+
+    private static var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    static func compute(
+        meta: BudgetAnalysisMeta?,
+        transactions: [Transaction],
+        budgets: [BudgetAnalysisBudgetEntry],
+        categories: [Category],
+        categoryGroups: [CategoryGroup],
+        today: Date,
+        context: ConditionsFilter.Context = .empty
+    ) -> BudgetAnalysisData {
+        let cal = calendar
+
+        // Stored time frame, or the card's default sliding window of the
+        // trailing six months (BudgetAnalysisCard.tsx).
+        let startMonth: Int
+        let endMonth: Int
+        if let tf = meta?.timeFrame {
+            let (start, end) = TimeFrame.resolve(tf, asOf: today)
+            startMonth = yyyymm(from: start, calendar: cal)
+            endMonth = yyyymm(from: end, calendar: cal)
+        } else {
+            endMonth = yyyymm(from: today, calendar: cal)
+            startMonth = addMonths(endMonth, -5)
+        }
+
+        let graphType: BudgetAnalysisData.GraphType = meta?.graphType == "Line" ? .line : .bar
+        let showBalance = meta?.showBalance ?? true
+        let balanceOnly = meta?.balanceOnly ?? false
+        guard startMonth <= endMonth else {
+            return BudgetAnalysisData(
+                intervalData: [], totalBudgetedCents: 0, totalSpentCents: 0,
+                graphType: graphType, showBalance: showBalance, balanceOnly: balanceOnly
+            )
+        }
+
+        // Base set mirrors upstream isBaseCategory: expense categories only;
+        // hidden ones count only when showHiddenCategories.
+        let showHidden = meta?.showHiddenCategories ?? false
+        let base = categories.filter { !$0.isIncome && (showHidden || !$0.hidden) }
+        let included = filterCategoriesByConditions(
+            base,
+            groups: categoryGroups,
+            conditions: meta?.conditions,
+            conditionsOp: meta?.conditionsOp
+        )
+        let includedIds = Set(included.map(\.id))
+
+        // Bucket budgets and spending by month. Spending mirrors the
+        // envelope sum-amount cells: on-budget transactions of the included
+        // categories, amounts kept negative.
+        var budgetedByMonth: [Int: [String: Int]] = [:]
+        for entry in budgets where includedIds.contains(entry.categoryId) && entry.month <= endMonth {
+            budgetedByMonth[entry.month, default: [:]][entry.categoryId, default: 0] += entry.amountCents
+        }
+        var spentByMonth: [Int: [String: Int]] = [:]
+        for tx in transactions {
+            guard !tx.tombstone,
+                  let catId = tx.categoryId, includedIds.contains(catId),
+                  !context.offBudgetAccountIds.contains(tx.accountId) else { continue }
+            let month = tx.date / 100
+            guard month <= endMonth else { continue }
+            spentByMonth[month, default: [:]][catId, default: 0] += tx.amount
+        }
+
+        // Upstream seeds the running balance from the leftover cells of the
+        // month before the range; replaying every earlier month we were given
+        // produces the same per-category carryovers.
+        let earliest = min(
+            budgetedByMonth.keys.min() ?? startMonth,
+            spentByMonth.keys.min() ?? startMonth,
+            startMonth
+        )
+
+        var carried: [String: Int] = [:]  // category id → balance carried into the current month
+        var overspendingFromPrevMonth = 0
+        var intervalData: [BudgetAnalysisIntervalPoint] = []
+        var totalBudgeted = 0
+        var totalSpent = 0
+
+        var month = earliest
+        while month <= endMonth {
+            // Upstream starts the display loop with a zero adjustment
+            // regardless of pre-range overspending.
+            if month == startMonth { overspendingFromPrevMonth = 0 }
+
+            var budgeted = 0
+            var spent = 0
+            var runningBalance = 0
+            var overspendingThisMonth = 0
+            var carriedNext: [String: Int] = [:]
+
+            for cat in included {
+                let catBudgeted = budgetedByMonth[month]?[cat.id] ?? 0
+                let catSpent = spentByMonth[month]?[cat.id] ?? 0
+                let carriedIn = carried[cat.id] ?? 0
+                let catBalance = catBudgeted + catSpent + carriedIn
+
+                budgeted += catBudgeted
+                spent += catSpent
+                runningBalance += carriedIn
+
+                if catBalance > 0 {
+                    carriedNext[cat.id] = catBalance
+                } else if catBalance < 0 {
+                    overspendingThisMonth += catBalance
+                }
+            }
+
+            if month >= startMonth {
+                totalBudgeted += budgeted
+                totalSpent += spent
+                intervalData.append(BudgetAnalysisIntervalPoint(
+                    month: month,
+                    budgetedCents: budgeted,
+                    spentCents: spent,
+                    balanceCents: budgeted + spent + runningBalance,
+                    overspendingAdjustmentCents: abs(overspendingFromPrevMonth)
+                ))
+            }
+
+            carried = carriedNext
+            overspendingFromPrevMonth = overspendingThisMonth
+            month = addMonths(month, 1)
+        }
+
+        return BudgetAnalysisData(
+            intervalData: intervalData,
+            totalBudgetedCents: totalBudgeted,
+            totalSpentCents: totalSpent,
+            graphType: graphType,
+            showBalance: showBalance,
+            balanceOnly: balanceOnly
+        )
+    }
+
+    // MARK: - Category condition filtering
+
+    /// Port of budgetDataQuery.ts filterCategoriesByConditions: only
+    /// category / category_group conditions narrow the set, and if any of
+    /// them can't be safely interpreted, no filtering happens at all (better
+    /// to be broad than to silently exclude data).
+    private static func filterCategoriesByConditions(
+        _ categories: [Category],
+        groups: [CategoryGroup],
+        conditions: [WidgetRuleCondition]?,
+        conditionsOp: String?
+    ) -> [Category] {
+        let categoryConditions = (conditions ?? []).filter {
+            $0.customName == nil && ($0.field == "category" || $0.field == "category_group")
+        }
+        guard !categoryConditions.isEmpty,
+              categoryConditions.allSatisfy(isSupportedCategoryCondition) else {
+            return categories
+        }
+
+        let groupNameById = Dictionary(groups.map { ($0.id, $0.name) },
+                                       uniquingKeysWith: { first, _ in first })
+        let isOr = (conditionsOp ?? "and").lowercased() == "or"
+        return categories.filter { cat in
+            isOr
+                ? categoryConditions.contains { matches(cat, $0, groupNameById: groupNameById) }
+                : categoryConditions.allSatisfy { matches(cat, $0, groupNameById: groupNameById) }
+        }
+    }
+
+    /// Port of budgetDataQuery.ts isSupportedCategoryCondition.
+    private static func isSupportedCategoryCondition(_ cond: WidgetRuleCondition) -> Bool {
+        switch cond.op {
+        case "is", "isNot", "contains", "doesNotContain", "matches":
+            return decodeString(cond.value) != nil
+        case "oneOf", "notOneOf":
+            return decodeStringArray(cond.value) != nil
+        default:
+            return false
+        }
+    }
+
+    private static func matches(
+        _ cat: Category,
+        _ cond: WidgetRuleCondition,
+        groupNameById: [String: String]
+    ) -> Bool {
+        let key = cond.field == "category_group" ? cat.groupId : cat.id
+        // Text operators compare against the human-readable name, not the UUID.
+        let text = cond.field == "category_group" ? (groupNameById[key] ?? key) : cat.name
+
+        switch cond.op {
+        case "is":
+            return decodeString(cond.value) == key
+        case "isNot":
+            return decodeString(cond.value) != key
+        case "oneOf":
+            return decodeStringArray(cond.value)?.contains(key) ?? false
+        case "notOneOf":
+            return !(decodeStringArray(cond.value)?.contains(key) ?? false)
+        case "contains":
+            guard let value = decodeString(cond.value) else { return false }
+            return text.lowercased().contains(value.lowercased())
+        case "doesNotContain":
+            guard let value = decodeString(cond.value) else { return false }
+            return !text.lowercased().contains(value.lowercased())
+        case "matches":
+            guard let value = decodeString(cond.value), value.count <= 256,
+                  let regex = try? NSRegularExpression(pattern: value, options: [.caseInsensitive]) else {
+                return false
+            }
+            return regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+        default:
+            return true
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func decodeString(_ value: AnyCodable?) -> String? {
+        guard let value else { return nil }
+        return try? JSONDecoder().decode(String.self, from: value.raw)
+    }
+
+    private static func decodeStringArray(_ value: AnyCodable?) -> [String]? {
+        guard let value else { return nil }
+        return try? JSONDecoder().decode([String].self, from: value.raw)
+    }
+
+    private static func yyyymm(from date: Date, calendar: Calendar) -> Int {
+        let c = calendar.dateComponents([.year, .month], from: date)
+        return (c.year ?? 0) * 100 + (c.month ?? 0)
+    }
+
+    private static func addMonths(_ yyyymm: Int, _ delta: Int) -> Int {
+        let total = (yyyymm / 100) * 12 + (yyyymm % 100 - 1) + delta
+        return (total / 12) * 100 + total % 12 + 1
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/CalendarEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CalendarEngine.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Mirrors upstream `CalendarWidget['meta']` (CalendarCard.tsx).
+struct CalendarMeta: Codable, Equatable {
+    let name: String?
+    let conditions: [WidgetRuleCondition]?
+    let conditionsOp: String?
+    let timeFrame: WidgetTimeFrame?
+}
+
+/// One grid cell. `dayOfMonth` is nil for the leading/trailing padding cells
+/// that align the month grid to the configured first weekday.
+struct CalendarDayCell: Equatable {
+    let dayOfMonth: Int?
+    let incomeCents: Int    // absolute value
+    let expenseCents: Int   // absolute value
+    /// 0–100: this day's share of the month's income/expense total, matching
+    /// upstream `getBarLength` (calendar-spreadsheet.ts).
+    let incomeSize: Double
+    let expenseSize: Double
+}
+
+struct CalendarMonthData: Equatable {
+    let monthStart: Date
+    /// Row-major weeks; count is a multiple of 7 and the first cell falls on
+    /// the configured first weekday.
+    let days: [CalendarDayCell]
+    let totalIncomeCents: Int
+    let totalExpenseCents: Int
+}
+
+struct CalendarData: Equatable {
+    let months: [CalendarMonthData]
+    let totalIncomeCents: Int
+    let totalExpenseCents: Int
+    /// 0 = Sunday … 6 = Saturday, echoed back for the view's weekday header.
+    let firstDayOfWeekIdx: Int
+}
+
+enum CalendarEngine {
+
+    static func compute(
+        meta: CalendarMeta?,
+        transactions: [Transaction],
+        today: Date,
+        firstDayOfWeekIdx: Int,
+        context: ConditionsFilter.Context = .empty
+    ) -> CalendarData {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+
+        // Upstream expands the resolved range to whole months
+        // (firstDayOfMonth(start) .. lastDayOfMonth(end)).
+        let (rawStart, rawEnd) = TimeFrame.resolve(meta?.timeFrame, asOf: today)
+        let firstMonth = monthStart(of: rawStart, calendar: cal)
+        let lastMonth = monthStart(of: rawEnd, calendar: cal)
+
+        let startYMD = ymdInt(from: firstMonth, calendar: cal)
+        let endYMD = ymdInt(from: endOfMonth(lastMonth, calendar: cal), calendar: cal)
+
+        let filtered = transactions
+            .filter { !$0.tombstone }
+            .filter { $0.date >= startYMD && $0.date <= endYMD }
+            .filter { ConditionsFilter.matches(transaction: $0, conditions: meta?.conditions, op: meta?.conditionsOp, context: context) }
+
+        // Upstream buckets income (amount > 0) and expenses (amount < 0)
+        // separately per day; zero-amount transactions land in neither.
+        var incomeByDay: [Int: Int] = [:]   // YYYYMMDD -> cents
+        var expenseByDay: [Int: Int] = [:]
+        for tx in filtered {
+            if tx.amount > 0 {
+                incomeByDay[tx.date, default: 0] += tx.amount
+            } else if tx.amount < 0 {
+                expenseByDay[tx.date, default: 0] += tx.amount
+            }
+        }
+
+        // Out-of-range values fall back to Sunday, matching upstream.
+        let weekStart = (0...6).contains(firstDayOfWeekIdx) ? firstDayOfWeekIdx : 0
+
+        var months: [CalendarMonthData] = []
+        var cursor = firstMonth
+        while cursor <= lastMonth {
+            months.append(monthData(monthStart: cursor,
+                                    incomeByDay: incomeByDay,
+                                    expenseByDay: expenseByDay,
+                                    weekStart: weekStart,
+                                    calendar: cal))
+            guard let next = cal.date(byAdding: .month, value: 1, to: cursor) else { break }
+            cursor = next
+        }
+
+        return CalendarData(
+            months: months,
+            totalIncomeCents: months.reduce(0) { $0 + $1.totalIncomeCents },
+            totalExpenseCents: months.reduce(0) { $0 + $1.totalExpenseCents },
+            firstDayOfWeekIdx: weekStart
+        )
+    }
+
+    private static func monthData(
+        monthStart: Date,
+        incomeByDay: [Int: Int],
+        expenseByDay: [Int: Int],
+        weekStart: Int,
+        calendar: Calendar
+    ) -> CalendarMonthData {
+        let yyyymm = ymdInt(from: monthStart, calendar: calendar) / 100
+        let daysInMonth = calendar.range(of: .day, in: .month, for: monthStart)?.count ?? 30
+
+        var totalIncome = 0
+        var totalExpense = 0
+        for day in 1...daysInMonth {
+            totalIncome += incomeByDay[yyyymm * 100 + day] ?? 0
+            totalExpense += abs(expenseByDay[yyyymm * 100 + day] ?? 0)
+        }
+
+        // Leading padding back to the configured first weekday, trailing
+        // padding to a whole number of weeks (upstream recalculate()).
+        let jsWeekday = calendar.component(.weekday, from: monthStart) - 1  // 0 = Sunday
+        let leading = (jsWeekday - weekStart + 7) % 7
+        var totalCells = leading + daysInMonth
+        if totalCells % 7 != 0 { totalCells += 7 - totalCells % 7 }
+
+        let padding = CalendarDayCell(dayOfMonth: nil, incomeCents: 0, expenseCents: 0,
+                                      incomeSize: 0, expenseSize: 0)
+        var cells: [CalendarDayCell] = []
+        for i in 0..<totalCells {
+            let day = i - leading + 1
+            guard day >= 1 && day <= daysInMonth else {
+                cells.append(padding)
+                continue
+            }
+            let income = incomeByDay[yyyymm * 100 + day] ?? 0
+            let expense = abs(expenseByDay[yyyymm * 100 + day] ?? 0)
+            cells.append(CalendarDayCell(
+                dayOfMonth: day,
+                incomeCents: income,
+                expenseCents: expense,
+                incomeSize: totalIncome > 0 ? Double(income) / Double(totalIncome) * 100 : 0,
+                expenseSize: totalExpense > 0 ? Double(expense) / Double(totalExpense) * 100 : 0
+            ))
+        }
+
+        return CalendarMonthData(monthStart: monthStart, days: cells,
+                                 totalIncomeCents: totalIncome, totalExpenseCents: totalExpense)
+    }
+
+    private static func monthStart(of date: Date, calendar: Calendar) -> Date {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        return calendar.date(from: DateComponents(year: comps.year, month: comps.month, day: 1)) ?? date
+    }
+
+    private static func endOfMonth(_ monthStartDate: Date, calendar: Calendar) -> Date {
+        guard let next = calendar.date(byAdding: .month, value: 1, to: monthStartDate),
+              let last = calendar.date(byAdding: .day, value: -1, to: next) else { return monthStartDate }
+        return last
+    }
+
+    private static func ymdInt(from date: Date, calendar: Calendar) -> Int {
+        let c = calendar.dateComponents([.year, .month, .day], from: date)
+        return (c.year ?? 0) * 10000 + (c.month ?? 0) * 100 + (c.day ?? 0)
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/CrossoverEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CrossoverEngine.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+/// Mirrors upstream `CrossoverWidget` meta (loot-core dashboard models).
+/// `expectedContribution` is monthly cents, like all upstream amounts.
+struct CrossoverMeta: Codable, Equatable {
+    let name: String?
+    let expenseCategoryIds: [String]?
+    let incomeAccountIds: [String]?
+    let timeFrame: WidgetTimeFrame?
+    let safeWithdrawalRate: Double?      // annual, default 0.04
+    let estimatedReturn: Double?         // annual, nil = derive from history
+    let expectedContribution: Double?    // monthly cents, default 0
+    let projectionType: ProjectionType?  // default .hampel
+    let showHiddenCategories: Bool?
+    let expenseAdjustmentFactor: Double? // default 1.0
+
+    enum ProjectionType: String, Codable {
+        case hampel, median, mean
+    }
+}
+
+struct CrossoverPoint: Equatable {
+    let month: Date                       // first of month, UTC
+    let investmentIncomeCents: Int        // balance * monthly SWR
+    let expensesCents: Int
+    let nestEggCents: Int
+    let adjustedExpensesCents: Int?       // projection points only
+    let isProjection: Bool
+}
+
+struct CrossoverData: Equatable {
+    let points: [CrossoverPoint]
+    let crossoverMonth: Date?             // projected month income first covers adjusted expenses
+    let lastKnownBalanceCents: Int
+    let lastKnownMonthlyIncomeCents: Int
+    let lastKnownMonthlyExpensesCents: Int
+    let historicalReturn: Double?         // annualized CAGR of the selected accounts
+    let yearsToRetire: Double?
+    let targetMonthlyIncomeCents: Int?
+    let targetNestEggCents: Int?
+
+    static let empty = CrossoverData(
+        points: [], crossoverMonth: nil,
+        lastKnownBalanceCents: 0, lastKnownMonthlyIncomeCents: 0,
+        lastKnownMonthlyExpensesCents: 0, historicalReturn: nil,
+        yearsToRetire: nil, targetMonthlyIncomeCents: nil,
+        targetNestEggCents: nil
+    )
+}
+
+/// Port of upstream crossover-spreadsheet.ts + the date-range resolution in
+/// CrossoverCard.tsx, computed over in-memory transactions.
+enum CrossoverEngine {
+
+    /// - Parameters:
+    ///   - categories: all live categories — used to default the expense set
+    ///     to every non-income category and to honor `showHiddenCategories`.
+    ///   - accountIds: all live account ids — the default income-account set
+    ///     when meta doesn't select specific accounts (upstream `useAccounts`).
+    static func compute(
+        meta: CrossoverMeta?,
+        transactions: [Transaction],
+        categories: [Category],
+        accountIds: [String],
+        today: Date
+    ) -> CrossoverData {
+        let incomeAccountIds = meta?.incomeAccountIds ?? accountIds
+        guard !incomeAccountIds.isEmpty else { return .empty }
+
+        let live = transactions.filter { !$0.tombstone }
+
+        // Date range: months as year*12 + (month-1) indices. Upstream card
+        // clamps to [earliest transaction month, previous month] and defaults
+        // to mode "full" (Crossover.tsx defaultTimeFrame).
+        let currentMonth = monthIndex(of: today)
+        let latestMonth = currentMonth - 1
+        let earliestMonth = min(
+            live.map { monthIndex(ofYMD: $0.date) }.min() ?? latestMonth,
+            latestMonth
+        )
+        func clamp(_ m: Int) -> Int { min(max(m, earliestMonth), latestMonth) }
+
+        let tf = meta?.timeFrame
+        var start: Int
+        var end: Int
+        switch tf?.mode ?? .full {
+        case .full:
+            start = earliestMonth
+            end = latestMonth
+        case .slidingWindow:
+            // calculateTimeRange keeps the stored window width ending at the
+            // current month; the card then shifts both back one month.
+            let storedStart = parseMonthIndex(tf?.start) ?? currentMonth - 120
+            let storedEnd = parseMonthIndex(tf?.end) ?? currentMonth - 1
+            let offset = storedEnd - storedStart
+            start = clamp(currentMonth - offset - 1)
+            end = clamp(currentMonth - 1)
+        case .lastMonth:
+            start = clamp(currentMonth - 1)
+            end = clamp(currentMonth - 1)
+        case .lastYear:
+            let priorJan = ((currentMonth / 12) - 1) * 12
+            start = clamp(priorJan)
+            end = clamp(priorJan + 11)
+        case .yearToDate:
+            start = clamp((currentMonth / 12) * 12)
+            end = clamp(currentMonth)
+        case .priorYearToDate:
+            start = clamp(((currentMonth / 12) - 1) * 12)
+            end = clamp(currentMonth - 12)
+        case .static:
+            start = clamp(parseMonthIndex(tf?.start) ?? currentMonth - 120)
+            end = clamp(parseMonthIndex(tf?.end) ?? currentMonth - 1)
+        }
+        if end < start { end = start }
+        let months = Array(start...end)
+
+        // Expense category set: stored ids, or every non-income category,
+        // then filter hidden unless showHiddenCategories.
+        let showHidden = meta?.showHiddenCategories ?? false
+        let baseCategories: [Category]
+        if let storedIds = meta?.expenseCategoryIds {
+            let stored = Set(storedIds)
+            baseCategories = categories.filter { stored.contains($0.id) }
+        } else {
+            baseCategories = categories.filter { !$0.isIncome }
+        }
+        let expenseIds = Set(baseCategories.filter { showHidden || !$0.hidden }.map(\.id))
+
+        // Monthly expenses (expenses are negative; flip to positive spend).
+        var expenseByMonth: [Int: Int] = [:]
+        for t in live {
+            guard let categoryId = t.categoryId, expenseIds.contains(categoryId) else { continue }
+            let m = monthIndex(ofYMD: t.date)
+            guard start <= m, m <= end else { continue }
+            expenseByMonth[m, default: 0] += -t.amount
+        }
+
+        // Running balances of the selected accounts per month. Upstream seeds
+        // each account with its balance through the end of the start month,
+        // then applies per-month deltas; summing across accounts commutes.
+        let incomeSet = Set(incomeAccountIds)
+        var startingBalance = 0
+        var deltas = [Int](repeating: 0, count: months.count)
+        for t in live where incomeSet.contains(t.accountId) {
+            let m = monthIndex(ofYMD: t.date)
+            if m <= start {
+                startingBalance += t.amount
+            } else if m <= end {
+                deltas[m - start] += t.amount
+            }
+        }
+        var historicalBalances = [Int]()
+        var running = startingBalance
+        for i in months.indices {
+            if i > 0 { running += deltas[i] }
+            historicalBalances.append(running)
+        }
+
+        let monthlySWR = (meta?.safeWithdrawalRate ?? 0.04) / 12
+
+        var points: [CrossoverPoint] = []
+        for (i, m) in months.enumerated() {
+            let balance = historicalBalances[i]
+            points.append(CrossoverPoint(
+                month: monthDate(m),
+                investmentIncomeCents: jsRound(Double(balance) * monthlySWR),
+                expensesCents: expenseByMonth[m] ?? 0,
+                nestEggCents: balance,
+                adjustedExpensesCents: nil,
+                isProjection: false
+            ))
+        }
+        let lastBalance = historicalBalances.last ?? 0
+        let lastExpense = expenseByMonth[end] ?? 0
+
+        // Default monthly return: CAGR of the selected accounts' total balance.
+        var defaultMonthlyReturn: Double?
+        if historicalBalances.count >= 2 {
+            var startBalance = Double(historicalBalances[0])
+            let finalBalance = Double(historicalBalances.last!)
+            let n = historicalBalances.count - 1
+            if startBalance == 0 {
+                if let firstNonZero = historicalBalances.dropFirst().first(where: { $0 != 0 }) {
+                    startBalance = Double(firstNonZero)
+                }
+            }
+            if startBalance > 0, finalBalance > 0 {
+                let cagr = pow(finalBalance / startBalance, 1.0 / Double(n)) - 1
+                defaultMonthlyReturn = cagr.isFinite ? cagr : 0
+            } else {
+                defaultMonthlyReturn = 0
+            }
+        }
+
+        let monthlyReturn: Double?
+        if let annualReturn = meta?.estimatedReturn {
+            monthlyReturn = pow(1 + annualReturn, 1.0 / 12) - 1
+        } else {
+            monthlyReturn = defaultMonthlyReturn
+        }
+        let monthlyContribution = meta?.expectedContribution ?? 0
+        let adjustmentFactor = meta?.expenseAdjustmentFactor ?? 1.0
+
+        // Forward projection: flat expenses per projectionType, balance grows
+        // by contribution then return, up to 600 months or crossover.
+        var crossoverIndex: Int?
+        let y = months.map { Double(expenseByMonth[$0] ?? 0) }
+        let flatExpense: Double
+        switch meta?.projectionType ?? .hampel {
+        case .hampel: flatExpense = hampelFilteredMedian(y)
+        case .median: flatExpense = median(y)
+        case .mean: flatExpense = mean(y)
+        }
+
+        var projectedBalance = Double(lastBalance)
+        var cursor = end
+        for i in 1...600 {
+            cursor += 1
+            // Upstream adds the contribution BEFORE applying growth.
+            projectedBalance += monthlyContribution
+            if let monthlyReturn {
+                projectedBalance *= (1 + monthlyReturn)
+            }
+            let projectedIncome = projectedBalance * monthlySWR
+            let projectedExpenses = max(0, flatExpense)
+            let adjustedExpenses = projectedExpenses * adjustmentFactor
+
+            points.append(CrossoverPoint(
+                month: monthDate(cursor),
+                investmentIncomeCents: jsRound(projectedIncome),
+                expensesCents: jsRound(projectedExpenses),
+                nestEggCents: jsRound(projectedBalance),
+                adjustedExpensesCents: jsRound(adjustedExpenses),
+                isProjection: true
+            ))
+
+            // Crossover is checked against ADJUSTED expenses, projection only.
+            if jsRound(projectedIncome) >= jsRound(adjustedExpenses) {
+                crossoverIndex = months.count + (i - 1)
+                break
+            }
+        }
+
+        var crossoverMonth: Date?
+        var yearsToRetire: Double?
+        var targetMonthlyIncome: Int?
+        var targetNestEgg: Int?
+        if let crossoverIndex, crossoverIndex < points.count {
+            let crossoverPoint = points[crossoverIndex]
+            crossoverMonth = crossoverPoint.month
+            // Upstream measures whole months from "now" to the crossover month
+            // (date-fns parse reuses today's day-of-month), floored at 0.
+            let monthsDiff = (start + crossoverIndex) - currentMonth
+            yearsToRetire = monthsDiff > 0 ? Double(monthsDiff) / 12 : 0
+            targetMonthlyIncome = crossoverPoint.adjustedExpensesCents
+            if let targetMonthlyIncome, monthlySWR > 0 {
+                targetNestEgg = jsRound(Double(targetMonthlyIncome) / monthlySWR)
+            }
+        }
+
+        return CrossoverData(
+            points: points,
+            crossoverMonth: crossoverMonth,
+            lastKnownBalanceCents: lastBalance,
+            lastKnownMonthlyIncomeCents: jsRound(Double(lastBalance) * monthlySWR),
+            lastKnownMonthlyExpensesCents: lastExpense,
+            historicalReturn: defaultMonthlyReturn.map { pow(1 + $0, 12) - 1 },
+            yearsToRetire: yearsToRetire,
+            targetMonthlyIncomeCents: targetMonthlyIncome,
+            targetNestEggCents: targetNestEgg
+        )
+    }
+
+    // MARK: - Statistics (upstream Hampel identifier utilities)
+
+    static func median(_ values: [Double]) -> Double {
+        if values.isEmpty { return 0 }
+        if values.count == 1 { return values[0] }
+        let sorted = values.sorted()
+        let mid = sorted.count / 2
+        return sorted.count % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+    }
+
+    static func mean(_ values: [Double]) -> Double {
+        values.isEmpty ? 0 : values.reduce(0, +) / Double(values.count)
+    }
+
+    /// Median after rejecting outliers beyond median ± 3 * 1.4826 * MAD.
+    static func hampelFilteredMedian(_ expenses: [Double]) -> Double {
+        if expenses.isEmpty { return 0 }
+        if expenses.count == 1 { return expenses[0] }
+        let med = median(expenses)
+        let mad = median(expenses.map { abs($0 - med) })
+        let threshold = 3.0
+        let lowerBound = med - 1.4826 * mad * threshold
+        let upperBound = med + 1.4826 * mad * threshold
+        return median(expenses.filter { $0 >= lowerBound && $0 <= upperBound })
+    }
+
+    // MARK: - Month helpers
+
+    private static var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private static func monthIndex(of date: Date) -> Int {
+        let c = calendar.dateComponents([.year, .month], from: date)
+        return (c.year ?? 0) * 12 + (c.month ?? 1) - 1
+    }
+
+    private static func monthIndex(ofYMD date: Int) -> Int {
+        let ym = date / 100
+        return (ym / 100) * 12 + (ym % 100) - 1
+    }
+
+    private static func monthDate(_ index: Int) -> Date {
+        calendar.date(from: DateComponents(year: index / 12, month: index % 12 + 1, day: 1))!
+    }
+
+    /// Parses "YYYY-MM" or "YYYY-MM-DD" to a month index.
+    private static func parseMonthIndex(_ s: String?) -> Int? {
+        guard let s, s.count >= 7,
+              let year = Int(s.prefix(4)),
+              let month = Int(s.dropFirst(5).prefix(2)),
+              (1...12).contains(month) else { return nil }
+        return year * 12 + month - 1
+    }
+
+    /// JS Math.round (half toward +infinity), for upstream parity.
+    private static func jsRound(_ x: Double) -> Int {
+        Int((x + 0.5).rounded(.down))
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/MonteCarloEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/MonteCarloEngine.swift
@@ -1,0 +1,1093 @@
+import Foundation
+
+// MARK: - Widget meta (upstream loot-core dashboard.ts, MonteCarloWidget)
+
+struct MonteCarloPotMeta: Codable, Equatable {
+    let id: String?
+    let name: String?
+    /// Starting balance in minor units (cents).
+    let startingBalance: Double?
+    /// One of "equity-100" | "equity-80" | "equity-60" | "equity-40" | "cash" | "custom".
+    let allocationPreset: String?
+    let expectedReturnMean: Double?
+    let returnStdDev: Double?
+    /// Age from which the pot can fund withdrawals; nil = immediately.
+    let accessAge: Double?
+    /// Account whose live balance supplies the starting balance; nil = manual.
+    let accountId: String?
+    let withdrawalTaxRate: Double?
+    let taxableFraction: Double?
+    let annualFeeFixed: Double?
+    let feeAdjustsWithInflation: Bool?
+    let annualFeeRate: Double?
+}
+
+struct MonteCarloWithdrawalRuleMeta: Codable, Equatable {
+    /// One of "none" | "guardrails" | "ratcheting" | "floor-ceiling" | "boundaries".
+    let type: String?
+    let prosperityTriggerPct: Double?
+    let prosperityIncreasePct: Double?
+    let preservationTriggerPct: Double?
+    let preservationCutPct: Double?
+    let balanceThresholdMultiple: Double?
+    let consecutiveYears: Double?
+    let ratchetIncreasePct: Double?
+    let floorPct: Double?
+    let ceilingPct: Double?
+    let upperRateThreshold: Double?
+    let upperCutPct: Double?
+    let lowerRateThreshold: Double?
+    let lowerIncreasePct: Double?
+}
+
+struct MonteCarloSpendingPhaseMeta: Codable, Equatable {
+    let id: String?
+    let name: String?
+    /// Age the phase begins (inclusive); nil = starts immediately.
+    let fromAge: Double?
+    /// Yearly spending in minor units, in today's money.
+    let annualWithdrawal: Double?
+}
+
+struct MonteCarloTaxBandMeta: Codable, Equatable {
+    let id: String?
+    /// Annual taxable income threshold in minor units, today's money.
+    let from: Double?
+    /// Decimal fraction (0.2 = 20%).
+    let rate: Double?
+}
+
+struct MonteCarloMeta: Codable, Equatable {
+    let name: String?
+    let pots: [MonteCarloPotMeta]?
+    let withdrawalStrategy: String?
+    let returnModel: String?
+    let withdrawalRule: MonteCarloWithdrawalRuleMeta?
+    let minimumWithdrawal: Double?
+    let spendingPhases: [MonteCarloSpendingPhaseMeta]?
+    /// Upstream distinguishes absent (use the default) from an explicit JSON
+    /// null (flat withdrawals): outer nil = absent, `.some(nil)` = null.
+    let inflationMean: Double??
+    let inflationStdDev: Double?
+    let taxModel: String?
+    let taxBands: [MonteCarloTaxBandMeta]?
+    let currentAge: Double?
+    let targetAge: Double?
+    let simulationCount: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case name, pots, withdrawalStrategy, returnModel, withdrawalRule
+        case minimumWithdrawal, spendingPhases, inflationMean, inflationStdDev
+        case taxModel, taxBands, currentAge, targetAge, simulationCount
+    }
+
+    init(
+        name: String? = nil,
+        pots: [MonteCarloPotMeta]? = nil,
+        withdrawalStrategy: String? = nil,
+        returnModel: String? = nil,
+        withdrawalRule: MonteCarloWithdrawalRuleMeta? = nil,
+        minimumWithdrawal: Double? = nil,
+        spendingPhases: [MonteCarloSpendingPhaseMeta]? = nil,
+        inflationMean: Double?? = nil,
+        inflationStdDev: Double? = nil,
+        taxModel: String? = nil,
+        taxBands: [MonteCarloTaxBandMeta]? = nil,
+        currentAge: Double? = nil,
+        targetAge: Double? = nil,
+        simulationCount: Double? = nil
+    ) {
+        self.name = name
+        self.pots = pots
+        self.withdrawalStrategy = withdrawalStrategy
+        self.returnModel = returnModel
+        self.withdrawalRule = withdrawalRule
+        self.minimumWithdrawal = minimumWithdrawal
+        self.spendingPhases = spendingPhases
+        self.inflationMean = inflationMean
+        self.inflationStdDev = inflationStdDev
+        self.taxModel = taxModel
+        self.taxBands = taxBands
+        self.currentAge = currentAge
+        self.targetAge = targetAge
+        self.simulationCount = simulationCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        pots = try container.decodeIfPresent([MonteCarloPotMeta].self, forKey: .pots)
+        withdrawalStrategy = try container.decodeIfPresent(String.self, forKey: .withdrawalStrategy)
+        returnModel = try container.decodeIfPresent(String.self, forKey: .returnModel)
+        withdrawalRule = try container.decodeIfPresent(MonteCarloWithdrawalRuleMeta.self, forKey: .withdrawalRule)
+        minimumWithdrawal = try container.decodeIfPresent(Double.self, forKey: .minimumWithdrawal)
+        spendingPhases = try container.decodeIfPresent([MonteCarloSpendingPhaseMeta].self, forKey: .spendingPhases)
+        if container.contains(.inflationMean) {
+            inflationMean = .some(try container.decodeIfPresent(Double.self, forKey: .inflationMean))
+        } else {
+            inflationMean = nil
+        }
+        inflationStdDev = try container.decodeIfPresent(Double.self, forKey: .inflationStdDev)
+        taxModel = try container.decodeIfPresent(String.self, forKey: .taxModel)
+        taxBands = try container.decodeIfPresent([MonteCarloTaxBandMeta].self, forKey: .taxBands)
+        currentAge = try container.decodeIfPresent(Double.self, forKey: .currentAge)
+        targetAge = try container.decodeIfPresent(Double.self, forKey: .targetAge)
+        simulationCount = try container.decodeIfPresent(Double.self, forKey: .simulationCount)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(pots, forKey: .pots)
+        try container.encodeIfPresent(withdrawalStrategy, forKey: .withdrawalStrategy)
+        try container.encodeIfPresent(returnModel, forKey: .returnModel)
+        try container.encodeIfPresent(withdrawalRule, forKey: .withdrawalRule)
+        try container.encodeIfPresent(minimumWithdrawal, forKey: .minimumWithdrawal)
+        try container.encodeIfPresent(spendingPhases, forKey: .spendingPhases)
+        if let wrapped = inflationMean {
+            if let value = wrapped {
+                try container.encode(value, forKey: .inflationMean)
+            } else {
+                try container.encodeNil(forKey: .inflationMean)
+            }
+        }
+        try container.encodeIfPresent(inflationStdDev, forKey: .inflationStdDev)
+        try container.encodeIfPresent(taxModel, forKey: .taxModel)
+        try container.encodeIfPresent(taxBands, forKey: .taxBands)
+        try container.encodeIfPresent(currentAge, forKey: .currentAge)
+        try container.encodeIfPresent(targetAge, forKey: .targetAge)
+        try container.encodeIfPresent(simulationCount, forKey: .simulationCount)
+    }
+}
+
+// MARK: - Resolved configuration (upstream monteCarloSimulation.ts)
+
+enum MonteCarloWithdrawalStrategy: String {
+    case proportional
+    case sequential
+    case bestPerformer = "best-performer"
+    case targetMix = "target-mix"
+}
+
+enum MonteCarloReturnModel: String {
+    case normal
+    case historicalBootstrap = "historical-bootstrap"
+    case historicalSequence = "historical-sequence"
+}
+
+enum MonteCarloTaxModel: String {
+    case flat
+    case bands
+}
+
+enum MonteCarloWithdrawalRuleType: String {
+    case none
+    case guardrails
+    case ratcheting
+    case floorCeiling = "floor-ceiling"
+    case boundaries
+}
+
+enum MonteCarloAllocationPreset: String {
+    case equity100 = "equity-100"
+    case equity80 = "equity-80"
+    case equity60 = "equity-60"
+    case equity40 = "equity-40"
+    case cash
+    case custom
+
+    /// Asset mix behind each preset, used by the historical return models
+    /// (upstream PRESET_ASSET_WEIGHTS).
+    var assetWeights: (stocks: Double, bonds: Double, cash: Double)? {
+        switch self {
+        case .equity100: return (1, 0, 0)
+        case .equity80: return (0.8, 0.2, 0)
+        case .equity60: return (0.6, 0.4, 0)
+        case .equity40: return (0.4, 0.6, 0)
+        case .cash: return (0, 0, 1)
+        case .custom: return nil
+        }
+    }
+}
+
+/// One invested pot; defaults mirror upstream createMonteCarloPot.
+struct MonteCarloPot: Equatable {
+    var id: String
+    var name: String = ""
+    var startingBalance: Double = 50_000_000
+    var allocationPreset: MonteCarloAllocationPreset = .equity60
+    var expectedReturnMean: Double = 0.06
+    var returnStdDev: Double = 0.1
+    var accessAge: Double?
+    var accountId: String?
+    var withdrawalTaxRate: Double = 0
+    var taxableFraction: Double = 1
+    var annualFeeFixed: Double = 0
+    var feeAdjustsWithInflation: Bool = false
+    var annualFeeRate: Double = 0
+}
+
+/// Fully-populated rule settings; defaults mirror upstream WITHDRAWAL_RULE_DEFAULTS.
+struct MonteCarloWithdrawalRule: Equatable {
+    var type: MonteCarloWithdrawalRuleType = .none
+    // Guardrails (Guyton-Klinger)
+    var prosperityTriggerPct: Double = 0.2
+    var prosperityIncreasePct: Double = 0.1
+    var preservationTriggerPct: Double = 0.2
+    var preservationCutPct: Double = 0.1
+    // Ratcheting (Kitces)
+    var balanceThresholdMultiple: Double = 1.5
+    var consecutiveYears: Double = 3
+    var ratchetIncreasePct: Double = 0.05
+    // Floor & ceiling (Bengen)
+    var floorPct: Double = 0.15
+    var ceilingPct: Double = 0.2
+    // Boundaries
+    var upperRateThreshold: Double = 0.06
+    var upperCutPct: Double = 0.1
+    var lowerRateThreshold: Double = 0.04
+    var lowerIncreasePct: Double = 0.05
+}
+
+struct MonteCarloSpendingPhase: Equatable {
+    var id: String
+    var name: String = ""
+    var fromAge: Double?
+    var annualWithdrawal: Double = 2_000_000
+}
+
+struct MonteCarloTaxBand: Equatable {
+    var id: String
+    var from: Double = 0
+    var rate: Double = 0
+}
+
+/// Defaults mirror upstream MONTE_CARLO_DEFAULTS.
+struct MonteCarloConfig: Equatable {
+    var pots: [MonteCarloPot] = [MonteCarloPot(id: "pot-1")]
+    var withdrawalStrategy: MonteCarloWithdrawalStrategy = .proportional
+    var returnModel: MonteCarloReturnModel = .normal
+    var withdrawalRule = MonteCarloWithdrawalRule()
+    var minimumWithdrawal: Double = 0
+    var spendingPhases: [MonteCarloSpendingPhase] = [MonteCarloSpendingPhase(id: "phase-1")]
+    /// nil = flat withdrawals (upstream's explicit null).
+    var inflationMean: Double? = 0.025
+    var inflationStdDev: Double = 0.02
+    var taxModel: MonteCarloTaxModel = .flat
+    var taxBands: [MonteCarloTaxBand] = [MonteCarloTaxBand(id: "band-1")]
+    var currentAge: Double = 60
+    var targetAge: Double = 90
+    var simulationCount: Double = 5000
+}
+
+// MARK: - Historical returns (upstream monteCarloHistoricalReturns.ts)
+
+/// Historical annual nominal US returns (Damodaran, NYU Stern, 1928-2025):
+/// stocks = S&P 500 total return, bonds = 10y Treasury, cash = 3m T-bill.
+struct MonteCarloHistoricalReturn: Equatable {
+    let year: Int
+    let stocks: Double
+    let bonds: Double
+    let cash: Double
+
+    static let all: [MonteCarloHistoricalReturn] = [
+        MonteCarloHistoricalReturn(year: 1928, stocks: 0.4381, bonds: 0.0084, cash: 0.0308),
+        MonteCarloHistoricalReturn(year: 1929, stocks: -0.083, bonds: 0.042, cash: 0.0316),
+        MonteCarloHistoricalReturn(year: 1930, stocks: -0.2512, bonds: 0.0454, cash: 0.0455),
+        MonteCarloHistoricalReturn(year: 1931, stocks: -0.4384, bonds: -0.0256, cash: 0.0231),
+        MonteCarloHistoricalReturn(year: 1932, stocks: -0.0864, bonds: 0.0879, cash: 0.0107),
+        MonteCarloHistoricalReturn(year: 1933, stocks: 0.4998, bonds: 0.0186, cash: 0.0096),
+        MonteCarloHistoricalReturn(year: 1934, stocks: -0.0119, bonds: 0.0796, cash: 0.0028),
+        MonteCarloHistoricalReturn(year: 1935, stocks: 0.4674, bonds: 0.0447, cash: 0.0017),
+        MonteCarloHistoricalReturn(year: 1936, stocks: 0.3194, bonds: 0.0502, cash: 0.0017),
+        MonteCarloHistoricalReturn(year: 1937, stocks: -0.3534, bonds: 0.0138, cash: 0.0028),
+        MonteCarloHistoricalReturn(year: 1938, stocks: 0.2928, bonds: 0.0421, cash: 0.0007),
+        MonteCarloHistoricalReturn(year: 1939, stocks: -0.011, bonds: 0.0441, cash: 0.0005),
+        MonteCarloHistoricalReturn(year: 1940, stocks: -0.1067, bonds: 0.054, cash: 0.0004),
+        MonteCarloHistoricalReturn(year: 1941, stocks: -0.1277, bonds: -0.0202, cash: 0.0013),
+        MonteCarloHistoricalReturn(year: 1942, stocks: 0.1917, bonds: 0.0229, cash: 0.0034),
+        MonteCarloHistoricalReturn(year: 1943, stocks: 0.2506, bonds: 0.0249, cash: 0.0038),
+        MonteCarloHistoricalReturn(year: 1944, stocks: 0.1903, bonds: 0.0258, cash: 0.0038),
+        MonteCarloHistoricalReturn(year: 1945, stocks: 0.3582, bonds: 0.038, cash: 0.0038),
+        MonteCarloHistoricalReturn(year: 1946, stocks: -0.0843, bonds: 0.0313, cash: 0.0038),
+        MonteCarloHistoricalReturn(year: 1947, stocks: 0.052, bonds: 0.0092, cash: 0.006),
+        MonteCarloHistoricalReturn(year: 1948, stocks: 0.057, bonds: 0.0195, cash: 0.0105),
+        MonteCarloHistoricalReturn(year: 1949, stocks: 0.183, bonds: 0.0466, cash: 0.0112),
+        MonteCarloHistoricalReturn(year: 1950, stocks: 0.3081, bonds: 0.0043, cash: 0.012),
+        MonteCarloHistoricalReturn(year: 1951, stocks: 0.2368, bonds: -0.003, cash: 0.0152),
+        MonteCarloHistoricalReturn(year: 1952, stocks: 0.1815, bonds: 0.0227, cash: 0.0172),
+        MonteCarloHistoricalReturn(year: 1953, stocks: -0.0121, bonds: 0.0414, cash: 0.0189),
+        MonteCarloHistoricalReturn(year: 1954, stocks: 0.5256, bonds: 0.0329, cash: 0.0094),
+        MonteCarloHistoricalReturn(year: 1955, stocks: 0.326, bonds: -0.0134, cash: 0.0172),
+        MonteCarloHistoricalReturn(year: 1956, stocks: 0.0744, bonds: -0.0226, cash: 0.0262),
+        MonteCarloHistoricalReturn(year: 1957, stocks: -0.1046, bonds: 0.068, cash: 0.0322),
+        MonteCarloHistoricalReturn(year: 1958, stocks: 0.4372, bonds: -0.021, cash: 0.0177),
+        MonteCarloHistoricalReturn(year: 1959, stocks: 0.1206, bonds: -0.0265, cash: 0.0339),
+        MonteCarloHistoricalReturn(year: 1960, stocks: 0.0034, bonds: 0.1164, cash: 0.0287),
+        MonteCarloHistoricalReturn(year: 1961, stocks: 0.2664, bonds: 0.0206, cash: 0.0235),
+        MonteCarloHistoricalReturn(year: 1962, stocks: -0.0881, bonds: 0.0569, cash: 0.0277),
+        MonteCarloHistoricalReturn(year: 1963, stocks: 0.2261, bonds: 0.0168, cash: 0.0316),
+        MonteCarloHistoricalReturn(year: 1964, stocks: 0.1642, bonds: 0.0373, cash: 0.0355),
+        MonteCarloHistoricalReturn(year: 1965, stocks: 0.124, bonds: 0.0072, cash: 0.0395),
+        MonteCarloHistoricalReturn(year: 1966, stocks: -0.0997, bonds: 0.0291, cash: 0.0486),
+        MonteCarloHistoricalReturn(year: 1967, stocks: 0.238, bonds: -0.0158, cash: 0.0429),
+        MonteCarloHistoricalReturn(year: 1968, stocks: 0.1081, bonds: 0.0327, cash: 0.0534),
+        MonteCarloHistoricalReturn(year: 1969, stocks: -0.0824, bonds: -0.0501, cash: 0.0667),
+        MonteCarloHistoricalReturn(year: 1970, stocks: 0.0356, bonds: 0.1675, cash: 0.0639),
+        MonteCarloHistoricalReturn(year: 1971, stocks: 0.1422, bonds: 0.0979, cash: 0.0433),
+        MonteCarloHistoricalReturn(year: 1972, stocks: 0.1876, bonds: 0.0282, cash: 0.0406),
+        MonteCarloHistoricalReturn(year: 1973, stocks: -0.1431, bonds: 0.0366, cash: 0.0704),
+        MonteCarloHistoricalReturn(year: 1974, stocks: -0.259, bonds: 0.0199, cash: 0.0785),
+        MonteCarloHistoricalReturn(year: 1975, stocks: 0.37, bonds: 0.0361, cash: 0.0579),
+        MonteCarloHistoricalReturn(year: 1976, stocks: 0.2383, bonds: 0.1598, cash: 0.0498),
+        MonteCarloHistoricalReturn(year: 1977, stocks: -0.0698, bonds: 0.0129, cash: 0.0526),
+        MonteCarloHistoricalReturn(year: 1978, stocks: 0.0651, bonds: -0.0078, cash: 0.0718),
+        MonteCarloHistoricalReturn(year: 1979, stocks: 0.1852, bonds: 0.0067, cash: 0.1005),
+        MonteCarloHistoricalReturn(year: 1980, stocks: 0.3174, bonds: -0.0299, cash: 0.1139),
+        MonteCarloHistoricalReturn(year: 1981, stocks: -0.047, bonds: 0.082, cash: 0.1404),
+        MonteCarloHistoricalReturn(year: 1982, stocks: 0.2042, bonds: 0.3281, cash: 0.1109),
+        MonteCarloHistoricalReturn(year: 1983, stocks: 0.2234, bonds: 0.032, cash: 0.0895),
+        MonteCarloHistoricalReturn(year: 1984, stocks: 0.0615, bonds: 0.1373, cash: 0.0992),
+        MonteCarloHistoricalReturn(year: 1985, stocks: 0.3124, bonds: 0.2571, cash: 0.0772),
+        MonteCarloHistoricalReturn(year: 1986, stocks: 0.1849, bonds: 0.2428, cash: 0.0615),
+        MonteCarloHistoricalReturn(year: 1987, stocks: 0.0581, bonds: -0.0496, cash: 0.0596),
+        MonteCarloHistoricalReturn(year: 1988, stocks: 0.1654, bonds: 0.0822, cash: 0.0689),
+        MonteCarloHistoricalReturn(year: 1989, stocks: 0.3148, bonds: 0.1769, cash: 0.0839),
+        MonteCarloHistoricalReturn(year: 1990, stocks: -0.0306, bonds: 0.0624, cash: 0.0775),
+        MonteCarloHistoricalReturn(year: 1991, stocks: 0.3023, bonds: 0.15, cash: 0.0554),
+        MonteCarloHistoricalReturn(year: 1992, stocks: 0.0749, bonds: 0.0936, cash: 0.0351),
+        MonteCarloHistoricalReturn(year: 1993, stocks: 0.0997, bonds: 0.1421, cash: 0.0307),
+        MonteCarloHistoricalReturn(year: 1994, stocks: 0.0133, bonds: -0.0804, cash: 0.0437),
+        MonteCarloHistoricalReturn(year: 1995, stocks: 0.372, bonds: 0.2348, cash: 0.0566),
+        MonteCarloHistoricalReturn(year: 1996, stocks: 0.2268, bonds: 0.0143, cash: 0.0515),
+        MonteCarloHistoricalReturn(year: 1997, stocks: 0.331, bonds: 0.0994, cash: 0.052),
+        MonteCarloHistoricalReturn(year: 1998, stocks: 0.2834, bonds: 0.1492, cash: 0.0491),
+        MonteCarloHistoricalReturn(year: 1999, stocks: 0.2089, bonds: -0.0825, cash: 0.0478),
+        MonteCarloHistoricalReturn(year: 2000, stocks: -0.0903, bonds: 0.1666, cash: 0.06),
+        MonteCarloHistoricalReturn(year: 2001, stocks: -0.1185, bonds: 0.0557, cash: 0.0348),
+        MonteCarloHistoricalReturn(year: 2002, stocks: -0.2197, bonds: 0.1512, cash: 0.0164),
+        MonteCarloHistoricalReturn(year: 2003, stocks: 0.2836, bonds: 0.0038, cash: 0.0103),
+        MonteCarloHistoricalReturn(year: 2004, stocks: 0.1074, bonds: 0.0449, cash: 0.014),
+        MonteCarloHistoricalReturn(year: 2005, stocks: 0.0483, bonds: 0.0287, cash: 0.0322),
+        MonteCarloHistoricalReturn(year: 2006, stocks: 0.1561, bonds: 0.0196, cash: 0.0485),
+        MonteCarloHistoricalReturn(year: 2007, stocks: 0.0548, bonds: 0.1021, cash: 0.0448),
+        MonteCarloHistoricalReturn(year: 2008, stocks: -0.3655, bonds: 0.201, cash: 0.014),
+        MonteCarloHistoricalReturn(year: 2009, stocks: 0.2594, bonds: -0.1112, cash: 0.0015),
+        MonteCarloHistoricalReturn(year: 2010, stocks: 0.1482, bonds: 0.0846, cash: 0.0014),
+        MonteCarloHistoricalReturn(year: 2011, stocks: 0.021, bonds: 0.1604, cash: 0.0005),
+        MonteCarloHistoricalReturn(year: 2012, stocks: 0.1589, bonds: 0.0297, cash: 0.0009),
+        MonteCarloHistoricalReturn(year: 2013, stocks: 0.3215, bonds: -0.091, cash: 0.0006),
+        MonteCarloHistoricalReturn(year: 2014, stocks: 0.1352, bonds: 0.1075, cash: 0.0003),
+        MonteCarloHistoricalReturn(year: 2015, stocks: 0.0138, bonds: 0.0128, cash: 0.0005),
+        MonteCarloHistoricalReturn(year: 2016, stocks: 0.1177, bonds: 0.0069, cash: 0.0032),
+        MonteCarloHistoricalReturn(year: 2017, stocks: 0.2161, bonds: 0.028, cash: 0.0095),
+        MonteCarloHistoricalReturn(year: 2018, stocks: -0.0423, bonds: -0.0002, cash: 0.0197),
+        MonteCarloHistoricalReturn(year: 2019, stocks: 0.3121, bonds: 0.0964, cash: 0.0211),
+        MonteCarloHistoricalReturn(year: 2020, stocks: 0.1802, bonds: 0.1133, cash: 0.0036),
+        MonteCarloHistoricalReturn(year: 2021, stocks: 0.2847, bonds: -0.0442, cash: 0.0004),
+        MonteCarloHistoricalReturn(year: 2022, stocks: -0.1804, bonds: -0.1783, cash: 0.0209),
+        MonteCarloHistoricalReturn(year: 2023, stocks: 0.2606, bonds: 0.0388, cash: 0.0528),
+        MonteCarloHistoricalReturn(year: 2024, stocks: 0.2488, bonds: -0.0164, cash: 0.0518),
+        MonteCarloHistoricalReturn(year: 2025, stocks: 0.1778, bonds: 0.078, cash: 0.0421),
+    ]
+}
+
+// MARK: - Output
+
+struct MonteCarloPercentileBand: Equatable {
+    /// 0 = starting point, 1..horizonYears = end of that year. Values in cents.
+    let year: Int
+    let p5: Int
+    let p10: Int
+    let p25: Int
+    let p30: Int
+    let p50: Int
+    let p70: Int
+    let p75: Int
+    let p90: Int
+}
+
+struct MonteCarloData: Equatable {
+    /// Fraction (0..1) of simulations that survived the full horizon.
+    let successRate: Double
+    let currentAge: Double
+    let horizonYears: Int
+    let simulationCount: Int
+    let percentileBands: [MonteCarloPercentileBand]
+}
+
+// MARK: - PRNG
+
+/// Exact port of upstream mulberry32 + Box-Muller normal sampler, so seeded
+/// runs reproduce the web app's numbers bit for bit.
+struct MonteCarloRandom {
+    private var state: UInt32
+
+    init(seed: UInt32) {
+        state = seed
+    }
+
+    /// Uniform in [0, 1) (upstream mulberry32).
+    mutating func next() -> Double {
+        state = state &+ 0x6D2B79F5
+        var mixed = (state ^ (state >> 15)) &* (state | 1)
+        mixed = (mixed &+ ((mixed ^ (mixed >> 7)) &* (mixed | 61))) ^ mixed
+        return Double(mixed ^ (mixed >> 14)) / 4294967296
+    }
+
+    /// Standard normal draw via the Box-Muller transform (upstream
+    /// makeNormalSampler; the 1 - next() shift avoids log(0)).
+    mutating func nextNormal() -> Double {
+        let uniform1 = 1 - next()
+        let uniform2 = next()
+        return (-2 * Foundation.log(uniform1)).squareRoot() * Foundation.cos(2 * .pi * uniform2)
+    }
+}
+
+// MARK: - Engine
+
+/// Port of the webapp's monteCarloSimulation.ts drawdown engine. Pure and
+/// deterministic for a given seed; upstream seeds with 1234 by default so
+/// identical inputs always produce identical headline numbers.
+///
+/// Integrator wiring: pots may reference an account (`accountId`); pass the
+/// current balance of those accounts (in cents) via `accountBalances` and the
+/// pot's starting balance is replaced with `max(0, balance)`, mirroring
+/// upstream useResolvedMonteCarloConfig. Pots without a match keep their
+/// stored starting balance.
+enum MonteCarloEngine {
+
+    /// 1e14 minor units; keeps compounded results formatter-safe (upstream MAX_AMOUNT).
+    static let maxAmount: Double = 100_000_000_000_000
+    static let minSimulationCount = 1000.0
+    static let maxSimulationCount = 10000.0
+    static let minHorizonYears = 1
+    static let maxHorizonYears = 100
+    static let maxWithdrawalTaxRate = 0.75
+    static let maxTaxBandRate = 0.99
+    static let maxAnnualFeeRate = 0.1
+    /// Upstream DEFAULT_SIMULATION_SEED.
+    static let defaultSeed: UInt32 = 1234
+
+    // MARK: Meta resolution (upstream monteCarloConfigFromMeta)
+
+    static func config(from meta: MonteCarloMeta?) -> MonteCarloConfig {
+        var config = MonteCarloConfig()
+        if let potMetas = meta?.pots, !potMetas.isEmpty {
+            config.pots = potMetas.enumerated().map { index, potMeta in
+                var pot = MonteCarloPot(id: potMeta.id?.isEmpty == false ? potMeta.id! : "pot-\(index + 1)")
+                pot.name = potMeta.name ?? pot.name
+                pot.startingBalance = potMeta.startingBalance ?? pot.startingBalance
+                pot.allocationPreset = potMeta.allocationPreset.flatMap(MonteCarloAllocationPreset.init) ?? pot.allocationPreset
+                pot.expectedReturnMean = potMeta.expectedReturnMean ?? pot.expectedReturnMean
+                pot.returnStdDev = potMeta.returnStdDev ?? pot.returnStdDev
+                pot.accessAge = potMeta.accessAge
+                pot.accountId = potMeta.accountId
+                pot.withdrawalTaxRate = potMeta.withdrawalTaxRate ?? pot.withdrawalTaxRate
+                pot.taxableFraction = potMeta.taxableFraction ?? pot.taxableFraction
+                pot.annualFeeFixed = potMeta.annualFeeFixed ?? pot.annualFeeFixed
+                pot.feeAdjustsWithInflation = potMeta.feeAdjustsWithInflation ?? pot.feeAdjustsWithInflation
+                pot.annualFeeRate = potMeta.annualFeeRate ?? pot.annualFeeRate
+                return pot
+            }
+        }
+        config.withdrawalStrategy = meta?.withdrawalStrategy.flatMap(MonteCarloWithdrawalStrategy.init) ?? config.withdrawalStrategy
+        config.returnModel = meta?.returnModel.flatMap(MonteCarloReturnModel.init) ?? config.returnModel
+        if let ruleMeta = meta?.withdrawalRule {
+            var rule = MonteCarloWithdrawalRule()
+            rule.type = ruleMeta.type.flatMap(MonteCarloWithdrawalRuleType.init) ?? rule.type
+            rule.prosperityTriggerPct = ruleMeta.prosperityTriggerPct ?? rule.prosperityTriggerPct
+            rule.prosperityIncreasePct = ruleMeta.prosperityIncreasePct ?? rule.prosperityIncreasePct
+            rule.preservationTriggerPct = ruleMeta.preservationTriggerPct ?? rule.preservationTriggerPct
+            rule.preservationCutPct = ruleMeta.preservationCutPct ?? rule.preservationCutPct
+            rule.balanceThresholdMultiple = ruleMeta.balanceThresholdMultiple ?? rule.balanceThresholdMultiple
+            rule.consecutiveYears = ruleMeta.consecutiveYears ?? rule.consecutiveYears
+            rule.ratchetIncreasePct = ruleMeta.ratchetIncreasePct ?? rule.ratchetIncreasePct
+            rule.floorPct = ruleMeta.floorPct ?? rule.floorPct
+            rule.ceilingPct = ruleMeta.ceilingPct ?? rule.ceilingPct
+            rule.upperRateThreshold = ruleMeta.upperRateThreshold ?? rule.upperRateThreshold
+            rule.upperCutPct = ruleMeta.upperCutPct ?? rule.upperCutPct
+            rule.lowerRateThreshold = ruleMeta.lowerRateThreshold ?? rule.lowerRateThreshold
+            rule.lowerIncreasePct = ruleMeta.lowerIncreasePct ?? rule.lowerIncreasePct
+            config.withdrawalRule = rule
+        }
+        config.minimumWithdrawal = meta?.minimumWithdrawal ?? config.minimumWithdrawal
+        if let phaseMetas = meta?.spendingPhases, !phaseMetas.isEmpty {
+            config.spendingPhases = phaseMetas.enumerated().map { index, phaseMeta in
+                var phase = MonteCarloSpendingPhase(id: phaseMeta.id?.isEmpty == false ? phaseMeta.id! : "phase-\(index + 1)")
+                phase.name = phaseMeta.name ?? phase.name
+                phase.fromAge = phaseMeta.fromAge
+                phase.annualWithdrawal = phaseMeta.annualWithdrawal ?? phase.annualWithdrawal
+                return phase
+            }
+        }
+        // Absent = default; explicit null = flat withdrawals
+        if let inflationMean = meta?.inflationMean {
+            config.inflationMean = inflationMean
+        }
+        config.inflationStdDev = meta?.inflationStdDev ?? config.inflationStdDev
+        config.taxModel = meta?.taxModel.flatMap(MonteCarloTaxModel.init) ?? config.taxModel
+        if let bandMetas = meta?.taxBands, !bandMetas.isEmpty {
+            config.taxBands = bandMetas.enumerated().map { index, bandMeta in
+                var band = MonteCarloTaxBand(id: bandMeta.id?.isEmpty == false ? bandMeta.id! : "band-\(index + 1)")
+                band.from = bandMeta.from ?? band.from
+                band.rate = bandMeta.rate ?? band.rate
+                return band
+            }
+        }
+        config.currentAge = meta?.currentAge ?? config.currentAge
+        config.targetAge = meta?.targetAge ?? config.targetAge
+        config.simulationCount = meta?.simulationCount ?? config.simulationCount
+        return config
+    }
+
+    /// Simulated years, derived from the configured ages (upstream
+    /// getMonteCarloHorizonYears).
+    static func horizonYears(currentAge: Double, targetAge: Double) -> Int {
+        // Clamp before converting so absurd ages can't overflow Int
+        let years = min(Double(maxHorizonYears), max(Double(minHorizonYears), (targetAge - currentAge).rounded()))
+        return Int(years)
+    }
+
+    /// Card entry point: resolves account-linked pots then simulates in
+    /// today's money, as the dashboard card does upstream (MonteCarloCard.tsx).
+    static func compute(
+        meta: MonteCarloMeta?,
+        accountBalances: [String: Int] = [:],
+        seed: UInt32 = defaultSeed
+    ) -> MonteCarloData {
+        var resolved = Self.config(from: meta)
+        // Upstream useResolvedMonteCarloConfig: linked pots take the
+        // account's live balance, falling back to the stored one
+        resolved.pots = resolved.pots.map { pot in
+            guard let accountId = pot.accountId, let balance = accountBalances[accountId] else { return pot }
+            var linked = pot
+            linked.startingBalance = Double(max(0, balance))
+            return linked
+        }
+        return simulate(config: resolved, seed: seed, deflateToTodaysMoney: true)
+    }
+
+    // MARK: Simulation (upstream runMonteCarloSimulation)
+
+    /// Each year, in each simulation: the withdrawal is taken at the start of
+    /// the year across the pots that have reached their access age; if the
+    /// accessible pots can't cover it the simulation is marked depleted for
+    /// that year; otherwise each pot earns that year's return. Returns are
+    /// nominal - inflation only grows withdrawals.
+    static func simulate(
+        config: MonteCarloConfig,
+        seed: UInt32 = defaultSeed,
+        deflateToTodaysMoney: Bool = false,
+        historicalReturns: [MonteCarloHistoricalReturn]? = nil
+    ) -> MonteCarloData {
+        func clamp(_ value: Double, _ low: Double, _ high: Double) -> Double {
+            Swift.min(high, Swift.max(low, value))
+        }
+
+        let pots = config.pots.isEmpty ? [MonteCarloPot(id: "pot-1")] : config.pots
+        let potCount = pots.count
+        let potStartBalances = pots.map { clamp($0.startingBalance, 0, maxAmount) }
+        let potMeans = pots.map { $0.expectedReturnMean }
+        let potStdDevs = pots.map { Swift.max(0, $0.returnStdDev) }
+        let isSequential = config.withdrawalStrategy == .sequential
+        let isBestPerformer = config.withdrawalStrategy == .bestPerformer
+        let isTargetMix = config.withdrawalStrategy == .targetMix
+        var previousReturns = [Double](repeating: 0, count: potCount)
+        var drainOrder = Array(0..<potCount)
+        var potIdealBalances = [Double](repeating: 0, count: potCount)
+        var potTakes = [Double](repeating: 0, count: potCount)
+
+        // First simulation year (1-based) in which each pot can fund
+        // withdrawals; the year-y withdrawal happens at age currentAge + (y - 1)
+        let potAccessFromYear: [Int] = pots.map { pot in
+            guard let accessAge = pot.accessAge else { return 1 }
+            // Clamp before converting so absurd ages can't overflow Int; the
+            // year is only ever compared against year <= maxHorizonYears
+            let offset = clamp((accessAge - config.currentAge).rounded(), 0, Double(maxHorizonYears) + 1)
+            return Swift.max(1, Int(offset) + 1)
+        }
+
+        // --- Tax ------------------------------------------------------------
+        let taxModel = config.taxModel
+        let potTaxRates = pots.map { clamp($0.withdrawalTaxRate, 0, maxWithdrawalTaxRate) }
+        let potTaxableFractions = pots.map { clamp($0.taxableFraction, 0, 1) }
+        // Bands sorted ascending (stable, like JS sort), with a guaranteed
+        // 0-threshold first band so income below the first threshold is untaxed
+        var taxBands = config.taxBands
+            .map { (from: clamp($0.from, 0, maxAmount), rate: clamp($0.rate, 0, maxTaxBandRate)) }
+            .enumerated()
+            .sorted { ($0.element.from, $0.offset) < ($1.element.from, $1.offset) }
+            .map(\.element)
+        if taxBands.isEmpty || taxBands[0].from > 0 {
+            taxBands.insert((from: 0, rate: 0), at: 0)
+        }
+        let hasTax = taxModel == .bands
+            ? taxBands.contains { $0.rate > 0 } && potTaxableFractions.contains { $0 > 0 }
+            : potTaxRates.contains { $0 > 0 }
+
+        // --- Fees -----------------------------------------------------------
+        let potFeeFixed = pots.map { clamp($0.annualFeeFixed, 0, maxAmount) }
+        let potFeeAdjusts = pots.map { $0.feeAdjustsWithInflation }
+        let potFeeRates = pots.map { clamp($0.annualFeeRate, 0, maxAnnualFeeRate) }
+        let hasFees = potFeeFixed.contains { $0 > 0 } || potFeeRates.contains { $0 > 0 }
+
+        // Worst-case share of a gross withdrawal lost to tax; used to skip the
+        // per-year shortfall precheck when capacity is comfortably sufficient
+        let maxTaxRate = taxModel == .bands
+            ? taxBands.map(\.rate).reduce(0, Swift.max)
+            : potTaxRates.reduce(0, Swift.max)
+        let minNetFactor = 1 - maxTaxRate
+
+        // Progressive tax on an annual taxable income, in today's money
+        func bandTax(_ taxableIncome: Double) -> Double {
+            var tax = 0.0
+            for bandIndex in 0..<taxBands.count {
+                if taxableIncome <= taxBands[bandIndex].from {
+                    break
+                }
+                let upper = bandIndex + 1 < taxBands.count ? taxBands[bandIndex + 1].from : .infinity
+                tax += taxBands[bandIndex].rate * (Swift.min(taxableIncome, upper) - taxBands[bandIndex].from)
+            }
+            return tax
+        }
+
+        // Tax due on the takes currently in potTakes. Band thresholds are in
+        // today's money, so taxable income is deflated by the replay's
+        // inflation path before banding
+        func taxForTakes(_ cumulativeInflationNow: Double) -> Double {
+            if !hasTax {
+                return 0
+            }
+            if taxModel == .flat {
+                var tax = 0.0
+                for potIndex in 0..<potCount {
+                    tax += potTakes[potIndex] * potTaxRates[potIndex]
+                }
+                return tax
+            }
+            var taxable = 0.0
+            for potIndex in 0..<potCount {
+                taxable += potTakes[potIndex] * potTaxableFractions[potIndex]
+            }
+            return bandTax(taxable / cumulativeInflationNow) * cumulativeInflationNow
+        }
+
+        var potBalances = [Double](repeating: 0, count: potCount)
+
+        // Split a gross withdrawal across pots per the configured strategy,
+        // writing each pot's take into potTakes (upstream computeTakes)
+        func computeTakes(_ grossTotal: Double, _ year: Int, _ accessibleTotal: Double, _ lastAccessibleIndex: Int) {
+            for potIndex in 0..<potCount {
+                potTakes[potIndex] = 0
+            }
+            if grossTotal <= 0 || accessibleTotal <= 0 {
+                return
+            }
+            if isSequential || isBestPerformer {
+                if isBestPerformer {
+                    // Drain the pot with the highest return last year first;
+                    // ties fall back to the listed order (JS stable sort)
+                    for potIndex in 0..<potCount {
+                        drainOrder[potIndex] = potIndex
+                    }
+                    drainOrder.sort { potA, potB in
+                        previousReturns[potA] != previousReturns[potB]
+                            ? previousReturns[potA] > previousReturns[potB]
+                            : potA < potB
+                    }
+                }
+                var remaining = grossTotal
+                for orderIndex in 0..<potCount where remaining > 0 {
+                    let potIndex = isBestPerformer ? drainOrder[orderIndex] : orderIndex
+                    if year < potAccessFromYear[potIndex] {
+                        continue
+                    }
+                    let take = Swift.min(potBalances[potIndex], remaining)
+                    potTakes[potIndex] = take
+                    remaining -= take
+                }
+            } else if isTargetMix {
+                // Withdraw so the accessible pots move back toward their
+                // target mix (weights = shares of the starting balances)
+                var targetAccessible = 0.0
+                for potIndex in 0..<potCount where year >= potAccessFromYear[potIndex] {
+                    targetAccessible += potStartBalances[potIndex]
+                }
+                let remainingTotal = accessibleTotal - grossTotal
+                for potIndex in 0..<potCount {
+                    drainOrder[potIndex] = potIndex
+                    potIdealBalances[potIndex] =
+                        year >= potAccessFromYear[potIndex] && targetAccessible > 0
+                            ? (potStartBalances[potIndex] / targetAccessible) * remainingTotal
+                            : 0
+                }
+                drainOrder.sort { potA, potB in
+                    let excessA = potBalances[potA] - potIdealBalances[potA]
+                    let excessB = potBalances[potB] - potIdealBalances[potB]
+                    return excessA != excessB ? excessA > excessB : potA < potB
+                }
+                var remaining = grossTotal
+                for orderIndex in 0..<potCount where remaining > 0 {
+                    let potIndex = drainOrder[orderIndex]
+                    if year < potAccessFromYear[potIndex] {
+                        continue
+                    }
+                    let excess = potBalances[potIndex] - potIdealBalances[potIndex]
+                    if excess <= 0 {
+                        continue
+                    }
+                    let take = Swift.min(remaining, Swift.min(potBalances[potIndex], excess))
+                    potTakes[potIndex] = take
+                    remaining -= take
+                }
+                // Float-drift safety net: drain any accessible pot for
+                // whatever tiny residue the excess passes left behind
+                for potIndex in 0..<potCount where remaining > 0 {
+                    if year < potAccessFromYear[potIndex] {
+                        continue
+                    }
+                    let take = Swift.min(potBalances[potIndex] - potTakes[potIndex], remaining)
+                    potTakes[potIndex] += take
+                    remaining -= take
+                }
+            } else {
+                // Proportional split across accessible pots; the last
+                // accessible pot takes the remainder (no float drift)
+                var remaining = grossTotal
+                for potIndex in 0..<Swift.max(0, lastAccessibleIndex) {
+                    if year < potAccessFromYear[potIndex] {
+                        continue
+                    }
+                    let take = grossTotal * (potBalances[potIndex] / accessibleTotal)
+                    potTakes[potIndex] = take
+                    remaining -= take
+                }
+                if lastAccessibleIndex >= 0 {
+                    potTakes[lastAccessibleIndex] = remaining
+                }
+            }
+        }
+
+        let returnModel = config.returnModel
+        let history = (historicalReturns?.isEmpty == false) ? historicalReturns! : MonteCarloHistoricalReturn.all
+        let historyCount = history.count
+
+        // For historical models, each preset pot gets the blended return of
+        // its asset mix in every historical year; 'custom' pots keep using
+        // normal draws around their own mean/volatility
+        let potHistoricalReturns: [[Double]?] = pots.map { pot in
+            guard returnModel != .normal, let weights = pot.allocationPreset.assetWeights else {
+                return nil
+            }
+            return history.map { weights.stocks * $0.stocks + weights.bonds * $0.bonds + weights.cash * $0.cash }
+        }
+        let hasNormalDrawPot = potHistoricalReturns.contains { $0 == nil }
+
+        let inflationMean = config.inflationMean
+        let inflationStdDev = inflationMean != nil ? Swift.max(0, config.inflationStdDev) : 0
+        let horizonYears = Self.horizonYears(currentAge: config.currentAge, targetAge: config.targetAge)
+
+        // The planned spending path in today's money: the active phase's
+        // amount for every year (phases ordered by starting age, no-age first,
+        // stable like upstream sortMonteCarloSpendingPhases)
+        let spendingPhases = (config.spendingPhases.isEmpty
+            ? [MonteCarloSpendingPhase(id: "phase-1")]
+            : config.spendingPhases)
+            .enumerated()
+            .sorted { ($0.element.fromAge ?? -.infinity, $0.offset) < ($1.element.fromAge ?? -.infinity, $1.offset) }
+            .map(\.element)
+        var plannedTodayByYear = [Double](repeating: 0, count: horizonYears + 1)
+        for year in 1...horizonYears {
+            let age = config.currentAge + Double(year - 1)
+            var amount = clamp(spendingPhases[0].annualWithdrawal, 0, maxAmount)
+            for phase in spendingPhases {
+                if phase.fromAge == nil || phase.fromAge! <= age {
+                    amount = clamp(phase.annualWithdrawal, 0, maxAmount)
+                } else {
+                    break
+                }
+            }
+            plannedTodayByYear[year] = amount
+        }
+
+        let deflate = deflateToTodaysMoney && inflationMean != nil
+        // Sequence replay runs exactly one scenario per historical start year
+        let simulationCount = returnModel == .historicalSequence
+            ? historyCount
+            : Int(clamp(config.simulationCount.rounded(), minSimulationCount, maxSimulationCount))
+
+        var random = MonteCarloRandom(seed: seed)
+
+        // Year-major balance buffers (totals across pots)
+        var balancesByYear = [[Double]](repeating: [Double](repeating: 0, count: simulationCount), count: horizonYears + 1)
+        var depletionCounts = [Int](repeating: 0, count: horizonYears + 1)
+        var survivedCount = 0
+
+        let startingTotal = potStartBalances.reduce(0, +)
+        let rule = config.withdrawalRule
+        let minimumWithdrawal = clamp(config.minimumWithdrawal, 0, maxAmount)
+
+        // Keep every emitted amount formatter-safe; absurd configs flat-line
+        // at the cap instead of overflowing (upstream toSafeAmount)
+        let maxEmitted = Double(1 << 50)  // 2^50, upstream maxEmitted
+        func toSafeAmount(_ value: Double) -> Double {
+            clamp(value, -maxEmitted, maxEmitted)
+        }
+
+        // Starting wealth accessible in each simulated year: withdrawal rules
+        // measure rates against pots that can actually fund spending
+        var accessibleStartByYear = [Double](repeating: 0, count: horizonYears + 1)
+        for year in 1...horizonYears {
+            var accessibleStart = 0.0
+            for potIndex in 0..<potCount where year >= potAccessFromYear[potIndex] {
+                accessibleStart += potStartBalances[potIndex]
+            }
+            accessibleStartByYear[year] = accessibleStart
+        }
+
+        let initialRate = accessibleStartByYear[1] > 0 ? plannedTodayByYear[1] / accessibleStartByYear[1] : 0
+
+        for simulationIndex in 0..<simulationCount {
+            potBalances = potStartBalances
+            for potIndex in 0..<potCount {
+                previousReturns[potIndex] = 0
+            }
+            var total = startingTotal
+            // Cuts/raises from the withdrawal rule compound here, on top of
+            // the planned spending path
+            var adjustmentFactor = 1.0
+            // This replay's realized inflation path
+            var cumulativeInflation = 1.0
+            var ratchetStreak = 0.0
+            var depleted = false
+
+            balancesByYear[0][simulationIndex] = toSafeAmount(total)
+
+            for year in 1...horizonYears {
+                if depleted {
+                    // Post-depletion years stay at zero
+                    continue
+                }
+                let planned = plannedTodayByYear[year] * cumulativeInflation
+                var withdrawal: Double
+
+                // Only pots that have reached their access age can fund this
+                // year's withdrawal; locked pots stay invested but untouchable
+                var accessibleTotal = 0.0
+                var lastAccessibleIndex = -1
+                for potIndex in 0..<potCount where year >= potAccessFromYear[potIndex] {
+                    accessibleTotal += potBalances[potIndex]
+                    lastAccessibleIndex = potIndex
+                }
+
+                // Apply the dynamic withdrawal rule before taking this year's
+                // withdrawal (from year 2 - year 1 always uses the plan).
+                // Rules evaluate accessible wealth only.
+                if year > 1 && rule.type == .floorCeiling {
+                    // Recompute rule: a fixed share of the accessible balance,
+                    // kept within limits around the planned spending
+                    withdrawal = clamp(
+                        initialRate * accessibleTotal,
+                        planned * (1 - rule.floorPct),
+                        planned * (1 + rule.ceilingPct)
+                    )
+                } else {
+                    if year > 1 && rule.type != .none && accessibleTotal > 0 && accessibleStartByYear[year] > 0 {
+                        let currentRate = (planned * adjustmentFactor) / accessibleTotal
+                        switch rule.type {
+                        case .guardrails:
+                            // Drift is measured against the planned spending
+                            // path, so a deliberate phase change doesn't read
+                            // as a trigger - only market-driven drift does
+                            let referenceRate = plannedTodayByYear[year] / accessibleStartByYear[year]
+                            if currentRate > referenceRate * (1 + rule.preservationTriggerPct) {
+                                adjustmentFactor *= 1 - rule.preservationCutPct
+                            } else if currentRate < referenceRate * (1 - rule.prosperityTriggerPct) {
+                                adjustmentFactor *= 1 + rule.prosperityIncreasePct
+                            }
+                        case .ratcheting:
+                            if accessibleTotal > accessibleStartByYear[year] * rule.balanceThresholdMultiple {
+                                ratchetStreak += 1
+                                if ratchetStreak >= rule.consecutiveYears {
+                                    adjustmentFactor *= 1 + rule.ratchetIncreasePct
+                                    ratchetStreak = 0
+                                }
+                            } else {
+                                ratchetStreak = 0
+                            }
+                        case .boundaries:
+                            if currentRate > rule.upperRateThreshold {
+                                adjustmentFactor *= 1 - rule.upperCutPct
+                            } else if currentRate < rule.lowerRateThreshold {
+                                adjustmentFactor *= 1 + rule.lowerIncreasePct
+                            }
+                        case .none, .floorCeiling:
+                            break
+                        }
+                    }
+                    withdrawal = planned * adjustmentFactor
+                }
+                // The minimum floor guards against rule-driven cuts, so it
+                // only applies with an active rule in years with planned
+                // spending; like the phase amounts it's in today's money
+                let minimumThisYear = minimumWithdrawal * cumulativeInflation
+                if rule.type != .none && minimumWithdrawal > 0 && planned > 0 && withdrawal < minimumThisYear {
+                    withdrawal = minimumThisYear
+                }
+
+                // The spending requirement is net of tax; the gross that
+                // leaves the pots must deliver it
+                let netRequired = withdrawal
+                var fundingShortfall = false
+
+                // Net capacity: what withdrawing every accessible penny would
+                // actually deliver after tax
+                var accessibleNetCapacity = accessibleTotal
+                if hasTax && accessibleTotal * minNetFactor <= netRequired {
+                    computeTakes(accessibleTotal, year, accessibleTotal, lastAccessibleIndex)
+                    accessibleNetCapacity = accessibleTotal - taxForTakes(cumulativeInflation)
+                }
+
+                if accessibleNetCapacity <= netRequired {
+                    fundingShortfall = true
+                    // The accessible pots can't cover this year's spending
+                    // (locked pots may still hold money)
+                    for potIndex in 0..<potCount {
+                        potBalances[potIndex] = 0
+                    }
+                    total = 0
+                    depleted = true
+                    depletionCounts[year] += 1
+                } else {
+                    // Solve the gross withdrawal that delivers the net
+                    // requirement: g = net + tax(takes(g)). Tax is piecewise
+                    // linear in g, so this fixed point converges geometrically
+                    var grossTotal = netRequired
+                    if hasTax {
+                        for _ in 0..<40 {
+                            computeTakes(grossTotal, year, accessibleTotal, lastAccessibleIndex)
+                            let next = netRequired + taxForTakes(cumulativeInflation)
+                            if abs(next - grossTotal) <= 1e-7 * Swift.max(1, next) {
+                                grossTotal = next
+                                break
+                            }
+                            grossTotal = next
+                        }
+                        grossTotal = Swift.min(grossTotal, accessibleTotal)
+                    }
+
+                    computeTakes(grossTotal, year, accessibleTotal, lastAccessibleIndex)
+                    for potIndex in 0..<potCount {
+                        potBalances[potIndex] -= potTakes[potIndex]
+                    }
+
+                    // Every pot experiences the same market year: historical
+                    // models pick one history year for all pots, and
+                    // normally-drawn pots share one market shock scaled by
+                    // their own volatility
+                    var historyIndex = -1
+                    if returnModel == .historicalBootstrap {
+                        historyIndex = Int(random.next() * Double(historyCount))
+                    } else if returnModel == .historicalSequence {
+                        historyIndex = (simulationIndex + year - 1) % historyCount
+                    }
+                    let marketShock = hasNormalDrawPot ? random.nextNormal() : 0
+
+                    total = 0
+                    for potIndex in 0..<potCount {
+                        if potBalances[potIndex] > 0 {
+                            let yearReturn: Double
+                            if let blended = potHistoricalReturns[potIndex], historyIndex >= 0 {
+                                yearReturn = blended[historyIndex]
+                            } else {
+                                yearReturn = potMeans[potIndex] + potStdDevs[potIndex] * marketShock
+                            }
+                            previousReturns[potIndex] = yearReturn
+                            potBalances[potIndex] *= 1 + yearReturn
+                            if potBalances[potIndex] <= 0 {
+                                // A sub-(-100%) return draw wiped this pot out
+                                potBalances[potIndex] = 0
+                            }
+                        }
+                        total += potBalances[potIndex]
+                    }
+                    if total <= 0 {
+                        total = 0
+                        depleted = true
+                        depletionCounts[year] += 1
+                    }
+                }
+
+                // Realize this year's inflation, drawing a random rate when
+                // volatility is set (fixed mean otherwise)
+                if let inflationMean {
+                    let yearInflation = inflationStdDev > 0
+                        ? Swift.max(-0.9, inflationMean + inflationStdDev * random.nextNormal())
+                        : inflationMean
+                    cumulativeInflation *= 1 + yearInflation
+                }
+
+                // Management fees come out at the end of the year, after
+                // growth and inflation; fees can deplete a plan on their own
+                if hasFees && !fundingShortfall && total > 0 {
+                    for potIndex in 0..<potCount where potBalances[potIndex] > 0 {
+                        let fee = potBalances[potIndex] * potFeeRates[potIndex]
+                            + potFeeFixed[potIndex] * (potFeeAdjusts[potIndex] ? cumulativeInflation : 1)
+                        let charged = Swift.min(potBalances[potIndex], fee)
+                        potBalances[potIndex] -= charged
+                    }
+                    total = 0
+                    for potIndex in 0..<potCount {
+                        total += potBalances[potIndex]
+                    }
+                    if total <= 0 {
+                        total = 0
+                        depleted = true
+                        depletionCounts[year] += 1
+                    }
+                }
+                let endDeflator = deflate ? 1 / cumulativeInflation : 1
+
+                // Store this replay's balance, in today's money when deflating
+                balancesByYear[year][simulationIndex] = toSafeAmount(total * endDeflator)
+            }
+
+            if !depleted {
+                survivedCount += 1
+            }
+        }
+
+        func percentileOfSorted(_ sorted: [Double], _ percentile: Double) -> Double {
+            let position = Double(sorted.count - 1) * percentile
+            let lower = Int(position.rounded(.down))
+            let upper = Int(position.rounded(.up))
+            if lower == upper {
+                return sorted[lower]
+            }
+            let weight = position - Double(lower)
+            return sorted[lower] * (1 - weight) + sorted[upper] * weight
+        }
+
+        var percentileBands: [MonteCarloPercentileBand] = []
+        for year in 0...horizonYears {
+            let sorted = balancesByYear[year].sorted()
+            func p(_ percentile: Double) -> Int {
+                Int(percentileOfSorted(sorted, percentile).rounded())
+            }
+            percentileBands.append(MonteCarloPercentileBand(
+                year: year,
+                p5: p(0.05), p10: p(0.1), p25: p(0.25), p30: p(0.3),
+                p50: p(0.5), p70: p(0.7), p75: p(0.75), p90: p(0.9)
+            ))
+        }
+
+        return MonteCarloData(
+            successRate: Double(survivedCount) / Double(simulationCount),
+            currentAge: config.currentAge,
+            horizonYears: horizonYears,
+            simulationCount: simulationCount,
+            percentileBands: percentileBands
+        )
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/SankeyEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/SankeyEngine.swift
@@ -1,0 +1,978 @@
+import Foundation
+
+// MARK: - Meta
+
+/// Mirrors upstream `SankeyWidget['meta']` (sankey-card).
+struct SankeyMeta: Codable, Equatable {
+    let name: String?
+    let conditions: [WidgetRuleCondition]?
+    let conditionsOp: String?
+    let timeFrame: WidgetTimeFrame?
+    let mode: String?           // "budgeted" | "spent"; nil = "spent"
+    let topNcategories: Int?
+    let categorySort: String?   // "per-group" | "global" | "budget-order"
+    let showPercentages: Bool?
+    let groupAccounts: Bool?
+    let layerFrom: String?      // SankeyLayer raw value
+    let layerTo: String?
+}
+
+// MARK: - Layers
+
+/// Upstream `GraphLayers`; case order is GRAPH_LAYER_ORDER.
+enum SankeyLayer: String, CaseIterable, Equatable {
+    case incomePayee = "payee"
+    case incomeCategory = "income_category"
+    case account
+    case budget
+    case categoryGroup = "category_group"
+    case category
+
+    var orderIndex: Int { Self.allCases.firstIndex(of: self)! }
+}
+
+enum SankeySortMode: String {
+    case perGroup = "per-group"
+    case global
+    case budgetOrder = "budget-order"
+}
+
+// MARK: - Output
+
+struct SankeyData: Equatable {
+    struct Node: Equatable {
+        let key: String
+        let name: String
+        let percentageLabel: String
+        let layer: SankeyLayer
+        let isNegative: Bool
+
+        var isHidden: Bool { key.hasSuffix("__HIDDEN") }
+    }
+    struct Link: Equatable {
+        let source: Int
+        let target: Int
+        let value: Int  // cents; hidden layout-scaffolding links carry -1
+    }
+
+    let nodes: [Node]
+    let links: [Link]
+    let showPercentages: Bool
+
+    static let empty = SankeyData(nodes: [], links: [], showPercentages: false)
+}
+
+// MARK: - Graph
+
+/// Insertion-ordered directed graph mirroring upstream's `Graph` (a JS Map;
+/// Map iteration order is insertion order, which the sort/layout relies on).
+struct SankeyGraph {
+    struct Node {
+        var type: SankeyLayer
+        var name: String?
+        var isNegative: Bool = false
+        var percentageLabel: String?
+        var toOrder: [String] = []
+        var toValues: [String: Int] = [:]
+
+        var hasChild: Bool { !toOrder.isEmpty }
+    }
+
+    private(set) var order: [String] = []
+    var nodes: [String: Node] = [:]
+
+    var keys: [String] { order }
+
+    subscript(key: String) -> Node? { nodes[key] }
+
+    mutating func addNode(_ key: String, type: SankeyLayer, name: String?, isNegative: Bool = false) {
+        guard nodes[key] == nil else { return }
+        nodes[key] = Node(type: type, name: name, isNegative: isNegative)
+        order.append(key)
+    }
+
+    mutating func addValueToLink(from: String, to: String, value: Int) {
+        guard var node = nodes[from] else { return }
+        if node.toValues[to] == nil { node.toOrder.append(to) }
+        node.toValues[to] = (node.toValues[to] ?? 0) + value
+        nodes[from] = node
+    }
+
+    mutating func deleteLink(from: String, to: String) {
+        guard var node = nodes[from] else { return }
+        node.toValues[to] = nil
+        node.toOrder.removeAll { $0 == to }
+        nodes[from] = node
+    }
+
+    mutating func delete(_ key: String) {
+        nodes[key] = nil
+        order.removeAll { $0 == key }
+    }
+
+    mutating func reorder(_ newOrder: [String]) { order = newOrder }
+
+    func links(from key: String) -> [(to: String, value: Int)] {
+        guard let node = nodes[key] else { return [] }
+        return node.toOrder.map { ($0, node.toValues[$0] ?? 0) }
+    }
+}
+
+// MARK: - Inputs
+
+/// Upstream `CategoryEntry`. Spent mode stores `value` as abs(cents);
+/// budgeted mode keeps the sign (matching upstream, whose createBudgetGraph
+/// branches on the raw signed value).
+struct SankeyCategoryEntry: Equatable {
+    let categoryGroup: String
+    let categoryGroupId: String
+    let category: String
+    let categoryId: String
+    let value: Int
+    let isIncome: Bool
+    let isNegative: Bool
+    var accountName: String? = nil
+    var accountId: String? = nil
+    var payeeName: String? = nil
+    var payeeId: String? = nil
+}
+
+/// Budget-mode input. INTEGRATOR WIRING: `entries` come from
+/// zero_budgets/reflect_budgets rows (month YYYYMM, category, amount cents).
+/// The envelope aggregates mirror upstream `api/budget-month`:
+/// - `toBudgetCents`: "to budget" of the range's LAST month
+/// - `fromPreviousMonthCents`: fromLastMonth of the range's FIRST month
+/// - `lastMonthOverspentCents`: sum of lastMonthOverspent across the range
+/// - `forNextMonthCents`: nextMonth(end).fromLastMonth - toBudget
+/// Leaving them 0 simply omits those flows (zero links are cleaned up).
+struct SankeyBudgetInput: Equatable {
+    struct Entry: Equatable {
+        let month: Int  // YYYYMM
+        let categoryId: String
+        let amountCents: Int
+    }
+    var entries: [Entry] = []
+    var toBudgetCents: Int = 0
+    var fromPreviousMonthCents: Int = 0
+    var lastMonthOverspentCents: Int = 0
+    var forNextMonthCents: Int = 0
+}
+
+// MARK: - Engine
+
+/// Port of the webapp's sankey-spreadsheet.ts at dashboard-card fidelity.
+/// Deliberate cuts vs upstream: no tooltip info, no colors (the view derives
+/// them), i18n labels resolved inline at node creation.
+enum SankeyEngine {
+
+    enum SpecialKey {
+        static let toBudget = "to_budget"
+        static let budgeted = "budgeted"
+        static let lastMonthOverspent = "last_month_overspent"
+        static let forNextMonth = "for_next_month"
+        static let fromPrevMonth = "from_previous_month"
+        static let availableIncome = "available_income"
+        static let allAccounts = "all_income"
+        static let otherSuffix = "__OTHER_BUCKET"
+        static let hiddenSuffix = "__HIDDEN"
+        static let negativeSuffix = "__NEGATIVE"
+        // Upstream builds this from Object.values(SpecialNodeKeys), which
+        // includes the literal suffix strings.
+        static let structural: Set<String> = [
+            toBudget, budgeted, lastMonthOverspent, forNextMonth, fromPrevMonth,
+            availableIncome, allAccounts, otherSuffix, hiddenSuffix, negativeSuffix
+        ]
+    }
+
+    private static var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    // MARK: Compute
+
+    /// Account display names come from `context.accountNames` (the same map
+    /// the conditions filter uses); missing entries fall back to the id so
+    /// the card still renders. `maxNodesPerLayer` mirrors the card's
+    /// height-based cap (upstream topNNodes: 35px per node, ~6 at card height)
+    /// and is min'd with `meta.topNcategories ?? 15` like SankeyCard.tsx.
+    static func compute(
+        meta: SankeyMeta?,
+        transactions: [Transaction],
+        categoryGroups: [CategoryGroup],
+        budget: SankeyBudgetInput? = nil,
+        today: Date,
+        context: ConditionsFilter.Context = .empty,
+        maxNodesPerLayer: Int = 6
+    ) -> SankeyData {
+        var (start, end) = TimeFrame.resolve(meta?.timeFrame, asOf: today)
+        // Upstream queries firstDayOfMonth(start)..lastDayOfMonth(end).
+        start = monthStart(of: start)
+        end = endOfMonth(monthStart(of: end))
+        let startYMD = ymdInt(from: start)
+        let endYMD = ymdInt(from: end)
+
+        let isBudgeted = meta?.mode == "budgeted"
+        // AQL `transactions` defaults to inline splits: children shown,
+        // parents excluded.
+        let live = transactions.filter {
+            !$0.tombstone && !$0.isParent && $0.date >= startYMD && $0.date <= endYMD
+        }
+
+        let graph: SankeyGraph
+        if isBudgeted {
+            let entries = budgetEntries(
+                categoryGroups: categoryGroups,
+                conditions: meta?.conditions,
+                conditionsOp: meta?.conditionsOp,
+                budget: budget ?? SankeyBudgetInput(),
+                transactions: live,
+                months: monthsInRange(start: start, end: end)
+            )
+            graph = createBudgetGraph(
+                entries,
+                budget: budget ?? SankeyBudgetInput(),
+                startMonth: monthLabel(start),
+                endMonth: monthLabel(end)
+            )
+        } else {
+            let entries = transactionEntries(
+                categoryGroups: categoryGroups,
+                transactions: live,
+                conditions: meta?.conditions,
+                conditionsOp: meta?.conditionsOp,
+                groupAccounts: meta?.groupAccounts ?? false,
+                context: context
+            )
+            graph = createTransactionsGraph(entries)
+        }
+
+        let topN = min(meta?.topNcategories ?? 15, maxNodesPerLayer)
+        let sort = SankeySortMode(rawValue: meta?.categorySort ?? "") ?? .perGroup
+
+        let layerFrom: SankeyLayer
+        let layerTo: SankeyLayer
+        if let f = meta?.layerFrom.flatMap(SankeyLayer.init(rawValue:)),
+           let t = meta?.layerTo.flatMap(SankeyLayer.init(rawValue:)) {
+            layerFrom = f
+            layerTo = t
+        } else {
+            // Upstream getDefaultLayerRange(mode).
+            layerFrom = isBudgeted ? .incomeCategory : .incomePayee
+            layerTo = .category
+        }
+
+        return buildSankeyData(
+            graph,
+            topN: topN,
+            categoryGroups: categoryGroups,
+            categorySort: sort,
+            layerFrom: layerFrom,
+            layerTo: layerTo,
+            showPercentages: meta?.showPercentages ?? false
+        )
+    }
+
+    // MARK: Entry building (spent)
+
+    /// Upstream fetchCategoryData: per category, transactions grouped by
+    /// account (expense) or account+payee (income), summed.
+    static func transactionEntries(
+        categoryGroups: [CategoryGroup],
+        transactions: [Transaction],
+        conditions: [WidgetRuleCondition]?,
+        conditionsOp: String?,
+        groupAccounts: Bool,
+        context: ConditionsFilter.Context
+    ) -> [SankeyCategoryEntry] {
+        let filtered = transactions.filter {
+            ConditionsFilter.matches(transaction: $0, conditions: conditions, op: conditionsOp, context: context)
+        }
+
+        var entries: [SankeyCategoryEntry] = []
+        for group in categoryGroups {
+            for cat in group.categories {
+                let txs = filtered.filter { $0.categoryId == cat.id }
+                var bucketOrder: [String] = []
+                var buckets: [String: (accountId: String, payeeId: String?, payeeName: String?, sum: Int)] = [:]
+                for tx in txs {
+                    let key = group.isIncome ? tx.accountId + "|" + (tx.payeeId ?? "") : tx.accountId
+                    if buckets[key] == nil {
+                        bucketOrder.append(key)
+                        buckets[key] = (
+                            tx.accountId,
+                            group.isIncome ? tx.payeeId : nil,
+                            group.isIncome ? tx.payeeName : nil,
+                            0
+                        )
+                    }
+                    buckets[key]?.sum += tx.amount
+                }
+                for key in bucketOrder {
+                    guard let b = buckets[key] else { continue }
+                    entries.append(SankeyCategoryEntry(
+                        categoryGroup: group.name,
+                        categoryGroupId: group.id,
+                        category: cat.name,
+                        categoryId: cat.id,
+                        value: abs(b.sum),
+                        isIncome: group.isIncome,
+                        isNegative: b.sum < 0,
+                        accountName: context.accountNames[b.accountId] ?? b.accountId,
+                        accountId: b.accountId,
+                        payeeName: b.payeeName,
+                        payeeId: b.payeeId
+                    ))
+                }
+            }
+        }
+
+        if groupAccounts {
+            entries = entries.map { entry in
+                var e = entry
+                if e.accountId?.isEmpty == false && e.accountName?.isEmpty == false {
+                    e.accountId = SpecialKey.allAccounts
+                    e.accountName = SpecialKey.allAccounts
+                }
+                return e
+            }
+        }
+        return entries
+    }
+
+    static func createTransactionsGraph(_ categoryData: [SankeyCategoryEntry]) -> SankeyGraph {
+        var graph = SankeyGraph()
+
+        func addAccountNode(_ accountId: String, _ accountName: String) {
+            graph.addNode(
+                accountId,
+                type: .account,
+                name: accountId == SpecialKey.allAccounts ? "Income" : accountName
+            )
+        }
+
+        for entry in categoryData {
+            guard let accountId = entry.accountId, !accountId.isEmpty,
+                  let accountName = entry.accountName, !accountName.isEmpty,
+                  !entry.categoryId.isEmpty else { continue }
+            // Upstream falls back `payeeName ?? category`; we also treat the
+            // empty string as missing (upstream's AQL always yields '').
+            let payeeOrCategory = (entry.payeeName?.isEmpty == false) ? entry.payeeName! : entry.category
+
+            if entry.isIncome {
+                if entry.isNegative {
+                    // Account > (negative income shown as an outflow bucket)
+                    addAccountNode(accountId, accountName)
+                    let negKey = entry.categoryId + SpecialKey.negativeSuffix
+                    graph.addNode(negKey, type: .categoryGroup, name: payeeOrCategory, isNegative: true)
+                    graph.addValueToLink(from: accountId, to: negKey, value: entry.value)
+                } else {
+                    // Payee > Income category > Account
+                    graph.addNode(entry.categoryId, type: .incomeCategory, name: entry.category)
+                    addAccountNode(accountId, accountName)
+                    graph.addValueToLink(from: entry.categoryId, to: accountId, value: entry.value)
+                    if let payeeId = entry.payeeId, !payeeId.isEmpty {
+                        graph.addNode(payeeId, type: .incomePayee, name: entry.payeeName)
+                        graph.addValueToLink(from: payeeId, to: entry.categoryId, value: entry.value)
+                    }
+                }
+            } else {
+                if entry.isNegative {
+                    // Account > Category group > Category
+                    addAccountNode(accountId, accountName)
+                    graph.addNode(entry.categoryGroupId, type: .categoryGroup, name: entry.categoryGroup)
+                    graph.addNode(entry.categoryId, type: .category, name: entry.category)
+                    graph.addValueToLink(from: accountId, to: entry.categoryGroupId, value: entry.value)
+                    graph.addValueToLink(from: entry.categoryGroupId, to: entry.categoryId, value: entry.value)
+                } else {
+                    // Refund: Category (as income-side node) > Account
+                    let negKey = entry.categoryId + SpecialKey.negativeSuffix
+                    graph.addNode(negKey, type: .incomeCategory, name: payeeOrCategory)
+                    addAccountNode(accountId, accountName)
+                    graph.addValueToLink(from: negKey, to: accountId, value: entry.value)
+                }
+            }
+        }
+        return graph
+    }
+
+    // MARK: Entry building (budgeted)
+
+    /// Income categories use "received" (sum of transactions in range, NOT
+    /// filtered by conditions — upstream budget-month data is unconditioned);
+    /// expense categories use budgeted amounts. Zero entries are dropped.
+    static func budgetEntries(
+        categoryGroups: [CategoryGroup],
+        conditions: [WidgetRuleCondition]?,
+        conditionsOp: String?,
+        budget: SankeyBudgetInput,
+        transactions: [Transaction],
+        months: Set<Int>
+    ) -> [SankeyCategoryEntry] {
+        let filteredGroups = filterCategoryGroups(categoryGroups, conditions: conditions, conditionsOp: conditionsOp)
+
+        var budgetedByCat: [String: Int] = [:]
+        for entry in budget.entries where months.contains(entry.month) {
+            budgetedByCat[entry.categoryId, default: 0] += entry.amountCents
+        }
+
+        var entries: [SankeyCategoryEntry] = []
+        for group in filteredGroups {
+            for cat in group.categories {
+                let raw = group.isIncome
+                    ? transactions.filter { $0.categoryId == cat.id }.reduce(0) { $0 + $1.amount }
+                    : budgetedByCat[cat.id] ?? 0
+                guard raw != 0 else { continue }
+                entries.append(SankeyCategoryEntry(
+                    categoryGroup: group.name,
+                    categoryGroupId: group.id,
+                    category: cat.name,
+                    categoryId: cat.id,
+                    value: raw,
+                    isIncome: group.isIncome,
+                    isNegative: raw < 0
+                ))
+            }
+        }
+        return entries
+    }
+
+    /// Upstream filterCategoryGroups: budget data is fetched unconditionally,
+    /// so category/category_group conditions are applied manually.
+    static func filterCategoryGroups(
+        _ groups: [CategoryGroup],
+        conditions: [WidgetRuleCondition]?,
+        conditionsOp: String?
+    ) -> [CategoryGroup] {
+        let all = conditions ?? []
+        let catConds = all.filter { $0.field == "category" }
+        let groupConds = all.filter { $0.field == "category_group" }
+        guard !catConds.isEmpty || !groupConds.isEmpty else { return groups }
+
+        let isOr = (conditionsOp ?? "and").lowercased() == "or"
+
+        func matches(_ catId: String, _ catName: String, _ groupId: String, _ groupName: String) -> Bool {
+            let matchesCat = { (c: WidgetRuleCondition) in matchesStringCondition(id: catId, name: catName, condition: c) }
+            let matchesGroup = { (c: WidgetRuleCondition) in matchesStringCondition(id: groupId, name: groupName, condition: c) }
+            if isOr {
+                return catConds.contains(where: matchesCat) || groupConds.contains(where: matchesGroup)
+            }
+            return (catConds.isEmpty || catConds.allSatisfy(matchesCat))
+                && (groupConds.isEmpty || groupConds.allSatisfy(matchesGroup))
+        }
+
+        return groups
+            .map { group -> CategoryGroup in
+                var g = group
+                g.categories = group.categories.filter { matches($0.id, $0.name, group.id, group.name) }
+                return g
+            }
+            .filter { !$0.categories.isEmpty }
+    }
+
+    private static func matchesStringCondition(id: String, name: String, condition: WidgetRuleCondition) -> Bool {
+        switch condition.op {
+        case "is":
+            return id == decodeString(condition.value)
+        case "isNot":
+            return id != decodeString(condition.value)
+        case "oneOf":
+            return decodeStringArray(condition.value)?.contains(id) ?? false
+        case "notOneOf":
+            return !(decodeStringArray(condition.value)?.contains(id) ?? false)
+        case "contains":
+            guard let value = decodeString(condition.value) else { return false }
+            return name.lowercased().contains(value.lowercased())
+        case "doesNotContain":
+            guard let value = decodeString(condition.value) else { return false }
+            return !name.lowercased().contains(value.lowercased())
+        case "matches":
+            guard let value = decodeString(condition.value), value.count <= 256 else { return false }
+            // Upstream accepts "/pattern/" or a bare pattern, case-insensitive.
+            var pattern = value
+            if pattern.hasPrefix("/"), let lastSlash = pattern.lastIndex(of: "/"), lastSlash != pattern.startIndex {
+                pattern = String(pattern[pattern.index(after: pattern.startIndex)..<lastSlash])
+            }
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return false }
+            return regex.firstMatch(in: name, range: NSRange(name.startIndex..., in: name)) != nil
+        default:
+            return false
+        }
+    }
+
+    static func createBudgetGraph(
+        _ categoryData: [SankeyCategoryEntry],
+        budget: SankeyBudgetInput,
+        startMonth: String,
+        endMonth: String
+    ) -> SankeyGraph {
+        var graph = SankeyGraph()
+
+        graph.addNode(SpecialKey.budgeted, type: .budget, name: "Budgeted")
+        graph.addNode(SpecialKey.availableIncome, type: .account, name: "Available funds")
+
+        for entry in categoryData {
+            if entry.isIncome {
+                // Income category > Available income
+                graph.addNode(entry.categoryId, type: .incomeCategory, name: entry.category)
+                graph.addValueToLink(from: entry.categoryId, to: SpecialKey.availableIncome, value: entry.value)
+            } else if entry.value >= 0 {
+                // Budgeted > Category group > Category
+                graph.addNode(entry.categoryGroupId, type: .categoryGroup, name: entry.categoryGroup)
+                graph.addNode(entry.categoryId, type: .category, name: entry.category)
+                graph.addValueToLink(from: entry.categoryGroupId, to: entry.categoryId, value: entry.value)
+                graph.addValueToLink(from: SpecialKey.budgeted, to: entry.categoryGroupId, value: entry.value)
+                graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.budgeted, value: entry.value)
+            } else {
+                // Negative budget: category feeds the budget pool
+                graph.addNode(entry.categoryId, type: .account, name: "From \(entry.category)", isNegative: true)
+                graph.addValueToLink(from: entry.categoryId, to: SpecialKey.budgeted, value: abs(entry.value))
+                graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.budgeted, value: entry.value)
+            }
+        }
+
+        if budget.toBudgetCents > 0 {
+            graph.addNode(SpecialKey.toBudget, type: .categoryGroup, name: "To budget")
+            graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.toBudget, value: budget.toBudgetCents)
+        } else {
+            graph.addNode(SpecialKey.toBudget, type: .account, name: "Overbudgeted", isNegative: true)
+            graph.addValueToLink(from: SpecialKey.toBudget, to: SpecialKey.budgeted, value: abs(budget.toBudgetCents))
+            graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.budgeted, value: -abs(budget.toBudgetCents))
+        }
+
+        graph.addNode(SpecialKey.fromPrevMonth, type: .incomeCategory, name: "From \(shiftMonth(startMonth, by: -1))")
+        graph.addValueToLink(from: SpecialKey.fromPrevMonth, to: SpecialKey.availableIncome, value: budget.fromPreviousMonthCents)
+        graph.addNode(SpecialKey.forNextMonth, type: .budget, name: "For \(shiftMonth(endMonth, by: 1))")
+        graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.forNextMonth, value: budget.forNextMonthCents)
+        graph.addNode(SpecialKey.lastMonthOverspent, type: .budget, name: "Overspent")
+        graph.addValueToLink(from: SpecialKey.availableIncome, to: SpecialKey.lastMonthOverspent, value: abs(budget.lastMonthOverspentCents))
+
+        return graph
+    }
+
+    // MARK: Pipeline (upstream buildSankeyData)
+
+    static func buildSankeyData(
+        _ baseGraph: SankeyGraph,
+        topN: Int,
+        categoryGroups: [CategoryGroup],
+        categorySort: SankeySortMode,
+        layerFrom: SankeyLayer,
+        layerTo: SankeyLayer,
+        showPercentages: Bool = false
+    ) -> SankeyData {
+        var graph = baseGraph  // value type; upstream clones
+        groupOtherCategories(&graph, topN: topN, categorySort: categorySort)
+        sortGraph(&graph, categorySort: categorySort, categoryGroups: categoryGroups)
+        addPercentageLabels(&graph)
+        cleanUpNodes(&graph)
+        addHiddenNodes(&graph)
+        filterGraphByLayers(&graph, from: layerFrom, to: layerTo)
+        return convertToSankeyData(graph, showPercentages: showPercentages)
+    }
+
+    // MARK: Graph queries
+
+    static func getLayer(_ graph: SankeyGraph, _ key: String) -> Int {
+        let parents = graph.keys.filter { graph[$0]?.toValues[key] != nil }
+        guard !parents.isEmpty else { return 0 }
+        return 1 + parents.map { getLayer(graph, $0) }.max()!
+    }
+
+    static func getNodeValue(_ graph: SankeyGraph, _ key: String) -> Int {
+        if getLayer(graph, key) == 0 {
+            return graph[key]?.toValues.values.reduce(0, +) ?? 0
+        }
+        var value = 0
+        for k in graph.keys {
+            value += graph[k]?.toValues[key] ?? 0
+        }
+        // Root node masked behind hidden (-1) links
+        if value < 0 {
+            value = graph[key]?.toValues.values.reduce(0, +) ?? 0
+        }
+        return value
+    }
+
+    static func nodesInLayer(_ graph: SankeyGraph, _ layer: SankeyLayer) -> [String] {
+        graph.keys.filter { graph[$0]?.type == layer }
+    }
+
+    static func hasParent(_ graph: SankeyGraph, _ key: String) -> Bool {
+        graph.keys.contains { graph[$0]?.toValues[key] != nil }
+    }
+
+    static func getCategoryGroup(_ graph: SankeyGraph, _ key: String) -> String? {
+        graph.keys.first { graph[$0]?.toValues[key] != nil && graph[$0]?.type == .categoryGroup }
+    }
+
+    // MARK: Other-bucket grouping
+
+    static func groupOtherCategories(_ graph: inout SankeyGraph, topN: Int, categorySort: SankeySortMode) {
+        func isGroupable(_ key: String) -> Bool {
+            guard let node = graph[key] else { return false }
+            return !key.hasSuffix(SpecialKey.otherSuffix)
+                && !SpecialKey.structural.contains(key)
+                && !node.isNegative
+        }
+
+        for layer in SankeyLayer.allCases {
+            var ordinary = nodesInLayer(graph, layer).filter(isGroupable)
+            var others = nodesInLayer(graph, layer).filter { $0.hasSuffix(SpecialKey.otherSuffix) }
+
+            while ordinary.count + others.count > topN {
+                // min(by:) keeps the first of equal elements, matching the
+                // upstream strict `<` scan.
+                guard let nodeToDelete = ordinary.min(by: { getNodeValue(graph, $0) < getNodeValue(graph, $1) }) else { break }
+                moveToOther(&graph, nodeToDelete, globalOther: categorySort == .global)
+                ordinary = nodesInLayer(graph, layer).filter(isGroupable)
+                others = nodesInLayer(graph, layer).filter { $0.hasSuffix(SpecialKey.otherSuffix) }
+            }
+        }
+    }
+
+    static func moveToOther(_ graph: inout SankeyGraph, _ key: String, globalOther: Bool) {
+        guard let nodeData = graph[key] else { return }
+
+        let toNodes = nodeData.toOrder
+        let fromNodes = graph.keys.filter { graph[$0]?.toValues[key] != nil }
+
+        var otherKey = nodeData.type.rawValue + SpecialKey.otherSuffix
+        if !globalOther {
+            if nodeData.type == .category, let groupKey = getCategoryGroup(graph, key) {
+                otherKey = groupKey + SpecialKey.otherSuffix
+            } else if nodeData.type == .incomePayee,
+                      let incomeCatKey = nodeData.toOrder.first(where: { graph[$0]?.type == .incomeCategory }) {
+                otherKey = incomeCatKey + SpecialKey.otherSuffix
+            }
+        }
+
+        graph.addNode(otherKey, type: nodeData.type, name: "Other")
+
+        for fromKey in fromNodes {
+            if let value = graph[fromKey]?.toValues[key] {
+                graph.addValueToLink(from: fromKey, to: otherKey, value: value)
+            }
+        }
+        for toKey in toNodes {
+            if let value = graph[key]?.toValues[toKey] {
+                graph.addValueToLink(from: otherKey, to: toKey, value: value)
+            }
+        }
+
+        for toKey in toNodes { graph.deleteLink(from: key, to: toKey) }
+        for fromKey in fromNodes { graph.deleteLink(from: fromKey, to: key) }
+        graph.delete(key)
+    }
+
+    // MARK: Sorting
+
+    static func sortGraph(_ graph: inout SankeyGraph, categorySort: SankeySortMode, categoryGroups: [CategoryGroup]) {
+        let snapshot = graph
+
+        // Stable value-descending sort (JS Array.sort is stable).
+        func valueSortedKeys() -> [String] {
+            snapshot.keys.enumerated().sorted { a, b in
+                let va = getNodeValue(snapshot, a.element)
+                let vb = getNodeValue(snapshot, b.element)
+                return va == vb ? a.offset < b.offset : va > vb
+            }.map(\.element)
+        }
+
+        func sortRelatedNodesAroundAnchors(
+            _ entries: inout [String],
+            anchorLayer: SankeyLayer,
+            relatedLayer: SankeyLayer,
+            placeAfter: Bool
+        ) {
+            for anchorKey in nodesInLayer(snapshot, anchorLayer) {
+                guard let anchor = snapshot[anchorKey] else { continue }
+
+                let relatedKeys: [String] = placeAfter
+                    ? anchor.toOrder.filter { snapshot[$0]?.type == relatedLayer }
+                    : snapshot.keys.filter { snapshot[$0]?.type == relatedLayer && snapshot[$0]?.toValues[anchorKey] != nil }
+
+                let otherKey = anchorKey + SpecialKey.otherSuffix
+                let relatedOtherKey: String? = snapshot[otherKey]?.type == relatedLayer ? otherKey : nil
+                let orderedRelatedKeys = relatedKeys.filter { $0 != otherKey }
+
+                let present = orderedRelatedKeys.filter { entries.contains($0) }
+                let relatedEntries = present.enumerated().sorted { a, b in
+                    let va = getNodeValue(snapshot, a.element)
+                    let vb = getNodeValue(snapshot, b.element)
+                    return va == vb ? a.offset < b.offset : va > vb
+                }.map(\.element)
+
+                let otherEntry: String? = relatedOtherKey.flatMap { entries.contains($0) ? $0 : nil }
+
+                var keysToMove = Set(orderedRelatedKeys)
+                if let relatedOtherKey { keysToMove.insert(relatedOtherKey) }
+                var without = entries.filter { !keysToMove.contains($0) }
+                guard let anchorIndex = without.firstIndex(of: anchorKey) else { continue }
+
+                let insertionIndex = placeAfter ? anchorIndex + 1 : anchorIndex
+                var nodesToInsert = relatedEntries
+                if let otherEntry { nodesToInsert.append(otherEntry) }
+                without.insert(contentsOf: nodesToInsert, at: insertionIndex)
+                entries = without
+            }
+        }
+
+        var entries: [String]
+        switch categorySort {
+        case .global:
+            entries = valueSortedKeys()
+            for key in entries.filter({ $0.hasSuffix(SpecialKey.otherSuffix) }) {
+                moveNodeToEnd(&entries, key)
+            }
+        case .perGroup:
+            entries = valueSortedKeys()
+            sortRelatedNodesAroundAnchors(&entries, anchorLayer: .categoryGroup, relatedLayer: .category, placeAfter: true)
+            sortRelatedNodesAroundAnchors(&entries, anchorLayer: .incomeCategory, relatedLayer: .incomePayee, placeAfter: false)
+        case .budgetOrder:
+            var used = Set<String>()
+            entries = []
+            for group in categoryGroups {
+                if snapshot[group.id] != nil {
+                    entries.append(group.id)
+                    used.insert(group.id)
+                }
+                for cat in group.categories where snapshot[cat.id] != nil {
+                    entries.append(cat.id)
+                    used.insert(cat.id)
+                }
+                let otherKey = group.id + SpecialKey.otherSuffix
+                if snapshot[otherKey] != nil {
+                    entries.append(otherKey)
+                    used.insert(otherKey)
+                }
+            }
+            for key in snapshot.keys where !used.contains(key) {
+                entries.append(key)
+            }
+        }
+
+        // Pin certain nodes to the start/end of the graph.
+        for key in entries.filter({ snapshot[$0]?.isNegative == true }) {
+            moveNodeToStart(&entries, key)
+        }
+        if let toBudgetNode = snapshot[SpecialKey.toBudget] {
+            if toBudgetNode.isNegative {
+                moveNodeToStart(&entries, SpecialKey.toBudget)
+            } else {
+                moveNodeToEnd(&entries, SpecialKey.toBudget)
+            }
+        }
+        moveNodeToEnd(&entries, SpecialKey.lastMonthOverspent)
+        moveNodeToEnd(&entries, SpecialKey.forNextMonth)
+        moveNodeToEnd(&entries, SpecialKey.fromPrevMonth)
+
+        graph.reorder(entries)
+    }
+
+    static func moveNodeToEnd(_ entries: inout [String], _ key: String) {
+        if let index = entries.firstIndex(of: key) {
+            entries.append(entries.remove(at: index))
+        }
+    }
+
+    static func moveNodeToStart(_ entries: inout [String], _ key: String) {
+        if let index = entries.firstIndex(of: key) {
+            entries.insert(entries.remove(at: index), at: 0)
+        }
+    }
+
+    // MARK: Labels / cleanup
+
+    static func addPercentageLabels(_ graph: inout SankeyGraph) {
+        var layerSums: [SankeyLayer: Int] = [:]
+        for key in graph.keys {
+            guard let layer = graph[key]?.type else { continue }
+            layerSums[layer, default: 0] += getNodeValue(graph, key)
+        }
+        for key in graph.keys {
+            guard let node = graph[key] else { continue }
+            let total = layerSums[node.type] ?? 1
+            let percentage = total != 0 ? Double(getNodeValue(graph, key)) / Double(total) * 100 : 0
+            graph.nodes[key]?.percentageLabel = String(format: "%.1f%%", percentage)
+        }
+    }
+
+    static func cleanUpNodes(_ graph: inout SankeyGraph) {
+        for key in graph.keys {
+            for (to, value) in graph.links(from: key) where value == 0 {
+                graph.deleteLink(from: key, to: to)
+            }
+        }
+        var hasIncoming = Set<String>()
+        for key in graph.keys {
+            graph[key]?.toOrder.forEach { hasIncoming.insert($0) }
+        }
+        for key in graph.keys where graph[key]?.hasChild == false && !hasIncoming.contains(key) {
+            graph.delete(key)
+        }
+    }
+
+    // MARK: Hidden layout nodes
+
+    /// Nodes whose parents/children sit in different layers than their peers
+    /// would land in the wrong column; invisible -1 chains pin them in place.
+    static func addHiddenNodes(_ graph: inout SankeyGraph) {
+        var nodesByType: [SankeyLayer: [String]] = [:]
+        for key in graph.keys {
+            guard let type = graph[key]?.type else { continue }
+            nodesByType[type, default: []].append(key)
+        }
+
+        var typeHasParent: [SankeyLayer: Bool] = [:]
+        var typeHasChild: [SankeyLayer: Bool] = [:]
+        for (type, keys) in nodesByType {
+            typeHasParent[type] = keys.contains { hasParent(graph, $0) }
+            typeHasChild[type] = keys.contains { graph[$0]?.hasChild == true }
+        }
+
+        let activeLayerOrder = SankeyLayer.allCases.filter { !(nodesByType[$0] ?? []).isEmpty }
+        var layerIndex: [SankeyLayer: Int] = [:]
+        for (index, layer) in activeLayerOrder.enumerated() {
+            layerIndex[layer] = index
+        }
+
+        func addHiddenParentChain(_ key: String, _ type: SankeyLayer) {
+            guard let typeIndex = layerIndex[type], typeIndex > 0 else { return }
+            var childKey = key
+            for i in stride(from: typeIndex - 1, through: 0, by: -1) {
+                let parentType = activeLayerOrder[i]
+                let parentKey = "\(key)_\(parentType.rawValue)\(SpecialKey.hiddenSuffix)"
+                graph.addNode(parentKey, type: parentType, name: "")
+                graph.addValueToLink(from: parentKey, to: childKey, value: -1)
+                childKey = parentKey
+            }
+        }
+
+        func addHiddenChildChain(_ key: String, _ type: SankeyLayer) {
+            guard let typeIndex = layerIndex[type], typeIndex < activeLayerOrder.count - 1 else { return }
+            var parentKey = key
+            for i in (typeIndex + 1)..<activeLayerOrder.count {
+                let childType = activeLayerOrder[i]
+                let childKey = "\(key)_\(childType.rawValue)\(SpecialKey.hiddenSuffix)"
+                graph.addNode(childKey, type: childType, name: "")
+                graph.addValueToLink(from: parentKey, to: childKey, value: -1)
+                parentKey = childKey
+            }
+        }
+
+        for layer in SankeyLayer.allCases {
+            for key in nodesByType[layer] ?? [] {
+                let nodeHasParent = hasParent(graph, key)
+                let nodeHasChild = graph[key]?.hasChild == true
+                if !nodeHasParent && typeHasParent[layer] == true {
+                    addHiddenParentChain(key, layer)
+                }
+                if !nodeHasChild && typeHasChild[layer] == true {
+                    addHiddenChildChain(key, layer)
+                }
+            }
+        }
+    }
+
+    static func filterGraphByLayers(_ graph: inout SankeyGraph, from: SankeyLayer, to: SankeyLayer) {
+        let fromIndex = from.orderIndex
+        let toIndex = to.orderIndex
+        for key in graph.keys {
+            guard let index = graph[key]?.type.orderIndex else { continue }
+            if index < fromIndex || index > toIndex {
+                graph.delete(key)
+            }
+        }
+    }
+
+    // MARK: Conversion
+
+    static func convertToSankeyData(_ graph: SankeyGraph, showPercentages: Bool = false) -> SankeyData {
+        let keys = graph.keys
+        var indexByKey: [String: Int] = [:]
+        for (index, key) in keys.enumerated() {
+            indexByKey[key] = index
+        }
+
+        let nodes = keys.map { key -> SankeyData.Node in
+            let node = graph[key]
+            return SankeyData.Node(
+                key: key,
+                name: node?.name ?? key,
+                percentageLabel: node?.percentageLabel ?? "",
+                layer: node?.type ?? .category,
+                isNegative: node?.isNegative ?? false
+            )
+        }
+
+        var links: [SankeyData.Link] = []
+        for (sourceIndex, key) in keys.enumerated() {
+            for (to, value) in graph.links(from: key) {
+                // Upstream emits dangling links (index -1) after layer
+                // trimming; we drop them so the view never sees bad indices.
+                guard let targetIndex = indexByKey[to] else { continue }
+                links.append(SankeyData.Link(source: sourceIndex, target: targetIndex, value: value))
+            }
+        }
+
+        return SankeyData(nodes: nodes, links: links, showPercentages: showPercentages)
+    }
+
+    // MARK: Date helpers
+
+    private static func monthStart(of date: Date) -> Date {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        return calendar.date(from: DateComponents(year: comps.year, month: comps.month, day: 1)) ?? date
+    }
+
+    private static func endOfMonth(_ monthStartDate: Date) -> Date {
+        guard let next = calendar.date(byAdding: .month, value: 1, to: monthStartDate),
+              let last = calendar.date(byAdding: .day, value: -1, to: next) else { return monthStartDate }
+        return last
+    }
+
+    private static func ymdInt(from date: Date) -> Int {
+        let comps = calendar.dateComponents([.year, .month, .day], from: date)
+        return (comps.year ?? 0) * 10000 + (comps.month ?? 0) * 100 + (comps.day ?? 0)
+    }
+
+    private static func monthLabel(_ date: Date) -> String {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        return String(format: "%04d-%02d", comps.year ?? 0, comps.month ?? 0)
+    }
+
+    private static func shiftMonth(_ label: String, by months: Int) -> String {
+        let parts = label.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 2,
+              let date = calendar.date(from: DateComponents(year: parts[0], month: parts[1], day: 1)),
+              let shifted = calendar.date(byAdding: .month, value: months, to: date) else { return label }
+        return monthLabel(shifted)
+    }
+
+    private static func monthsInRange(start: Date, end: Date) -> Set<Int> {
+        var months = Set<Int>()
+        var cursor = monthStart(of: start)
+        let endMonth = monthStart(of: end)
+        while cursor <= endMonth {
+            let comps = calendar.dateComponents([.year, .month], from: cursor)
+            months.insert((comps.year ?? 0) * 100 + (comps.month ?? 0))
+            guard let next = calendar.date(byAdding: .month, value: 1, to: cursor) else { break }
+            cursor = next
+        }
+        return months
+    }
+
+    // MARK: Condition value decoding (private in ConditionsFilter, so local)
+
+    private static func decodeString(_ value: AnyCodable?) -> String? {
+        guard let value else { return nil }
+        return try? JSONDecoder().decode(String.self, from: value.raw)
+    }
+
+    private static func decodeStringArray(_ value: AnyCodable?) -> [String]? {
+        guard let value else { return nil }
+        return try? JSONDecoder().decode([String].self, from: value.raw)
+    }
+}

--- a/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
@@ -16,6 +16,9 @@ enum SpendingEngine {
     static func compute(
         meta: SpendingMeta?,
         transactions: [Transaction],
+        budgets: [BudgetAnalysisBudgetEntry] = [],
+        categories: [Category] = [],
+        categoryGroups: [CategoryGroup] = [],
         today: Date,
         context: ConditionsFilter.Context = .empty
     ) -> SpendingData {
@@ -57,9 +60,13 @@ enum SpendingEngine {
                                        calendar: cal,
                                        throughDay: sameDayCutoff)
         case .budget:
-            // Budget-mode target needs zero_budgets/reflect_budgets data that
-            // isn't plumbed into the engine yet; the widget shows spending only.
-            comparison = 0
+            comparison = budgetComparison(meta: meta,
+                                          budgets: budgets,
+                                          categories: categories,
+                                          categoryGroups: categoryGroups,
+                                          compareStart: compareStart,
+                                          throughDay: sameDayCutoff,
+                                          calendar: cal)
         case .average:
             comparison = averageSpending(transactions: filtered,
                                          allTransactions: live,
@@ -106,6 +113,44 @@ enum SpendingEngine {
         }
         let compare = stored ?? currentMonthStart
         return (compare, storedTo ?? prevMonth(compare))
+    }
+
+    /// Port of spending-spreadsheet.ts dailyBudget + getSpendingBudgetFilters:
+    /// the compare month's budgeted total — narrowed to categories matching
+    /// the widget's category/category_group conditions only when all of them
+    /// are supported, else unfiltered — spread evenly over the month's days
+    /// and accumulated through the same day bucket the card reads.
+    private static func budgetComparison(
+        meta: SpendingMeta?,
+        budgets: [BudgetAnalysisBudgetEntry],
+        categories: [Category],
+        categoryGroups: [CategoryGroup],
+        compareStart: Date,
+        throughDay: Int?,
+        calendar: Calendar
+    ) -> Int {
+        let c = calendar.dateComponents([.year, .month], from: compareStart)
+        let monthInt = (c.year ?? 0) * 100 + (c.month ?? 0)
+        var rows = budgets.filter { $0.month == monthInt }
+
+        let categoryConditions = (meta?.conditions ?? []).filter {
+            $0.customName == nil && ($0.field == "category" || $0.field == "category_group")
+        }
+        if !categoryConditions.isEmpty,
+           categoryConditions.allSatisfy(BudgetAnalysisEngine.isSupportedCategoryCondition) {
+            let allowed = Set(BudgetAnalysisEngine.filterCategoriesByConditions(
+                categories, groups: categoryGroups,
+                conditions: categoryConditions, conditionsOp: meta?.conditionsOp
+            ).map(\.id))
+            rows = rows.filter { allowed.contains($0.categoryId) }
+        }
+
+        let total = rows.reduce(0) { $0 + $1.amountCents }
+        guard total != 0,
+              let daysInMonth = calendar.range(of: .day, in: .month, for: compareStart)?.count,
+              daysInMonth > 0 else { return 0 }
+        let daysElapsed = throughDay ?? daysInMonth
+        return Int((Double(total) / Double(daysInMonth) * Double(daysElapsed)).rounded())
     }
 
     /// Net spending for one month as positive cents. `throughDay` limits to a

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -102,6 +102,7 @@ struct DashboardView: View {
         let needsBudgets = widgets.contains {
             switch $0 {
             case .budgetAnalysis, .sankey, .balanceForecast: return true
+            case .spending(_, let meta): return meta?.mode == .budget
             default: return false
             }
         }
@@ -168,7 +169,11 @@ struct DashboardView: View {
             }
         case .spending(_, let meta):
             WidgetCard(transactions: reportTransactions, loadingHeight: 120) { transactions in
-                SpendingEngine.compute(meta: meta, transactions: spendingScope(transactions), today: Date(), context: conditionsContext)
+                SpendingEngine.compute(meta: meta, transactions: spendingScope(transactions),
+                                       budgets: reportBudgets.entries,
+                                       categories: budgetStore.categoryGroups.flatMap(\.categories),
+                                       categoryGroups: budgetStore.categoryGroups,
+                                       today: Date(), context: conditionsContext)
             } content: { data in
                 SpendingWidgetView(
                     displayName: widget.displayName,

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -15,6 +15,12 @@ struct DashboardView: View {
     @State private var customReportConfigs: [String: CustomReportConfig] = [:]
     @State private var firstDayOfWeekIdx = 0
 
+    /// Budget/schedule inputs some widgets need, fetched only when such a
+    /// widget is on the dashboard (same pattern as customReportConfigs).
+    @State private var reportBudgets = BudgetDatabase.ReportBudgetData()
+    @State private var trackingBudgetMonths: [BalanceForecastBudgetMonth] = []
+    @State private var forecastSchedules: [Schedule] = []
+
     /// Unsupported widgets never render as cards; a single top banner notes
     /// that only a limited set of reports is available.
     private var hasUnsupportedWidgets: Bool {
@@ -93,6 +99,23 @@ struct DashboardView: View {
         }
         customReportConfigs = (try? await database.fetchCustomReportConfigs(ids: reportIds)) ?? [:]
         firstDayOfWeekIdx = (try? await database.fetchFirstDayOfWeekIdx()) ?? 0
+        let needsBudgets = widgets.contains {
+            switch $0 {
+            case .budgetAnalysis, .sankey, .balanceForecast: return true
+            default: return false
+            }
+        }
+        if needsBudgets {
+            reportBudgets = (try? await database.fetchBudgetDataForReports()) ?? BudgetDatabase.ReportBudgetData()
+        }
+        let needsForecast = widgets.contains {
+            if case .balanceForecast = $0 { return true }
+            return false
+        }
+        if needsForecast {
+            forecastSchedules = (try? await database.fetchForecastSchedules()) ?? []
+            trackingBudgetMonths = (try? await database.fetchTrackingBudgetMonths()) ?? []
+        }
         reportTransactions = (try? await database.fetchTransactionsForReports()) ?? []
     }
 
@@ -184,10 +207,110 @@ struct DashboardView: View {
             } content: { data in
                 CustomReportWidgetView(data: data)
             }
+        case .calendar(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 200) { transactions in
+                CalendarEngine.compute(
+                    meta: meta,
+                    transactions: transactions,
+                    today: Date(),
+                    firstDayOfWeekIdx: firstDayOfWeekIdx,
+                    context: conditionsContext
+                )
+            } content: { data in
+                CalendarWidgetView(displayName: widget.displayName, data: data)
+            }
+        case .crossover(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 200) { transactions in
+                CrossoverEngine.compute(
+                    meta: meta,
+                    transactions: transactions,
+                    categories: budgetStore.categoryGroups.flatMap(\.categories),
+                    accountIds: budgetStore.accounts.map(\.id),
+                    today: Date()
+                )
+            } content: { data in
+                CrossoverWidgetView(displayName: widget.displayName, data: data)
+            }
+        case .budgetAnalysis(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 200) { transactions in
+                BudgetAnalysisEngine.compute(
+                    meta: meta,
+                    transactions: transactions,
+                    budgets: reportBudgets.entries,
+                    categories: budgetStore.categoryGroups.flatMap(\.categories),
+                    categoryGroups: budgetStore.categoryGroups,
+                    today: Date(),
+                    context: conditionsContext
+                )
+            } content: { data in
+                BudgetAnalysisWidgetView(displayName: widget.displayName, data: data)
+            }
+        case .sankey(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 240) { transactions in
+                SankeyEngine.compute(
+                    meta: meta,
+                    transactions: transactions,
+                    categoryGroups: budgetStore.categoryGroups,
+                    // ponytail: budgeted-mode envelope aggregates (To Budget /
+                    // carryover flows) are omitted — wire per-month toBudget
+                    // math if those flows turn out to matter on the card.
+                    budget: SankeyBudgetInput(entries: reportBudgets.entries.map {
+                        SankeyBudgetInput.Entry(month: $0.month, categoryId: $0.categoryId, amountCents: $0.amountCents)
+                    }),
+                    today: Date(),
+                    context: conditionsContext
+                )
+            } content: { data in
+                SankeyWidgetView(displayName: widget.displayName, data: data)
+            }
+        case .balanceForecast(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 200) { transactions in
+                BalanceForecastEngine.compute(
+                    meta: forecastMeta(meta),
+                    transactions: transactions,
+                    schedules: forecastSchedules,
+                    trackingBudgetMonths: trackingBudgetMonths,
+                    offBudgetAccountIds: Set(budgetStore.accounts.filter(\.offBudget).map(\.id)),
+                    transferAccountsByPayeeId: Dictionary(
+                        budgetStore.payees.compactMap { payee in
+                            payee.transferAccountId.map { (payee.id, $0) }
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    ),
+                    today: Date(),
+                    context: conditionsContext
+                )
+            } content: { data in
+                BalanceForecastWidgetView(displayName: widget.displayName, data: data)
+            }
+        case .monteCarlo(_, let meta):
+            WidgetCard(transactions: reportTransactions, loadingHeight: 220) { _ in
+                MonteCarloEngine.compute(
+                    meta: meta,
+                    accountBalances: Dictionary(
+                        budgetStore.accounts.map { ($0.id, $0.balance) },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                )
+            } content: { data in
+                MonteCarloWidgetView(displayName: widget.displayName, data: data)
+            }
         case .unsupported:
             // Filtered out of visibleWidgets; listed in the top notice instead.
             EmptyView()
         }
+    }
+
+    /// Upstream's card falls back to the schedules source when the file
+    /// isn't a tracking budget (BalanceForecastCard.tsx budgetType check).
+    private func forecastMeta(_ meta: BalanceForecastMeta?) -> BalanceForecastMeta? {
+        guard let meta, meta.source == .trackingBudget, !reportBudgets.isTracking else { return meta }
+        return BalanceForecastMeta(
+            name: meta.name, startDate: meta.startDate, endDate: meta.endDate,
+            accounts: meta.accounts, conditions: meta.conditions,
+            conditionsOp: meta.conditionsOp, timeFrame: meta.timeFrame,
+            granularity: meta.granularity, source: .schedules
+        )
     }
 
     /// Match WebUI spending-spreadsheet.ts default exclusions: drop

--- a/Actuali/Actuali/Views/Reports/Widgets/BalanceForecastWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/BalanceForecastWidgetView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import Charts
+
+struct BalanceForecastWidgetView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let displayName: String
+    let data: BalanceForecastData
+
+    private var historyPoints: [BalanceForecastPoint] {
+        data.points.filter { !$0.isForecast }
+    }
+
+    /// Forecast segment, prefixed with the last historical point so the
+    /// dashed line connects to the solid one.
+    private var forecastPoints: [BalanceForecastPoint] {
+        let forecast = data.points.filter(\.isForecast)
+        guard let boundary = historyPoints.last, !forecast.isEmpty else { return forecast }
+        return [boundary] + forecast
+    }
+
+    private var hasNegativeBalance: Bool {
+        data.points.contains { $0.balanceCents < 0 }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Text(displayName).font(.headline)
+                Spacer()
+                if let ending = data.points.last {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("Ending: \(budgetStore.displayBalanceWholeUnits(ending.balanceCents))")
+                            .font(.subheadline)
+                            .monospacedDigit()
+                            .foregroundStyle(ending.balanceCents < 0 ? Color.red : .secondary)
+                        if let lowest = data.points.min(by: { $0.balanceCents < $1.balanceCents }),
+                           lowest.date != ending.date {
+                            Text("Low: \(budgetStore.displayBalanceWholeUnits(lowest.balanceCents))")
+                                .font(.caption)
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            if data.points.count >= 2 {
+                Chart {
+                    ForEach(historyPoints, id: \.date) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Balance", Double(point.balanceCents) / 100.0),
+                            series: .value("Segment", "History")
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.blue)
+                    }
+                    ForEach(forecastPoints, id: \.date) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Balance", Double(point.balanceCents) / 100.0),
+                            series: .value("Segment", "Forecast")
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.blue.opacity(0.5))
+                        .lineStyle(StrokeStyle(lineWidth: 2, dash: [4, 3]))
+                    }
+                    if hasNegativeBalance {
+                        RuleMark(y: .value("Zero", 0))
+                            .foregroundStyle(.secondary.opacity(0.5))
+                    }
+                }
+                .frame(height: 180)
+                // Keep the trend visible without exposing chart-axis amounts.
+                .chartYAxis(budgetStore.hideBalances ? .hidden : .automatic)
+                .accessibilityHidden(budgetStore.hideBalances)
+            } else {
+                Text("Not enough data")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Actuali/Actuali/Views/Reports/Widgets/BudgetAnalysisWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/BudgetAnalysisWidgetView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import Charts
+
+struct BudgetAnalysisWidgetView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let displayName: String
+    let data: BudgetAnalysisData
+
+    private struct Mark: Identifiable {
+        let month: Date
+        let series: String
+        let amount: Double
+
+        var id: String { "\(series)-\(month.timeIntervalSinceReferenceDate)" }
+    }
+
+    private static func monthDate(_ yyyymm: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.date(from: DateComponents(year: yyyymm / 100, month: yyyymm % 100, day: 1)) ?? Date()
+    }
+
+    // Budgeted / spent / overspending, matching upstream's graph series.
+    // Spent stays negative, as upstream plots it.
+    private var valueMarks: [Mark] {
+        data.intervalData.flatMap { p in
+            [
+                Mark(month: Self.monthDate(p.month), series: "Budgeted", amount: Double(p.budgetedCents) / 100),
+                Mark(month: Self.monthDate(p.month), series: "Spent", amount: Double(p.spentCents) / 100),
+                Mark(month: Self.monthDate(p.month), series: "Overspending", amount: Double(p.overspendingAdjustmentCents) / 100)
+            ]
+        }
+    }
+
+    private var balanceMarks: [Mark] {
+        data.intervalData.map { p in
+            Mark(month: Self.monthDate(p.month), series: "Balance", amount: Double(p.balanceCents) / 100)
+        }
+    }
+
+    private var seriesDomain: [String] {
+        var domain: [String] = []
+        if !data.balanceOnly { domain += ["Budgeted", "Spent", "Overspending"] }
+        if data.showBalance || data.balanceOnly { domain.append("Balance") }
+        return domain
+    }
+
+    private var seriesRange: [Color] {
+        let colors: [String: Color] = [
+            "Budgeted": .green, "Spent": .red, "Overspending": .orange, "Balance": .gray
+        ]
+        return seriesDomain.compactMap { colors[$0] }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(displayName).font(.headline)
+                Spacer()
+                // Upstream's card headline: the latest interval's balance,
+                // green when non-negative, red otherwise.
+                if let last = data.intervalData.last {
+                    Text(budgetStore.displayBalanceWholeUnits(last.balanceCents))
+                        .font(.subheadline)
+                        .monospacedDigit()
+                        .foregroundStyle(last.balanceCents >= 0 ? Color.green : Color.red)
+                }
+            }
+
+            if data.intervalData.isEmpty {
+                Text("No data")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 180, alignment: .center)
+            } else {
+                Chart {
+                    if !data.balanceOnly {
+                        ForEach(valueMarks) { mark in
+                            if data.graphType == .bar {
+                                BarMark(
+                                    x: .value("Month", mark.month, unit: .month),
+                                    y: .value("Amount", mark.amount)
+                                )
+                                .foregroundStyle(by: .value("Series", mark.series))
+                                .position(by: .value("Series", mark.series))
+                            } else {
+                                LineMark(
+                                    x: .value("Month", mark.month, unit: .month),
+                                    y: .value("Amount", mark.amount)
+                                )
+                                .foregroundStyle(by: .value("Series", mark.series))
+                            }
+                        }
+                    }
+                    if data.showBalance || data.balanceOnly {
+                        ForEach(balanceMarks) { mark in
+                            LineMark(
+                                x: .value("Month", mark.month, unit: .month),
+                                y: .value("Amount", mark.amount)
+                            )
+                            .foregroundStyle(by: .value("Series", mark.series))
+                        }
+                    }
+                }
+                .chartForegroundStyleScale(domain: seriesDomain, range: seriesRange)
+                .frame(height: 200)
+                // Keep the trend visible without exposing chart-axis amounts.
+                .chartYAxis(budgetStore.hideBalances ? .hidden : .automatic)
+                .accessibilityHidden(budgetStore.hideBalances)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Actuali/Actuali/Views/Reports/Widgets/CalendarWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/CalendarWidgetView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+struct CalendarWidgetView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let displayName: String
+    let data: CalendarData
+
+    /// Upstream's card lays every month out horizontally with scrolling; on
+    /// iPhone we show the most recent two so cells stay readable.
+    private var visibleMonths: [CalendarMonthData] {
+        Array(data.months.suffix(2))
+    }
+
+    private var weekdaySymbols: [String] {
+        let symbols = DateFormatter().veryShortStandaloneWeekdaySymbols ?? ["S", "M", "T", "W", "T", "F", "S"]
+        return (0..<7).map { symbols[($0 + data.firstDayOfWeekIdx) % 7] }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(displayName).font(.headline)
+                Spacer()
+                CalendarTotalsView(
+                    incomeCents: data.totalIncomeCents,
+                    expenseCents: data.totalExpenseCents
+                )
+            }
+            if data.months.isEmpty {
+                Text("No data")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 120, alignment: .center)
+            } else {
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(visibleMonths, id: \.monthStart) { month in
+                        CalendarMonthGridView(month: month, weekdaySymbols: weekdaySymbols)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct CalendarTotalsView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let incomeCents: Int
+    let expenseCents: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if incomeCents != 0 {
+                Label(budgetStore.displayBalance(incomeCents), systemImage: "arrowtriangle.up.fill")
+                    .foregroundStyle(.green)
+            }
+            if expenseCents != 0 {
+                Label(budgetStore.displayBalance(expenseCents), systemImage: "arrowtriangle.down.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+        .font(.caption2.monospacedDigit())
+        .labelStyle(CalendarCompactLabelStyle())
+    }
+}
+
+private struct CalendarCompactLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 2) {
+            configuration.icon.imageScale(.small)
+            configuration.title
+        }
+    }
+}
+
+private struct CalendarMonthGridView: View {
+    let month: CalendarMonthData
+    let weekdaySymbols: [String]
+
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM yyyy"
+        // Month starts are UTC dates; format them in UTC so the label can't
+        // shift into the neighboring month in negative-offset timezones.
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 2), count: 7)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(Self.monthFormatter.string(from: month.monthStart))
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                CalendarTotalsView(
+                    incomeCents: month.totalIncomeCents,
+                    expenseCents: month.totalExpenseCents
+                )
+            }
+            LazyVGrid(columns: columns, spacing: 2) {
+                ForEach(0..<7, id: \.self) { i in
+                    Text(weekdaySymbols[i])
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(Array(month.days.enumerated()), id: \.offset) { _, cell in
+                    CalendarDayCellView(cell: cell)
+                }
+            }
+        }
+    }
+}
+
+private struct CalendarDayCellView: View {
+    let cell: CalendarDayCell
+
+    var body: some View {
+        ZStack {
+            if let day = cell.dayOfMonth {
+                Color(.tertiarySystemFill)
+                // Upstream DayButton: bottom-anchored bars, income left half,
+                // expense right half, height = share of the month's total.
+                GeometryReader { geo in
+                    HStack(alignment: .bottom, spacing: 0) {
+                        Rectangle()
+                            .fill(.green.opacity(0.7))
+                            .frame(height: geo.size.height * cell.incomeSize / 100)
+                        Rectangle()
+                            .fill(.red.opacity(0.7))
+                            .frame(height: geo.size.height * cell.expenseSize / 100)
+                    }
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                }
+                Text("\(day)")
+                    .font(.system(size: 8, weight: .medium))
+            } else {
+                Color.clear
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}

--- a/Actuali/Actuali/Views/Reports/Widgets/CrossoverWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/CrossoverWidgetView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import Charts
+
+struct CrossoverWidgetView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let displayName: String
+    let data: CrossoverData
+
+    private var yearsToRetireText: String {
+        guard let years = data.yearsToRetire else { return "N/A" }
+        return "\(years.formatted(.number.precision(.fractionLength(0...2)))) years"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Text(displayName).font(.headline)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(yearsToRetireText)
+                        .font(.subheadline)
+                        .monospacedDigit()
+                    Text("Years to Retire")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if data.points.count >= 2 {
+                Chart {
+                    ForEach(data.points, id: \.month) { point in
+                        LineMark(
+                            x: .value("Month", point.month),
+                            y: .value("Income", Double(point.investmentIncomeCents) / 100.0),
+                            series: .value("Series", "Investment income")
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.green)
+                        LineMark(
+                            x: .value("Month", point.month),
+                            y: .value("Expenses", Double(point.expensesCents) / 100.0),
+                            series: .value("Series", "Expenses")
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.red)
+                    }
+                    // Upstream draws adjusted (target) expenses as a dashed
+                    // red line over the projected months only.
+                    ForEach(data.points.filter { $0.adjustedExpensesCents != nil }, id: \.month) { point in
+                        LineMark(
+                            x: .value("Month", point.month),
+                            y: .value("Target", Double(point.adjustedExpensesCents ?? 0) / 100.0),
+                            series: .value("Series", "Target income")
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.red)
+                        .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 5]))
+                    }
+                    if let crossoverMonth = data.crossoverMonth {
+                        RuleMark(x: .value("Crossover", crossoverMonth))
+                            .foregroundStyle(.blue)
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                    }
+                }
+                .frame(height: 180)
+                // Keep the trend visible without exposing chart-axis amounts.
+                .chartYAxis(budgetStore.hideBalances ? .hidden : .automatic)
+                .accessibilityHidden(budgetStore.hideBalances)
+            } else {
+                Text("Not enough data")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Actuali/Actuali/Views/Reports/Widgets/MonteCarloWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/MonteCarloWidgetView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import Charts
+
+/// Dashboard card for the Monte Carlo retirement simulation. Mirrors
+/// upstream MonteCarloCard.tsx: headline success rate to the target age,
+/// plus the compact fan chart (p10-p90 band, p25-p75 band, p50 line) from
+/// MonteCarloGraph.tsx with axes hidden.
+struct MonteCarloWidgetView: View {
+    let displayName: String
+    let data: MonteCarloData
+
+    // Upstream: Math.round(successRate * 1000) / 10
+    private var successPercent: Double {
+        (data.successRate * 1000).rounded() / 10
+    }
+
+    private var endAge: Double {
+        data.currentAge + Double(data.horizonYears)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Text(displayName).font(.headline)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(successPercent.formatted(.number.precision(.fractionLength(0...1))) + "%")
+                        .font(.subheadline.weight(.semibold))
+                        .monospacedDigit()
+                    Text("Success rate to age \(endAge.formatted(.number.precision(.fractionLength(0...1))))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Chart(data.percentileBands, id: \.year) { band in
+                let age = data.currentAge + Double(band.year)
+                AreaMark(
+                    x: .value("Age", age),
+                    yStart: .value("p10", Double(band.p10) / 100.0),
+                    yEnd: .value("p90", Double(band.p90) / 100.0)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(.purple.opacity(0.15))
+                AreaMark(
+                    x: .value("Age", age),
+                    yStart: .value("p25", Double(band.p25) / 100.0),
+                    yEnd: .value("p75", Double(band.p75) / 100.0)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(.purple.opacity(0.3))
+                LineMark(
+                    x: .value("Age", age),
+                    y: .value("Median", Double(band.p50) / 100.0)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(.purple)
+            }
+            .chartXScale(domain: data.currentAge...endAge)
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .frame(height: 140)
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/Actuali/Actuali/Views/Reports/Widgets/SankeyWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/SankeyWidgetView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+
+/// Compact sankey card: layered columns of node bars joined by curved
+/// ribbons. Dashboard-tile fidelity — the deterministic top-aligned layout
+/// stands in for upstream's d3-style layout; the node/link data is faithful.
+struct SankeyWidgetView: View {
+    let displayName: String
+    let data: SankeyData
+
+    private static let chartHeight: CGFloat = 200
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(displayName).font(.headline)
+
+            if hasDrawableFlows {
+                Canvas { context, size in
+                    guard let layout = SankeyCardLayout(data: data, size: size) else { return }
+                    for ribbon in layout.ribbons {
+                        context.fill(ribbon.path, with: .color(ribbon.color.opacity(0.3)))
+                    }
+                    for bar in layout.bars {
+                        context.fill(Path(roundedRect: bar.rect, cornerRadius: 1.5), with: .color(bar.color))
+                    }
+                    for label in layout.labels {
+                        context.draw(
+                            Text(label.text).font(.system(size: 9)).foregroundStyle(.secondary),
+                            in: label.rect
+                        )
+                    }
+                }
+                .frame(height: Self.chartHeight)
+            } else {
+                Text("No data")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var hasDrawableFlows: Bool {
+        data.links.contains { $0.value > 0 }
+    }
+}
+
+// MARK: - Layout
+
+private struct SankeyCardLayout {
+    struct Bar {
+        let rect: CGRect
+        let color: Color
+    }
+    struct Ribbon {
+        let path: Path
+        let color: Color
+    }
+    struct Label {
+        let text: String
+        let rect: CGRect
+    }
+
+    let bars: [Bar]
+    let ribbons: [Ribbon]
+    let labels: [Label]
+
+    private static let nodeWidth: CGFloat = 8
+    private static let nodeGap: CGFloat = 4
+    private static let minLabelHeight: CGFloat = 11
+    private static let labelWidth: CGFloat = 76
+
+    init?(data: SankeyData, size: CGSize) {
+        let nodeCount = data.nodes.count
+        guard nodeCount > 0, size.width > 40, size.height > 20 else { return nil }
+
+        // Node value = max(inflow, outflow) from positive links; hidden
+        // scaffolding (-1 links) contributes nothing and stays invisible.
+        var inflow = [Int](repeating: 0, count: nodeCount)
+        var outflow = [Int](repeating: 0, count: nodeCount)
+        for link in data.links where link.value > 0 {
+            outflow[link.source] += link.value
+            inflow[link.target] += link.value
+        }
+        let values = (0..<nodeCount).map { max(inflow[$0], outflow[$0]) }
+
+        let visible = (0..<nodeCount).filter { values[$0] > 0 && !data.nodes[$0].isHidden }
+        guard !visible.isEmpty else { return nil }
+
+        // Columns: one per layer present, in layer order; nodes keep the
+        // engine's (sorted) order within a column.
+        let layersPresent = Array(Set(visible.map { data.nodes[$0].layer }))
+            .sorted { $0.orderIndex < $1.orderIndex }
+        var columnOfLayer: [SankeyLayer: Int] = [:]
+        for (index, layer) in layersPresent.enumerated() {
+            columnOfLayer[layer] = index
+        }
+        let columnCount = layersPresent.count
+        var columns: [[Int]] = Array(repeating: [], count: columnCount)
+        for index in visible {
+            columns[columnOfLayer[data.nodes[index].layer]!].append(index)
+        }
+
+        let maxColumnTotal = columns.map { column in column.reduce(0) { $0 + values[$1] } }.max() ?? 1
+        guard maxColumnTotal > 0 else { return nil }
+        let maxGaps = CGFloat((columns.map(\.count).max() ?? 1) - 1) * Self.nodeGap
+        let scale = max(size.height - maxGaps, 10) / CGFloat(maxColumnTotal)
+
+        func x(forColumn column: Int) -> CGFloat {
+            guard columnCount > 1 else { return (size.width - Self.nodeWidth) / 2 }
+            return CGFloat(column) / CGFloat(columnCount - 1) * (size.width - Self.nodeWidth)
+        }
+
+        var frames: [Int: CGRect] = [:]
+        for (column, nodeIndices) in columns.enumerated() {
+            var y: CGFloat = 0
+            let barX = x(forColumn: column)
+            for index in nodeIndices {
+                let height = max(CGFloat(values[index]) * scale, 1.5)
+                frames[index] = CGRect(x: barX, y: y, width: Self.nodeWidth, height: height)
+                y += height + Self.nodeGap
+            }
+        }
+
+        var bars: [Bar] = []
+        var labels: [Label] = []
+        for index in visible {
+            guard let rect = frames[index] else { continue }
+            let node = data.nodes[index]
+            bars.append(Bar(rect: rect, color: Self.color(for: node)))
+
+            // Small labels for the largest nodes only.
+            if rect.height >= Self.minLabelHeight, !node.name.isEmpty {
+                let text = data.showPercentages && !node.percentageLabel.isEmpty
+                    ? "\(node.name) \(node.percentageLabel)"
+                    : node.name
+                let isLastColumn = columnOfLayer[node.layer] == columnCount - 1
+                let labelX = isLastColumn
+                    ? rect.minX - Self.labelWidth - 3
+                    : rect.maxX + 3
+                labels.append(Label(
+                    text: text,
+                    rect: CGRect(x: labelX, y: rect.midY - 6, width: Self.labelWidth, height: 12)
+                ))
+            }
+        }
+
+        // Ribbons: stacked offsets per node side, in link order.
+        var ribbons: [Ribbon] = []
+        var sourceOffset = [CGFloat](repeating: 0, count: nodeCount)
+        var targetOffset = [CGFloat](repeating: 0, count: nodeCount)
+        for link in data.links where link.value > 0 {
+            guard let sourceRect = frames[link.source], let targetRect = frames[link.target] else { continue }
+            let thickness = CGFloat(link.value) * scale
+            let sy = sourceRect.minY + sourceOffset[link.source]
+            let ty = targetRect.minY + targetOffset[link.target]
+            sourceOffset[link.source] += thickness
+            targetOffset[link.target] += thickness
+
+            let x0 = sourceRect.maxX
+            let x1 = targetRect.minX
+            let midX = (x0 + x1) / 2
+            var path = Path()
+            path.move(to: CGPoint(x: x0, y: sy))
+            path.addCurve(
+                to: CGPoint(x: x1, y: ty),
+                control1: CGPoint(x: midX, y: sy),
+                control2: CGPoint(x: midX, y: ty)
+            )
+            path.addLine(to: CGPoint(x: x1, y: ty + thickness))
+            path.addCurve(
+                to: CGPoint(x: x0, y: sy + thickness),
+                control1: CGPoint(x: midX, y: ty + thickness),
+                control2: CGPoint(x: midX, y: sy + thickness)
+            )
+            path.closeSubpath()
+            ribbons.append(Ribbon(path: path, color: Self.color(for: data.nodes[link.source])))
+        }
+
+        self.bars = bars
+        self.ribbons = ribbons
+        self.labels = labels
+    }
+
+    private static let palette: [Color] = [
+        .blue, .teal, .indigo, .orange, .purple, .pink, .cyan, .mint
+    ]
+
+    private static func color(for node: SankeyData.Node) -> Color {
+        if node.isNegative { return .red }
+        switch node.key {
+        case "to_budget": return .green
+        case "budgeted", "available_income", "all_income": return .blue
+        case "last_month_overspent": return .red
+        case "from_previous_month", "for_next_month": return .gray
+        default: break
+        }
+        if node.key.hasSuffix("__OTHER_BUCKET") { return .gray }
+        // Upstream colorIndexFromKey: first 3 hex chars of the (UUID) key as
+        // a stable color index.
+        let hex = node.key.lowercased().filter { $0.isHexDigit }.prefix(3)
+        let value = Int(hex, radix: 16) ?? 0
+        return palette[value % palette.count]
+    }
+}

--- a/Actuali/ActualiTests/BalanceForecastEngineTests.swift
+++ b/Actuali/ActualiTests/BalanceForecastEngineTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BalanceForecastEngineTests {
+
+    // Fixed "now": 2026-05-14 (UTC).
+    private var asOf: Date {
+        var c = DateComponents(); c.year = 2026; c.month = 5; c.day = 14
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func utcDate(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    private func tx(date: Int, amount: Int, account: String = "a1", schedule: String? = nil) -> Transaction {
+        var t = Transaction(
+            id: UUID().uuidString,
+            accountId: account, date: date, amount: amount,
+            payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: false, parentId: nil,
+            tombstone: false, sortOrder: nil, importedPayee: nil
+        )
+        t.schedule = schedule
+        return t
+    }
+
+    private func schedule(
+        id: String = "s1",
+        nextDate: Int,
+        account: String = "a1",
+        payee: String? = nil,
+        amount: Int,
+        dateCondition: ScheduleDateCondition
+    ) -> Schedule {
+        Schedule(
+            id: id, name: nil,
+            nextDate: DayDate(yyyymmdd: nextDate)!,
+            nextDateRowId: "nd-\(id)", baseNextDateTs: nil,
+            accountId: account, payeeId: payee, categoryId: nil,
+            amount: .fixed(amount), dateCondition: dateCondition
+        )
+    }
+
+    private func monthlyRecurrence(startingOn iso: String) -> ScheduleDateCondition {
+        .recurring(RecurConfig(json: ["frequency": "monthly", "start": iso])!)
+    }
+
+    private func meta(
+        accounts: [String]? = nil,
+        start: String, end: String,
+        granularity: BalanceForecastMeta.Granularity = .monthly,
+        source: BalanceForecastMeta.Source? = nil
+    ) -> BalanceForecastMeta {
+        BalanceForecastMeta(
+            name: nil, startDate: nil, endDate: nil, accounts: accounts,
+            conditions: nil, conditionsOp: nil,
+            timeFrame: WidgetTimeFrame(start: start, end: end, mode: .static),
+            granularity: granularity, source: source
+        )
+    }
+
+    // MARK: - Historical balances
+
+    // Upstream: "combines balances across accounts for monthly data".
+    @Test func monthlyHistoryCombinesAccounts() {
+        let transactions = [
+            tx(date: 20260301, amount: 1000, account: "checking"),
+            tx(date: 20260301, amount: 500, account: "savings"),
+            tx(date: 20260401, amount: -100, account: "checking"),
+            tx(date: 20260401, amount: 200, account: "savings")
+        ]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-03", end: "2026-04"),
+            transactions: transactions, today: asOf
+        )
+        #expect(result.points == [
+            BalanceForecastPoint(date: utcDate(2026, 3, 31), balanceCents: 1500, isForecast: false),
+            BalanceForecastPoint(date: utcDate(2026, 4, 30), balanceCents: 1600, isForecast: false)
+        ])
+    }
+
+    @Test func accountSelectionRestrictsBalances() {
+        let transactions = [
+            tx(date: 20260301, amount: 1000, account: "checking"),
+            tx(date: 20260301, amount: 500, account: "savings"),
+            tx(date: 20260401, amount: -100, account: "checking")
+        ]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(accounts: ["checking"], start: "2026-03", end: "2026-04"),
+            transactions: transactions, today: asOf
+        )
+        #expect(result.points.map(\.balanceCents) == [1000, 900])
+    }
+
+    // Upstream: "carries monthly balances through the full end month for daily data".
+    @Test func dailyCarriesBalanceAcrossDays() {
+        let transactions = [
+            tx(date: 20260301, amount: 1000),
+            tx(date: 20260401, amount: 200)
+        ]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-03", end: "2026-04", granularity: .daily),
+            transactions: transactions, today: asOf
+        )
+        #expect(result.points.count == 61)
+        #expect(result.points[0] == BalanceForecastPoint(date: utcDate(2026, 3, 1), balanceCents: 1000, isForecast: false))
+        #expect(result.points[30].balanceCents == 1000)  // Mar 31
+        #expect(result.points[31].balanceCents == 1200)  // Apr 1
+        #expect(result.points.last == BalanceForecastPoint(date: utcDate(2026, 4, 30), balanceCents: 1200, isForecast: false))
+    }
+
+    // Upstream: "preserves exact day-shaped bounds" + "carries the balance
+    // forward from points before a day-shaped start".
+    @Test func dailyDayShapedBoundsStayExact() {
+        let transactions = [
+            tx(date: 20260301, amount: 1000),
+            tx(date: 20260315, amount: -200)
+        ]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-03-10", end: "2026-03-20", granularity: .daily),
+            transactions: transactions, today: asOf
+        )
+        #expect(result.points.count == 11)
+        #expect(result.points.first == BalanceForecastPoint(date: utcDate(2026, 3, 10), balanceCents: 1000, isForecast: false))
+        #expect(result.points.last == BalanceForecastPoint(date: utcDate(2026, 3, 20), balanceCents: 800, isForecast: false))
+    }
+
+    // MARK: - Schedules source
+
+    @Test func schedulesSourceProjectsRecurringOccurrences() {
+        let transactions = [tx(date: 20260410, amount: 100_000)]
+        let schedules = [schedule(nextDate: 20260520, amount: -5000, dateCondition: monthlyRecurrence(startingOn: "2026-05-20"))]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-04", end: "2026-07"),
+            transactions: transactions, schedules: schedules, today: asOf
+        )
+        #expect(result.points.map(\.balanceCents) == [100_000, 95_000, 90_000, 85_000])
+        #expect(result.points.map(\.isForecast) == [false, true, true, true])
+    }
+
+    @Test func pastDueOccurrencesDoNotProject() {
+        // nextDate 2026-05-01 is before today (2026-05-14): upstream's
+        // firstForecastDate excludes it; only Jun/Jul occurrences project.
+        let schedules = [schedule(nextDate: 20260501, amount: -5000, dateCondition: monthlyRecurrence(startingOn: "2026-05-01"))]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-05", end: "2026-07"),
+            transactions: [], schedules: schedules, today: asOf
+        )
+        #expect(result.points.map(\.balanceCents) == [0, -5000, -10_000])
+    }
+
+    @Test func postedOccurrenceIsNotDoubleCounted() {
+        // The May 20 occurrence was already posted (transaction linked to the
+        // schedule): only the posted transaction counts, plus the Jun/Jul
+        // projections.
+        let transactions = [tx(date: 20260520, amount: -5000, schedule: "s1")]
+        let schedules = [schedule(nextDate: 20260520, amount: -5000, dateCondition: monthlyRecurrence(startingOn: "2026-05-20"))]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-05", end: "2026-07"),
+            transactions: transactions, schedules: schedules, today: asOf
+        )
+        #expect(result.points.map(\.balanceCents) == [-5000, -10_000, -15_000])
+    }
+
+    @Test func transferScheduleProjectsBothLegs() {
+        let schedules = [schedule(nextDate: 20260520, payee: "p-transfer", amount: -25_000, dateCondition: .fixed(DayDate(yyyymmdd: 20260520)!))]
+        let transferMap = ["p-transfer": "savings"]
+
+        // Both accounts included: the legs cancel out.
+        let combined = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-05", end: "2026-05"),
+            transactions: [], schedules: schedules,
+            transferAccountsByPayeeId: transferMap, today: asOf
+        )
+        #expect(combined.points.map(\.balanceCents) == [0])
+
+        // Only the transfer side selected: its leg still projects.
+        let savingsOnly = BalanceForecastEngine.compute(
+            meta: meta(accounts: ["savings"], start: "2026-05", end: "2026-05"),
+            transactions: [], schedules: schedules,
+            transferAccountsByPayeeId: transferMap, today: asOf
+        )
+        #expect(savingsOnly.points.map(\.balanceCents) == [25_000])
+    }
+
+    // MARK: - Tracking-budget source
+
+    @Test func trackingBudgetSourceProjectsFromBudgetedTotals() {
+        let transactions = [
+            tx(date: 20260110, amount: 100_000, account: "checking"),
+            tx(date: 20260110, amount: 999, account: "offbudget")  // excluded from starting balance
+        ]
+        let months = [
+            BalanceForecastBudgetMonth(month: 202605, budgetedIncomeCents: 20_000, budgetedExpensesCents: 15_000),
+            BalanceForecastBudgetMonth(month: 202606, budgetedIncomeCents: 0, budgetedExpensesCents: 10_000)
+        ]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-05", end: "2026-07", source: .trackingBudget),
+            transactions: transactions, trackingBudgetMonths: months,
+            offBudgetAccountIds: ["offbudget"], today: asOf
+        )
+        // May: 100000 + 5000; Jun: -10000; Jul has no budget rows → carries.
+        #expect(result.points.map(\.balanceCents) == [105_000, 95_000, 95_000])
+        #expect(result.points.map(\.isForecast) == [true, true, true])
+    }
+
+    // MARK: - Boundaries and edge cases
+
+    @Test func dailyBoundaryBetweenHistoryAndForecast() {
+        let transactions = [tx(date: 20260512, amount: 1000)]
+        let schedules = [schedule(nextDate: 20260516, amount: -300, dateCondition: .fixed(DayDate(yyyymmdd: 20260516)!))]
+        let result = BalanceForecastEngine.compute(
+            meta: meta(start: "2026-05-10", end: "2026-05-18", granularity: .daily),
+            transactions: transactions, schedules: schedules, today: asOf
+        )
+        let byDay = Dictionary(uniqueKeysWithValues: result.points.map { ($0.date, $0) })
+        #expect(byDay[utcDate(2026, 5, 14)]?.isForecast == false)
+        #expect(byDay[utcDate(2026, 5, 15)]?.isForecast == true)
+        #expect(byDay[utcDate(2026, 5, 15)]?.balanceCents == 1000)
+        #expect(byDay[utcDate(2026, 5, 16)]?.balanceCents == 700)
+        #expect(byDay[utcDate(2026, 5, 18)]?.balanceCents == 700)
+    }
+
+    @Test func emptyAccountSelectionYieldsNoPoints() {
+        let result = BalanceForecastEngine.compute(
+            meta: meta(accounts: [], start: "2026-05", end: "2026-07"),
+            transactions: [tx(date: 20260501, amount: 1000)], today: asOf
+        )
+        #expect(result.points.isEmpty)
+    }
+
+    @Test func defaultTimeFrameIsCurrentMonthPlusElevenMonths() {
+        // Card default (BalanceForecastCard.tsx): current month → +11 months.
+        let result = BalanceForecastEngine.compute(
+            meta: nil, transactions: [tx(date: 20260101, amount: 4200)], today: asOf
+        )
+        #expect(result.points.count == 12)
+        #expect(result.points.first?.date == utcDate(2026, 5, 31))
+        #expect(result.points.last?.date == utcDate(2027, 4, 30))
+        #expect(result.points.allSatisfy { $0.balanceCents == 4200 })
+    }
+}

--- a/Actuali/ActualiTests/BudgetAnalysisEngineTests.swift
+++ b/Actuali/ActualiTests/BudgetAnalysisEngineTests.swift
@@ -1,0 +1,317 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetAnalysisEngineTests {
+
+    private var asOf: Date {
+        var c = DateComponents(); c.year = 2026; c.month = 5; c.day = 14
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    // Fixture mirrors upstream budgetDataQuery.test.ts / budget-analysis-spreadsheet.test.ts:
+    // expense categories across two groups, plus a hidden expense and income categories.
+    private let groups = [
+        CategoryGroup(id: "gr-food", name: "Food", isIncome: false, hidden: false, sortOrder: 0, categories: []),
+        CategoryGroup(id: "gr-fun", name: "Fun Money", isIncome: false, hidden: false, sortOrder: 1, categories: [])
+    ]
+    // Actuali.Category: the ObjC runtime also exports a `Category` type.
+    private let groceries = Actuali.Category(id: "c-groceries", name: "Groceries", groupId: "gr-food", isIncome: false, hidden: false, sortOrder: 0)
+    private let fun = Actuali.Category(id: "c-fun", name: "Dining Out", groupId: "gr-fun", isIncome: false, hidden: false, sortOrder: 1)
+    private let hiddenExpense = Actuali.Category(id: "c-hidden", name: "Car Fund", groupId: "gr-fun", isIncome: false, hidden: true, sortOrder: 2)
+    private let income = Actuali.Category(id: "c-income", name: "Salary", groupId: "gr-food", isIncome: true, hidden: false, sortOrder: 3)
+
+    private var allCategories: [Actuali.Category] { [groceries, fun, hiddenExpense, income] }
+
+    private func tx(date: Int, amount: Int, category: String?, account: String = "a1") -> Transaction {
+        Transaction(
+            id: UUID().uuidString,
+            accountId: account, date: date, amount: amount,
+            payeeId: nil, payeeName: nil, categoryId: category, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: false, parentId: nil,
+            tombstone: false, sortOrder: nil, importedPayee: nil
+        )
+    }
+
+    private func budget(_ month: Int, _ category: String, _ cents: Int) -> BudgetAnalysisBudgetEntry {
+        BudgetAnalysisBudgetEntry(month: month, categoryId: category, amountCents: cents)
+    }
+
+    private func cond(_ field: String, _ op: String, json: String) -> WidgetRuleCondition {
+        WidgetRuleCondition(op: op, field: field,
+                            value: AnyCodable(rawJSON: Data(json.utf8)),
+                            options: nil, customName: nil)
+    }
+
+    private func meta(
+        conditions: [WidgetRuleCondition]? = nil,
+        conditionsOp: String? = nil,
+        start: String = "2026-01", end: String = "2026-03",
+        graphType: String? = nil,
+        showBalance: Bool? = nil,
+        balanceOnly: Bool? = nil,
+        showHiddenCategories: Bool? = nil
+    ) -> BudgetAnalysisMeta {
+        BudgetAnalysisMeta(
+            name: nil, conditions: conditions, conditionsOp: conditionsOp,
+            timeFrame: WidgetTimeFrame(start: start, end: end, mode: .static),
+            interval: nil, graphType: graphType,
+            showBalance: showBalance, balanceOnly: balanceOnly,
+            showHiddenCategories: showHiddenCategories
+        )
+    }
+
+    private func compute(
+        _ meta: BudgetAnalysisMeta?,
+        transactions: [Transaction] = [],
+        budgets: [BudgetAnalysisBudgetEntry] = [],
+        context: ConditionsFilter.Context = .empty
+    ) -> BudgetAnalysisData {
+        BudgetAnalysisEngine.compute(
+            meta: meta, transactions: transactions, budgets: budgets,
+            categories: allCategories, categoryGroups: groups,
+            today: asOf, context: context
+        )
+    }
+
+    // MARK: - Monthly budgeted vs spent, balance accumulation
+
+    @Test func monthlyBudgetedVsSpentWithCarryover() {
+        let result = compute(
+            meta(),
+            transactions: [
+                tx(date: 20260110, amount: -30000, category: "c-groceries"),
+                tx(date: 20260210, amount: -60000, category: "c-groceries"),
+                tx(date: 20260310, amount: -20000, category: "c-groceries")
+            ],
+            budgets: [
+                budget(202601, "c-groceries", 50000),
+                budget(202602, "c-groceries", 50000),
+                budget(202603, "c-groceries", 50000)
+            ]
+        )
+
+        #expect(result.intervalData.map(\.month) == [202601, 202602, 202603])
+        #expect(result.intervalData.map(\.budgetedCents) == [50000, 50000, 50000])
+        // Spent stays negative, mirroring upstream's sum-amount cells.
+        #expect(result.intervalData.map(\.spentCents) == [-30000, -60000, -20000])
+        // Positive leftovers carry forward: 20000 into Feb, 10000 into Mar.
+        #expect(result.intervalData.map(\.balanceCents) == [20000, 10000, 40000])
+        #expect(result.intervalData.map(\.overspendingAdjustmentCents) == [0, 0, 0])
+        #expect(result.totalBudgetedCents == 150000)
+        #expect(result.totalSpentCents == -110000)
+    }
+
+    @Test func overspendingZeroesOutAndSurfacesNextMonth() {
+        let result = compute(
+            meta(start: "2026-01", end: "2026-02"),
+            transactions: [tx(date: 20260105, amount: -15000, category: "c-groceries")],
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202602, "c-groceries", 10000)
+            ]
+        )
+
+        #expect(result.intervalData.map(\.balanceCents) == [-5000, 10000])
+        // The negative leftover doesn't carry (no carryover flag); it shows
+        // up as the next month's overspending adjustment instead.
+        #expect(result.intervalData.map(\.overspendingAdjustmentCents) == [0, 5000])
+    }
+
+    @Test func earlierMonthsSeedTheRunningBalance() {
+        // Range starts in Feb; January's data initializes the carryover the
+        // way upstream reads the previous month's leftover cells. January's
+        // fun overspending is zeroed and must not leak into the range.
+        let result = compute(
+            meta(start: "2026-02", end: "2026-02"),
+            transactions: [
+                tx(date: 20260110, amount: -4000, category: "c-groceries"),
+                tx(date: 20260112, amount: -3000, category: "c-fun")
+            ],
+            budgets: [budget(202601, "c-groceries", 10000)]
+        )
+
+        #expect(result.intervalData.count == 1)
+        #expect(result.intervalData[0].budgetedCents == 0)
+        #expect(result.intervalData[0].spentCents == 0)
+        #expect(result.intervalData[0].balanceCents == 6000)
+        #expect(result.intervalData[0].overspendingAdjustmentCents == 0)
+    }
+
+    // MARK: - Category conditions (mirrors budgetDataQuery.test.ts)
+
+    @Test func categoryConditionNarrowsBudgetsAndTransactions() {
+        let result = compute(
+            meta(conditions: [cond("category", "is", json: "\"c-groceries\"")],
+                 start: "2026-01", end: "2026-01"),
+            transactions: [
+                tx(date: 20260105, amount: -5000, category: "c-groceries"),
+                tx(date: 20260106, amount: -7000, category: "c-fun")
+            ],
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 99900)
+            ]
+        )
+
+        #expect(result.intervalData.map(\.budgetedCents) == [10000])
+        #expect(result.intervalData.map(\.spentCents) == [-5000])
+    }
+
+    @Test func categoryGroupConditionFiltersByGroup() {
+        let result = compute(
+            meta(conditions: [cond("category_group", "is", json: "\"gr-food\"")],
+                 start: "2026-01", end: "2026-01"),
+            transactions: [
+                tx(date: 20260105, amount: -5000, category: "c-groceries"),
+                tx(date: 20260106, amount: -7000, category: "c-fun")
+            ],
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 99900)
+            ]
+        )
+
+        #expect(result.intervalData.map(\.budgetedCents) == [10000])
+        #expect(result.intervalData.map(\.spentCents) == [-5000])
+    }
+
+    @Test func categoryGroupOneOfAndAndCombination() {
+        // oneOf on group
+        let oneOf = compute(
+            meta(conditions: [cond("category_group", "oneOf", json: "[\"gr-fun\"]")],
+                 start: "2026-01", end: "2026-01"),
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 20000)
+            ]
+        )
+        #expect(oneOf.intervalData.map(\.budgetedCents) == [20000])
+
+        // AND of category_group + category (upstream: intersection)
+        let combined = compute(
+            meta(conditions: [
+                cond("category_group", "is", json: "\"gr-food\""),
+                cond("category", "is", json: "\"c-groceries\"")
+            ], start: "2026-01", end: "2026-01"),
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 20000)
+            ]
+        )
+        #expect(combined.intervalData.map(\.budgetedCents) == [10000])
+    }
+
+    @Test func textOperatorsMatchGroupNames() {
+        // Upstream: contains matches against the group's name, not its UUID.
+        let result = compute(
+            meta(conditions: [cond("category_group", "contains", json: "\"fun\"")],
+                 start: "2026-01", end: "2026-01"),
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 20000)
+            ]
+        )
+        #expect(result.intervalData.map(\.budgetedCents) == [20000])
+    }
+
+    @Test func unsupportedConditionDisablesCategoryFilter() {
+        // Upstream isSupportedCategoryCondition: an op like "gt" (or a
+        // mistyped value) means no category filtering at all — even when
+        // other conditions are supported.
+        let result = compute(
+            meta(conditions: [
+                cond("category", "is", json: "\"c-groceries\""),
+                cond("category", "gt", json: "\"x\"")
+            ], start: "2026-01", end: "2026-01"),
+            transactions: [
+                tx(date: 20260105, amount: -5000, category: "c-groceries"),
+                tx(date: 20260106, amount: -7000, category: "c-fun")
+            ],
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 99900)
+            ]
+        )
+
+        #expect(result.intervalData.map(\.budgetedCents) == [109900])
+        #expect(result.intervalData.map(\.spentCents) == [-12000])
+    }
+
+    @Test func nonCategoryConditionsAreIgnored() {
+        let result = compute(
+            meta(conditions: [cond("amount", "gt", json: "100")],
+                 start: "2026-01", end: "2026-01"),
+            budgets: [
+                budget(202601, "c-groceries", 10000),
+                budget(202601, "c-fun", 20000)
+            ]
+        )
+        #expect(result.intervalData.map(\.budgetedCents) == [30000])
+    }
+
+    // MARK: - Hidden and income categories (mirrors budget-analysis-spreadsheet.test.ts)
+
+    @Test func hiddenCategoriesExcludedUnlessRequested() {
+        let transactions = [
+            tx(date: 20260105, amount: -5000, category: "c-groceries"),
+            tx(date: 20260106, amount: -1000, category: "c-hidden")
+        ]
+        let budgets = [
+            budget(202601, "c-groceries", 10000),
+            budget(202601, "c-hidden", 20000)
+        ]
+
+        let withoutHidden = compute(meta(start: "2026-01", end: "2026-01"),
+                                    transactions: transactions, budgets: budgets)
+        #expect(withoutHidden.intervalData.map(\.budgetedCents) == [10000])
+        #expect(withoutHidden.intervalData.map(\.spentCents) == [-5000])
+
+        let withHidden = compute(meta(start: "2026-01", end: "2026-01", showHiddenCategories: true),
+                                 transactions: transactions, budgets: budgets)
+        #expect(withHidden.intervalData.map(\.budgetedCents) == [30000])
+        #expect(withHidden.intervalData.map(\.spentCents) == [-6000])
+    }
+
+    @Test func incomeCategoriesAlwaysExcluded() {
+        let result = compute(
+            meta(start: "2026-01", end: "2026-01", showHiddenCategories: true),
+            transactions: [tx(date: 20260105, amount: 100000, category: "c-income")],
+            budgets: [budget(202601, "c-income", 50000)]
+        )
+        #expect(result.intervalData.map(\.budgetedCents) == [0])
+        #expect(result.intervalData.map(\.spentCents) == [0])
+    }
+
+    @Test func offBudgetAccountsExcludedFromSpending() {
+        let result = compute(
+            meta(start: "2026-01", end: "2026-01"),
+            transactions: [
+                tx(date: 20260105, amount: -5000, category: "c-groceries"),
+                tx(date: 20260106, amount: -9000, category: "c-groceries", account: "a-off")
+            ],
+            context: ConditionsFilter.Context(offBudgetAccountIds: ["a-off"], accountNames: [:])
+        )
+        #expect(result.intervalData.map(\.spentCents) == [-5000])
+    }
+
+    // MARK: - Defaults
+
+    @Test func defaultTimeFrameIsTrailingSixMonthsAndDisplayDefaultsMatchUpstream() {
+        let result = compute(nil)
+        #expect(result.intervalData.map(\.month) == [202512, 202601, 202602, 202603, 202604, 202605])
+        #expect(result.graphType == .bar)
+        #expect(result.showBalance == true)
+        #expect(result.balanceOnly == false)
+    }
+
+    @Test func displayFlagsComeFromMeta() {
+        let result = compute(meta(graphType: "Line", showBalance: false, balanceOnly: true))
+        #expect(result.graphType == .line)
+        #expect(result.showBalance == false)
+        #expect(result.balanceOnly == true)
+    }
+}

--- a/Actuali/ActualiTests/BudgetDatabaseDashboardTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseDashboardTests.swift
@@ -155,13 +155,13 @@ struct BudgetDatabaseDashboardTests {
 
     @Test func unknownTypeReturnsAsUnsupported() async throws {
         let (database, path) = try makeDatabase()
-        try insertWidget(path: path, id: "x", type: "sankey-card", meta: "{}")
+        try insertWidget(path: path, id: "x", type: "future-card", meta: "{}")
 
         let widgets = try await database.fetchWidgets(pageId: nil)
         #expect(widgets.count == 1)
         if case .unsupported(let id, let type) = widgets.first {
             #expect(id == "x")
-            #expect(type == "sankey-card")
+            #expect(type == "future-card")
         } else {
             Issue.record("Expected .unsupported")
         }

--- a/Actuali/ActualiTests/CalendarEngineTests.swift
+++ b/Actuali/ActualiTests/CalendarEngineTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct CalendarEngineTests {
+
+    private var asOf: Date {
+        var c = DateComponents(); c.year = 2026; c.month = 5; c.day = 14
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func tx(date: Int, amount: Int, categoryId: String? = nil, tombstone: Bool = false) -> Transaction {
+        Transaction(
+            id: UUID().uuidString,
+            accountId: "a1", date: date, amount: amount,
+            payeeId: nil, payeeName: nil, categoryId: categoryId, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: false, parentId: nil,
+            tombstone: tombstone, sortOrder: nil, importedPayee: nil
+        )
+    }
+
+    private func meta(
+        conditions: [WidgetRuleCondition]? = nil,
+        conditionsOp: String? = nil,
+        timeFrame: WidgetTimeFrame? = nil
+    ) -> CalendarMeta {
+        CalendarMeta(name: nil, conditions: conditions, conditionsOp: conditionsOp, timeFrame: timeFrame)
+    }
+
+    private var mayTimeFrame: WidgetTimeFrame {
+        WidgetTimeFrame(start: "2026-05", end: "2026-05", mode: .static)
+    }
+
+    private func cell(_ data: CalendarData, month: Int, day: Int) -> CalendarDayCell? {
+        data.months[month].days.first { $0.dayOfMonth == day }
+    }
+
+    @Test func bucketsIncomeAndExpensePerDay() {
+        let transactions = [
+            tx(date: 20260510, amount: 5000),
+            tx(date: 20260510, amount: -3000),
+            tx(date: 20260512, amount: -1000)
+        ]
+        let result = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                            transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months.count == 1)
+        #expect(cell(result, month: 0, day: 10)?.incomeCents == 5000)
+        #expect(cell(result, month: 0, day: 10)?.expenseCents == 3000)
+        #expect(cell(result, month: 0, day: 12)?.expenseCents == 1000)
+        #expect(result.months[0].totalIncomeCents == 5000)
+        #expect(result.months[0].totalExpenseCents == 4000)
+        // Bar sizes are the day's share of the month total (upstream getBarLength).
+        #expect(cell(result, month: 0, day: 10)?.incomeSize == 100)
+        #expect(cell(result, month: 0, day: 10)?.expenseSize == 75)
+        #expect(cell(result, month: 0, day: 12)?.expenseSize == 25)
+    }
+
+    @Test func staticTimeFrameExcludesOutsideRange() {
+        let transactions = [
+            tx(date: 20260430, amount: -9999),   // April — outside
+            tx(date: 20260501, amount: -100),
+            tx(date: 20260601, amount: -9999)    // June — outside
+        ]
+        let result = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                            transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months.count == 1)
+        #expect(result.months[0].totalExpenseCents == 100)
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month, .day], from: result.months[0].monthStart)
+        #expect(comps.year == 2026 && comps.month == 5 && comps.day == 1)
+    }
+
+    @Test func multiMonthRangeSumsOverallTotals() {
+        let transactions = [
+            tx(date: 20260410, amount: -1000),
+            tx(date: 20260510, amount: -2000),
+            tx(date: 20260511, amount: 500)
+        ]
+        let tf = WidgetTimeFrame(start: "2026-04", end: "2026-05", mode: .static)
+        let result = CalendarEngine.compute(meta: meta(timeFrame: tf),
+                                            transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months.count == 2)
+        #expect(result.totalExpenseCents == 3000)
+        #expect(result.totalIncomeCents == 500)
+    }
+
+    @Test func conditionsFilterTransactions() {
+        let condition = WidgetRuleCondition(
+            op: "is", field: "category",
+            value: AnyCodable(rawJSON: Data("\"c1\"".utf8)),
+            options: nil, customName: nil
+        )
+        let transactions = [
+            tx(date: 20260510, amount: -3000, categoryId: "c1"),
+            tx(date: 20260511, amount: -7000, categoryId: "c2")
+        ]
+        let result = CalendarEngine.compute(meta: meta(conditions: [condition], conditionsOp: "and", timeFrame: mayTimeFrame),
+                                            transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months[0].totalExpenseCents == 3000)
+        #expect(cell(result, month: 0, day: 11)?.expenseCents == 0)
+    }
+
+    @Test func tombstonedTransactionsExcluded() {
+        let transactions = [
+            tx(date: 20260510, amount: -3000, tombstone: true),
+            tx(date: 20260511, amount: -1000)
+        ]
+        let result = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                            transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months[0].totalExpenseCents == 1000)
+    }
+
+    // May 2026 starts on a Friday: Sunday-start grids need 5 leading padding
+    // cells (42 total), Monday-start grids need 4 (35 total).
+    @Test func gridAlignsToFirstDayOfWeek() {
+        let sunday = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                            transactions: [], today: asOf, firstDayOfWeekIdx: 0)
+        #expect(sunday.months[0].days.count == 42)
+        #expect(sunday.months[0].days.prefix(5).allSatisfy { $0.dayOfMonth == nil })
+        #expect(sunday.months[0].days[5].dayOfMonth == 1)
+        #expect(sunday.firstDayOfWeekIdx == 0)
+
+        let monday = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                            transactions: [], today: asOf, firstDayOfWeekIdx: 1)
+        #expect(monday.months[0].days.count == 35)
+        #expect(monday.months[0].days[4].dayOfMonth == 1)
+
+        // Out-of-range index falls back to Sunday, matching upstream.
+        let invalid = CalendarEngine.compute(meta: meta(timeFrame: mayTimeFrame),
+                                             transactions: [], today: asOf, firstDayOfWeekIdx: 9)
+        #expect(invalid.firstDayOfWeekIdx == 0)
+        #expect(invalid.months[0].days.count == 42)
+    }
+
+    @Test func nilTimeFrameDefaultsToCurrentMonth() {
+        let transactions = [
+            tx(date: 20260520, amount: -1500),   // later in the current month still counts
+            tx(date: 20260410, amount: -9999)    // prior month excluded
+        ]
+        let result = CalendarEngine.compute(meta: nil, transactions: transactions,
+                                            today: asOf, firstDayOfWeekIdx: 0)
+        #expect(result.months.count == 1)
+        #expect(result.months[0].totalExpenseCents == 1500)
+    }
+}

--- a/Actuali/ActualiTests/CrossoverEngineTests.swift
+++ b/Actuali/ActualiTests/CrossoverEngineTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct CrossoverEngineTests {
+
+    private func utcDate(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var c = DateComponents(); c.year = year; c.month = month; c.day = day
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func tx(date: Int, amount: Int, account: String = "a1", category: String? = nil) -> Transaction {
+        Transaction(
+            id: UUID().uuidString,
+            accountId: account, date: date, amount: amount,
+            payeeId: nil, payeeName: nil, categoryId: category, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: false, parentId: nil,
+            tombstone: false, sortOrder: nil, importedPayee: nil
+        )
+    }
+
+    // `Category` alone is ambiguous in the test target (clashes with the ObjC
+    // runtime's Category typedef), so qualify the app type.
+    private func cat(_ id: String, isIncome: Bool = false, hidden: Bool = false) -> Actuali.Category {
+        Actuali.Category(id: id, name: id, groupId: "g1", isIncome: isIncome, hidden: hidden, sortOrder: 0)
+    }
+
+    private var categories: [Actuali.Category] {
+        [cat("food"), cat("salary", isIncome: true), cat("secret", hidden: true)]
+    }
+
+    private func meta(
+        expenseCategoryIds: [String]? = nil,
+        incomeAccountIds: [String]? = nil,
+        timeFrame: WidgetTimeFrame? = nil,
+        safeWithdrawalRate: Double? = nil,
+        estimatedReturn: Double? = nil,
+        expectedContribution: Double? = nil,
+        projectionType: CrossoverMeta.ProjectionType? = nil,
+        showHiddenCategories: Bool? = nil,
+        expenseAdjustmentFactor: Double? = nil
+    ) -> CrossoverMeta {
+        CrossoverMeta(
+            name: nil,
+            expenseCategoryIds: expenseCategoryIds,
+            incomeAccountIds: incomeAccountIds,
+            timeFrame: timeFrame,
+            safeWithdrawalRate: safeWithdrawalRate,
+            estimatedReturn: estimatedReturn,
+            expectedContribution: expectedContribution,
+            projectionType: projectionType,
+            showHiddenCategories: showHiddenCategories,
+            expenseAdjustmentFactor: expenseAdjustmentFactor
+        )
+    }
+
+    @Test func expenseBucketingByMonthForSelectedCategories() {
+        // Range is earliest tx month through the previous month (May 2026).
+        let transactions = [
+            tx(date: 20260110, amount: -1000, category: "food"),
+            tx(date: 20260205, amount: -2000, category: "food"),
+            tx(date: 20260220, amount: -500, category: "food"),
+            tx(date: 20260215, amount: 90000, category: "salary"),   // income category — excluded
+            tx(date: 20260310, amount: -700, category: "secret"),    // hidden — excluded by default
+            tx(date: 20260601, amount: -300, category: "food")       // current month — outside range
+        ]
+        let result = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"]),
+            transactions: transactions, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 6, 15)
+        )
+        let historical = result.points.filter { !$0.isProjection }
+        #expect(historical.count == 5)  // Jan..May
+        #expect(historical.map(\.expensesCents) == [1000, 2500, 0, 0, 0])
+
+        // showHiddenCategories includes the hidden category's spending.
+        let withHidden = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"], showHiddenCategories: true),
+            transactions: transactions, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 6, 15)
+        )
+        #expect(withHidden.points.filter { !$0.isProjection }.map(\.expensesCents)
+                == [1000, 2500, 700, 0, 0])
+    }
+
+    @Test func incomeAccountBalanceAccumulation() {
+        let transactions = [
+            tx(date: 20260115, amount: 100_000, account: "inv"),
+            tx(date: 20260320, amount: 50_000, account: "inv"),
+            tx(date: 20260112, amount: -1000, account: "a1", category: "food")
+        ]
+        let result = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"]),
+            transactions: transactions, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 6, 15)
+        )
+        let historical = result.points.filter { !$0.isProjection }
+        #expect(historical.map(\.nestEggCents) == [100_000, 100_000, 150_000, 150_000, 150_000])
+        // Monthly income = balance * (0.04 / 12).
+        #expect(historical.last?.investmentIncomeCents == 500)
+        #expect(result.lastKnownBalanceCents == 150_000)
+        #expect(result.lastKnownMonthlyIncomeCents == 500)
+        // Annualized CAGR: monthly (1.5)^(1/4) - 1 over 4 steps → 1.5^3 - 1.
+        #expect(abs((result.historicalReturn ?? 0) - 2.375) < 1e-9)
+    }
+
+    @Test func staticTimeFrameFoldsPriorTransactionsIntoStartingBalance() {
+        let transactions = [
+            tx(date: 20260115, amount: 100_000, account: "inv"),
+            tx(date: 20260320, amount: 50_000, account: "inv")
+        ]
+        let result = CrossoverEngine.compute(
+            meta: meta(
+                incomeAccountIds: ["inv"],
+                timeFrame: WidgetTimeFrame(start: "2026-03", end: "2026-05", mode: .static)
+            ),
+            transactions: transactions, categories: categories,
+            accountIds: ["inv"], today: utcDate(2026, 6, 15)
+        )
+        let historical = result.points.filter { !$0.isProjection }
+        #expect(historical.count == 3)  // Mar..May
+        #expect(historical.map(\.nestEggCents) == [150_000, 150_000, 150_000])
+        #expect(historical.first?.month == utcDate(2026, 3, 1))
+    }
+
+    // Expenses [100, 100, 110, 90, 1000, 1200]:
+    //   median = 105; MAD = median(|v - 105|) = median([15,5,5,5,895,1095]) = 10;
+    //   Hampel bounds = 105 ± 1.4826 * 10 * 3 = [60.522, 149.478] → drops 1000
+    //   and 1200 → median([90,100,100,110]) = 100. Mean = 2600/6 ≈ 433.33.
+    private var projectionFixture: [Transaction] {
+        [
+            tx(date: 20260110, amount: -100, category: "food"),
+            tx(date: 20260210, amount: -100, category: "food"),
+            tx(date: 20260310, amount: -110, category: "food"),
+            tx(date: 20260410, amount: -90, category: "food"),
+            tx(date: 20260510, amount: -1000, category: "food"),
+            tx(date: 20260610, amount: -1200, category: "food"),
+            tx(date: 20260115, amount: 100_000, account: "inv")
+        ]
+    }
+
+    private func projectionResult(_ type: CrossoverMeta.ProjectionType) -> CrossoverData {
+        CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"], projectionType: type),
+            transactions: projectionFixture, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 7, 15)
+        )
+    }
+
+    @Test func hampelProjectionRejectsOutliers() {
+        let result = projectionResult(.hampel)
+        let firstProjection = result.points.first { $0.isProjection }
+        #expect(firstProjection?.expensesCents == 100)
+        #expect(firstProjection?.adjustedExpensesCents == 100)
+        // Balance is flat 100k → income 333 ≥ 100, crossover on the first
+        // projected month.
+        #expect(result.crossoverMonth == utcDate(2026, 7, 1))
+    }
+
+    @Test func medianProjectionKeepsOutliers() {
+        let result = projectionResult(.median)
+        #expect(result.points.first { $0.isProjection }?.expensesCents == 105)
+    }
+
+    @Test func meanProjection() {
+        let result = projectionResult(.mean)
+        #expect(result.points.first { $0.isProjection }?.expensesCents == 433)
+        // Income stays at 333 with zero growth — mean expenses are never covered.
+        #expect(result.crossoverMonth == nil)
+        #expect(result.yearsToRetire == nil)
+    }
+
+    @Test func safeWithdrawalRateMath() {
+        let transactions = [tx(date: 20260110, amount: 100_000, account: "inv")]
+        let result = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"], safeWithdrawalRate: 0.12),
+            transactions: transactions, categories: categories,
+            accountIds: ["inv"], today: utcDate(2026, 3, 15)
+        )
+        // 0.12 / 12 = 1% monthly of a 100,000-cent balance.
+        #expect(result.lastKnownMonthlyIncomeCents == 1000)
+        #expect(result.points.first?.investmentIncomeCents == 1000)
+    }
+
+    @Test func expenseAdjustmentFactorScalesTarget() {
+        let transactions = [
+            tx(date: 20260110, amount: -1000, category: "food"),
+            tx(date: 20260210, amount: -1000, category: "food"),
+            tx(date: 20260310, amount: -1000, category: "food"),
+            tx(date: 20260115, amount: 100_000, account: "inv")
+        ]
+        let result = CrossoverEngine.compute(
+            meta: meta(
+                incomeAccountIds: ["inv"],
+                expectedContribution: 100_000,
+                expenseAdjustmentFactor: 0.5
+            ),
+            transactions: transactions, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 4, 15)
+        )
+        // Contribution pushes income to 667 in the first projected month,
+        // above the adjusted target of 1000 * 0.5 = 500.
+        let firstProjection = result.points.first { $0.isProjection }
+        #expect(firstProjection?.expensesCents == 1000)
+        #expect(firstProjection?.adjustedExpensesCents == 500)
+        #expect(result.targetMonthlyIncomeCents == 500)
+        // Target nest egg = target income / monthly SWR = 500 / (0.04/12).
+        #expect(result.targetNestEggCents == 150_000)
+        #expect(result.crossoverMonth == utcDate(2026, 4, 1))
+        #expect(result.yearsToRetire == 0)
+    }
+
+    @Test func crossoverDetectionAtKnownMonth() {
+        // Balance 100k + 50k/month contribution, zero growth, SWR 4%:
+        // income_i = (100000 + 50000 i) * 0.04/12 → 833 at i=3, 1000 at i=4.
+        // Flat expenses 999 → crossover on the 4th projected month (Jul 2026).
+        let transactions = [
+            tx(date: 20260110, amount: -999, category: "food"),
+            tx(date: 20260210, amount: -999, category: "food"),
+            tx(date: 20260310, amount: -999, category: "food"),
+            tx(date: 20260115, amount: 100_000, account: "inv")
+        ]
+        let result = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: ["inv"], expectedContribution: 50_000),
+            transactions: transactions, categories: categories,
+            accountIds: ["a1", "inv"], today: utcDate(2026, 4, 15)
+        )
+        #expect(result.crossoverMonth == utcDate(2026, 7, 1))
+        #expect(result.points.count == 3 + 4)  // Jan..Mar + 4 projected months
+        #expect(result.points.last?.isProjection == true)
+        #expect(result.yearsToRetire == 0.25)  // 3 months out
+        #expect(result.targetMonthlyIncomeCents == 999)
+        #expect(result.lastKnownMonthlyExpensesCents == 999)
+    }
+
+    @Test func emptyIncomeAccountsProducesEmptyData() {
+        let result = CrossoverEngine.compute(
+            meta: meta(incomeAccountIds: []),
+            transactions: [tx(date: 20260110, amount: -1000, category: "food")],
+            categories: categories, accountIds: [], today: utcDate(2026, 6, 15)
+        )
+        #expect(result == .empty)
+    }
+}

--- a/Actuali/ActualiTests/DashboardWidgetParserTests.swift
+++ b/Actuali/ActualiTests/DashboardWidgetParserTests.swift
@@ -79,14 +79,93 @@ struct DashboardWidgetParserTests {
     @Test func unknownTypeBecomesUnsupported() throws {
         let widget = DashboardWidget.parse(
             id: "w6",
-            type: "sankey-card",
-            metaJSON: #"{"name":"Money Flow"}"#
+            type: "future-card",
+            metaJSON: #"{"name":"From The Future"}"#
         )
         if case .unsupported(let id, let type) = widget {
             #expect(id == "w6")
-            #expect(type == "sankey-card")
+            #expect(type == "future-card")
         } else {
             Issue.record("Expected .unsupported")
+        }
+    }
+
+    @Test func parsesCalendarCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w10", type: "calendar-card",
+            metaJSON: #"{"name":"Calendar","timeFrame":{"mode":"sliding-window","start":"2026-04","end":"2026-05"}}"#
+        )
+        if case .calendar(let id, let meta) = widget {
+            #expect(id == "w10")
+            #expect(meta?.name == "Calendar")
+            #expect(meta?.timeFrame?.mode == .slidingWindow)
+        } else {
+            Issue.record("Expected .calendar")
+        }
+    }
+
+    @Test func parsesCrossoverCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w11", type: "crossover-card",
+            metaJSON: #"{"name":"FI","safeWithdrawalRate":0.04,"projectionType":"hampel"}"#
+        )
+        if case .crossover(let id, let meta) = widget {
+            #expect(id == "w11")
+            #expect(meta?.safeWithdrawalRate == 0.04)
+        } else {
+            Issue.record("Expected .crossover")
+        }
+    }
+
+    @Test func parsesBudgetAnalysisCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w12", type: "budget-analysis-card",
+            metaJSON: #"{"name":"Budget vs Actual","graphType":"Bar","showBalance":true}"#
+        )
+        if case .budgetAnalysis(let id, let meta) = widget {
+            #expect(id == "w12")
+            #expect(meta?.name == "Budget vs Actual")
+        } else {
+            Issue.record("Expected .budgetAnalysis")
+        }
+    }
+
+    @Test func parsesSankeyCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w13", type: "sankey-card",
+            metaJSON: #"{"name":"Money Flow","mode":"spent","topNcategories":5}"#
+        )
+        if case .sankey(let id, let meta) = widget {
+            #expect(id == "w13")
+            #expect(meta?.topNcategories == 5)
+        } else {
+            Issue.record("Expected .sankey")
+        }
+    }
+
+    @Test func parsesBalanceForecastCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w14", type: "balance-forecast-card",
+            metaJSON: #"{"name":"Forecast","granularity":"Monthly","source":"tracking-budget"}"#
+        )
+        if case .balanceForecast(let id, let meta) = widget {
+            #expect(id == "w14")
+            #expect(meta?.source == .trackingBudget)
+        } else {
+            Issue.record("Expected .balanceForecast")
+        }
+    }
+
+    @Test func parsesMonteCarloCard() throws {
+        let widget = DashboardWidget.parse(
+            id: "w15", type: "monte-carlo-card",
+            metaJSON: #"{"name":"Retirement","currentAge":40,"targetAge":90,"simulationCount":1000}"#
+        )
+        if case .monteCarlo(let id, let meta) = widget {
+            #expect(id == "w15")
+            #expect(meta?.currentAge == 40)
+        } else {
+            Issue.record("Expected .monteCarlo")
         }
     }
 

--- a/Actuali/ActualiTests/MonteCarloEngineTests.swift
+++ b/Actuali/ActualiTests/MonteCarloEngineTests.swift
@@ -1,0 +1,620 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Mirrors upstream monteCarloSimulation.test.ts. Deterministic (zero
+/// volatility) scenarios are hand-computable; seeded scenarios pin values
+/// computed with the upstream mulberry32/Box-Muller PRNG in node.
+struct MonteCarloEngineTests {
+
+    /// Upstream makePot: custom preset, mean 0.06, stdDev 0.1, balance 50M cents.
+    private func pot(
+        id: String = "pot-1",
+        balance: Double = 50_000_000,
+        mean: Double = 0.06,
+        stdDev: Double = 0.1,
+        accessAge: Double? = nil,
+        taxRate: Double = 0,
+        taxableFraction: Double = 1,
+        feeFixed: Double = 0,
+        feeRate: Double = 0,
+        preset: MonteCarloAllocationPreset = .custom
+    ) -> MonteCarloPot {
+        var pot = MonteCarloPot(id: id)
+        pot.startingBalance = balance
+        pot.allocationPreset = preset
+        pot.expectedReturnMean = mean
+        pot.returnStdDev = stdDev
+        pot.accessAge = accessAge
+        pot.withdrawalTaxRate = taxRate
+        pot.taxableFraction = taxableFraction
+        pot.annualFeeFixed = feeFixed
+        pot.annualFeeRate = feeRate
+        return pot
+    }
+
+    /// Upstream makeParams: single phase, no inflation, no tax bands,
+    /// horizon expressed via targetAge = 60 + horizonYears, 1000 sims.
+    private func config(
+        pots: [MonteCarloPot],
+        annualWithdrawal: Double = 2_000_000,
+        strategy: MonteCarloWithdrawalStrategy = .proportional,
+        returnModel: MonteCarloReturnModel = .normal,
+        rule: MonteCarloWithdrawalRule = MonteCarloWithdrawalRule(),
+        minimumWithdrawal: Double = 0,
+        phases: [MonteCarloSpendingPhase]? = nil,
+        inflationMean: Double? = nil,
+        inflationStdDev: Double = 0,
+        taxModel: MonteCarloTaxModel = .flat,
+        taxBands: [MonteCarloTaxBand] = [],
+        horizonYears: Double = 30
+    ) -> MonteCarloConfig {
+        var config = MonteCarloConfig()
+        config.pots = pots
+        config.withdrawalStrategy = strategy
+        config.returnModel = returnModel
+        config.withdrawalRule = rule
+        config.minimumWithdrawal = minimumWithdrawal
+        config.spendingPhases = phases ?? [MonteCarloSpendingPhase(id: "phase-1", fromAge: nil, annualWithdrawal: annualWithdrawal)]
+        config.inflationMean = inflationMean
+        config.inflationStdDev = inflationStdDev
+        config.taxModel = taxModel
+        config.taxBands = taxBands
+        config.currentAge = 60
+        config.targetAge = 60 + horizonYears
+        config.simulationCount = 1000
+        return config
+    }
+
+    /// In deterministic runs every simulation is identical, so the first
+    /// year whose median balance is zero is the depletion year.
+    private func firstDepletedYear(_ data: MonteCarloData) -> Int? {
+        data.percentileBands.first { $0.year >= 1 && $0.p50 == 0 }?.year
+    }
+
+    // MARK: PRNG parity with upstream
+
+    @Test func mulberry32MatchesUpstreamSequence() {
+        // First five uniforms of mulberry32(42) computed with the upstream
+        // JS implementation in node
+        var random = MonteCarloRandom(seed: 42)
+        let expected = [
+            0.60110375192016363, 0.44829055899754167, 0.85246579349040985,
+            0.66973404143936932, 0.17481389874592423
+        ]
+        for value in expected {
+            #expect(random.next() == value)
+        }
+    }
+
+    @Test func boxMullerMatchesUpstreamSequence() {
+        // First four normals of makeNormalSampler(mulberry32(42)) in node
+        var random = MonteCarloRandom(seed: 42)
+        let expected = [
+            -1.2848381576290195, -0.94535280997472959,
+            -0.61128028465146289, -0.56583258521268753
+        ]
+        for value in expected {
+            #expect(random.nextNormal() == value)
+        }
+    }
+
+    @Test func seededRunMatchesUpstreamReplica() {
+        // Pinned from a node replica of the upstream engine's exact
+        // random-call order for this config (seed 42, 1000 sims x 30 years,
+        // single custom pot 50M, withdrawal 2M, mean 0.06, sd 0.1)
+        let result = MonteCarloEngine.simulate(config: config(pots: [pot()]), seed: 42)
+        #expect(result.successRate == 0.971)
+        #expect(result.percentileBands[1].p50 == 51_097_236)
+        #expect(result.percentileBands[1].p10 == 44_738_562)
+        #expect(result.percentileBands[1].p90 == 57_505_924)
+        #expect(result.percentileBands[30].p50 == 95_582_181)
+    }
+
+    // MARK: Horizon derivation
+
+    @Test func horizonDerivedFromAgesAndClamped() {
+        #expect(MonteCarloEngine.horizonYears(currentAge: 60, targetAge: 90) == 30)
+        #expect(MonteCarloEngine.horizonYears(currentAge: 62.4, targetAge: 90) == 28)
+        #expect(MonteCarloEngine.horizonYears(currentAge: 90, targetAge: 60) == 1)
+        #expect(MonteCarloEngine.horizonYears(currentAge: 70, targetAge: 70) == 1)
+        #expect(MonteCarloEngine.horizonYears(currentAge: 0, targetAge: 500) == 100)
+    }
+
+    // MARK: Deterministic closed-form scenarios
+
+    @Test func closedFormDepletionWithZeroVolatility() {
+        // Pot 1.2M cents, flat 0% return, withdraw 100k/yr: 12 full years,
+        // hits exactly zero (and fails) in year 12
+        let result = MonteCarloEngine.simulate(
+            config: config(pots: [pot(balance: 1_200_000, mean: 0, stdDev: 0)], annualWithdrawal: 100_000),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 12)
+        #expect(result.percentileBands[11].p50 == 100_000)
+        #expect(result.percentileBands[0].p50 == 1_200_000)
+    }
+
+    @Test func survivesWhenReturnsOutpaceWithdrawals() {
+        let result = MonteCarloEngine.simulate(
+            config: config(pots: [pot(balance: 100_000, mean: 0.05, stdDev: 0)], annualWithdrawal: 3_000),
+            seed: 42
+        )
+        #expect(result.successRate == 1)
+        #expect(firstDepletedYear(result) == nil)
+        #expect(result.percentileBands[30].p50 > 100_000)
+    }
+
+    @Test func alwaysSucceedsWithNoWithdrawals() {
+        let result = MonteCarloEngine.simulate(
+            config: config(pots: [pot(stdDev: 0.2)], annualWithdrawal: 0),
+            seed: 42
+        )
+        #expect(result.successRate == 1)
+    }
+
+    @Test func depletesInYearOneWhenWithdrawalExceedsPot() {
+        let result = MonteCarloEngine.simulate(
+            config: config(pots: [pot(balance: 10_000)], annualWithdrawal: 20_000),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 1)
+    }
+
+    @Test func inflationGrowsWithdrawals() {
+        // pot 200, withdrawal 50, no growth, 100% inflation:
+        // y1: 200-50=150 (w -> 100); y2: 150-100=50 (w -> 200); y3: depleted
+        let inflated = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 200, mean: 0, stdDev: 0)],
+                annualWithdrawal: 50, inflationMean: 1, horizonYears: 10
+            ),
+            seed: 42
+        )
+        #expect(firstDepletedYear(inflated) == 3)
+
+        // Flat withdrawals last one year longer: y4 hits exactly 0
+        let flat = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 200, mean: 0, stdDev: 0)],
+                annualWithdrawal: 50, inflationMean: nil, horizonYears: 10
+            ),
+            seed: 42
+        )
+        #expect(firstDepletedYear(flat) == 4)
+    }
+
+    @Test func spendingPhasesSwitchAtStartingAge() {
+        // Ages 60-64 spend 10k (years 1-5), from 65 spend 20k
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 1_000_000, mean: 0, stdDev: 0)],
+                phases: [
+                    MonteCarloSpendingPhase(id: "phase-1", fromAge: nil, annualWithdrawal: 10_000),
+                    MonteCarloSpendingPhase(id: "phase-2", fromAge: 65, annualWithdrawal: 20_000)
+                ],
+                horizonYears: 13
+            ),
+            seed: 42
+        )
+        #expect(result.percentileBands[5].p50 == 950_000)
+        #expect(result.percentileBands[6].p50 == 930_000)
+        #expect(result.percentileBands[13].p50 == 1_000_000 - 5 * 10_000 - 8 * 20_000)
+    }
+
+    // MARK: Withdrawal rules
+
+    @Test func boundariesCutWithdrawalsAndExtendSurvival() {
+        // 10% withdrawal rate on a flat pot depletes in exactly year 10
+        let base = config(
+            pots: [pot(balance: 100_000, mean: 0, stdDev: 0)],
+            annualWithdrawal: 10_000
+        )
+        let withoutRule = MonteCarloEngine.simulate(config: base, seed: 42)
+        #expect(firstDepletedYear(withoutRule) == 10)
+
+        var rule = MonteCarloWithdrawalRule()
+        rule.type = .boundaries
+        var withRuleConfig = base
+        withRuleConfig.withdrawalRule = rule
+        let withRule = MonteCarloEngine.simulate(config: withRuleConfig, seed: 42)
+        #expect((firstDepletedYear(withRule) ?? Int.max) > 10)
+    }
+
+    @Test func floorCeilingScalesWithdrawalsWithinLimits() {
+        var rule = MonteCarloWithdrawalRule()
+        rule.type = .floorCeiling
+        rule.floorPct = 0.5
+        rule.ceilingPct = 0.5
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 100_000, mean: 0, stdDev: 0)],
+                annualWithdrawal: 10_000, rule: rule
+            ),
+            seed: 42
+        )
+        #expect((firstDepletedYear(result) ?? Int.max) > 14)
+    }
+
+    @Test func guardrailsRaiseWithdrawalsWhenPotRacesAhead() {
+        // 4% initial rate with steady 20% growth triggers prosperity raises;
+        // the extra income leaves a lower ending balance than no rule
+        let base = config(
+            pots: [pot(balance: 100_000, mean: 0.2, stdDev: 0)],
+            annualWithdrawal: 4_000, horizonYears: 20
+        )
+        let withoutRule = MonteCarloEngine.simulate(config: base, seed: 42)
+        var rule = MonteCarloWithdrawalRule()
+        rule.type = .guardrails
+        var withRuleConfig = base
+        withRuleConfig.withdrawalRule = rule
+        let withRule = MonteCarloEngine.simulate(config: withRuleConfig, seed: 42)
+
+        #expect(withRule.successRate == 1)
+        #expect(withRule.percentileBands[20].p50 < withoutRule.percentileBands[20].p50)
+    }
+
+    @Test func ratchetingIncreasesWithdrawalsAfterConsecutiveYears() {
+        let base = config(
+            pots: [pot(balance: 100_000, mean: 0.3, stdDev: 0)],
+            annualWithdrawal: 1_000, horizonYears: 20
+        )
+        let withoutRule = MonteCarloEngine.simulate(config: base, seed: 42)
+        var rule = MonteCarloWithdrawalRule()
+        rule.type = .ratcheting
+        rule.balanceThresholdMultiple = 1.5
+        rule.consecutiveYears = 3
+        rule.ratchetIncreasePct = 0.5
+        var withRuleConfig = base
+        withRuleConfig.withdrawalRule = rule
+        let withRule = MonteCarloEngine.simulate(config: withRuleConfig, seed: 42)
+
+        #expect(withRule.percentileBands[20].p50 < withoutRule.percentileBands[20].p50)
+    }
+
+    @Test func minimumWithdrawalFloorNeutralizesRuleCuts() {
+        let base = config(
+            pots: [pot(balance: 100_000, mean: 0, stdDev: 0)],
+            annualWithdrawal: 10_000
+        )
+        let withoutRule = MonteCarloEngine.simulate(config: base, seed: 42)
+
+        var rule = MonteCarloWithdrawalRule()
+        rule.type = .boundaries
+        var flooredConfig = base
+        flooredConfig.withdrawalRule = rule
+        flooredConfig.minimumWithdrawal = 10_000
+        let cutsFloored = MonteCarloEngine.simulate(config: flooredConfig, seed: 42)
+
+        #expect(cutsFloored.percentileBands == withoutRule.percentileBands)
+    }
+
+    @Test func minimumWithdrawalIgnoredWithoutActiveRule() {
+        // Upstream: with no rule the planned spending is taken as-is
+        let base = config(
+            pots: [pot(balance: 100_000, mean: 0, stdDev: 0)],
+            annualWithdrawal: 5_000
+        )
+        var flooredConfig = base
+        flooredConfig.minimumWithdrawal = 50_000
+        let result = MonteCarloEngine.simulate(config: flooredConfig, seed: 42)
+        let baseline = MonteCarloEngine.simulate(config: base, seed: 42)
+        #expect(result.percentileBands == baseline.percentileBands)
+    }
+
+    // MARK: Access ages
+
+    @Test func failsWhenAccessiblePotsRunDryBeforeLockedPotUnlocks() {
+        // Accessible 100 funds 30/year: y1 70, y2 40, y3 10, year 4 fails;
+        // the pot locked until age 120 doesn't save the plan
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [
+                    pot(id: "isa", balance: 100, mean: 0, stdDev: 0),
+                    pot(id: "pension", balance: 1_000, mean: 0, stdDev: 0, accessAge: 120)
+                ],
+                annualWithdrawal: 30, horizonYears: 20
+            ),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 4)
+    }
+
+    @Test func survivesWhenLockedPotUnlocksInTime() {
+        // Same setup, but the pension unlocks at 63 - exactly year 4
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [
+                    pot(id: "isa", balance: 100, mean: 0, stdDev: 0),
+                    pot(id: "pension", balance: 1_000, mean: 0, stdDev: 0, accessAge: 63)
+                ],
+                annualWithdrawal: 30, horizonYears: 20
+            ),
+            seed: 42
+        )
+        #expect(result.successRate == 1)
+    }
+
+    @Test func accessAgeAtOrBelowCurrentAgeIsImmediate() {
+        let immediate = MonteCarloEngine.simulate(config: config(pots: [pot(accessAge: nil)]), seed: 42)
+        let alreadyReached = MonteCarloEngine.simulate(config: config(pots: [pot(accessAge: 40)]), seed: 42)
+        #expect(immediate == alreadyReached)
+    }
+
+    @Test func sequentialOrderSkipsLockedPotsUntilTheyUnlock() {
+        // First-listed pot locked past the horizon, so sequential drains the
+        // second pot: 100 at 10/year fails in year 10
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [
+                    pot(id: "locked", balance: 1_000, mean: 0, stdDev: 0, accessAge: 200),
+                    pot(id: "open", balance: 100, mean: 0, stdDev: 0)
+                ],
+                annualWithdrawal: 10, strategy: .sequential, horizonYears: 20
+            ),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 10)
+    }
+
+    // MARK: Tax
+
+    @Test func flatTaxGrossesUpWithdrawals() {
+        // 20% tax pot: delivering 8,000 net costs 10,000 gross each year, so
+        // 95,000 funds nine full years and fails in year ten
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 95_000, mean: 0, stdDev: 0, taxRate: 0.2)],
+                annualWithdrawal: 8_000, horizonYears: 12
+            ),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 10)
+        #expect(result.percentileBands[9].p50 == 5_000)
+    }
+
+    @Test func taxBandsGrossUpProgressively() {
+        // Bands: first 10,000 tax-free, 20% above. Delivering 18,000 net
+        // needs 20,000 gross each year
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 200_000, mean: 0, stdDev: 0)],
+                annualWithdrawal: 18_000,
+                taxModel: .bands,
+                taxBands: [
+                    MonteCarloTaxBand(id: "a", from: 0, rate: 0),
+                    MonteCarloTaxBand(id: "b", from: 10_000, rate: 0.2)
+                ],
+                horizonYears: 3
+            ),
+            seed: 42
+        )
+        #expect(result.percentileBands[1].p50 == 180_000)
+        #expect(result.percentileBands[2].p50 == 160_000)
+        #expect(result.percentileBands[3].p50 == 140_000)
+    }
+
+    @Test func taxBandsPoolTaxableIncomeAcrossPots() {
+        // Proportional split takes half the gross from each pot; only the
+        // pension half is 75% taxable, so taxable income is 0.375x gross.
+        // Solving 0.925g = 38,000 gives g = 41,081.08 for 40,000 net
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [
+                    pot(id: "isa", balance: 100_000, mean: 0, stdDev: 0, taxableFraction: 0),
+                    pot(id: "pension", balance: 100_000, mean: 0, stdDev: 0, taxableFraction: 0.75)
+                ],
+                annualWithdrawal: 40_000,
+                taxModel: .bands,
+                taxBands: [
+                    MonteCarloTaxBand(id: "a", from: 0, rate: 0),
+                    MonteCarloTaxBand(id: "b", from: 10_000, rate: 0.2)
+                ],
+                horizonYears: 1
+            ),
+            seed: 42
+        )
+        // 200,000 - 41,081.081... = 158,918.92 rounds to 158,919
+        #expect(result.percentileBands[1].p50 == 158_919)
+    }
+
+    @Test func singleTaxBandBehavesLikeFlatRate() {
+        let flat = MonteCarloEngine.simulate(
+            config: config(pots: [pot(taxRate: 0.25)]),
+            seed: 42
+        )
+        let bands = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(taxableFraction: 1)],
+                taxModel: .bands,
+                taxBands: [MonteCarloTaxBand(id: "a", from: 0, rate: 0.25)]
+            ),
+            seed: 42
+        )
+        #expect(bands.successRate == flat.successRate)
+        #expect(abs(bands.percentileBands[30].p50 - flat.percentileBands[30].p50) <= 1)
+    }
+
+    @Test func zeroRateTaxMatchesUntaxedEngineExactly() {
+        let untaxed = MonteCarloEngine.simulate(config: config(pots: [pot()]), seed: 42)
+        let zeroBands = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot()],
+                taxModel: .bands,
+                taxBands: [MonteCarloTaxBand(id: "a", from: 0, rate: 0)]
+            ),
+            seed: 42
+        )
+        #expect(zeroBands.percentileBands == untaxed.percentileBands)
+        #expect(zeroBands.successRate == untaxed.successRate)
+    }
+
+    // MARK: Fees
+
+    @Test func fixedFeeDeductedAtYearEnd() {
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 100_000, mean: 0, stdDev: 0, feeFixed: 1_000)],
+                annualWithdrawal: 0, horizonYears: 5
+            ),
+            seed: 42
+        )
+        #expect(result.percentileBands[1].p50 == 99_000)
+        #expect(result.percentileBands[2].p50 == 98_000)
+    }
+
+    @Test func percentageFeeDeductedFromEndOfYearBalance() {
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 100_000, mean: 0, stdDev: 0, feeRate: 0.01)],
+                annualWithdrawal: 0, horizonYears: 5
+            ),
+            seed: 42
+        )
+        #expect(result.percentileBands[1].p50 == 99_000)
+        #expect(result.percentileBands[2].p50 == 98_010)
+    }
+
+    @Test func feesAloneCanDepleteAPlan() {
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 10_000, mean: 0, stdDev: 0, feeFixed: 5_000)],
+                annualWithdrawal: 0, horizonYears: 10
+            ),
+            seed: 42
+        )
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 2)
+    }
+
+    // MARK: Historical models
+
+    @Test func bootstrapWithOneYearHistoryIsDeterministic() {
+        // A single history year means every bootstrap draw returns it; an
+        // equity-60 pot earns the blended 0.6*0.1 + 0.4*0.1 = 10% every year
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(balance: 100_000, mean: 0, stdDev: 0, preset: .equity60)],
+                annualWithdrawal: 10_000,
+                returnModel: .historicalBootstrap,
+                horizonYears: 5
+            ),
+            seed: 42,
+            historicalReturns: [MonteCarloHistoricalReturn(year: 2000, stocks: 0.1, bonds: 0.1, cash: 0.1)]
+        )
+        // (100,000 - 10,000) * 1.1 = 99,000; (99,000 - 10,000) * 1.1 = 97,900
+        #expect(result.percentileBands[1].p50 == 99_000)
+        #expect(result.percentileBands[2].p50 == 97_900)
+    }
+
+    @Test func sequenceModeRunsOneScenarioPerStartYear() {
+        let history = [
+            MonteCarloHistoricalReturn(year: 2000, stocks: 0.1, bonds: 0.1, cash: 0.1),
+            MonteCarloHistoricalReturn(year: 2001, stocks: -0.2, bonds: -0.2, cash: -0.2),
+            MonteCarloHistoricalReturn(year: 2002, stocks: 0.05, bonds: 0.05, cash: 0.05)
+        ]
+        let result = MonteCarloEngine.simulate(
+            config: config(
+                pots: [pot(preset: .equity60)],
+                returnModel: .historicalSequence,
+                horizonYears: 10
+            ),
+            seed: 42,
+            historicalReturns: history
+        )
+        #expect(result.simulationCount == history.count)
+    }
+
+    // MARK: Determinism and statistics
+
+    @Test func deterministicForAGivenSeed() {
+        let firstRun = MonteCarloEngine.simulate(config: config(pots: [pot()]), seed: 7)
+        let secondRun = MonteCarloEngine.simulate(config: config(pots: [pot()]), seed: 7)
+        #expect(firstRun == secondRun)
+
+        let differentSeed = MonteCarloEngine.simulate(config: config(pots: [pot()]), seed: 8)
+        #expect(differentSeed.percentileBands != firstRun.percentileBands)
+    }
+
+    @Test func producesOrderedPercentileBands() {
+        let result = MonteCarloEngine.simulate(config: config(pots: [pot(stdDev: 0.15)]), seed: 42)
+        for band in result.percentileBands {
+            #expect(band.p5 <= band.p10)
+            #expect(band.p10 <= band.p25)
+            #expect(band.p25 <= band.p30)
+            #expect(band.p30 <= band.p50)
+            #expect(band.p50 <= band.p70)
+            #expect(band.p70 <= band.p75)
+            #expect(band.p75 <= band.p90)
+        }
+        #expect(result.percentileBands.count == result.horizonYears + 1)
+        #expect(result.percentileBands[0].p10 == 50_000_000)
+        #expect(result.percentileBands[0].p90 == 50_000_000)
+    }
+
+    // MARK: Meta decoding and account resolution
+
+    @Test func metaDistinguishesNullInflationFromAbsent() throws {
+        let explicitNull = try JSONDecoder().decode(
+            MonteCarloMeta.self,
+            from: Data(#"{"inflationMean": null}"#.utf8)
+        )
+        #expect(MonteCarloEngine.config(from: explicitNull).inflationMean == nil)
+
+        let absent = try JSONDecoder().decode(MonteCarloMeta.self, from: Data("{}".utf8))
+        #expect(MonteCarloEngine.config(from: absent).inflationMean == 0.025)
+    }
+
+    @Test func configFromMetaAppliesUpstreamDefaults() throws {
+        let meta = try JSONDecoder().decode(
+            MonteCarloMeta.self,
+            from: Data(#"{"pots":[{"id":"p1","startingBalance":123}],"withdrawalStrategy":"best-performer","returnModel":"historical-bootstrap","currentAge":55,"targetAge":85}"#.utf8)
+        )
+        let config = MonteCarloEngine.config(from: meta)
+        #expect(config.pots.count == 1)
+        #expect(config.pots[0].startingBalance == 123)
+        #expect(config.pots[0].allocationPreset == .equity60)
+        #expect(config.pots[0].taxableFraction == 1)
+        #expect(config.withdrawalStrategy == .bestPerformer)
+        #expect(config.returnModel == .historicalBootstrap)
+        #expect(config.withdrawalRule.type == .none)
+        #expect(config.currentAge == 55)
+        #expect(config.targetAge == 85)
+        #expect(config.simulationCount == 5000)
+    }
+
+    @Test func computeResolvesAccountLinkedPotBalances() throws {
+        // A pot linked to an account takes the account's live balance
+        // (clamped at zero); unlinked pots keep their stored balance
+        let meta = MonteCarloMeta(
+            pots: [
+                MonteCarloPotMeta(
+                    id: "p1", name: nil, startingBalance: 1_200_000, allocationPreset: "custom",
+                    expectedReturnMean: 0, returnStdDev: 0, accessAge: nil, accountId: "acct-1",
+                    withdrawalTaxRate: nil, taxableFraction: nil, annualFeeFixed: nil,
+                    feeAdjustsWithInflation: nil, annualFeeRate: nil
+                )
+            ],
+            spendingPhases: [MonteCarloSpendingPhaseMeta(id: "s1", name: nil, fromAge: nil, annualWithdrawal: 100_000)],
+            inflationMean: .some(nil),
+            currentAge: 60,
+            targetAge: 90
+        )
+        // 600k cents from the account instead of the stored 1.2M: depletes
+        // in year 6 instead of year 12
+        let result = MonteCarloEngine.compute(meta: meta, accountBalances: ["acct-1": 600_000])
+        #expect(result.successRate == 0)
+        #expect(firstDepletedYear(result) == 6)
+
+        let negative = MonteCarloEngine.compute(meta: meta, accountBalances: ["acct-1": -500])
+        #expect(negative.percentileBands[0].p50 == 0)
+
+        let unresolved = MonteCarloEngine.compute(meta: meta)
+        #expect(firstDepletedYear(unresolved) == 12)
+    }
+}

--- a/Actuali/ActualiTests/SankeyEngineTests.swift
+++ b/Actuali/ActualiTests/SankeyEngineTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Scenarios ported from upstream sankey-spreadsheet.test.ts, plus
+/// engine-level compute coverage.
+struct SankeyEngineTests {
+
+    // 2024-01-15 UTC, so the default (nil) time frame is 2024-01.
+    private var asOf: Date {
+        var c = DateComponents(); c.year = 2024; c.month = 1; c.day = 15
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func tx(
+        date: Int, amount: Int, account: String = "a_checking",
+        category: String? = nil, payeeId: String? = nil, payeeName: String? = nil
+    ) -> Transaction {
+        Transaction(
+            id: UUID().uuidString,
+            accountId: account, date: date, amount: amount,
+            payeeId: payeeId, payeeName: payeeName,
+            categoryId: category, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: false, parentId: nil,
+            tombstone: false, sortOrder: nil, importedPayee: nil
+        )
+    }
+
+    private var groups: [CategoryGroup] {
+        [
+            CategoryGroup(id: "g_income", name: "Income", isIncome: true, hidden: false, sortOrder: 0, categories: [
+                Category(id: "c_salary", name: "Salary", groupId: "g_income", isIncome: true, hidden: false, sortOrder: 0)
+            ]),
+            CategoryGroup(id: "g_food", name: "Food", isIncome: false, hidden: false, sortOrder: 1, categories: [
+                Category(id: "c_groceries", name: "Groceries", groupId: "g_food", isIncome: false, hidden: false, sortOrder: 0),
+                Category(id: "c_restaurants", name: "Restaurants", groupId: "g_food", isIncome: false, hidden: false, sortOrder: 1),
+                Category(id: "c_coffee", name: "Coffee", groupId: "g_food", isIncome: false, hidden: false, sortOrder: 2)
+            ])
+        ]
+    }
+
+    private var context: ConditionsFilter.Context {
+        ConditionsFilter.Context(
+            offBudgetAccountIds: [],
+            accountNames: ["a_checking": "Checking", "a_savings": "Savings"]
+        )
+    }
+
+    private func meta(
+        mode: String? = nil, topN: Int? = nil, sort: String? = nil,
+        groupAccounts: Bool? = nil, layerFrom: String? = nil, layerTo: String? = nil
+    ) -> SankeyMeta {
+        SankeyMeta(
+            name: nil, conditions: nil, conditionsOp: nil, timeFrame: nil,
+            mode: mode, topNcategories: topN, categorySort: sort,
+            showPercentages: nil, groupAccounts: groupAccounts,
+            layerFrom: layerFrom, layerTo: layerTo
+        )
+    }
+
+    private func node(_ data: SankeyData, key: String) -> SankeyData.Node? {
+        data.nodes.first { $0.key == key }
+    }
+
+    private func linkValue(_ data: SankeyData, from: String, to: String) -> Int? {
+        guard let s = data.nodes.firstIndex(where: { $0.key == from }),
+              let t = data.nodes.firstIndex(where: { $0.key == to }) else { return nil }
+        return data.links.first { $0.source == s && $0.target == t }?.value
+    }
+
+    // MARK: - Graph primitives (upstream test ports)
+
+    @Test func getLayerReturnsDepth() {
+        var graph = SankeyGraph()
+        graph.addNode("root", type: .account, name: "Root")
+        graph.addNode("child", type: .category, name: "Child")
+        graph.addNode("grandchild", type: .category, name: "Grandchild")
+        graph.addValueToLink(from: "root", to: "child", value: 100)
+        graph.addValueToLink(from: "child", to: "grandchild", value: 50)
+
+        #expect(SankeyEngine.getLayer(graph, "root") == 0)
+        #expect(SankeyEngine.getLayer(graph, "child") == 1)
+        #expect(SankeyEngine.getLayer(graph, "grandchild") == 2)
+    }
+
+    @Test func getNodeValueSumsOutgoingForRootsIncomingOtherwise() {
+        var graph = SankeyGraph()
+        graph.addNode("root", type: .account, name: "Root")
+        graph.addNode("child", type: .category, name: "Child")
+        graph.addValueToLink(from: "root", to: "child", value: 150)
+        graph.addValueToLink(from: "root", to: "other-child", value: 200)
+
+        #expect(SankeyEngine.getNodeValue(graph, "root") == 350)
+        #expect(SankeyEngine.getNodeValue(graph, "child") == 150)
+    }
+
+    @Test func linkValuesAccumulate() {
+        var graph = SankeyGraph()
+        graph.addNode("source", type: .category, name: "Source")
+        graph.addNode("target", type: .category, name: "Target")
+        graph.addValueToLink(from: "source", to: "target", value: 100)
+        graph.addValueToLink(from: "source", to: "target", value: 50)
+
+        #expect(graph["source"]?.toValues["target"] == 150)
+    }
+
+    @Test func sortGraphGlobalSortsByValueDescending() {
+        var graph = SankeyGraph()
+        graph.addNode("node1", type: .category, name: "Node 1")
+        graph.addNode("node2", type: .category, name: "Node 2")
+        graph.addNode("node3", type: .category, name: "Node 3")
+        graph.addValueToLink(from: "node1", to: "target", value: 100)
+        graph.addValueToLink(from: "node2", to: "target", value: 300)
+        graph.addValueToLink(from: "node3", to: "target", value: 200)
+
+        SankeyEngine.sortGraph(&graph, categorySort: .global, categoryGroups: [])
+
+        #expect(graph.keys == ["node2", "node3", "node1"])
+    }
+
+    @Test func sortGraphPerGroupSortsPayeesAroundIncomeCategories() {
+        var graph = SankeyGraph()
+        graph.addNode("payee1", type: .incomePayee, name: "Payee 1")
+        graph.addNode("payee2", type: .incomePayee, name: "Payee 2")
+        graph.addNode("payee3", type: .incomePayee, name: "Payee 3")
+        graph.addNode("income1", type: .incomeCategory, name: "Income 1")
+        graph.addNode("income2", type: .incomeCategory, name: "Income 2")
+        graph.addNode("account1", type: .account, name: "Account 1")
+        graph.addValueToLink(from: "payee1", to: "income1", value: 300)
+        graph.addValueToLink(from: "payee2", to: "income2", value: 200)
+        graph.addValueToLink(from: "payee3", to: "income2", value: 200)
+        graph.addValueToLink(from: "income1", to: "account1", value: 300)
+        graph.addValueToLink(from: "income2", to: "account1", value: 400)
+
+        SankeyEngine.sortGraph(&graph, categorySort: .perGroup, categoryGroups: [])
+        let keys = graph.keys
+
+        let payee1Index = keys.firstIndex(of: "payee1")!
+        #expect(keys.firstIndex(of: "payee2")! < payee1Index)
+        #expect(keys.firstIndex(of: "payee3")! < payee1Index)
+    }
+
+    @Test func sortGraphBudgetOrderFollowsCategoryList() {
+        var graph = SankeyGraph()
+        graph.addNode("c_groceries", type: .category, name: "Groceries")
+        graph.addNode("g_food", type: .categoryGroup, name: "Food")
+        graph.addValueToLink(from: "g_food", to: "c_groceries", value: 100)
+
+        SankeyEngine.sortGraph(&graph, categorySort: .budgetOrder, categoryGroups: groups)
+        let keys = graph.keys
+
+        #expect(keys.firstIndex(of: "g_food")! < keys.firstIndex(of: "c_groceries")!)
+    }
+
+    @Test func addPercentageLabelsNormalizesPerLayer() {
+        var graph = SankeyGraph()
+        graph.addNode("node1", type: .category, name: "Node 1")
+        graph.addNode("node2", type: .category, name: "Node 2")
+        graph.addValueToLink(from: "node1", to: "target", value: 250)
+        graph.addValueToLink(from: "node2", to: "target", value: 750)
+
+        SankeyEngine.addPercentageLabels(&graph)
+
+        #expect(graph["node1"]?.percentageLabel == "25.0%")
+        #expect(graph["node2"]?.percentageLabel == "75.0%")
+    }
+
+    @Test func addPercentageLabelsUsesGraphLayerNotDepth() {
+        var graph = SankeyGraph()
+        graph.addNode("payee", type: .incomePayee, name: "Payee")
+        graph.addNode("income-cat", type: .incomeCategory, name: "Income Cat")
+        graph.addNode("account-incoming", type: .account, name: "Account A")
+        graph.addNode("account-root", type: .account, name: "Account B")
+        graph.addNode("group", type: .categoryGroup, name: "Group")
+        graph.addValueToLink(from: "payee", to: "income-cat", value: 300)
+        graph.addValueToLink(from: "income-cat", to: "account-incoming", value: 300)
+        graph.addValueToLink(from: "account-root", to: "group", value: 100)
+
+        SankeyEngine.addPercentageLabels(&graph)
+
+        #expect(graph["account-root"]?.percentageLabel == "25.0%")
+        #expect(graph["account-incoming"]?.percentageLabel == "75.0%")
+    }
+
+    @Test func filterGraphByLayersKeepsRange() {
+        var graph = SankeyGraph()
+        graph.addNode("payee1", type: .incomePayee, name: "Payee 1")
+        graph.addNode("cat1", type: .incomeCategory, name: "Income Cat 1")
+        graph.addNode("acc1", type: .account, name: "Account 1")
+        graph.addNode("budget", type: .budget, name: "Budgeted")
+        graph.addNode("group1", type: .categoryGroup, name: "Group 1")
+        graph.addNode("cat2", type: .category, name: "Category 2")
+
+        SankeyEngine.filterGraphByLayers(&graph, from: .account, to: .categoryGroup)
+
+        #expect(graph["payee1"] == nil)
+        #expect(graph["cat1"] == nil)
+        #expect(graph["acc1"] != nil)
+        #expect(graph["budget"] != nil)
+        #expect(graph["group1"] != nil)
+        #expect(graph["cat2"] == nil)
+    }
+
+    @Test func cleanUpNodesRemovesOrphansAndZeroLinks() {
+        var graph = SankeyGraph()
+        graph.addNode("used1", type: .category, name: "Used 1")
+        graph.addNode("used2", type: .category, name: "Used 2")
+        graph.addNode("orphan", type: .category, name: "Orphan")
+        graph.addValueToLink(from: "used1", to: "used2", value: 100)
+
+        SankeyEngine.cleanUpNodes(&graph)
+        #expect(graph["used1"] != nil)
+        #expect(graph["used2"] != nil)
+        #expect(graph["orphan"] == nil)
+
+        var zeroed = SankeyGraph()
+        zeroed.addNode("node1", type: .category, name: "Node 1")
+        zeroed.addNode("node2", type: .category, name: "Node 2")
+        zeroed.addValueToLink(from: "node1", to: "node2", value: 0)
+
+        SankeyEngine.cleanUpNodes(&zeroed)
+        #expect(zeroed["node1"] == nil)
+        #expect(zeroed["node2"] == nil)
+    }
+
+    @Test func buildSankeyDataAddsHiddenChildChain() {
+        var graph = SankeyGraph()
+        graph.addNode("account", type: .account, name: "Account")
+        graph.addNode("group-with-child", type: .categoryGroup, name: "Group A")
+        graph.addNode("category", type: .category, name: "Category A")
+        graph.addValueToLink(from: "account", to: "group-with-child", value: 100)
+        graph.addValueToLink(from: "group-with-child", to: "category", value: 100)
+        graph.addNode("group-no-child", type: .categoryGroup, name: "Group B")
+        graph.addValueToLink(from: "account", to: "group-no-child", value: 50)
+
+        let data = SankeyEngine.buildSankeyData(
+            graph, topN: 100, categoryGroups: [], categorySort: .global,
+            layerFrom: .account, layerTo: .category
+        )
+
+        let keys = data.nodes.map(\.key)
+        #expect(keys.contains("group-no-child_category__HIDDEN"))
+        #expect(!keys.contains("group-no-child_category_group__HIDDEN"))
+    }
+
+    @Test func convertToSankeyDataBasics() {
+        var graph = SankeyGraph()
+        graph.addNode("node1", type: .category, name: "Node 1")
+        graph.addNode("node2", type: .category, name: "Node 2")
+        graph.addValueToLink(from: "node1", to: "node2", value: 100)
+        graph.nodes["node1"]?.percentageLabel = "100.0%"
+
+        let data = SankeyEngine.convertToSankeyData(graph)
+
+        #expect(data.nodes.count == 2)
+        #expect(data.links == [SankeyData.Link(source: 0, target: 1, value: 100)])
+        #expect(data.nodes[0].percentageLabel == "100.0%")
+        #expect(data.nodes[1].percentageLabel == "")
+    }
+
+    @Test func createBudgetGraphBuildsEnvelopeNodes() {
+        let entries = [
+            SankeyCategoryEntry(categoryGroup: "Income", categoryGroupId: "g_income",
+                                category: "Salary", categoryId: "c_salary",
+                                value: 5000, isIncome: true, isNegative: false),
+            SankeyCategoryEntry(categoryGroup: "Food", categoryGroupId: "g_food",
+                                category: "Groceries", categoryId: "c_groceries",
+                                value: 500, isIncome: false, isNegative: false)
+        ]
+        let input = SankeyBudgetInput(entries: [], toBudgetCents: 1000,
+                                      fromPreviousMonthCents: 200,
+                                      lastMonthOverspentCents: 0, forNextMonthCents: 300)
+
+        let graph = SankeyEngine.createBudgetGraph(entries, budget: input, startMonth: "2024-01", endMonth: "2024-01")
+
+        #expect(graph["c_salary"] != nil)
+        #expect(graph["c_groceries"] != nil)
+        #expect(graph["budgeted"] != nil)
+        #expect(graph["available_income"] != nil)
+        #expect(graph["to_budget"] != nil)
+        #expect(graph["from_previous_month"]?.name == "From 2023-12")
+        #expect(graph["for_next_month"]?.name == "For 2024-02")
+    }
+
+    @Test func createBudgetGraphMarksOverbudgeted() {
+        let input = SankeyBudgetInput(entries: [], toBudgetCents: -500)
+        let graph = SankeyEngine.createBudgetGraph([], budget: input, startMonth: "2024-01", endMonth: "2024-01")
+
+        #expect(graph["to_budget"]?.isNegative == true)
+        #expect(graph["to_budget"]?.name == "Overbudgeted")
+        #expect(graph["to_budget"]?.toValues["budgeted"] == 500)
+    }
+
+    @Test func createTransactionsGraphBuildsNodes() {
+        let entries = [
+            SankeyCategoryEntry(categoryGroup: "Food", categoryGroupId: "g_food",
+                                category: "Groceries", categoryId: "c_groceries",
+                                value: 100, isIncome: false, isNegative: true,
+                                accountName: "Checking", accountId: "a_checking"),
+            SankeyCategoryEntry(categoryGroup: "Income", categoryGroupId: "g_income",
+                                category: "Salary", categoryId: "c_salary",
+                                value: 5000, isIncome: true, isNegative: false,
+                                accountName: "Checking", accountId: "a_checking",
+                                payeeName: "Employer", payeeId: "p_employer")
+        ]
+
+        let graph = SankeyEngine.createTransactionsGraph(entries)
+
+        #expect(graph["a_checking"] != nil)
+        #expect(graph["c_groceries"] != nil)
+        #expect(graph["c_salary"] != nil)
+        #expect(graph["p_employer"] != nil)
+    }
+
+    @Test func filterCategoryGroupsByConditions() {
+        func cond(_ field: String, _ op: String, _ value: String) -> WidgetRuleCondition {
+            WidgetRuleCondition(op: op, field: field,
+                                value: AnyCodable(rawJSON: Data("\"\(value)\"".utf8)),
+                                options: nil, customName: nil)
+        }
+
+        let isCat = SankeyEngine.filterCategoryGroups(groups, conditions: [cond("category", "is", "c_groceries")], conditionsOp: "and")
+        #expect(isCat.count == 1)
+        #expect(isCat[0].categories.map(\.id) == ["c_groceries"])
+
+        let containsCat = SankeyEngine.filterCategoryGroups(groups, conditions: [cond("category", "contains", "groceries")], conditionsOp: "and")
+        #expect(containsCat[0].categories.map(\.name) == ["Groceries"])
+
+        let isGroup = SankeyEngine.filterCategoryGroups(groups, conditions: [cond("category_group", "is", "g_food")], conditionsOp: "and")
+        #expect(isGroup.map(\.id) == ["g_food"])
+
+        let none = SankeyEngine.filterCategoryGroups(groups, conditions: [cond("category", "is", "nonexistent")], conditionsOp: "and")
+        #expect(none.isEmpty)
+    }
+
+    // MARK: - Engine compute (spent)
+
+    @Test func spentModeBuildsPayeeIncomeAccountAndCategoryFlows() {
+        let transactions = [
+            tx(date: 20240105, amount: 500000, category: "c_salary", payeeId: "p_employer", payeeName: "Employer"),
+            tx(date: 20240110, amount: -10000, category: "c_groceries"),
+            tx(date: 20240112, amount: -2000, category: "c_groceries")
+        ]
+
+        let data = SankeyEngine.compute(
+            meta: meta(), transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+
+        #expect(node(data, key: "p_employer")?.name == "Employer")
+        #expect(node(data, key: "c_salary")?.name == "Salary")
+        #expect(node(data, key: "a_checking")?.name == "Checking")
+        #expect(node(data, key: "g_food")?.name == "Food")
+        #expect(node(data, key: "c_groceries")?.name == "Groceries")
+
+        #expect(linkValue(data, from: "p_employer", to: "c_salary") == 500000)
+        #expect(linkValue(data, from: "c_salary", to: "a_checking") == 500000)
+        #expect(linkValue(data, from: "a_checking", to: "g_food") == 12000)
+        #expect(linkValue(data, from: "g_food", to: "c_groceries") == 12000)
+    }
+
+    @Test func topNBucketsSmallestCategoriesIntoOther() {
+        let transactions = [
+            tx(date: 20240102, amount: -30000, category: "c_groceries"),
+            tx(date: 20240103, amount: -20000, category: "c_restaurants"),
+            tx(date: 20240104, amount: -10000, category: "c_coffee")
+        ]
+
+        let data = SankeyEngine.compute(
+            meta: meta(topN: 2), transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+
+        // per-group sort buckets into the category group's Other node
+        let other = node(data, key: "g_food__OTHER_BUCKET")
+        #expect(other?.name == "Other")
+        #expect(linkValue(data, from: "g_food", to: "g_food__OTHER_BUCKET") == 30000)
+        #expect(linkValue(data, from: "g_food", to: "c_groceries") == 30000)
+        #expect(node(data, key: "c_restaurants") == nil)
+        #expect(node(data, key: "c_coffee") == nil)
+    }
+
+    @Test func groupAccountsCollapsesAccountsIntoIncomeNode() {
+        let transactions = [
+            tx(date: 20240105, amount: 300000, account: "a_checking", category: "c_salary", payeeId: "p_employer", payeeName: "Employer"),
+            tx(date: 20240106, amount: 200000, account: "a_savings", category: "c_salary", payeeId: "p_employer", payeeName: "Employer")
+        ]
+
+        let grouped = SankeyEngine.compute(
+            meta: meta(groupAccounts: true), transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+        #expect(node(grouped, key: "all_income")?.name == "Income")
+        #expect(node(grouped, key: "a_checking") == nil)
+        #expect(linkValue(grouped, from: "c_salary", to: "all_income") == 500000)
+
+        let ungrouped = SankeyEngine.compute(
+            meta: meta(), transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+        #expect(node(ungrouped, key: "a_checking")?.name == "Checking")
+        #expect(node(ungrouped, key: "a_savings")?.name == "Savings")
+        #expect(node(ungrouped, key: "all_income") == nil)
+    }
+
+    @Test func layerTrimmingDropsOutOfRangeLayers() {
+        let transactions = [
+            tx(date: 20240105, amount: 500000, category: "c_salary", payeeId: "p_employer", payeeName: "Employer"),
+            tx(date: 20240110, amount: -10000, category: "c_groceries")
+        ]
+
+        let data = SankeyEngine.compute(
+            meta: meta(layerFrom: "account", layerTo: "category_group"),
+            transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+
+        #expect(node(data, key: "p_employer") == nil)
+        #expect(node(data, key: "c_salary") == nil)
+        #expect(node(data, key: "a_checking") != nil)
+        #expect(node(data, key: "g_food") != nil)
+        #expect(node(data, key: "c_groceries") == nil)
+    }
+
+    @Test func globalSortOrdersCategoriesByValue() {
+        let transactions = [
+            tx(date: 20240102, amount: -10000, category: "c_groceries"),
+            tx(date: 20240103, amount: -30000, category: "c_restaurants"),
+            tx(date: 20240104, amount: -20000, category: "c_coffee")
+        ]
+
+        let data = SankeyEngine.compute(
+            meta: meta(sort: "global"), transactions: transactions, categoryGroups: groups,
+            today: asOf, context: context
+        )
+
+        let categoryKeys = data.nodes.filter { $0.layer == .category }.map(\.key)
+        #expect(categoryKeys == ["c_restaurants", "c_coffee", "c_groceries"])
+    }
+
+    // MARK: - Engine compute (budgeted)
+
+    @Test func budgetedModeBuildsEnvelopeGraph() {
+        let transactions = [
+            tx(date: 20240105, amount: 500000, category: "c_salary", payeeId: "p_employer", payeeName: "Employer")
+        ]
+        let budget = SankeyBudgetInput(
+            entries: [SankeyBudgetInput.Entry(month: 202401, categoryId: "c_groceries", amountCents: 50000)],
+            toBudgetCents: 100000, fromPreviousMonthCents: 20000,
+            lastMonthOverspentCents: 0, forNextMonthCents: 30000
+        )
+
+        let data = SankeyEngine.compute(
+            meta: meta(mode: "budgeted"), transactions: transactions, categoryGroups: groups,
+            budget: budget, today: asOf, context: context
+        )
+
+        #expect(node(data, key: "budgeted")?.name == "Budgeted")
+        #expect(node(data, key: "available_income")?.name == "Available funds")
+        #expect(node(data, key: "to_budget")?.name == "To budget")
+        #expect(node(data, key: "from_previous_month")?.name == "From 2023-12")
+
+        #expect(linkValue(data, from: "c_salary", to: "available_income") == 500000)
+        #expect(linkValue(data, from: "available_income", to: "budgeted") == 50000)
+        #expect(linkValue(data, from: "budgeted", to: "g_food") == 50000)
+        #expect(linkValue(data, from: "g_food", to: "c_groceries") == 50000)
+        #expect(linkValue(data, from: "available_income", to: "to_budget") == 100000)
+        #expect(linkValue(data, from: "from_previous_month", to: "available_income") == 20000)
+
+        // Zero-value overspent flow is cleaned up entirely.
+        #expect(node(data, key: "last_month_overspent") == nil)
+        // Payee layer never appears in budgeted mode (default layer range).
+        #expect(node(data, key: "p_employer") == nil)
+        // "To budget" sits in the group layer with no child, so it gets a
+        // hidden child chain to pin its column.
+        #expect(data.nodes.map(\.key).contains("to_budget_category__HIDDEN"))
+    }
+}

--- a/Actuali/ActualiTests/SpendingEngineTests.swift
+++ b/Actuali/ActualiTests/SpendingEngineTests.swift
@@ -23,15 +23,29 @@ struct SpendingEngineTests {
     }
 
     private func meta(
+        conditions: [WidgetRuleCondition]? = nil,
         compare: String? = nil,
         compareTo: String? = nil,
         isLive: Bool? = true,
         mode: SpendingMeta.Mode? = nil,
         averageRange: SpendingAverageRange? = nil
     ) -> SpendingMeta {
-        SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
+        SpendingMeta(name: nil, conditions: conditions, conditionsOp: nil,
                      compare: compare, compareTo: compareTo, isLive: isLive,
                      mode: mode, averageRange: averageRange)
+    }
+
+    // Actuali.Category: the ObjC runtime also exports a `Category` type.
+    private var budgetCategories: [Actuali.Category] {
+        [
+            Actuali.Category(id: "groceries", name: "Groceries", groupId: "g1", isIncome: false, hidden: false, sortOrder: 0),
+            Actuali.Category(id: "rent", name: "Rent", groupId: "g1", isIncome: false, hidden: false, sortOrder: 1)
+        ]
+    }
+
+    private var budgetGroups: [CategoryGroup] {
+        [CategoryGroup(id: "g1", name: "Expenses", isIncome: false, hidden: false, sortOrder: 0,
+                       categories: budgetCategories)]
     }
 
     // Upstream nets positive amounts (refunds) into spending; income
@@ -181,5 +195,62 @@ struct SpendingEngineTests {
     @Test func budgetModeReturnsZeroComparison() {
         let result = SpendingEngine.compute(meta: meta(mode: .budget), transactions: [], today: asOf)
         #expect(result.comparisonCents == 0)
+    }
+
+    // Upstream spreads the compare month's budgeted total over its days and
+    // accumulates through today's day bucket (spending-spreadsheet.ts
+    // dailyBudget / SpendingCard.tsx todayDay).
+    @Test func budgetModeProratesBudgetThroughToday() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 200000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 110000),
+            BudgetAnalysisBudgetEntry(month: 202604, categoryId: "rent", amountCents: 999999)  // other month — ignored
+        ]
+        let result = SpendingEngine.compute(meta: meta(mode: .budget), transactions: [],
+                                            budgets: budgets, categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 310000 over May's 31 days × 14 elapsed days
+        #expect(result.comparisonCents == 140000)
+    }
+
+    @Test func budgetModeUsesFullMonthForPastCompare() {
+        let budgets = [BudgetAnalysisBudgetEntry(month: 202603, categoryId: "rent", amountCents: 155000)]
+        let result = SpendingEngine.compute(
+            meta: meta(compare: "2026-03", isLive: false, mode: .budget),
+            transactions: [], budgets: budgets, categories: budgetCategories,
+            categoryGroups: budgetGroups, today: asOf
+        )
+        #expect(result.comparisonCents == 155000)
+    }
+
+    // getSpendingBudgetFilters: category conditions narrow the budgets too.
+    @Test func budgetModeFiltersByCategoryConditions() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 100000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 200000)
+        ]
+        let cond = WidgetRuleCondition.makeMock(op: "is", field: "category", stringValue: "groceries")
+        let result = SpendingEngine.compute(meta: meta(conditions: [cond], mode: .budget),
+                                            transactions: [], budgets: budgets,
+                                            categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 100000 / 31 × 14 = 45161.29…
+        #expect(result.comparisonCents == 45161)
+    }
+
+    // getSpendingBudgetFilters: any unsupported category condition ⇒ budgets
+    // are not narrowed at all.
+    @Test func budgetModeUnsupportedCategoryConditionSkipsFilter() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 100000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 200000)
+        ]
+        let cond = WidgetRuleCondition.makeMock(op: "gt", field: "category", stringValue: "x")
+        let result = SpendingEngine.compute(meta: meta(conditions: [cond], mode: .budget),
+                                            transactions: [], budgets: budgets,
+                                            categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 300000 / 31 × 14 = 135483.87…
+        #expect(result.comparisonCents == 135484)
     }
 }


### PR DESCRIPTION
Stacked on #231 (branched from it to avoid DashboardView conflicts) — merge that first, then this retargets to main.

Actuali previously rendered 8 of upstream's 14 dashboard widget types. This adds the missing six, each ported from the upstream source at dashboard-card fidelity (pure engine + SwiftUI card + tests):

| Widget | Upstream source | Tests |
|-|-|-|
| `calendar-card` | calendar-spreadsheet.ts, CalendarGraph.tsx | 7 |
| `crossover-card` | crossover-spreadsheet.ts (incl. exact Hampel/median/mean projection math, CAGR default return, JS rounding parity) | 10 |
| `budget-analysis-card` | budget-analysis-spreadsheet.ts + budgetDataQuery.ts (their unit-test scenarios mirrored) | 14 |
| `sankey-card` | sankey-spreadsheet.ts full pipeline (income→Budget→groups→categories, topN "Other" bucketing, all 3 sort modes, layer trimming); upstream test scenarios ported | 22 |
| `balance-forecast-card` | balanceForecastChartData.ts + loot-core forecast/ (schedules + tracking-budget sources; card's budgetType fallback to schedules mirrored) | 12 |
| `monte-carlo-card` | monteCarloSimulation.ts (mulberry32 + Box-Muller PRNG pinned against node-computed upstream sequences; seeded end-to-end run matches upstream exactly) | 35 |

Calendar and crossover are stable upstream; the other four are behind upstream experimental feature flags but sync like any widget, so they now render instead of falling into the unsupported banner. Custom-report and formula widgets were already supported.

Integration plumbing: `DashboardWidget` parse cases, `DashboardView` wiring, and three `BudgetDatabase` additions — `fetchBudgetDataForReports()` (live budgets table + tracking flag), `fetchTrackingBudgetMonths()` (reflect_budgets sums for the forecast), `fetchForecastSchedules()` (same schedule parsing as the poster, shared via a private helper, without the `posts_transaction` filter).

Test notes: two existing tests used `sankey-card` as their "unknown type" fixture; they now use `future-card` since sankey is supported. Views render as compact cards only (no drill-in pages, tooltips, or i18n), sankey uses a simple layered layout rather than d3-sankey, and budgeted-mode sankey omits the envelope aggregate flows (To Budget / carryover) — marked in code.

## Verification

`xcodebuild test -skip-testing:ActualiUITests` on iPhone 17 Pro (iOS 26.2): **929 tests in 122 suites passed** (was 823 before this branch), 0 failures. Each engine was additionally built and tested in isolation during development. Not yet eyeballed against a live budget with these widgets configured — worth a visual pass on-device before release.