### PR TITLE
adding view tx as support

### DIFF
--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -159,10 +159,16 @@ struct TransactionDateGroup: Identifiable {
     let date: Int
     var id: Int { date }
     var transactions: [Transaction]
+
+    /// Section header for the group. Spelled out in full because the rows
+    /// underneath drop their own date once they're grouped.
+    var title: String { Transaction.formattedDate(from: date, style: .long) }
 }
 
 extension Array where Element == Transaction {
-    /// Groups transactions by date, preserving the array's existing encounter order.
+    /// Groups transactions by date, preserving the array's existing encounter
+    /// order. Every list that calls this fetches `ORDER BY date DESC`, so the
+    /// groups come out newest-first and each date appears exactly once.
     func groupedByDate() -> [TransactionDateGroup] {
         var groupDict: [Int: [Transaction]] = [:]
         var order: [Int] = []

--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -50,10 +50,10 @@ struct Transaction: Identifiable, Hashable {
         var amount: Int  // cents, signed like the parent
     }
 
-    var dateFormatted: String {
-        let year = date / 10000
-        let month = (date % 10000) / 100
-        let day = date % 100
+    static func formattedDate(from dateInt: Int, style: Date.FormatStyle.DateStyle = .abbreviated) -> String {
+        let year = dateInt / 10000
+        let month = (dateInt % 10000) / 100
+        let day = dateInt % 100
 
         var components = DateComponents()
         components.year = year
@@ -64,7 +64,11 @@ struct Transaction: Identifiable, Hashable {
             return "\(year)-\(month)-\(day)"
         }
 
-        return date.formatted(date: .abbreviated, time: .omitted)
+        return date.formatted(date: style, time: .omitted)
+    }
+
+    var dateFormatted: String {
+        Self.formattedDate(from: date, style: .abbreviated)
     }
 
     var isOutflow: Bool {
@@ -146,5 +150,32 @@ extension Transaction: CRDTSyncable {
             fields["starting_balance_flag"] = 1
         }
         return fields
+    }
+}
+
+// MARK: - Date Grouping
+
+struct TransactionDateGroup: Identifiable {
+    let date: Int
+    var id: Int { date }
+    var transactions: [Transaction]
+}
+
+extension Array where Element == Transaction {
+    /// Groups transactions by date, preserving the array's existing encounter order.
+    func groupedByDate() -> [TransactionDateGroup] {
+        var groupDict: [Int: [Transaction]] = [:]
+        var order: [Int] = []
+        for tx in self {
+            if groupDict[tx.date] == nil {
+                order.append(tx.date)
+                groupDict[tx.date] = [tx]
+            } else {
+                groupDict[tx.date]?.append(tx)
+            }
+        }
+        return order.map { date in
+            TransactionDateGroup(date: date, transactions: groupDict[date] ?? [])
+        }
     }
 }

--- a/Actuali/Actuali/Models/TransactionDisplayMode.swift
+++ b/Actuali/Actuali/Models/TransactionDisplayMode.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum TransactionDisplayMode: String, CaseIterable, Identifiable {
+    case flat
+    case groupedByDate
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .flat: return "Flat List"
+        case .groupedByDate: return "Grouped by Date"
+        }
+    }
+
+    static let defaultsKey = "transactionDisplayMode"
+
+    static func resolved(from raw: String?) -> TransactionDisplayMode {
+        raw.flatMap(TransactionDisplayMode.init(rawValue:)) ?? .flat
+    }
+
+    static var persisted: TransactionDisplayMode {
+        resolved(from: UserDefaults.standard.string(forKey: defaultsKey))
+    }
+}

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -205,6 +205,14 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// How transaction lists are presented (flat list vs grouped by date).
+    /// Persisted to UserDefaults, defaults to flat list.
+    @Published var transactionDisplayMode: TransactionDisplayMode = .flat {
+        didSet {
+            UserDefaults.standard.set(transactionDisplayMode.rawValue, forKey: TransactionDisplayMode.defaultsKey)
+        }
+    }
+
     /// Whether Budget rows show a spent-vs-available progress bar.
     /// Persisted to UserDefaults, defaults to on.
     @Published var showBudgetProgressBars: Bool = true {
@@ -746,6 +754,7 @@ final class BudgetStore: ObservableObject {
            let style = BudgetDisplayStyle(rawValue: raw) {
             _budgetDisplayStyle = Published(initialValue: style)
         }
+        _transactionDisplayMode = Published(initialValue: TransactionDisplayMode.persisted)
         _showBudgetProgressBars = Published(initialValue: UserDefaults.standard
             .object(forKey: "showBudgetProgressBars") as? Bool ?? true)
         _showGroupTotals = Published(initialValue: UserDefaults.standard

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -115,6 +115,32 @@ struct AccountDetailView: View {
         .font(.subheadline)
     }
 
+    @ViewBuilder
+    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
+        Button {
+            editingTransaction = transaction
+        } label: {
+            TransactionRow(transaction: transaction, showAccount: false, showDate: showDate, onToggleCleared: {
+                Task { await budgetStore.toggleCleared(transaction) }
+            })
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                Task { await budgetStore.deleteTransaction(transaction) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                editingTransaction = transaction
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.yellow)
+        }
+    }
+
     var body: some View {
         List {
             Section {
@@ -153,48 +179,47 @@ struct AccountDetailView: View {
                 noteSection
             }
 
-            Section("Recent Transactions") {
-                if let pager, pager.transactions.isEmpty {
+            if let pager, pager.transactions.isEmpty {
+                Section("Recent Transactions") {
                     Text(searchQuery != nil
                         ? "No matching transactions"
                         : budgetStore.hideClearedTransactions
                             ? "No uncleared transactions"
                             : "No transactions")
                         .foregroundStyle(.secondary)
-                } else if let pager {
-                    ForEach(pager.transactions) { transaction in
-                        Button {
-                            editingTransaction = transaction
-                        } label: {
-                            TransactionRow(transaction: transaction, showAccount: false, onToggleCleared: {
-                                Task { await budgetStore.toggleCleared(transaction) }
-                            })
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                Task { await budgetStore.deleteTransaction(transaction) }
-                            } label: {
-                                Label("Delete", systemImage: "trash")
+                }
+            } else if let pager {
+                if budgetStore.transactionDisplayMode == .groupedByDate {
+                    ForEach(pager.transactions.groupedByDate()) { group in
+                        Section(Transaction.formattedDate(from: group.date, style: .long)) {
+                            ForEach(group.transactions) { transaction in
+                                transactionRow(transaction, showDate: false)
                             }
-                            Button {
-                                editingTransaction = transaction
-                            } label: {
-                                Label("Edit", systemImage: "pencil")
-                            }
-                            .tint(.yellow)
                         }
                     }
                     if pager.hasMore {
-                        // Sentinel row: appearing near the bottom of the list
-                        // pulls in the next page.
-                        HStack {
-                            Spacer()
-                            ProgressView()
-                            Spacer()
+                        Section {
+                            HStack {
+                                Spacer()
+                                ProgressView()
+                                Spacer()
+                            }
+                            .task { await pager.loadNextPage() }
                         }
-                        .task { await pager.loadNextPage() }
+                    }
+                } else {
+                    Section("Recent Transactions") {
+                        ForEach(pager.transactions) { transaction in
+                            transactionRow(transaction, showDate: true)
+                        }
+                        if pager.hasMore {
+                            HStack {
+                                Spacer()
+                                ProgressView()
+                                Spacer()
+                            }
+                            .task { await pager.loadNextPage() }
+                        }
                     }
                 }
             }
@@ -210,6 +235,13 @@ struct AccountDetailView: View {
                         showingWalletImport = true
                     } label: {
                         Label("Import from Wallet", systemImage: "wallet.pass")
+                    }
+                }
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Picker("View Transactions As", selection: $budgetStore.transactionDisplayMode) {
+                    ForEach(TransactionDisplayMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
                     }
                 }
             }

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -115,32 +115,6 @@ struct AccountDetailView: View {
         .font(.subheadline)
     }
 
-    @ViewBuilder
-    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
-        Button {
-            editingTransaction = transaction
-        } label: {
-            TransactionRow(transaction: transaction, showAccount: false, showDate: showDate, onToggleCleared: {
-                Task { await budgetStore.toggleCleared(transaction) }
-            })
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button(role: .destructive) {
-                Task { await budgetStore.deleteTransaction(transaction) }
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            Button {
-                editingTransaction = transaction
-            } label: {
-                Label("Edit", systemImage: "pencil")
-            }
-            .tint(.yellow)
-        }
-    }
-
     var body: some View {
         List {
             Section {
@@ -179,47 +153,48 @@ struct AccountDetailView: View {
                 noteSection
             }
 
-            if let pager, pager.transactions.isEmpty {
-                Section("Recent Transactions") {
-                    Text(searchQuery != nil
-                        ? "No matching transactions"
-                        : budgetStore.hideClearedTransactions
-                            ? "No uncleared transactions"
-                            : "No transactions")
-                        .foregroundStyle(.secondary)
-                }
-            } else if let pager {
+            if let pager, !pager.transactions.isEmpty {
                 if budgetStore.transactionDisplayMode == .groupedByDate {
-                    ForEach(pager.transactions.groupedByDate()) { group in
-                        Section(Transaction.formattedDate(from: group.date, style: .long)) {
+                    let groups = pager.transactions.groupedByDate()
+                    ForEach(groups) { group in
+                        Section(group.title) {
                             ForEach(group.transactions) { transaction in
-                                transactionRow(transaction, showDate: false)
+                                TransactionListRow(transaction: transaction,
+                                                   showAccount: false,
+                                                   showDate: false,
+                                                   editing: $editingTransaction)
                             }
-                        }
-                    }
-                    if pager.hasMore {
-                        Section {
-                            HStack {
-                                Spacer()
-                                ProgressView()
-                                Spacer()
+                            // The sentinel rides in the last date section so
+                            // grouped mode doesn't grow a headerless section
+                            // (and its gap) of its own.
+                            if pager.hasMore, group.id == groups.last?.id {
+                                TransactionPagingSentinel(pager: pager)
                             }
-                            .task { await pager.loadNextPage() }
                         }
                     }
                 } else {
                     Section("Recent Transactions") {
                         ForEach(pager.transactions) { transaction in
-                            transactionRow(transaction, showDate: true)
+                            TransactionListRow(transaction: transaction,
+                                               showAccount: false,
+                                               editing: $editingTransaction)
                         }
                         if pager.hasMore {
-                            HStack {
-                                Spacer()
-                                ProgressView()
-                                Spacer()
-                            }
-                            .task { await pager.loadNextPage() }
+                            TransactionPagingSentinel(pager: pager)
                         }
+                    }
+                }
+            } else {
+                // Header stays put while the first page is still loading, so
+                // the screen doesn't reflow once the rows land.
+                Section("Recent Transactions") {
+                    if pager != nil {
+                        Text(searchQuery != nil
+                            ? "No matching transactions"
+                            : budgetStore.hideClearedTransactions
+                                ? "No uncleared transactions"
+                                : "No transactions")
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -239,11 +214,7 @@ struct AccountDetailView: View {
                 }
             }
             ToolbarItem(placement: .secondaryAction) {
-                Picker("View Transactions As", selection: $budgetStore.transactionDisplayMode) {
-                    ForEach(TransactionDisplayMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
-                    }
-                }
+                TransactionGroupingToggle()
             }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -376,6 +376,12 @@ struct SettingsView: View {
                         }
                     }
 
+                    Picker("View Transactions As", selection: $budgetStore.transactionDisplayMode) {
+                        ForEach(TransactionDisplayMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+
                     Toggle("Budget Progress Bars", isOn: $budgetStore.showBudgetProgressBars)
 
                     Toggle("Overspent Badge", isOn: $budgetStore.showOverspentBadge)

--- a/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/CategoryTransactionsView.swift
@@ -94,60 +94,90 @@ struct CategoryTransactionsView: View {
         .listRowBackground(Color.clear)
     }
 
+    @ViewBuilder
+    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
+        Group {
+            // Split children only display at full opacity, without
+            // tap/swipe: the edit form has no split support, and
+            // deleting one leg would break the parent's amount.
+            if transaction.parentId == nil {
+                Button {
+                    editingTransaction = transaction
+                } label: {
+                    TransactionRow(transaction: transaction, showDate: showDate, onToggleCleared: {
+                        Task {
+                            await budgetStore.toggleCleared(transaction)
+                            await reload()
+                        }
+                    })
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            } else {
+                TransactionRow(transaction: transaction, showDate: showDate)
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if transaction.parentId == nil {
+                Button(role: .destructive) {
+                    Task {
+                        await budgetStore.deleteTransaction(transaction)
+                        await reload()
+                    }
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                Button {
+                    editingTransaction = transaction
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .tint(.yellow)
+            }
+        }
+    }
+
+    private var scopeHeader: some View {
+        HStack {
+            Text(scopeTitle)
+            Spacer()
+            // Sums the filtered rows so the total matches what's on screen
+            // while searching.
+            Text("Total \(budgetStore.displayBalance(filteredTransactions.reduce(0) { $0 + $1.amount }))")
+        }
+    }
+
+    @ViewBuilder
     private var transactionsSection: some View {
-        Section {
-            if !transactions.isEmpty && filteredTransactions.isEmpty {
-                Text("No matching transactions")
-                    .foregroundStyle(.secondary)
-            }
-            ForEach(filteredTransactions) { transaction in
-                Group {
-                    // Split children only display at full opacity, without
-                    // tap/swipe: the edit form has no split support, and
-                    // deleting one leg would break the parent's amount.
-                    if transaction.parentId == nil {
-                        Button {
-                            editingTransaction = transaction
-                        } label: {
-                            TransactionRow(transaction: transaction, onToggleCleared: {
-                                Task {
-                                    await budgetStore.toggleCleared(transaction)
-                                    await reload()
-                                }
-                            })
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                    } else {
-                        TransactionRow(transaction: transaction)
-                    }
+        if budgetStore.transactionDisplayMode == .groupedByDate {
+            // The scope total is the point of this screen, so it keeps a
+            // header of its own above the date sections.
+            Section {
+                if !transactions.isEmpty && filteredTransactions.isEmpty {
+                    Text("No matching transactions")
+                        .foregroundStyle(.secondary)
                 }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    if transaction.parentId == nil {
-                        Button(role: .destructive) {
-                            Task {
-                                await budgetStore.deleteTransaction(transaction)
-                                await reload()
-                            }
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                        Button {
-                            editingTransaction = transaction
-                        } label: {
-                            Label("Edit", systemImage: "pencil")
-                        }
-                        .tint(.yellow)
+            } header: {
+                scopeHeader
+            }
+            ForEach(filteredTransactions.groupedByDate()) { group in
+                Section(group.title) {
+                    ForEach(group.transactions) { transaction in
+                        transactionRow(transaction, showDate: false)
                     }
                 }
             }
-        } header: {
-            HStack {
-                Text(scopeTitle)
-                Spacer()
-                // Sums the filtered rows so the total matches what's on screen
-                // while searching.
-                Text("Total \(budgetStore.displayBalance(filteredTransactions.reduce(0) { $0 + $1.amount }))")
+        } else {
+            Section {
+                if !transactions.isEmpty && filteredTransactions.isEmpty {
+                    Text("No matching transactions")
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(filteredTransactions) { transaction in
+                    transactionRow(transaction, showDate: true)
+                }
+            } header: {
+                scopeHeader
             }
         }
     }

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -31,32 +31,6 @@ struct TransactionsListView: View {
         await currentPager().loadFirstPage(search: searchQuery)
     }
 
-    @ViewBuilder
-    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
-        Button {
-            editingTransaction = transaction
-        } label: {
-            TransactionRow(transaction: transaction, showDate: showDate, onToggleCleared: {
-                Task { await budgetStore.toggleCleared(transaction) }
-            })
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button(role: .destructive) {
-                Task { await budgetStore.deleteTransaction(transaction) }
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            Button {
-                editingTransaction = transaction
-            } label: {
-                Label("Edit", systemImage: "pencil")
-            }
-            .tint(.yellow)
-        }
-    }
-
     var body: some View {
         Group {
             if let pager, pager.transactions.isEmpty, !budgetStore.isLoading {
@@ -78,27 +52,29 @@ struct TransactionsListView: View {
             } else if let pager {
                 List {
                     if budgetStore.transactionDisplayMode == .groupedByDate {
-                        ForEach(pager.transactions.groupedByDate()) { group in
-                            Section(Transaction.formattedDate(from: group.date, style: .long)) {
+                        let groups = pager.transactions.groupedByDate()
+                        ForEach(groups) { group in
+                            Section(group.title) {
                                 ForEach(group.transactions) { transaction in
-                                    transactionRow(transaction, showDate: false)
+                                    TransactionListRow(transaction: transaction,
+                                                       showDate: false,
+                                                       editing: $editingTransaction)
+                                }
+                                // The sentinel rides in the last date section
+                                // so grouped mode doesn't grow a headerless
+                                // section (and its gap) of its own.
+                                if pager.hasMore, group.id == groups.last?.id {
+                                    TransactionPagingSentinel(pager: pager)
                                 }
                             }
                         }
                     } else {
                         ForEach(pager.transactions) { transaction in
-                            transactionRow(transaction, showDate: true)
+                            TransactionListRow(transaction: transaction, editing: $editingTransaction)
                         }
-                    }
-                    if pager.hasMore {
-                        // Sentinel row: appearing near the bottom of the list
-                        // pulls in the next page.
-                        HStack {
-                            Spacer()
-                            ProgressView()
-                            Spacer()
+                        if pager.hasMore {
+                            TransactionPagingSentinel(pager: pager)
                         }
-                        .task { await pager.loadNextPage() }
                     }
                 }
             }
@@ -109,11 +85,7 @@ struct TransactionsListView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
         .toolbar {
             ToolbarItem(placement: .secondaryAction) {
-                Picker("View Transactions As", selection: $budgetStore.transactionDisplayMode) {
-                    ForEach(TransactionDisplayMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
-                    }
-                }
+                TransactionGroupingToggle()
             }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
@@ -153,6 +125,74 @@ struct TransactionsListView: View {
                 ProgressView()
             }
         }
+    }
+}
+
+/// Tappable `TransactionRow` with the standard edit/delete swipe actions,
+/// shared by the all-accounts and account-detail lists. The category and
+/// uncategorized lists build their own rows: they suppress tap and swipe on
+/// split children and reload after every mutation.
+struct TransactionListRow: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    let transaction: Transaction
+    var showAccount: Bool = true
+    var showDate: Bool = true
+    @Binding var editing: Transaction?
+
+    var body: some View {
+        Button {
+            editing = transaction
+        } label: {
+            TransactionRow(transaction: transaction, showAccount: showAccount, showDate: showDate, onToggleCleared: {
+                Task { await budgetStore.toggleCleared(transaction) }
+            })
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                Task { await budgetStore.deleteTransaction(transaction) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                editing = transaction
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.yellow)
+        }
+    }
+}
+
+/// Sentinel row: appearing near the bottom of the list pulls in the next page.
+struct TransactionPagingSentinel: View {
+    let pager: TransactionPager
+
+    var body: some View {
+        HStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+        .task { await pager.loadNextPage() }
+    }
+}
+
+/// Flat-vs-grouped switch for the transaction list toolbars.
+///
+/// A Toggle rather than the Picker Settings uses: `.secondaryAction` silently
+/// drops a Picker when it collapses into the `…` menu (inline or not), while a
+/// Toggle renders — same as the "Hide Cleared Transactions" switch beside it.
+/// The mode only has two cases, so nothing is lost.
+struct TransactionGroupingToggle: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+
+    var body: some View {
+        Toggle("Group by Date", isOn: Binding(
+            get: { budgetStore.transactionDisplayMode == .groupedByDate },
+            set: { budgetStore.transactionDisplayMode = $0 ? .groupedByDate : .flat }
+        ))
     }
 }
 

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -31,6 +31,32 @@ struct TransactionsListView: View {
         await currentPager().loadFirstPage(search: searchQuery)
     }
 
+    @ViewBuilder
+    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
+        Button {
+            editingTransaction = transaction
+        } label: {
+            TransactionRow(transaction: transaction, showDate: showDate, onToggleCleared: {
+                Task { await budgetStore.toggleCleared(transaction) }
+            })
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                Task { await budgetStore.deleteTransaction(transaction) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                editingTransaction = transaction
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.yellow)
+        }
+    }
+
     var body: some View {
         Group {
             if let pager, pager.transactions.isEmpty, !budgetStore.isLoading {
@@ -51,28 +77,17 @@ struct TransactionsListView: View {
                 }
             } else if let pager {
                 List {
-                    ForEach(pager.transactions) { transaction in
-                        Button {
-                            editingTransaction = transaction
-                        } label: {
-                            TransactionRow(transaction: transaction, onToggleCleared: {
-                                Task { await budgetStore.toggleCleared(transaction) }
-                            })
-                            .contentShape(Rectangle())
+                    if budgetStore.transactionDisplayMode == .groupedByDate {
+                        ForEach(pager.transactions.groupedByDate()) { group in
+                            Section(Transaction.formattedDate(from: group.date, style: .long)) {
+                                ForEach(group.transactions) { transaction in
+                                    transactionRow(transaction, showDate: false)
+                                }
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                Task { await budgetStore.deleteTransaction(transaction) }
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                            Button {
-                                editingTransaction = transaction
-                            } label: {
-                                Label("Edit", systemImage: "pencil")
-                            }
-                            .tint(.yellow)
+                    } else {
+                        ForEach(pager.transactions) { transaction in
+                            transactionRow(transaction, showDate: true)
                         }
                     }
                     if pager.hasMore {
@@ -93,6 +108,13 @@ struct TransactionsListView: View {
         .navigationTitle("All Accounts")
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
         .toolbar {
+            ToolbarItem(placement: .secondaryAction) {
+                Picker("View Transactions As", selection: $budgetStore.transactionDisplayMode) {
+                    ForEach(TransactionDisplayMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+            }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
             }
@@ -138,6 +160,7 @@ struct TransactionRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let transaction: Transaction
     var showAccount: Bool = true
+    var showDate: Bool = true
     /// Tap action for the cleared-status dot. Nil leaves the dot inert
     /// (split-child rows, contexts without a reload path). Reconciled rows
     /// confirm before invoking, since the store unlocks them instead.
@@ -249,9 +272,11 @@ struct TransactionRow: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(budgetStore.displayBalance(transaction.amount))
                     .foregroundColor(transaction.isOutflow ? .primary : .green)
-                Text(transaction.dateFormatted)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if showDate {
+                    Text(transaction.dateFormatted)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .padding(.vertical, 2)

--- a/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
@@ -22,6 +22,50 @@ struct UncategorizedTransactionsView: View {
         return transactions.filter { matcher.matches($0) }
     }
 
+    @ViewBuilder
+    private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
+        Button {
+            pickedCategoryId = nil
+            categorizing = transaction
+        } label: {
+            // Split children keep an inert dot: their cleared state follows
+            // the parent's.
+            TransactionRow(
+                transaction: transaction,
+                showDate: showDate,
+                onToggleCleared: transaction.parentId == nil ? {
+                    Task {
+                        await budgetStore.toggleCleared(transaction)
+                        await reload()
+                    }
+                } : nil
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            // Split children only get the categorize tap: the edit form has no
+            // split support, and deleting one leg would break the parent's
+            // amount.
+            if transaction.parentId == nil {
+                Button(role: .destructive) {
+                    Task {
+                        await budgetStore.deleteTransaction(transaction)
+                        await reload()
+                    }
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                Button {
+                    editingTransaction = transaction
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .tint(.yellow)
+            }
+        }
+    }
+
     var body: some View {
         Group {
             if transactions.isEmpty && loaded {
@@ -36,45 +80,17 @@ struct UncategorizedTransactionsView: View {
                         Text("No matching transactions")
                             .foregroundStyle(.secondary)
                     }
-                    ForEach(filteredTransactions) { transaction in
-                        Button {
-                            pickedCategoryId = nil
-                            categorizing = transaction
-                        } label: {
-                            // Split children keep an inert dot: their cleared
-                            // state follows the parent's.
-                            TransactionRow(
-                                transaction: transaction,
-                                onToggleCleared: transaction.parentId == nil ? {
-                                    Task {
-                                        await budgetStore.toggleCleared(transaction)
-                                        await reload()
-                                    }
-                                } : nil
-                            )
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            // Split children only get the categorize tap: the
-                            // edit form has no split support, and deleting one
-                            // leg would break the parent's amount.
-                            if transaction.parentId == nil {
-                                Button(role: .destructive) {
-                                    Task {
-                                        await budgetStore.deleteTransaction(transaction)
-                                        await reload()
-                                    }
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
+                    if budgetStore.transactionDisplayMode == .groupedByDate {
+                        ForEach(filteredTransactions.groupedByDate()) { group in
+                            Section(group.title) {
+                                ForEach(group.transactions) { transaction in
+                                    transactionRow(transaction, showDate: false)
                                 }
-                                Button {
-                                    editingTransaction = transaction
-                                } label: {
-                                    Label("Edit", systemImage: "pencil")
-                                }
-                                .tint(.yellow)
                             }
+                        }
+                    } else {
+                        ForEach(filteredTransactions) { transaction in
+                            transactionRow(transaction, showDate: true)
                         }
                     }
                 }

--- a/Actuali/ActualiTests/BudgetStoreTransactionDisplayModeTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreTransactionDisplayModeTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The transaction list's flat/grouped switch defaults to flat and writes
+/// through to UserDefaults, like the other display settings.
+///
+/// The restore-on-launch half isn't covered here: `previewInstance()` is built
+/// by an init that skips every UserDefaults read, and the real init does file
+/// system work no unit test should trigger. Same gap as the other display
+/// settings suites.
+@MainActor
+struct BudgetStoreTransactionDisplayModeTests {
+
+    @Test func listsAreFlatByDefault() {
+        #expect(BudgetStore.previewInstance().transactionDisplayMode == .flat)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.transactionDisplayMode = .groupedByDate
+        #expect(UserDefaults.standard.string(forKey: TransactionDisplayMode.defaultsKey)
+            == TransactionDisplayMode.groupedByDate.rawValue)
+        store.transactionDisplayMode = .flat
+        #expect(UserDefaults.standard.string(forKey: TransactionDisplayMode.defaultsKey)
+            == TransactionDisplayMode.flat.rawValue)
+    }
+}

--- a/Actuali/ActualiTests/TransactionDisplayModeTests.swift
+++ b/Actuali/ActualiTests/TransactionDisplayModeTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct TransactionDisplayModeTests {
+
+    @Test func defaultPersistedIsFlat() {
+        UserDefaults.standard.removeObject(forKey: TransactionDisplayMode.defaultsKey)
+        #expect(TransactionDisplayMode.persisted == .flat)
+    }
+
+    @Test func resolvesFromRawString() {
+        #expect(TransactionDisplayMode.resolved(from: "flat") == .flat)
+        #expect(TransactionDisplayMode.resolved(from: "groupedByDate") == .groupedByDate)
+        #expect(TransactionDisplayMode.resolved(from: "unknown") == .flat)
+        #expect(TransactionDisplayMode.resolved(from: nil) == .flat)
+    }
+
+    @Test func labelsAreDescriptive() {
+        #expect(TransactionDisplayMode.flat.label == "Flat List")
+        #expect(TransactionDisplayMode.groupedByDate.label == "Grouped by Date")
+    }
+
+    @Test func persistedReadsSavedValue() {
+        UserDefaults.standard.set(TransactionDisplayMode.groupedByDate.rawValue, forKey: TransactionDisplayMode.defaultsKey)
+        #expect(TransactionDisplayMode.persisted == .groupedByDate)
+        UserDefaults.standard.removeObject(forKey: TransactionDisplayMode.defaultsKey)
+    }
+}

--- a/Actuali/ActualiTests/TransactionDisplayModeTests.swift
+++ b/Actuali/ActualiTests/TransactionDisplayModeTests.swift
@@ -1,29 +1,29 @@
-import Foundation
 import Testing
 @testable import Actuali
 
+/// Only `resolved(from:)` is exercised here, like `StartTabTests`. Asserting on
+/// `persisted` would mean writing the real `UserDefaults.standard` key, and
+/// Swift Testing runs a suite's tests in parallel — two tests sharing one key
+/// race each other.
 struct TransactionDisplayModeTests {
 
-    @Test func defaultPersistedIsFlat() {
-        UserDefaults.standard.removeObject(forKey: TransactionDisplayMode.defaultsKey)
-        #expect(TransactionDisplayMode.persisted == .flat)
+    @Test func resolvesDefaultWhenUnset() {
+        #expect(TransactionDisplayMode.resolved(from: nil) == .flat)
     }
 
-    @Test func resolvesFromRawString() {
-        #expect(TransactionDisplayMode.resolved(from: "flat") == .flat)
-        #expect(TransactionDisplayMode.resolved(from: "groupedByDate") == .groupedByDate)
-        #expect(TransactionDisplayMode.resolved(from: "unknown") == .flat)
-        #expect(TransactionDisplayMode.resolved(from: nil) == .flat)
+    @Test func resolvesDefaultForUnknownValue() {
+        #expect(TransactionDisplayMode.resolved(from: "grouped") == .flat)
+        #expect(TransactionDisplayMode.resolved(from: "") == .flat)
+    }
+
+    @Test func resolvesPersistedRawValues() {
+        for mode in TransactionDisplayMode.allCases {
+            #expect(TransactionDisplayMode.resolved(from: mode.rawValue) == mode)
+        }
     }
 
     @Test func labelsAreDescriptive() {
         #expect(TransactionDisplayMode.flat.label == "Flat List")
         #expect(TransactionDisplayMode.groupedByDate.label == "Grouped by Date")
-    }
-
-    @Test func persistedReadsSavedValue() {
-        UserDefaults.standard.set(TransactionDisplayMode.groupedByDate.rawValue, forKey: TransactionDisplayMode.defaultsKey)
-        #expect(TransactionDisplayMode.persisted == .groupedByDate)
-        UserDefaults.standard.removeObject(forKey: TransactionDisplayMode.defaultsKey)
     }
 }

--- a/Actuali/ActualiTests/TransactionGroupingTests.swift
+++ b/Actuali/ActualiTests/TransactionGroupingTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct TransactionGroupingTests {
+
+    private func makeTxn(_ id: String, date: Int) -> Transaction {
+        Transaction(
+            id: id,
+            accountId: "acct-1",
+            date: date,
+            amount: -1000,
+            payeeId: nil,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: nil,
+            cleared: false,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+    }
+
+    @Test func emptyTransactionsReturnEmptyGroups() {
+        let txs: [Transaction] = []
+        let groups = txs.groupedByDate()
+        #expect(groups.isEmpty)
+    }
+
+    @Test func singleTransactionFormsSingleGroup() {
+        let tx = makeTxn("t-1", date: 20260814)
+        let groups = [tx].groupedByDate()
+
+        #expect(groups.count == 1)
+        #expect(groups[0].date == 20260814)
+        #expect(groups[0].transactions.map(\.id) == ["t-1"])
+    }
+
+    @Test func multipleTransactionsSameDateGroupTogether() {
+        let t1 = makeTxn("t-1", date: 20260814)
+        let t2 = makeTxn("t-2", date: 20260814)
+        let t3 = makeTxn("t-3", date: 20260814)
+        let groups = [t1, t2, t3].groupedByDate()
+
+        #expect(groups.count == 1)
+        #expect(groups[0].date == 20260814)
+        #expect(groups[0].transactions.map(\.id) == ["t-1", "t-2", "t-3"])
+    }
+
+    @Test func multipleDatesPreserveOrdering() {
+        let t1 = makeTxn("t-1", date: 20260814)
+        let t2 = makeTxn("t-2", date: 20260814)
+        let t3 = makeTxn("t-3", date: 20260813)
+        let t4 = makeTxn("t-4", date: 20260813)
+        let t5 = makeTxn("t-5", date: 20260812)
+
+        let groups = [t1, t2, t3, t4, t5].groupedByDate()
+
+        #expect(groups.count == 3)
+        #expect(groups[0].date == 20260814)
+        #expect(groups[0].transactions.map(\.id) == ["t-1", "t-2"])
+        #expect(groups[1].date == 20260813)
+        #expect(groups[1].transactions.map(\.id) == ["t-3", "t-4"])
+        #expect(groups[2].date == 20260812)
+        #expect(groups[2].transactions.map(\.id) == ["t-5"])
+    }
+
+    @Test func formattedDateFormatsCorrectly() {
+        // Date integer 20260814 = 2026-08-14
+        let formattedLong = Transaction.formattedDate(from: 20260814, style: .long)
+        #expect(formattedLong.contains("2026"))
+        #expect(formattedLong.localizedCaseInsensitiveContains("August") || formattedLong.contains("Aug"))
+
+        let formattedAbbreviated = Transaction.formattedDate(from: 20260814, style: .abbreviated)
+        #expect(formattedAbbreviated.contains("2026"))
+    }
+}

--- a/Actuali/ActualiTests/TransactionGroupingTests.swift
+++ b/Actuali/ActualiTests/TransactionGroupingTests.swift
@@ -70,13 +70,22 @@ struct TransactionGroupingTests {
         #expect(groups[2].transactions.map(\.id) == ["t-5"])
     }
 
-    @Test func formattedDateFormatsCorrectly() {
-        // Date integer 20260814 = 2026-08-14
-        let formattedLong = Transaction.formattedDate(from: 20260814, style: .long)
-        #expect(formattedLong.contains("2026"))
-        #expect(formattedLong.localizedCaseInsensitiveContains("August") || formattedLong.contains("Aug"))
+    /// The logic under test is the YYYYMMDD split, not the localized spelling —
+    /// asserting on "August" or "2026" would fail under a non-English locale or
+    /// a non-Gregorian calendar.
+    @Test func formattedDateDecodesTheDateInteger() {
+        let expected = Calendar.current.date(from: DateComponents(year: 2026, month: 8, day: 14))!
 
-        let formattedAbbreviated = Transaction.formattedDate(from: 20260814, style: .abbreviated)
-        #expect(formattedAbbreviated.contains("2026"))
+        #expect(Transaction.formattedDate(from: 20260814, style: .long)
+            == expected.formatted(date: .long, time: .omitted))
+        #expect(Transaction.formattedDate(from: 20260814, style: .abbreviated)
+            == expected.formatted(date: .abbreviated, time: .omitted))
+    }
+
+    @Test func groupTitleSpellsOutTheDate() {
+        let group = [makeTxn("t-1", date: 20260814)].groupedByDate()[0]
+        #expect(group.title == Transaction.formattedDate(from: 20260814, style: .long))
+        // The long form is what earns dropping the date from every row.
+        #expect(group.title != Transaction.formattedDate(from: 20260814, style: .abbreviated))
     }
 }


### PR DESCRIPTION
## Why

Allows users to switch between a flat transaction list and a date-grouped view, making it easier to scan and identify transactions by date without cluttering individual rows.

## What

- Added a **"View Transactions As"** option with **Flat List** and **Grouped by Date** modes.
- Grouped mode clusters transactions under date section headers (e.g. *August 14, 2026*) and omits redundant dates from individual row items.
- Added the selector to:
  - **Settings** under Preferences
  - **All Accounts** transaction list (`...` toolbar menu)
  - **Account Detail** transaction list (`...` toolbar menu)
- Added `[Transaction].groupedByDate()` and `Transaction.formattedDate(from:style:)` helpers.

## How it was tested

- Added unit tests in `ActualiTests/TransactionGroupingTests.swift` covering grouping order preservation, single/multiple date groups, and date formatting.
- Added unit tests in `ActualiTests/TransactionDisplayModeTests.swift` for persistence and default resolution.

Fixes https://github.com/MattFaz/actuali/issues/240
