### PR TITLE
Spending widget: budget-mode comparison from real budgets

### DIFF
--- a/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/BudgetAnalysisEngine.swift
@@ -200,8 +200,9 @@ enum BudgetAnalysisEngine {
     /// Port of budgetDataQuery.ts filterCategoriesByConditions: only
     /// category / category_group conditions narrow the set, and if any of
     /// them can't be safely interpreted, no filtering happens at all (better
-    /// to be broad than to silently exclude data).
-    private static func filterCategoriesByConditions(
+    /// to be broad than to silently exclude data). Shared with SpendingEngine,
+    /// mirroring upstream's import into getSpendingBudgetFilters.
+    static func filterCategoriesByConditions(
         _ categories: [Category],
         groups: [CategoryGroup],
         conditions: [WidgetRuleCondition]?,
@@ -226,7 +227,7 @@ enum BudgetAnalysisEngine {
     }
 
     /// Port of budgetDataQuery.ts isSupportedCategoryCondition.
-    private static func isSupportedCategoryCondition(_ cond: WidgetRuleCondition) -> Bool {
+    static func isSupportedCategoryCondition(_ cond: WidgetRuleCondition) -> Bool {
         switch cond.op {
         case "is", "isNot", "contains", "doesNotContain", "matches":
             return decodeString(cond.value) != nil

--- a/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/SpendingEngine.swift
@@ -16,6 +16,9 @@ enum SpendingEngine {
     static func compute(
         meta: SpendingMeta?,
         transactions: [Transaction],
+        budgets: [BudgetAnalysisBudgetEntry] = [],
+        categories: [Category] = [],
+        categoryGroups: [CategoryGroup] = [],
         today: Date,
         context: ConditionsFilter.Context = .empty
     ) -> SpendingData {
@@ -57,9 +60,13 @@ enum SpendingEngine {
                                        calendar: cal,
                                        throughDay: sameDayCutoff)
         case .budget:
-            // Budget-mode target needs zero_budgets/reflect_budgets data that
-            // isn't plumbed into the engine yet; the widget shows spending only.
-            comparison = 0
+            comparison = budgetComparison(meta: meta,
+                                          budgets: budgets,
+                                          categories: categories,
+                                          categoryGroups: categoryGroups,
+                                          compareStart: compareStart,
+                                          throughDay: sameDayCutoff,
+                                          calendar: cal)
         case .average:
             comparison = averageSpending(transactions: filtered,
                                          allTransactions: live,
@@ -106,6 +113,44 @@ enum SpendingEngine {
         }
         let compare = stored ?? currentMonthStart
         return (compare, storedTo ?? prevMonth(compare))
+    }
+
+    /// Port of spending-spreadsheet.ts dailyBudget + getSpendingBudgetFilters:
+    /// the compare month's budgeted total — narrowed to categories matching
+    /// the widget's category/category_group conditions only when all of them
+    /// are supported, else unfiltered — spread evenly over the month's days
+    /// and accumulated through the same day bucket the card reads.
+    private static func budgetComparison(
+        meta: SpendingMeta?,
+        budgets: [BudgetAnalysisBudgetEntry],
+        categories: [Category],
+        categoryGroups: [CategoryGroup],
+        compareStart: Date,
+        throughDay: Int?,
+        calendar: Calendar
+    ) -> Int {
+        let c = calendar.dateComponents([.year, .month], from: compareStart)
+        let monthInt = (c.year ?? 0) * 100 + (c.month ?? 0)
+        var rows = budgets.filter { $0.month == monthInt }
+
+        let categoryConditions = (meta?.conditions ?? []).filter {
+            $0.customName == nil && ($0.field == "category" || $0.field == "category_group")
+        }
+        if !categoryConditions.isEmpty,
+           categoryConditions.allSatisfy(BudgetAnalysisEngine.isSupportedCategoryCondition) {
+            let allowed = Set(BudgetAnalysisEngine.filterCategoriesByConditions(
+                categories, groups: categoryGroups,
+                conditions: categoryConditions, conditionsOp: meta?.conditionsOp
+            ).map(\.id))
+            rows = rows.filter { allowed.contains($0.categoryId) }
+        }
+
+        let total = rows.reduce(0) { $0 + $1.amountCents }
+        guard total != 0,
+              let daysInMonth = calendar.range(of: .day, in: .month, for: compareStart)?.count,
+              daysInMonth > 0 else { return 0 }
+        let daysElapsed = throughDay ?? daysInMonth
+        return Int((Double(total) / Double(daysInMonth) * Double(daysElapsed)).rounded())
     }
 
     /// Net spending for one month as positive cents. `throughDay` limits to a

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -102,6 +102,7 @@ struct DashboardView: View {
         let needsBudgets = widgets.contains {
             switch $0 {
             case .budgetAnalysis, .sankey, .balanceForecast: return true
+            case .spending(_, let meta): return meta?.mode == .budget
             default: return false
             }
         }
@@ -168,7 +169,11 @@ struct DashboardView: View {
             }
         case .spending(_, let meta):
             WidgetCard(transactions: reportTransactions, loadingHeight: 120) { transactions in
-                SpendingEngine.compute(meta: meta, transactions: spendingScope(transactions), today: Date(), context: conditionsContext)
+                SpendingEngine.compute(meta: meta, transactions: spendingScope(transactions),
+                                       budgets: reportBudgets.entries,
+                                       categories: budgetStore.categoryGroups.flatMap(\.categories),
+                                       categoryGroups: budgetStore.categoryGroups,
+                                       today: Date(), context: conditionsContext)
             } content: { data in
                 SpendingWidgetView(
                     displayName: widget.displayName,

--- a/Actuali/ActualiTests/SpendingEngineTests.swift
+++ b/Actuali/ActualiTests/SpendingEngineTests.swift
@@ -23,15 +23,29 @@ struct SpendingEngineTests {
     }
 
     private func meta(
+        conditions: [WidgetRuleCondition]? = nil,
         compare: String? = nil,
         compareTo: String? = nil,
         isLive: Bool? = true,
         mode: SpendingMeta.Mode? = nil,
         averageRange: SpendingAverageRange? = nil
     ) -> SpendingMeta {
-        SpendingMeta(name: nil, conditions: nil, conditionsOp: nil,
+        SpendingMeta(name: nil, conditions: conditions, conditionsOp: nil,
                      compare: compare, compareTo: compareTo, isLive: isLive,
                      mode: mode, averageRange: averageRange)
+    }
+
+    // Actuali.Category: the ObjC runtime also exports a `Category` type.
+    private var budgetCategories: [Actuali.Category] {
+        [
+            Actuali.Category(id: "groceries", name: "Groceries", groupId: "g1", isIncome: false, hidden: false, sortOrder: 0),
+            Actuali.Category(id: "rent", name: "Rent", groupId: "g1", isIncome: false, hidden: false, sortOrder: 1)
+        ]
+    }
+
+    private var budgetGroups: [CategoryGroup] {
+        [CategoryGroup(id: "g1", name: "Expenses", isIncome: false, hidden: false, sortOrder: 0,
+                       categories: budgetCategories)]
     }
 
     // Upstream nets positive amounts (refunds) into spending; income
@@ -181,5 +195,62 @@ struct SpendingEngineTests {
     @Test func budgetModeReturnsZeroComparison() {
         let result = SpendingEngine.compute(meta: meta(mode: .budget), transactions: [], today: asOf)
         #expect(result.comparisonCents == 0)
+    }
+
+    // Upstream spreads the compare month's budgeted total over its days and
+    // accumulates through today's day bucket (spending-spreadsheet.ts
+    // dailyBudget / SpendingCard.tsx todayDay).
+    @Test func budgetModeProratesBudgetThroughToday() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 200000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 110000),
+            BudgetAnalysisBudgetEntry(month: 202604, categoryId: "rent", amountCents: 999999)  // other month — ignored
+        ]
+        let result = SpendingEngine.compute(meta: meta(mode: .budget), transactions: [],
+                                            budgets: budgets, categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 310000 over May's 31 days × 14 elapsed days
+        #expect(result.comparisonCents == 140000)
+    }
+
+    @Test func budgetModeUsesFullMonthForPastCompare() {
+        let budgets = [BudgetAnalysisBudgetEntry(month: 202603, categoryId: "rent", amountCents: 155000)]
+        let result = SpendingEngine.compute(
+            meta: meta(compare: "2026-03", isLive: false, mode: .budget),
+            transactions: [], budgets: budgets, categories: budgetCategories,
+            categoryGroups: budgetGroups, today: asOf
+        )
+        #expect(result.comparisonCents == 155000)
+    }
+
+    // getSpendingBudgetFilters: category conditions narrow the budgets too.
+    @Test func budgetModeFiltersByCategoryConditions() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 100000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 200000)
+        ]
+        let cond = WidgetRuleCondition.makeMock(op: "is", field: "category", stringValue: "groceries")
+        let result = SpendingEngine.compute(meta: meta(conditions: [cond], mode: .budget),
+                                            transactions: [], budgets: budgets,
+                                            categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 100000 / 31 × 14 = 45161.29…
+        #expect(result.comparisonCents == 45161)
+    }
+
+    // getSpendingBudgetFilters: any unsupported category condition ⇒ budgets
+    // are not narrowed at all.
+    @Test func budgetModeUnsupportedCategoryConditionSkipsFilter() {
+        let budgets = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "groceries", amountCents: 100000),
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "rent", amountCents: 200000)
+        ]
+        let cond = WidgetRuleCondition.makeMock(op: "gt", field: "category", stringValue: "x")
+        let result = SpendingEngine.compute(meta: meta(conditions: [cond], mode: .budget),
+                                            transactions: [], budgets: budgets,
+                                            categories: budgetCategories,
+                                            categoryGroups: budgetGroups, today: asOf)
+        // 300000 / 31 × 14 = 135483.87…
+        #expect(result.comparisonCents == 135484)
     }
 }


### PR DESCRIPTION
Stacked on #237. The Spending card's budget mode always showed 0 as the comparison — the engine never saw budget data.

Now it ports the last missing piece of `spending-spreadsheet.ts`: sum the compare month's budgets from `zero_budgets`/`reflect_budgets` (via the `fetchBudgetDataForReports()` plumbing from #237), narrow them by the widget's category/category_group conditions per `getSpendingBudgetFilters` (any unsupported condition ⇒ no narrowing, matching upstream), then spread over the month's days and accumulate through today's day bucket — full month for past compare months or day ≥ 28, matching the card's day-28 bucketing.

Reuses `BudgetAnalysisEngine`'s `filterCategoriesByConditions` / `isSupportedCategoryCondition` ports (visibility widened from private), which mirrors upstream where `getSpendingBudgetFilters` imports those same functions from `budgetDataQuery.ts`.

Ran the full unit suite on the iPhone 17 Pro simulator: 933 tests in 122 suites, all passing (4 new budget-mode tests: proration through today, full month for pinned past compare, category-condition narrowing, unsupported-condition fallback).