### PR TITLE
Add actionable budget category guidance

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -51,10 +51,11 @@ struct BudgetMonth: Identifiable, Hashable {
 
     /// Whether the monthly check-in has anything actionable to show. This is
     /// intentionally independent of presentation preferences such as the
-    /// optional Budget tab badge.
+    /// optional Budget tab badge. Money left to assign is not an issue here:
+    /// the check-in draws no row for it (the Budget summary already shows it),
+    /// so counting it would suppress "Budget looks good" under an empty list.
     func hasCheckInIssues(uncategorizedCount: Int) -> Bool {
-        (toBudget ?? 0) > 0
-            || overspentCount > 0
+        overspentCount > 0
             || uncategorizedCount > 0
             || !unassignedCategories.isEmpty
             || !approachingLimitCategories.isEmpty
@@ -201,8 +202,9 @@ extension CategoryBudget {
             }
         }
 
+        // One month of history would just duplicate Spent Last Month.
         let spending = history.map { abs(min($0.spent, 0)) }
-        if !spending.isEmpty {
+        if spending.count >= 2 {
             let average = Int((Double(spending.reduce(0, +)) / Double(spending.count)).rounded())
             if average > 0 {
                 suggestions.append(.init(kind: .averageSpent, amount: average))

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -121,6 +121,24 @@ struct CategoryBudget: Identifiable, Hashable {
     var showsProgressBar: Bool {
         budgeted != 0 || spent != 0
     }
+
+    /// A compact, mode-neutral description of where this category stands.
+    /// Views translate it into envelope or tracking language as needed.
+    var progressState: CategoryProgressState {
+        if available < 0 { return .overspent }
+        if available == 0, spent != 0 { return .spent }
+        if available == 0, budgeted == 0, carryover == 0 { return .unassigned }
+        if spent != 0 { return .spending }
+        return .funded
+    }
+}
+
+enum CategoryProgressState: Equatable {
+    case unassigned
+    case funded
+    case spending
+    case spent
+    case overspent
 }
 
 /// Column sums for one category group, shown in the detailed style's group

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -15,6 +15,10 @@ struct BudgetMonth: Identifiable, Hashable {
     /// for envelope budgets — nil for tracking budgets.
     var toBudget: Int?
 
+    var isTrackingBudget: Bool {
+        toBudget == nil
+    }
+
     /// Number of expense categories in the red — drives the Budget tab badge.
     var overspentCount: Int {
         categoryBudgets.count(where: \.isOverspent)

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -141,6 +141,53 @@ enum CategoryProgressState: Equatable {
     case overspent
 }
 
+struct QuickAssignSuggestion: Identifiable, Equatable {
+    enum Kind: String {
+        case spentLastMonth
+        case averageSpent
+        case assignedLastMonth
+        case resetAvailable
+        case setToZero
+    }
+
+    var id: Kind { kind }
+    let kind: Kind
+    let amount: Int
+}
+
+extension CategoryBudget {
+    /// Suggested *final assigned amounts*, never deltas. This keeps the UI on
+    /// Actual's existing setBudgetAmount path and makes every choice previewable.
+    func quickAssignSuggestions(history: [CategoryBudget]) -> [QuickAssignSuggestion] {
+        var suggestions: [QuickAssignSuggestion] = []
+        if let lastMonth = history.first {
+            let spent = abs(min(lastMonth.spent, 0))
+            if spent > 0 {
+                suggestions.append(.init(kind: .spentLastMonth, amount: spent))
+            }
+            if lastMonth.budgeted != 0 {
+                suggestions.append(.init(kind: .assignedLastMonth, amount: lastMonth.budgeted))
+            }
+        }
+
+        let spending = history.map { abs(min($0.spent, 0)) }
+        if !spending.isEmpty {
+            let average = Int((Double(spending.reduce(0, +)) / Double(spending.count)).rounded())
+            if average > 0 {
+                suggestions.append(.init(kind: .averageSpent, amount: average))
+            }
+        }
+
+        if available != 0 {
+            suggestions.append(.init(kind: .resetAvailable, amount: budgeted - available))
+        }
+        if budgeted != 0 {
+            suggestions.append(.init(kind: .setToZero, amount: 0))
+        }
+        return suggestions
+    }
+}
+
 /// Column sums for one category group, shown in the detailed style's group
 /// header the way the PWA's table totals its group rows. Always built from a
 /// group's full category list — "Hide Spent Categories" trims which rows are

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -49,6 +49,17 @@ struct BudgetMonth: Identifiable, Hashable {
             .sorted { $0.progressFraction > $1.progressFraction }
     }
 
+    /// Whether the monthly check-in has anything actionable to show. This is
+    /// intentionally independent of presentation preferences such as the
+    /// optional Budget tab badge.
+    func hasCheckInIssues(uncategorizedCount: Int) -> Bool {
+        (toBudget ?? 0) > 0
+            || overspentCount > 0
+            || uncategorizedCount > 0
+            || !unassignedCategories.isEmpty
+            || !approachingLimitCategories.isEmpty
+    }
+
     var totalBudgeted: Int {
         categoryBudgets.reduce(0) { $0 + $1.budgeted }
     }

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -29,6 +29,22 @@ struct BudgetMonth: Identifiable, Hashable {
             .sorted { $0.available < $1.available }
     }
 
+    /// Categories with neither assigned money nor carried balance/activity.
+    /// This is a check-in prompt, not a target calculation.
+    var unassignedCategories: [CategoryBudget] {
+        categoryBudgets
+            .filter { $0.progressState == .unassigned }
+            .sorted { ($0.groupSortOrder, $0.categorySortOrder) < ($1.groupSortOrder, $1.categorySortOrder) }
+    }
+
+    /// Healthy categories that have consumed at least 80% of their available
+    /// capacity. Overspent and fully spent categories have separate guidance.
+    var approachingLimitCategories: [CategoryBudget] {
+        categoryBudgets
+            .filter { !$0.isOverspent && $0.available > 0 && $0.spent < 0 && $0.progressFraction >= 0.8 }
+            .sorted { $0.progressFraction > $1.progressFraction }
+    }
+
     var totalBudgeted: Int {
         categoryBudgets.reduce(0) { $0 + $1.budgeted }
     }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3445,7 +3445,9 @@ final class BudgetStore: ObservableObject {
         return result
     }
 
-    private static func shiftBudgetMonth(_ month: String, by offset: Int) -> String? {
+    /// Shift a "yyyy-MM" month key. Also backs the budget tab's month picker
+    /// (`BudgetView.shiftMonth`), so the format logic lives in one place.
+    static func shiftBudgetMonth(_ month: String, by offset: Int) -> String? {
         let parts = month.split(separator: "-")
         guard parts.count == 2,
               let year = Int(parts[0]),

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -12,6 +12,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case transferAmountNotPositive
     case transferPayeeMissing
     case transferCategoriesMatch
+    case transferAmountExceedsSource
     case invalidAmount
     case missingTransferDestination
     case payeeCreationFailed(String)
@@ -47,6 +48,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "Transfer payee not found for selected accounts"
         case .transferCategoriesMatch:
             return "Money must move between two different categories"
+        case .transferAmountExceedsSource:
+            return "That source does not have enough available money"
         case .invalidAmount:
             return "Invalid amount"
         case .missingTransferDestination:

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3447,7 +3447,8 @@ final class BudgetStore: ObservableObject {
 
     /// Shift a "yyyy-MM" month key. Also backs the budget tab's month picker
     /// (`BudgetView.shiftMonth`), so the format logic lives in one place.
-    static func shiftBudgetMonth(_ month: String, by offset: Int) -> String? {
+    /// Pure computation, so it stays callable off the main actor.
+    nonisolated static func shiftBudgetMonth(_ month: String, by offset: Int) -> String? {
         let parts = month.split(separator: "-")
         guard parts.count == 2,
               let year = Int(parts[0]),

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3424,6 +3424,39 @@ final class BudgetStore: ObservableObject {
 
     // MARK: - Budget Amounts
 
+    /// Prior category-month rows used for Quick Assign suggestions. Reading
+    /// history never changes the displayed month or introduces new storage.
+    func budgetHistory(for category: CategoryBudget, monthCount: Int = 3) async -> [CategoryBudget] {
+        guard let database, monthCount > 0 else { return [] }
+        var result: [CategoryBudget] = []
+        var month = category.month
+        for _ in 0..<monthCount {
+            guard let previous = Self.shiftBudgetMonth(month, by: -1) else { break }
+            month = previous
+            guard let budget = try? await database.fetchBudgetMonth(month: previous),
+                  let priorCategory = budget.categoryBudgets.first(where: {
+                      $0.categoryId == category.categoryId
+                  }) else { continue }
+            result.append(priorCategory)
+        }
+        return result
+    }
+
+    private static func shiftBudgetMonth(_ month: String, by offset: Int) -> String? {
+        let parts = month.split(separator: "-")
+        guard parts.count == 2,
+              let year = Int(parts[0]),
+              let monthNumber = Int(parts[1]),
+              let date = Calendar.current.date(from: DateComponents(
+                  year: year, month: monthNumber, day: 1
+              )),
+              let shifted = Calendar.current.date(byAdding: .month, value: offset, to: date)
+        else { return nil }
+        let components = Calendar.current.dateComponents([.year, .month], from: shifted)
+        guard let shiftedYear = components.year, let shiftedMonth = components.month else { return nil }
+        return String(format: "%04d-%02d", shiftedYear, shiftedMonth)
+    }
+
     /// Parse the budget edit field ("25.50") into cents. Negative amounts
     /// (intentional overdraw, as Actual's web client allows) are only valid
     /// where the caller opts in — a transfer, for instance, must stay

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -109,7 +109,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "On Budget",
-                                    subtitle: "Cash included in your budget",
                                     total: onBudgetTotal,
                                     isExpanded: $isOnBudgetExpanded
                                 )
@@ -127,7 +126,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Off Budget",
-                                    subtitle: "Assets and debts tracked outside your budget",
                                     total: offBudgetTotal,
                                     isExpanded: $isOffBudgetExpanded
                                 )
@@ -145,7 +143,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Closed Accounts",
-                                    subtitle: "Inactive accounts kept for history",
                                     total: closedTotal,
                                     isExpanded: $isClosedExpanded
                                 )
@@ -191,7 +188,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "On Budget",
-                                    subtitle: "Cash included in your budget",
                                     total: onBudgetTotal,
                                     isExpanded: $isOnBudgetExpanded,
                                     totalTrailingPadding: 0
@@ -209,7 +205,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Off Budget",
-                                    subtitle: "Assets and debts tracked outside your budget",
                                     total: offBudgetTotal,
                                     isExpanded: $isOffBudgetExpanded,
                                     totalTrailingPadding: 0
@@ -227,7 +222,6 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Closed Accounts",
-                                    subtitle: "Inactive accounts kept for history",
                                     total: closedTotal,
                                     isExpanded: $isClosedExpanded,
                                     totalTrailingPadding: 0
@@ -496,7 +490,6 @@ struct AccountsSummaryCard: View {
 struct AccountSectionHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let title: String
-    let subtitle: String
     let total: Int
     @Binding var isExpanded: Bool
     /// Extra trailing inset lining the total up with row balances that sit
@@ -512,14 +505,7 @@ struct AccountSectionHeader: View {
             HStack(spacing: 8) {
                 DisclosureChevron(isExpanded: isExpanded)
                                     .frame(width: 12)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                    Text(subtitle)
-                        .font(.caption2)
-                        .fontWeight(.regular)
-                        .foregroundStyle(.secondary)
-                        .textCase(nil)
-                }
+                Text(title)
                 Spacer()
                 Text(totalText)
                     .fontWeight(.regular)

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -109,6 +109,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "On Budget",
+                                    subtitle: "Cash included in your budget",
                                     total: onBudgetTotal,
                                     isExpanded: $isOnBudgetExpanded
                                 )
@@ -126,6 +127,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Off Budget",
+                                    subtitle: "Assets and debts tracked outside your budget",
                                     total: offBudgetTotal,
                                     isExpanded: $isOffBudgetExpanded
                                 )
@@ -143,6 +145,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Closed Accounts",
+                                    subtitle: "Inactive accounts kept for history",
                                     total: closedTotal,
                                     isExpanded: $isClosedExpanded
                                 )
@@ -188,6 +191,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "On Budget",
+                                    subtitle: "Cash included in your budget",
                                     total: onBudgetTotal,
                                     isExpanded: $isOnBudgetExpanded,
                                     totalTrailingPadding: 0
@@ -205,6 +209,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Off Budget",
+                                    subtitle: "Assets and debts tracked outside your budget",
                                     total: offBudgetTotal,
                                     isExpanded: $isOffBudgetExpanded,
                                     totalTrailingPadding: 0
@@ -222,6 +227,7 @@ struct AccountsListView: View {
                             } header: {
                                 AccountSectionHeader(
                                     title: "Closed Accounts",
+                                    subtitle: "Inactive accounts kept for history",
                                     total: closedTotal,
                                     isExpanded: $isClosedExpanded,
                                     totalTrailingPadding: 0
@@ -490,6 +496,7 @@ struct AccountsSummaryCard: View {
 struct AccountSectionHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let title: String
+    let subtitle: String
     let total: Int
     @Binding var isExpanded: Bool
     /// Extra trailing inset lining the total up with row balances that sit
@@ -505,7 +512,14 @@ struct AccountSectionHeader: View {
             HStack(spacing: 8) {
                 DisclosureChevron(isExpanded: isExpanded)
                                     .frame(width: 12)
-                Text(title)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                    Text(subtitle)
+                        .font(.caption2)
+                        .fontWeight(.regular)
+                        .foregroundStyle(.secondary)
+                        .textCase(nil)
+                }
                 Spacer()
                 Text(totalText)
                     .fontWeight(.regular)

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+enum BudgetCategoryFilter: String, CaseIterable, Identifiable {
+    case all
+    case needsAttention
+    case overspent
+    case unassigned
+    case onTrack
+
+    var id: Self { self }
+
+    func includes(_ category: CategoryBudget) -> Bool {
+        switch self {
+        case .all:
+            true
+        case .needsAttention:
+            category.progressState == .overspent || category.progressState == .unassigned
+        case .overspent:
+            category.progressState == .overspent
+        case .unassigned:
+            category.progressState == .unassigned
+        case .onTrack:
+            category.progressState == .funded || category.progressState == .spending
+        }
+    }
+}
+
 /// The Budget tab's single view-options control (GH #157).
 ///
 /// Layout, expand/collapse and the spent-category filter used to be three
@@ -10,6 +35,9 @@ import SwiftUI
 struct BudgetOptionsMenu: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
+    @Binding var categoryFilter: BudgetCategoryFilter
+    var isTrackingBudget = false
+
     /// Group actions are omitted when no budget is loaded — there are no
     /// groups to act on.
     var expandAllGroups: (() -> Void)?
@@ -17,6 +45,20 @@ struct BudgetOptionsMenu: View {
 
     var body: some View {
         Menu {
+            Picker("Categories", selection: $categoryFilter) {
+                Label("All Categories", systemImage: "list.bullet")
+                    .tag(BudgetCategoryFilter.all)
+                Label("Needs Attention", systemImage: "exclamationmark.circle")
+                    .tag(BudgetCategoryFilter.needsAttention)
+                Label(isTrackingBudget ? "Over Budget" : "Overspent", systemImage: "exclamationmark.triangle")
+                    .tag(BudgetCategoryFilter.overspent)
+                Label(isTrackingBudget ? "No Budget Set" : "Not Funded", systemImage: "circle.dashed")
+                    .tag(BudgetCategoryFilter.unassigned)
+                Label(isTrackingBudget ? "Within Budget" : "On Track", systemImage: "checkmark.circle")
+                    .tag(BudgetCategoryFilter.onTrack)
+            }
+            .pickerStyle(.inline)
+
             Picker("Layout", selection: $budgetStore.budgetDisplayStyle) {
                 Label("Clean", systemImage: "list.bullet.rectangle")
                     .tag(BudgetDisplayStyle.clean)
@@ -51,7 +93,9 @@ struct BudgetOptionsMenu: View {
                 }
             }
         } label: {
-            Image(systemName: "ellipsis.circle")
+            Image(systemName: categoryFilter == .all
+                ? "ellipsis.circle"
+                : "line.3.horizontal.decrease.circle.fill")
         }
         .accessibilityLabel("Budget options")
         .accessibilityHint("Layout, group and amount display options")
@@ -63,7 +107,11 @@ struct BudgetOptionsMenu: View {
         Text("Budget")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    BudgetOptionsMenu(expandAllGroups: {}, collapseAllGroups: {})
+                    BudgetOptionsMenu(
+                        categoryFilter: .constant(.all),
+                        expandAllGroups: {},
+                        collapseAllGroups: {}
+                    )
                 }
             }
     }

--- a/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
@@ -46,8 +46,8 @@ struct BudgetTransferSheet: View {
         // Overspent: default to covering from To Budget (like the web UI);
         // tracking budgets have no To Budget, so fall back to the first
         // category with funds. Surplus: default to sending back to To Budget.
-        let hasToBudget = context.budget.toBudget != nil
-        let firstCategory = Self.eligibleCategories(context).first.map { Endpoint.category($0.categoryId) }
+        let hasToBudget = Self.canUseToBudget(context)
+        let firstCategory = Self.rankedCategories(context).first.map { Endpoint.category($0.categoryId) }
         _endpoint = State(initialValue: hasToBudget ? .toBudget : (firstCategory ?? .toBudget))
         // Prefill with the full amount in play: the overspending to cover,
         // or the surplus available to move.
@@ -58,38 +58,97 @@ struct BudgetTransferSheet: View {
         context.category.available < 0
     }
 
-    /// Categories offered on the other side, in the budget table's order.
-    /// Covering only lists categories that have funds to give; a surplus can
-    /// go to any other category, including one at zero.
-    private static func eligibleCategories(_ context: BudgetTransferContext) -> [CategoryBudget] {
-        context.budget.categoryBudgets
+    /// Covering ranks sources that can fully solve the problem first, then
+    /// prefers the same group and the smallest sufficient balance. Partial
+    /// sources follow largest-first. Moving a surplus keeps table order.
+    static func rankedCategories(_ context: BudgetTransferContext) -> [CategoryBudget] {
+        let candidates = context.budget.categoryBudgets
             .filter { $0.categoryId != context.category.categoryId }
             .filter { context.category.available < 0 ? $0.available > 0 : true }
-            .sorted {
+        guard context.category.available < 0 else {
+            return candidates.sorted {
                 ($0.groupSortOrder, $0.categorySortOrder) < ($1.groupSortOrder, $1.categorySortOrder)
             }
+        }
+        let needed = abs(context.category.available)
+        return candidates.sorted { lhs, rhs in
+            let lhsCovers = lhs.available >= needed
+            let rhsCovers = rhs.available >= needed
+            if lhsCovers != rhsCovers { return lhsCovers }
+            let lhsSameGroup = lhs.groupId == context.category.groupId
+            let rhsSameGroup = rhs.groupId == context.category.groupId
+            if lhsSameGroup != rhsSameGroup { return lhsSameGroup }
+            if lhs.available != rhs.available {
+                return lhsCovers ? lhs.available < rhs.available : lhs.available > rhs.available
+            }
+            return (lhs.groupSortOrder, lhs.categorySortOrder)
+                < (rhs.groupSortOrder, rhs.categorySortOrder)
+        }
+    }
+
+    static func canUseToBudget(_ context: BudgetTransferContext) -> Bool {
+        guard let toBudget = context.budget.toBudget else { return false }
+        return context.category.available < 0 ? toBudget > 0 : true
     }
 
     private var eligibleCategories: [CategoryBudget] {
-        Self.eligibleCategories(context)
+        Self.rankedCategories(context)
     }
 
     private var hasOptions: Bool {
-        context.budget.toBudget != nil || !eligibleCategories.isEmpty
+        Self.canUseToBudget(context) || !eligibleCategories.isEmpty
+    }
+
+    private var rolledOverAmount: Int {
+        abs(context.category.rolledOverOverspending)
+    }
+
+    private var currentMonthShortfall: Int {
+        max(0, abs(context.category.available) - rolledOverAmount)
+    }
+
+    private var selectedSourceAvailable: Int? {
+        switch endpoint {
+        case .toBudget:
+            return context.budget.toBudget
+        case .category(let id):
+            return eligibleCategories.first(where: { $0.categoryId == id })?.available
+        }
     }
 
     var body: some View {
         NavigationStack {
             Form {
+                if isCovering {
+                    Section {
+                        LabeledContent("Amount to cover") {
+                            Text(budgetStore.displayBalance(abs(context.category.available)))
+                                .foregroundStyle(.red)
+                        }
+                        if currentMonthShortfall > 0 {
+                            LabeledContent("This month") {
+                                Text(budgetStore.displayBalance(currentMonthShortfall))
+                            }
+                        }
+                        if rolledOverAmount > 0 {
+                            LabeledContent("From earlier months") {
+                                Text(budgetStore.displayBalance(rolledOverAmount))
+                            }
+                        }
+                    } footer: {
+                        Text("Covering moves budgeted money only. It does not change or duplicate any transactions.")
+                    }
+                }
+
                 Section {
                     if hasOptions {
                         Picker(isCovering ? "From" : "To", selection: $endpoint) {
-                            if let toBudget = context.budget.toBudget {
+                            if Self.canUseToBudget(context), let toBudget = context.budget.toBudget {
                                 Text("To Budget (\(budgetStore.displayBalance(toBudget)))")
                                     .tag(Endpoint.toBudget)
                             }
-                            ForEach(eligibleCategories) { candidate in
-                                Text("\(candidate.categoryName) (\(budgetStore.displayBalance(candidate.available)))")
+                            ForEach(Array(eligibleCategories.enumerated()), id: \.element.id) { index, candidate in
+                                Text("\(index == 0 && isCovering ? "Recommended: " : "")\(candidate.categoryName) (\(budgetStore.displayBalance(candidate.available)))")
                                     .tag(Endpoint.category(candidate.categoryId))
                             }
                         }
@@ -141,6 +200,9 @@ struct BudgetTransferSheet: View {
         Task {
             do {
                 let cents = try BudgetStore.budgetAmountCents(from: amountText)
+                if isCovering, let selectedSourceAvailable, cents > selectedSourceAvailable {
+                    throw BudgetStoreError.transferAmountExceedsSource
+                }
                 // Covering pulls money into the tapped category; moving a
                 // surplus pushes money out of it.
                 let from = isCovering ? endpoint.categoryId : context.category.categoryId

--- a/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
@@ -99,8 +99,11 @@ struct BudgetTransferSheet: View {
         Self.canUseToBudget(context) || !eligibleCategories.isEmpty
     }
 
+    /// Clamped to the amount actually being covered: this month's budget can
+    /// offset part of the rolled-over overspending, and the breakdown must
+    /// never show more than the "Amount to cover" total above it.
     private var rolledOverAmount: Int {
-        abs(context.category.rolledOverOverspending)
+        min(abs(context.category.rolledOverOverspending), abs(context.category.available))
     }
 
     private var currentMonthShortfall: Int {
@@ -153,7 +156,9 @@ struct BudgetTransferSheet: View {
                             }
                         }
                     } else {
-                        Text("No other category has available funds to cover this.")
+                        Text(isCovering
+                            ? "Nothing can cover this right now: To Budget is empty and no other category has available funds."
+                            : "There are no other categories to move this to.")
                             .foregroundStyle(.secondary)
                     }
                 } header: {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -50,6 +50,7 @@ struct BudgetView: View {
     @State private var transferContext: BudgetTransferContext?
     @State private var transactionsDestination: CategoryTransactionsDestination?
     @State private var newBudgetItem: NewBudgetItem?
+    @State private var categoryFilter: BudgetCategoryFilter = .all
     /// Comma-joined group ids the user has collapsed, PWA-style. Stored as a
     /// string because @AppStorage can't hold a Set directly.
     @AppStorage("collapsedBudgetGroups") private var collapsedGroupsStorage = ""
@@ -126,6 +127,18 @@ struct BudgetView: View {
                         List {
                             BudgetCheckInSection(budget: budget)
 
+                            if categoryFilter != .all, groupedCategories.isEmpty {
+                                ContentUnavailableView {
+                                    Label("No Matching Categories", systemImage: "line.3.horizontal.decrease.circle")
+                                } description: {
+                                    Text("Try another category filter.")
+                                } actions: {
+                                    Button("Show All Categories") {
+                                        categoryFilter = .all
+                                    }
+                                }
+                            }
+
                             ForEach(groupedCategories, id: \.id) { group in
                                 let isCollapsed = collapsedGroups.contains(group.id)
                                 if budgetStore.budgetDisplayStyle == .clean {
@@ -190,7 +203,7 @@ struct BudgetView: View {
 
                             // Income group last, matching the bottom of the web
                             // UI's budget table.
-                            if !budget.incomeCategories.isEmpty {
+                            if categoryFilter == .all, !budget.incomeCategories.isEmpty {
                                 Section {
                                     ForEach(budget.incomeCategories) { income in
                                         IncomeCategoryRow(
@@ -356,6 +369,8 @@ struct BudgetView: View {
                     // menus don't fire inside the clean style's section
                     // headers (GH #130).
                     BudgetOptionsMenu(
+                        categoryFilter: $categoryFilter,
+                        isTrackingBudget: budgetStore.currentBudgetMonth?.isTrackingBudget == true,
                         expandAllGroups: budgetStore.currentBudgetMonth == nil ? nil : expandAllGroups,
                         collapseAllGroups: budgetStore.currentBudgetMonth == nil ? nil : collapseAllGroups
                     )
@@ -459,6 +474,7 @@ struct BudgetView: View {
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }
                 let visible = budgetStore.visibleCategoryBudgets(items)
+                    .filter(categoryFilter.includes)
                     .sorted { $0.categorySortOrder < $1.categorySortOrder }
                 // A group whose rows are all hidden drops out entirely rather
                 // than leaving a header stranded over an empty card.
@@ -469,7 +485,7 @@ struct BudgetView: View {
                         id: groupId,
                         name: first.groupName,
                         categories: visible,
-                        totals: CategoryGroupTotals(items)
+                        totals: CategoryGroupTotals(categoryFilter == .all ? items : visible)
                     )
                 )
             }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1353,11 +1353,15 @@ struct CategoryBudgetDetailSheet: View {
                                 } label: {
                                     HStack {
                                         Text(quickAssignTitle(for: suggestion.kind))
-                                        Spacer()
+                                            .foregroundStyle(.tint)
+                                        Spacer(minLength: 12)
                                         Text(budgetStore.displayBalance(suggestion.amount))
-                                            .foregroundStyle(.secondary)
+                                            .foregroundStyle(.primary)
+                                            .monospacedDigit()
+                                            .fixedSize(horizontal: true, vertical: false)
                                     }
                                 }
+                                .buttonStyle(.plain)
                                 .disabled(isApplyingSuggestion)
                             }
                         }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -615,26 +615,6 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if isExpanded, let toBudget = budget.toBudget, toBudget > 0 {
-                NavigationLink {
-                    BudgetGuidanceCategoryList(
-                        title: "Ready to Assign",
-                        message: "Choose categories for the money still waiting to be assigned.",
-                        categories: budget.unassignedCategories.isEmpty
-                            ? budget.categoryBudgets
-                            : budget.unassignedCategories
-                    )
-                } label: {
-                    Label {
-                        LabeledContent("Ready to Assign") {
-                            Text(budgetStore.displayBalance(toBudget)).foregroundStyle(.green)
-                        }
-                    } icon: {
-                        Image(systemName: "dollarsign.arrow.circlepath").foregroundStyle(.green)
-                    }
-                }
-            }
-
             if isExpanded, !budget.unassignedCategories.isEmpty {
                 NavigationLink {
                     BudgetGuidanceCategoryList(

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1061,6 +1061,9 @@ struct CategoryBudgetDetailSheet: View {
     @State private var editingNote = false
     @State private var note: EntityNote = .unsupported
     @State private var recentTransactions: [Transaction] = []
+    @State private var quickAssignSuggestions: [QuickAssignSuggestion] = []
+    @State private var isApplyingSuggestion = false
+    @State private var quickAssignError: String?
 
     private var isTracking: Bool {
         budgetStore.currentBudgetMonth?.isTrackingBudget == true
@@ -1166,6 +1169,35 @@ struct CategoryBudgetDetailSheet: View {
                     }
                 }
 
+                if !quickAssignSuggestions.isEmpty {
+                    Section {
+                        ForEach(quickAssignSuggestions) { suggestion in
+                            Button {
+                                Task { await apply(suggestion) }
+                            } label: {
+                                HStack {
+                                    Text(quickAssignTitle(for: suggestion.kind))
+                                    Spacer()
+                                    Text(budgetStore.displayBalance(suggestion.amount))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .disabled(isApplyingSuggestion)
+                        }
+                    } header: {
+                        Text(isTracking ? "Quick Budget" : "Quick Assign")
+                    } footer: {
+                        Text("Suggestions use this category's existing Actual history and replace the current month's amount.")
+                    }
+                }
+
+                if let quickAssignError {
+                    Section {
+                        Text(quickAssignError)
+                            .foregroundStyle(.red)
+                    }
+                }
+
                 if note.supported {
                     Section("Note") {
                         Button {
@@ -1222,8 +1254,36 @@ struct CategoryBudgetDetailSheet: View {
             month: category.month
         )
         async let fetchedNote = budgetStore.fetchNote(id: category.categoryId)
+        async let fetchedHistory = budgetStore.budgetHistory(for: category)
         recentTransactions = await fetchedTransactions
         note = await fetchedNote
+        quickAssignSuggestions = category.quickAssignSuggestions(history: await fetchedHistory)
+    }
+
+    private func quickAssignTitle(for kind: QuickAssignSuggestion.Kind) -> String {
+        switch kind {
+        case .spentLastMonth: "Spent Last Month"
+        case .averageSpent: "Average Spent (3 Months)"
+        case .assignedLastMonth: isTracking ? "Budgeted Last Month" : "Assigned Last Month"
+        case .resetAvailable: isTracking ? "Reset Balance to Zero" : "Reset Available to Zero"
+        case .setToZero: isTracking ? "Set Budget to Zero" : "Set Assigned to Zero"
+        }
+    }
+
+    private func apply(_ suggestion: QuickAssignSuggestion) async {
+        isApplyingSuggestion = true
+        quickAssignError = nil
+        do {
+            try await budgetStore.setBudgetAmount(
+                month: category.month,
+                categoryId: category.categoryId,
+                amountCents: suggestion.amount
+            )
+            dismiss()
+        } catch {
+            quickAssignError = error.localizedDescription
+            isApplyingSuggestion = false
+        }
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1214,8 +1214,8 @@ struct CategoryBudgetDetailSheet: View {
     @State private var quickAssignSuggestions: [QuickAssignSuggestion] = []
     @State private var isApplyingSuggestion = false
     @State private var quickAssignError: String?
-    @State private var actionsExpanded = true
-    @State private var quickAssignExpanded = true
+    @AppStorage("budgetDetailActionsExpanded") private var actionsExpanded = true
+    @AppStorage("budgetDetailQuickAssignExpanded") private var quickAssignExpanded = true
 
     private var isTracking: Bool {
         budgetStore.currentBudgetMonth?.isTrackingBudget == true

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -46,6 +46,7 @@ struct BudgetView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @State private var selectedMonth = currentMonthString()
     @State private var editingCategory: CategoryBudget?
+    @State private var selectedCategory: CategoryBudget?
     @State private var transferContext: BudgetTransferContext?
     @State private var transactionsDestination: CategoryTransactionsDestination?
     @State private var newBudgetItem: NewBudgetItem?
@@ -170,6 +171,7 @@ struct BudgetView: View {
                                             ForEach(group.categories) { category in
                                                 CleanCategoryBudgetRow(
                                                     category: category,
+                                                    onShowDetails: { selectedCategory = $0 },
                                                     onEditBudget: { editingCategory = $0 },
                                                     // Name shows all time, Spent shows
                                                     // the displayed month (GH #56).
@@ -205,6 +207,7 @@ struct BudgetView: View {
                                             ForEach(group.categories) { category in
                                                 CategoryBudgetRow(
                                                     category: category,
+                                                    onShowDetails: { selectedCategory = $0 },
                                                     onEditBudget: { editingCategory = $0 },
                                                     // Name shows all time, Spent shows
                                                     // the displayed month (GH #56).
@@ -404,6 +407,9 @@ struct BudgetView: View {
             .sheet(item: $editingCategory) { category in
                 EditBudgetAmountSheet(category: category)
             }
+            .sheet(item: $selectedCategory) { category in
+                CategoryBudgetDetailSheet(category: category)
+            }
             .sheet(item: $transferContext) { context in
                 BudgetTransferSheet(context: context)
             }
@@ -573,6 +579,7 @@ private struct TwoLineName: View {
 struct CategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
+    var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
     /// Push the category's transactions: month narrows to one "yyyy-MM",
     /// nil means all time (GH #56).
@@ -587,7 +594,7 @@ struct CategoryBudgetRow: View {
             // action (our enhancement over the PWA's read-only cells).
             HStack(spacing: BudgetColumn.spacing) {
                 Button {
-                    onShowTransactions(category, nil)
+                    onShowDetails(category)
                 } label: {
                     TwoLineName(
                         text: category.categoryName,
@@ -596,7 +603,7 @@ struct CategoryBudgetRow: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("All transactions for \(category.categoryName)")
+                .accessibilityLabel("Details for \(category.categoryName)")
                 Spacer(minLength: 4)
                 Button {
                     onEditBudget(category)
@@ -637,7 +644,7 @@ struct CategoryBudgetRow: View {
             if budgetStore.showBudgetProgressBars, category.showsProgressBar {
                 CategoryProgressBar(
                     fraction: category.progressFraction,
-                    isOverspent: category.isOverspent
+                    state: category.progressState
                 )
             }
         }
@@ -651,6 +658,7 @@ struct CategoryBudgetRow: View {
 struct CleanCategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
+    var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
     /// Push the category's transactions: month narrows to one "yyyy-MM",
     /// nil means all time (GH #56).
@@ -662,13 +670,13 @@ struct CleanCategoryBudgetRow: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Button {
-                    onShowTransactions(category, nil)
+                    onShowDetails(category)
                 } label: {
                     Text(category.categoryName)
                         .font(.body)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("All transactions for \(category.categoryName)")
+                .accessibilityLabel("Details for \(category.categoryName)")
                 Spacer()
                 // A zero balance has nothing to move and nothing to cover, so
                 // it stays a plain label.
@@ -687,7 +695,7 @@ struct CleanCategoryBudgetRow: View {
             if budgetStore.showBudgetProgressBars, category.showsProgressBar {
                 CategoryProgressBar(
                     fraction: category.progressFraction,
-                    isOverspent: category.isOverspent
+                    state: category.progressState
                 )
             }
             HStack {
@@ -1041,19 +1049,221 @@ struct IncomeCategoryRow: View {
     }
 }
 
+/// One YNAB-style place to understand and act on a category without losing
+/// the month context. Actual's tracking budgets keep their own terminology.
+struct CategoryBudgetDetailSheet: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+    let category: CategoryBudget
+
+    @State private var editingBudget = false
+    @State private var transferContext: BudgetTransferContext?
+    @State private var editingNote = false
+    @State private var note: EntityNote = .unsupported
+    @State private var recentTransactions: [Transaction] = []
+
+    private var isTracking: Bool {
+        budgetStore.currentBudgetMonth?.isTrackingBudget == true
+    }
+
+    private var statusTitle: String {
+        switch (isTracking, category.progressState) {
+        case (_, .overspent): isTracking ? "Over budget" : "Overspent"
+        case (true, .funded): "Budget set"
+        case (false, .funded): "Funded"
+        case (true, .spending): "Within budget"
+        case (false, .spending): "On track"
+        case (true, .spent): "Budget used"
+        case (false, .spent): "Fully spent"
+        case (true, .unassigned): "No budget set"
+        case (false, .unassigned): "Not funded"
+        }
+    }
+
+    private var statusColor: Color {
+        switch category.progressState {
+        case .overspent: .red
+        case .spent: .orange
+        case .spending: .blue
+        case .funded: .green
+        case .unassigned: .secondary
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Label(statusTitle, systemImage: category.isOverspent
+                                ? "exclamationmark.circle.fill"
+                                : "checkmark.circle.fill")
+                                .font(.headline)
+                                .foregroundStyle(statusColor)
+                            Spacer()
+                            Text(MonthPicker.title(for: category.month))
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        CategoryProgressBar(
+                            fraction: category.progressFraction,
+                            state: category.progressState
+                        )
+                        LabeledContent(isTracking ? "Budget" : "Assigned") {
+                            Text(budgetStore.displayBalance(category.budgeted))
+                        }
+                        LabeledContent("Activity") {
+                            Text(budgetStore.displayBalance(category.spent))
+                        }
+                        LabeledContent(isTracking ? "Balance" : "Available") {
+                            Text(budgetStore.displayBalance(category.available))
+                                .foregroundStyle(statusColor)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                Section("Actions") {
+                    Button {
+                        editingBudget = true
+                    } label: {
+                        Label(isTracking ? "Edit Budget" : "Assign Money", systemImage: "pencil")
+                    }
+
+                    if category.available != 0,
+                       let budget = budgetStore.currentBudgetMonth {
+                        Button {
+                            transferContext = BudgetTransferContext(category: category, budget: budget)
+                        } label: {
+                            Label(
+                                isTracking
+                                    ? "Reallocate Budget"
+                                    : (category.isOverspent ? "Cover Overspending" : "Move Money"),
+                                systemImage: "arrow.left.arrow.right"
+                            )
+                        }
+                    }
+
+                    NavigationLink {
+                        CategoryTransactionsView(destination: CategoryTransactionsDestination(
+                            categoryId: category.categoryId,
+                            categoryName: category.categoryName,
+                            month: category.month
+                        ))
+                    } label: {
+                        Label("This Month's Transactions", systemImage: "list.bullet.rectangle")
+                    }
+
+                    NavigationLink {
+                        CategoryTransactionsView(destination: CategoryTransactionsDestination(
+                            categoryId: category.categoryId,
+                            categoryName: category.categoryName,
+                            month: nil
+                        ))
+                    } label: {
+                        Label("All Transactions", systemImage: "clock.arrow.circlepath")
+                    }
+                }
+
+                if note.supported {
+                    Section("Note") {
+                        Button {
+                            editingNote = true
+                        } label: {
+                            if note.isEmpty {
+                                Label("Add Note", systemImage: "note.text.badge.plus")
+                            } else {
+                                Text(NoteLinkText.attributed(note.text))
+                                    .foregroundStyle(.primary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+                }
+
+                if !recentTransactions.isEmpty {
+                    Section("Recent Activity") {
+                        ForEach(recentTransactions.prefix(3)) { transaction in
+                            TransactionRow(transaction: transaction)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(category.categoryName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task { await reloadSupportingDetails() }
+            .sheet(isPresented: $editingBudget) {
+                EditBudgetAmountSheet(category: category)
+            }
+            .sheet(item: $transferContext) { context in
+                BudgetTransferSheet(context: context)
+            }
+            .sheet(isPresented: $editingNote, onDismiss: {
+                Task { note = await budgetStore.fetchNote(id: category.categoryId) }
+            }) {
+                NoteEditorView(
+                    noteId: category.categoryId,
+                    title: category.categoryName,
+                    note: note.text
+                )
+            }
+        }
+    }
+
+    private func reloadSupportingDetails() async {
+        async let fetchedTransactions = budgetStore.fetchCategoryTransactions(
+            categoryId: category.categoryId,
+            month: category.month
+        )
+        async let fetchedNote = budgetStore.fetchNote(id: category.categoryId)
+        recentTransactions = await fetchedTransactions
+        note = await fetchedNote
+    }
+}
+
 /// Spent-vs-available bar for a budget row. Fill and color mirror the row's
 /// Available amount: green while money remains, red once overspent.
 struct CategoryProgressBar: View {
     let fraction: Double
-    let isOverspent: Bool
+    let state: CategoryProgressState
+
+    private var tint: Color {
+        switch state {
+        case .overspent: .red
+        case .spent: .orange
+        case .spending: .blue
+        case .funded: .green
+        case .unassigned: .secondary
+        }
+    }
+
+    private var trackTint: Color {
+        state == .funded ? tint.opacity(0.25) : Color(.systemFill)
+    }
+
+    private var status: String {
+        switch state {
+        case .overspent: "Overspent"
+        case .spent: "Spent"
+        case .spending: "Spending"
+        case .funded: "Funded"
+        case .unassigned: "Unassigned"
+        }
+    }
 
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 Capsule()
-                    .fill(Color(.systemFill))
+                    .fill(trackTint)
                 Capsule()
-                    .fill(isOverspent ? Color.red : Color.green)
+                    .fill(tint)
                     .frame(width: geometry.size.width * fraction)
             }
         }
@@ -1062,7 +1272,7 @@ struct CategoryProgressBar: View {
         // edit is visible in the row itself and not only in the pill.
         .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
-        .accessibilityLabel("Spent \(Int((fraction * 100).rounded())) percent of available")
+        .accessibilityLabel("\(status), spent \(Int((fraction * 100).rounded())) percent")
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -622,7 +622,7 @@ struct BudgetCheckInSection: View {
                         message: budget.isTrackingBudget
                             ? "These categories have no budget or activity this month."
                             : "These categories have no assigned or carried money this month.",
-                        categories: budget.unassignedCategories
+                        kind: .unassigned
                     )
                 } label: {
                     Label(
@@ -639,7 +639,7 @@ struct BudgetCheckInSection: View {
                     BudgetGuidanceCategoryList(
                         title: budget.isTrackingBudget ? "Near Budget" : "Almost Spent",
                         message: "These categories have used at least 80% of their available amount.",
-                        categories: budget.approachingLimitCategories
+                        kind: .approachingLimit
                     )
                 } label: {
                     Label(
@@ -668,11 +668,31 @@ struct BudgetCheckInSection: View {
 /// detail sheet as the main budget table, so guidance always ends in a real
 /// resolution path rather than a dead-end status list.
 struct BudgetGuidanceCategoryList: View {
+    enum Kind {
+        case unassigned
+        case approachingLimit
+    }
+
     @EnvironmentObject var budgetStore: BudgetStore
     let title: String
     let message: String
-    let categories: [CategoryBudget]
+    let kind: Kind
     @State private var selectedCategory: CategoryBudget?
+    @State private var editingCategory: CategoryBudget?
+
+    private var categories: [CategoryBudget] {
+        guard let budget = budgetStore.currentBudgetMonth else { return [] }
+        switch kind {
+        case .unassigned:
+            return budget.unassignedCategories
+        case .approachingLimit:
+            return budget.approachingLimitCategories
+        }
+    }
+
+    private var isTracking: Bool {
+        budgetStore.currentBudgetMonth?.isTrackingBudget == true
+    }
 
     var body: some View {
         List {
@@ -681,32 +701,47 @@ struct BudgetGuidanceCategoryList: View {
                     .foregroundStyle(.secondary)
             }
             Section {
-                ForEach(categories) { category in
-                    Button {
-                        selectedCategory = category
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text(category.categoryName)
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                Text(budgetStore.displayBalance(category.available))
-                                    .foregroundStyle(category.isOverspent ? .red : .secondary)
-                                    .monospacedDigit()
+                if categories.isEmpty {
+                    Label("No categories need attention", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                } else {
+                    ForEach(categories) { category in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Button {
+                                selectedCategory = category
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(category.categoryName)
+                                            .foregroundStyle(.primary)
+                                        Text(category.groupName)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Text(budgetStore.displayBalance(category.available))
+                                        .foregroundStyle(category.isOverspent ? .red : .secondary)
+                                        .monospacedDigit()
+                                }
+                                if category.showsProgressBar {
+                                    CategoryProgressBar(
+                                        fraction: category.progressFraction,
+                                        state: category.progressState
+                                    )
+                                }
                             }
-                            Text(category.groupName)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            if category.showsProgressBar {
-                                CategoryProgressBar(
-                                    fraction: category.progressFraction,
-                                    state: category.progressState
-                                )
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Details for \(category.categoryName)")
+
+                            Button {
+                                editingCategory = category
+                            } label: {
+                                Label(fundingActionTitle, systemImage: "plus.circle.fill")
                             }
+                            .buttonStyle(.bordered)
+                            .accessibilityIdentifier("Fund \(category.categoryName)")
                         }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Details for \(category.categoryName)")
                 }
             }
         }
@@ -715,6 +750,18 @@ struct BudgetGuidanceCategoryList: View {
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $selectedCategory) { category in
             CategoryBudgetDetailSheet(category: category)
+        }
+        .sheet(item: $editingCategory) { category in
+            EditBudgetAmountSheet(category: category)
+        }
+    }
+
+    private var fundingActionTitle: String {
+        switch (isTracking, kind) {
+        case (true, .unassigned): "Add Budget"
+        case (true, .approachingLimit): "Increase Budget"
+        case (false, .unassigned): "Assign Money"
+        case (false, .approachingLimit): "Assign More"
         }
     }
 }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -704,24 +704,29 @@ struct BudgetGuidanceCategoryList: View {
                             Button {
                                 selectedCategory = category
                             } label: {
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(category.categoryName)
-                                            .foregroundStyle(.primary)
-                                        Text(category.groupName)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                // One explicit VStack: a Button lays multiple
+                                // label views out side by side, which would
+                                // squash the bar next to the Spacer'd row.
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(category.categoryName)
+                                                .foregroundStyle(.primary)
+                                            Text(category.groupName)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        Spacer()
+                                        Text(budgetStore.displayBalance(category.available))
+                                            .foregroundStyle(category.isOverspent ? .red : .secondary)
+                                            .monospacedDigit()
                                     }
-                                    Spacer()
-                                    Text(budgetStore.displayBalance(category.available))
-                                        .foregroundStyle(category.isOverspent ? .red : .secondary)
-                                        .monospacedDigit()
-                                }
-                                if category.showsProgressBar {
-                                    CategoryProgressBar(
-                                        fraction: category.progressFraction,
-                                        state: category.progressState
-                                    )
+                                    if category.showsProgressBar {
+                                        CategoryProgressBar(
+                                            fraction: category.progressFraction,
+                                            state: category.progressState
+                                        )
+                                    }
                                 }
                             }
                             .buttonStyle(.plain)
@@ -1289,13 +1294,7 @@ struct CategoryBudgetDetailSheet: View {
     }
 
     private var statusColor: Color {
-        switch liveCategory.progressState {
-        case .overspent: .red
-        case .spent: .orange
-        case .spending: .blue
-        case .funded: .green
-        case .unassigned: .secondary
-        }
+        liveCategory.progressState.tint
     }
 
     private var statusIcon: String {
@@ -1543,14 +1542,13 @@ struct BudgetDetailSectionHeader: View {
     }
 }
 
-/// Spent-vs-available bar for a budget row. Fill and color mirror the row's
-/// Available amount: green while money remains, red once overspent.
-struct CategoryProgressBar: View {
-    let fraction: Double
-    let state: CategoryProgressState
-
-    private var tint: Color {
-        switch state {
+/// One place for the status color and mode-neutral wording, shared by the
+/// bar, the dot, and the detail sheet — so VoiceOver says the same thing for
+/// the same category everywhere. The detail sheet keeps its own
+/// envelope/tracking titles on top of this.
+extension CategoryProgressState {
+    var tint: Color {
+        switch self {
         case .overspent: .red
         case .spent: .orange
         case .spending: .blue
@@ -1559,18 +1557,25 @@ struct CategoryProgressBar: View {
         }
     }
 
-    private var trackTint: Color {
-        state == .funded ? tint.opacity(0.25) : Color(.systemFill)
-    }
-
-    private var status: String {
-        switch state {
+    var statusText: String {
+        switch self {
         case .overspent: "Overspent"
-        case .spent: "Spent"
-        case .spending: "Spending"
+        case .spent: "Fully spent"
+        case .spending: "Partially spent"
         case .funded: "Funded"
-        case .unassigned: "Unassigned"
+        case .unassigned: "No money assigned"
         }
+    }
+}
+
+/// Spent-vs-available bar for a budget row. Fill and color mirror the row's
+/// Available amount: green while money remains, red once overspent.
+struct CategoryProgressBar: View {
+    let fraction: Double
+    let state: CategoryProgressState
+
+    private var trackTint: Color {
+        state == .funded ? state.tint.opacity(0.25) : Color(.systemFill)
     }
 
     var body: some View {
@@ -1579,7 +1584,7 @@ struct CategoryProgressBar: View {
                 Capsule()
                     .fill(trackTint)
                 Capsule()
-                    .fill(tint)
+                    .fill(state.tint)
                     .frame(width: geometry.size.width * fraction)
             }
         }
@@ -1588,7 +1593,7 @@ struct CategoryProgressBar: View {
         // edit is visible in the row itself and not only in the pill.
         .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
-        .accessibilityLabel("\(status), spent \(Int((fraction * 100).rounded())) percent")
+        .accessibilityLabel("\(state.statusText), spent \(Int((fraction * 100).rounded())) percent")
     }
 }
 
@@ -1597,31 +1602,11 @@ struct CategoryProgressBar: View {
 struct CompactCategoryStatusDot: View {
     let state: CategoryProgressState
 
-    private var tint: Color {
-        switch state {
-        case .overspent: .red
-        case .spent: .orange
-        case .spending: .blue
-        case .funded: .green
-        case .unassigned: .secondary
-        }
-    }
-
-    private var status: String {
-        switch state {
-        case .overspent: "Overspent"
-        case .spent: "Fully spent"
-        case .spending: "Partially spent"
-        case .funded: "Funded"
-        case .unassigned: "No money assigned"
-        }
-    }
-
     var body: some View {
         Circle()
-            .fill(tint)
+            .fill(state.tint)
             .frame(width: 7, height: 7)
-            .accessibilityLabel(status)
+            .accessibilityLabel(state.statusText)
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -473,8 +473,13 @@ struct BudgetView: View {
         var sections = byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }
-                let visible = budgetStore.visibleCategoryBudgets(items)
-                    .filter(categoryFilter.includes)
+                // An explicit filter is its own visibility rule: "Not Funded"
+                // must still match zero-available categories even when the
+                // Hide Spent Categories setting would drop them from "All".
+                let base = categoryFilter == .all
+                    ? budgetStore.visibleCategoryBudgets(items)
+                    : items.filter(categoryFilter.includes)
+                let visible = base
                     .sorted { $0.categorySortOrder < $1.categorySortOrder }
                 // A group whose rows are all hidden drops out entirely rather
                 // than leaving a header stranded over an empty card.
@@ -494,8 +499,10 @@ struct BudgetView: View {
         // looks like it did nothing (GH #284). Income groups stay out: this
         // list is the expense table, and income has its own section below,
         // which likewise only appears once it has categories.
+        // Empty placeholders only belong in the unfiltered table: a filter
+        // that matches nothing should show the empty state, not bare headers.
         sections += budgetStore.categoryGroups
-            .filter { !$0.isIncome && !$0.hidden && $0.categories.isEmpty }
+            .filter { categoryFilter == .all && !$0.isIncome && !$0.hidden && $0.categories.isEmpty }
             .map { group -> (Double, CategoryGroupSection) in
                 (
                     group.sortOrder,
@@ -518,20 +525,7 @@ struct BudgetView: View {
     }
 
     static func shiftMonth(_ month: String, by offset: Int) -> String {
-        let parts = month.split(separator: "-")
-        guard parts.count == 2,
-              let year = Int(parts[0]),
-              let m = Int(parts[1]) else { return month }
-        var components = DateComponents()
-        components.year = year
-        components.month = m
-        components.day = 1
-        let calendar = Calendar.current
-        guard let date = calendar.date(from: components),
-              let shifted = calendar.date(byAdding: .month, value: offset, to: date) else {
-            return month
-        }
-        return yearMonthFormatter.string(from: shifted)
+        BudgetStore.shiftBudgetMonth(month, by: offset) ?? month
     }
 }
 
@@ -1257,7 +1251,7 @@ struct CategoryBudgetDetailSheet: View {
     @State private var editingNote = false
     @State private var note: EntityNote = .unsupported
     @State private var recentTransactions: [Transaction] = []
-    @State private var quickAssignSuggestions: [QuickAssignSuggestion] = []
+    @State private var history: [CategoryBudget] = []
     @State private var isApplyingSuggestion = false
     @State private var quickAssignError: String?
     @AppStorage("budgetDetailActionsExpanded") private var actionsExpanded = true
@@ -1267,8 +1261,21 @@ struct CategoryBudgetDetailSheet: View {
         budgetStore.currentBudgetMonth?.isTrackingBudget == true
     }
 
+    /// The sheet item is a snapshot taken at tap time; read the row live from
+    /// the store so Assign/Cover done from inside this sheet update the
+    /// figures immediately instead of only after reopening.
+    private var liveCategory: CategoryBudget {
+        budgetStore.currentBudgetMonth?.categoryBudgets
+            .first { $0.categoryId == category.categoryId && $0.month == category.month }
+            ?? category
+    }
+
+    private var quickAssignSuggestions: [QuickAssignSuggestion] {
+        liveCategory.quickAssignSuggestions(history: history)
+    }
+
     private var statusTitle: String {
-        switch (isTracking, category.progressState) {
+        switch (isTracking, liveCategory.progressState) {
         case (_, .overspent): isTracking ? "Over budget" : "Overspent"
         case (true, .funded): "Budget set"
         case (false, .funded): "Funded"
@@ -1282,12 +1289,20 @@ struct CategoryBudgetDetailSheet: View {
     }
 
     private var statusColor: Color {
-        switch category.progressState {
+        switch liveCategory.progressState {
         case .overspent: .red
         case .spent: .orange
         case .spending: .blue
         case .funded: .green
         case .unassigned: .secondary
+        }
+    }
+
+    private var statusIcon: String {
+        switch liveCategory.progressState {
+        case .overspent: "exclamationmark.circle.fill"
+        case .unassigned: "circle.dashed"
+        case .funded, .spending, .spent: "checkmark.circle.fill"
         }
     }
 
@@ -1297,9 +1312,7 @@ struct CategoryBudgetDetailSheet: View {
                 Section {
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
-                            Label(statusTitle, systemImage: category.isOverspent
-                                ? "exclamationmark.circle.fill"
-                                : "checkmark.circle.fill")
+                            Label(statusTitle, systemImage: statusIcon)
                                 .font(.headline)
                                 .foregroundStyle(statusColor)
                             Spacer()
@@ -1308,17 +1321,17 @@ struct CategoryBudgetDetailSheet: View {
                                 .foregroundStyle(.secondary)
                         }
                         CategoryProgressBar(
-                            fraction: category.progressFraction,
-                            state: category.progressState
+                            fraction: liveCategory.progressFraction,
+                            state: liveCategory.progressState
                         )
                         LabeledContent(isTracking ? "Budget" : "Assigned") {
-                            Text(budgetStore.displayBalance(category.budgeted))
+                            Text(budgetStore.displayBalance(liveCategory.budgeted))
                         }
                         LabeledContent("Activity") {
-                            Text(budgetStore.displayBalance(category.spent))
+                            Text(budgetStore.displayBalance(liveCategory.spent))
                         }
                         LabeledContent(isTracking ? "Balance" : "Available") {
-                            Text(budgetStore.displayBalance(category.available))
+                            Text(budgetStore.displayBalance(liveCategory.available))
                                 .foregroundStyle(statusColor)
                         }
                     }
@@ -1333,15 +1346,15 @@ struct CategoryBudgetDetailSheet: View {
                             Label(isTracking ? "Edit Budget" : "Assign Money", systemImage: "pencil")
                         }
 
-                        if category.available != 0,
+                        if liveCategory.available != 0,
                            let budget = budgetStore.currentBudgetMonth {
                             Button {
-                                transferContext = BudgetTransferContext(category: category, budget: budget)
+                                transferContext = BudgetTransferContext(category: liveCategory, budget: budget)
                             } label: {
                                 Label(
                                     isTracking
                                         ? "Reallocate Budget"
-                                        : (category.isOverspent ? "Cover Overspending" : "Move Money"),
+                                        : (liveCategory.isOverspent ? "Cover Overspending" : "Move Money"),
                                     systemImage: "arrow.left.arrow.right"
                                 )
                             }
@@ -1444,7 +1457,7 @@ struct CategoryBudgetDetailSheet: View {
             }
             .task { await reloadSupportingDetails() }
             .sheet(isPresented: $editingBudget) {
-                EditBudgetAmountSheet(category: category)
+                EditBudgetAmountSheet(category: liveCategory)
             }
             .sheet(item: $transferContext) { context in
                 BudgetTransferSheet(context: context)
@@ -1470,13 +1483,13 @@ struct CategoryBudgetDetailSheet: View {
         async let fetchedHistory = budgetStore.budgetHistory(for: category)
         recentTransactions = await fetchedTransactions
         note = await fetchedNote
-        quickAssignSuggestions = category.quickAssignSuggestions(history: await fetchedHistory)
+        history = await fetchedHistory
     }
 
     private func quickAssignTitle(for kind: QuickAssignSuggestion.Kind) -> String {
         switch kind {
         case .spentLastMonth: "Spent Last Month"
-        case .averageSpent: "Average Spent (3 Months)"
+        case .averageSpent: "Average Spent (\(history.count) Months)"
         case .assignedLastMonth: isTracking ? "Budgeted Last Month" : "Assigned Last Month"
         case .resetAvailable: isTracking ? "Reset Balance to Zero" : "Reset Available to Zero"
         case .setToZero: isTracking ? "Set Budget to Zero" : "Set Assigned to Zero"

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -547,6 +547,7 @@ private struct TwoLineName: View {
 struct BudgetCheckInSection: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let budget: BudgetMonth
+    @AppStorage("budgetCheckInExpanded") private var isExpanded = true
 
     private var hasIssues: Bool {
         (budget.toBudget ?? 0) > 0
@@ -558,7 +559,24 @@ struct BudgetCheckInSection: View {
 
     var body: some View {
         Section {
-            if let toBudget = budget.toBudget, toBudget > 0 {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                    Text("Budget Check-In")
+                        .font(.headline)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Budget Check-In, \(isExpanded ? "expanded" : "collapsed")")
+
+            if isExpanded, let toBudget = budget.toBudget, toBudget > 0 {
                 NavigationLink {
                     BudgetGuidanceCategoryList(
                         title: "Ready to Assign",
@@ -578,7 +596,7 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if budgetStore.showOverspentBadge, budget.overspentCount > 0 {
+            if isExpanded, budgetStore.showOverspentBadge, budget.overspentCount > 0 {
                 NavigationLink {
                     OverspentCategoriesView()
                 } label: {
@@ -592,7 +610,7 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if budgetStore.uncategorizedCount > 0 {
+            if isExpanded, budgetStore.uncategorizedCount > 0 {
                 NavigationLink {
                     UncategorizedTransactionsView()
                 } label: {
@@ -604,7 +622,7 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if !budget.unassignedCategories.isEmpty {
+            if isExpanded, !budget.unassignedCategories.isEmpty {
                 NavigationLink {
                     BudgetGuidanceCategoryList(
                         title: budget.isTrackingBudget ? "No Budget Set" : "Not Funded",
@@ -623,7 +641,7 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if !budget.approachingLimitCategories.isEmpty {
+            if isExpanded, !budget.approachingLimitCategories.isEmpty {
                 NavigationLink {
                     BudgetGuidanceCategoryList(
                         title: budget.isTrackingBudget ? "Near Budget" : "Almost Spent",
@@ -639,16 +657,16 @@ struct BudgetCheckInSection: View {
                 }
             }
 
-            if !hasIssues {
+            if isExpanded, !hasIssues {
                 Label("Budget looks good", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
             }
-        } header: {
-            Text("Budget Check-In")
         } footer: {
-            Text(budget.isTrackingBudget
-                ? "Review the plan against this month's actual activity."
-                : "Resolve the important items before assigning the rest of the month.")
+            if isExpanded {
+                Text(budget.isTrackingBudget
+                    ? "Review the plan against this month's actual activity."
+                    : "Resolve the important items before assigning the rest of the month.")
+            }
         }
     }
 }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -550,11 +550,7 @@ struct BudgetCheckInSection: View {
     @AppStorage("budgetCheckInExpanded") private var isExpanded = true
 
     private var hasIssues: Bool {
-        (budget.toBudget ?? 0) > 0
-            || (budgetStore.showOverspentBadge && budget.overspentCount > 0)
-            || budgetStore.uncategorizedCount > 0
-            || !budget.unassignedCategories.isEmpty
-            || !budget.approachingLimitCategories.isEmpty
+        budget.hasCheckInIssues(uncategorizedCount: budgetStore.uncategorizedCount)
     }
 
     var body: some View {
@@ -576,6 +572,33 @@ struct BudgetCheckInSection: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Budget Check-In, \(isExpanded ? "expanded" : "collapsed")")
 
+            if isExpanded, budget.overspentCount > 0 {
+                NavigationLink {
+                    OverspentCategoriesView()
+                } label: {
+                    Label(
+                        budget.isTrackingBudget
+                            ? "\(budget.overspentCount) over budget"
+                            : "\(budget.overspentCount) overspent",
+                        systemImage: "exclamationmark.circle.fill"
+                    )
+                    .foregroundStyle(.red)
+                }
+                .accessibilityIdentifier("budgetCheckInOverspent")
+            }
+
+            if isExpanded, budgetStore.uncategorizedCount > 0 {
+                NavigationLink {
+                    UncategorizedTransactionsView()
+                } label: {
+                    Label(
+                        "\(budgetStore.uncategorizedCount) uncategorized",
+                        systemImage: "questionmark.circle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                }
+            }
+
             if isExpanded, let toBudget = budget.toBudget, toBudget > 0 {
                 NavigationLink {
                     BudgetGuidanceCategoryList(
@@ -593,32 +616,6 @@ struct BudgetCheckInSection: View {
                     } icon: {
                         Image(systemName: "dollarsign.arrow.circlepath").foregroundStyle(.green)
                     }
-                }
-            }
-
-            if isExpanded, budgetStore.showOverspentBadge, budget.overspentCount > 0 {
-                NavigationLink {
-                    OverspentCategoriesView()
-                } label: {
-                    Label(
-                        budget.isTrackingBudget
-                            ? "\(budget.overspentCount) over budget"
-                            : "\(budget.overspentCount) overspent",
-                        systemImage: "exclamationmark.circle.fill"
-                    )
-                    .foregroundStyle(.red)
-                }
-            }
-
-            if isExpanded, budgetStore.uncategorizedCount > 0 {
-                NavigationLink {
-                    UncategorizedTransactionsView()
-                } label: {
-                    Label(
-                        "\(budgetStore.uncategorizedCount) uncategorized",
-                        systemImage: "questionmark.circle.fill"
-                    )
-                    .foregroundStyle(.orange)
                 }
             }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1196,6 +1196,8 @@ struct CategoryBudgetDetailSheet: View {
     @State private var quickAssignSuggestions: [QuickAssignSuggestion] = []
     @State private var isApplyingSuggestion = false
     @State private var quickAssignError: String?
+    @State private var actionsExpanded = true
+    @State private var quickAssignExpanded = true
 
     private var isTracking: Bool {
         budgetStore.currentBudgetMonth?.isTrackingBudget == true
@@ -1259,67 +1261,78 @@ struct CategoryBudgetDetailSheet: View {
                     .padding(.vertical, 4)
                 }
 
-                Section("Actions") {
-                    Button {
-                        editingBudget = true
-                    } label: {
-                        Label(isTracking ? "Edit Budget" : "Assign Money", systemImage: "pencil")
-                    }
-
-                    if category.available != 0,
-                       let budget = budgetStore.currentBudgetMonth {
+                Section {
+                    if actionsExpanded {
                         Button {
-                            transferContext = BudgetTransferContext(category: category, budget: budget)
+                            editingBudget = true
                         } label: {
-                            Label(
-                                isTracking
-                                    ? "Reallocate Budget"
-                                    : (category.isOverspent ? "Cover Overspending" : "Move Money"),
-                                systemImage: "arrow.left.arrow.right"
-                            )
+                            Label(isTracking ? "Edit Budget" : "Assign Money", systemImage: "pencil")
+                        }
+
+                        if category.available != 0,
+                           let budget = budgetStore.currentBudgetMonth {
+                            Button {
+                                transferContext = BudgetTransferContext(category: category, budget: budget)
+                            } label: {
+                                Label(
+                                    isTracking
+                                        ? "Reallocate Budget"
+                                        : (category.isOverspent ? "Cover Overspending" : "Move Money"),
+                                    systemImage: "arrow.left.arrow.right"
+                                )
+                            }
+                        }
+
+                        NavigationLink {
+                            CategoryTransactionsView(destination: CategoryTransactionsDestination(
+                                categoryId: category.categoryId,
+                                categoryName: category.categoryName,
+                                month: category.month
+                            ))
+                        } label: {
+                            Label("This Month's Transactions", systemImage: "list.bullet.rectangle")
+                        }
+
+                        NavigationLink {
+                            CategoryTransactionsView(destination: CategoryTransactionsDestination(
+                                categoryId: category.categoryId,
+                                categoryName: category.categoryName,
+                                month: nil
+                            ))
+                        } label: {
+                            Label("All Transactions", systemImage: "clock.arrow.circlepath")
                         }
                     }
-
-                    NavigationLink {
-                        CategoryTransactionsView(destination: CategoryTransactionsDestination(
-                            categoryId: category.categoryId,
-                            categoryName: category.categoryName,
-                            month: category.month
-                        ))
-                    } label: {
-                        Label("This Month's Transactions", systemImage: "list.bullet.rectangle")
-                    }
-
-                    NavigationLink {
-                        CategoryTransactionsView(destination: CategoryTransactionsDestination(
-                            categoryId: category.categoryId,
-                            categoryName: category.categoryName,
-                            month: nil
-                        ))
-                    } label: {
-                        Label("All Transactions", systemImage: "clock.arrow.circlepath")
-                    }
+                } header: {
+                    BudgetDetailSectionHeader(title: "Actions", isExpanded: $actionsExpanded)
                 }
 
                 if !quickAssignSuggestions.isEmpty {
                     Section {
-                        ForEach(quickAssignSuggestions) { suggestion in
-                            Button {
-                                Task { await apply(suggestion) }
-                            } label: {
-                                HStack {
-                                    Text(quickAssignTitle(for: suggestion.kind))
-                                    Spacer()
-                                    Text(budgetStore.displayBalance(suggestion.amount))
-                                        .foregroundStyle(.secondary)
+                        if quickAssignExpanded {
+                            ForEach(quickAssignSuggestions) { suggestion in
+                                Button {
+                                    Task { await apply(suggestion) }
+                                } label: {
+                                    HStack {
+                                        Text(quickAssignTitle(for: suggestion.kind))
+                                        Spacer()
+                                        Text(budgetStore.displayBalance(suggestion.amount))
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
+                                .disabled(isApplyingSuggestion)
                             }
-                            .disabled(isApplyingSuggestion)
                         }
                     } header: {
-                        Text(isTracking ? "Quick Budget" : "Quick Assign")
+                        BudgetDetailSectionHeader(
+                            title: isTracking ? "Quick Budget" : "Quick Assign",
+                            isExpanded: $quickAssignExpanded
+                        )
                     } footer: {
-                        Text("Suggestions use this category's existing Actual history and replace the current month's amount.")
+                        if quickAssignExpanded {
+                            Text("Suggestions use this category's existing Actual history and replace the current month's amount.")
+                        }
                     }
                 }
 
@@ -1416,6 +1429,36 @@ struct CategoryBudgetDetailSheet: View {
             quickAssignError = error.localizedDescription
             isApplyingSuggestion = false
         }
+    }
+}
+
+/// Tappable List section header used where a category detail can otherwise
+/// become action-heavy on a phone. The state is in the accessibility label so
+/// a collapsed section is distinguishable from an empty one.
+struct BudgetDetailSectionHeader: View {
+    let title: String
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack {
+                Text(title)
+                Spacer()
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption)
+                    .accessibilityHidden(true)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isHeader)
+        .accessibilityLabel("\(title), \(isExpanded ? "expanded" : "collapsed")")
+        .accessibilityIdentifier("\(title), \(isExpanded ? "expanded" : "collapsed")")
+        .accessibilityHint(isExpanded ? "Collapses this section" : "Expands this section")
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -743,11 +743,14 @@ struct CategoryBudgetRow: View {
                 Button {
                     onShowDetails(category)
                 } label: {
-                    TwoLineName(
-                        text: category.categoryName,
-                        font: .subheadline,
-                        minimumScaleFactor: 0.85
-                    )
+                    HStack(spacing: 5) {
+                        CompactCategoryStatusDot(state: category.progressState)
+                        TwoLineName(
+                            text: category.categoryName,
+                            font: .subheadline,
+                            minimumScaleFactor: 0.85
+                        )
+                    }
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Details for \(category.categoryName)")
@@ -819,8 +822,11 @@ struct CleanCategoryBudgetRow: View {
                 Button {
                     onShowDetails(category)
                 } label: {
-                    Text(category.categoryName)
-                        .font(.body)
+                    HStack(spacing: 6) {
+                        CompactCategoryStatusDot(state: category.progressState)
+                        Text(category.categoryName)
+                            .font(.body)
+                    }
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Details for \(category.categoryName)")
@@ -1523,6 +1529,39 @@ struct CategoryProgressBar: View {
         .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
         .accessibilityLabel("\(status), spent \(Int((fraction * 100).rounded())) percent")
+    }
+}
+
+/// A deliberately quiet status cue for budget rows. The category detail sheet
+/// carries the full plain-language status so the main budget remains scannable.
+struct CompactCategoryStatusDot: View {
+    let state: CategoryProgressState
+
+    private var tint: Color {
+        switch state {
+        case .overspent: .red
+        case .spent: .orange
+        case .spending: .blue
+        case .funded: .green
+        case .unassigned: .secondary
+        }
+    }
+
+    private var status: String {
+        switch state {
+        case .overspent: "Overspent"
+        case .spent: "Fully spent"
+        case .spending: "Partially spent"
+        case .funded: "Funded"
+        case .unassigned: "No money assigned"
+        }
+    }
+
+    var body: some View {
+        Circle()
+            .fill(tint)
+            .frame(width: 7, height: 7)
+            .accessibilityLabel(status)
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -124,39 +124,7 @@ struct BudgetView: View {
                         .padding(.bottom, 8)
 
                         List {
-                            // Explains the tab badge (GH #138): which categories
-                            // are overspent, including overspending rolled over
-                            // from earlier months. Shares the badge's Settings
-                            // toggle — off means no overspending callouts at all.
-                            if budgetStore.showOverspentBadge, budget.overspentCount > 0 {
-                                Section {
-                                    NavigationLink {
-                                        OverspentCategoriesView()
-                                    } label: {
-                                        Label {
-                                            Text("^[\(budget.overspentCount) Overspent Category](inflect: true)")
-                                        } icon: {
-                                            Image(systemName: "exclamationmark.circle.fill")
-                                                .foregroundStyle(.red)
-                                        }
-                                    }
-                                }
-                            }
-
-                            if budgetStore.uncategorizedCount > 0 {
-                                Section {
-                                    NavigationLink {
-                                        UncategorizedTransactionsView()
-                                    } label: {
-                                        Label {
-                                            Text("^[\(budgetStore.uncategorizedCount) Uncategorized Transaction](inflect: true)")
-                                        } icon: {
-                                            Image(systemName: "questionmark.circle.fill")
-                                                .foregroundStyle(.orange)
-                                        }
-                                    }
-                                }
-                            }
+                            BudgetCheckInSection(budget: budget)
 
                             ForEach(groupedCategories, id: \.id) { group in
                                 let isCollapsed = collapsedGroups.contains(group.id)
@@ -572,6 +540,170 @@ private struct TwoLineName: View {
                 .font(font)
                 .lineLimit(2)
                 .minimumScaleFactor(minimumScaleFactor)
+        }
+    }
+}
+
+struct BudgetCheckInSection: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    let budget: BudgetMonth
+
+    private var hasIssues: Bool {
+        (budget.toBudget ?? 0) > 0
+            || (budgetStore.showOverspentBadge && budget.overspentCount > 0)
+            || budgetStore.uncategorizedCount > 0
+            || !budget.unassignedCategories.isEmpty
+            || !budget.approachingLimitCategories.isEmpty
+    }
+
+    var body: some View {
+        Section {
+            if let toBudget = budget.toBudget, toBudget > 0 {
+                NavigationLink {
+                    BudgetGuidanceCategoryList(
+                        title: "Ready to Assign",
+                        message: "Choose categories for the money still waiting to be assigned.",
+                        categories: budget.unassignedCategories.isEmpty
+                            ? budget.categoryBudgets
+                            : budget.unassignedCategories
+                    )
+                } label: {
+                    Label {
+                        LabeledContent("Ready to Assign") {
+                            Text(budgetStore.displayBalance(toBudget)).foregroundStyle(.green)
+                        }
+                    } icon: {
+                        Image(systemName: "dollarsign.arrow.circlepath").foregroundStyle(.green)
+                    }
+                }
+            }
+
+            if budgetStore.showOverspentBadge, budget.overspentCount > 0 {
+                NavigationLink {
+                    OverspentCategoriesView()
+                } label: {
+                    Label(
+                        budget.isTrackingBudget
+                            ? "\(budget.overspentCount) over budget"
+                            : "\(budget.overspentCount) overspent",
+                        systemImage: "exclamationmark.circle.fill"
+                    )
+                    .foregroundStyle(.red)
+                }
+            }
+
+            if budgetStore.uncategorizedCount > 0 {
+                NavigationLink {
+                    UncategorizedTransactionsView()
+                } label: {
+                    Label(
+                        "\(budgetStore.uncategorizedCount) uncategorized",
+                        systemImage: "questionmark.circle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                }
+            }
+
+            if !budget.unassignedCategories.isEmpty {
+                NavigationLink {
+                    BudgetGuidanceCategoryList(
+                        title: budget.isTrackingBudget ? "No Budget Set" : "Not Funded",
+                        message: budget.isTrackingBudget
+                            ? "These categories have no budget or activity this month."
+                            : "These categories have no assigned or carried money this month.",
+                        categories: budget.unassignedCategories
+                    )
+                } label: {
+                    Label(
+                        budget.isTrackingBudget
+                            ? "\(budget.unassignedCategories.count) without a budget"
+                            : "\(budget.unassignedCategories.count) not funded",
+                        systemImage: "circle.dashed"
+                    )
+                }
+            }
+
+            if !budget.approachingLimitCategories.isEmpty {
+                NavigationLink {
+                    BudgetGuidanceCategoryList(
+                        title: budget.isTrackingBudget ? "Near Budget" : "Almost Spent",
+                        message: "These categories have used at least 80% of their available amount.",
+                        categories: budget.approachingLimitCategories
+                    )
+                } label: {
+                    Label(
+                        "\(budget.approachingLimitCategories.count) nearing the limit",
+                        systemImage: "gauge.with.dots.needle.67percent"
+                    )
+                    .foregroundStyle(.orange)
+                }
+            }
+
+            if !hasIssues {
+                Label("Budget looks good", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+        } header: {
+            Text("Budget Check-In")
+        } footer: {
+            Text(budget.isTrackingBudget
+                ? "Review the plan against this month's actual activity."
+                : "Resolve the important items before assigning the rest of the month.")
+        }
+    }
+}
+
+/// A focused check-in result. Selecting a category opens the same actionable
+/// detail sheet as the main budget table, so guidance always ends in a real
+/// resolution path rather than a dead-end status list.
+struct BudgetGuidanceCategoryList: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    let title: String
+    let message: String
+    let categories: [CategoryBudget]
+    @State private var selectedCategory: CategoryBudget?
+
+    var body: some View {
+        List {
+            Section {
+                Text(message)
+                    .foregroundStyle(.secondary)
+            }
+            Section {
+                ForEach(categories) { category in
+                    Button {
+                        selectedCategory = category
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(category.categoryName)
+                                    .foregroundStyle(.primary)
+                                Spacer()
+                                Text(budgetStore.displayBalance(category.available))
+                                    .foregroundStyle(category.isOverspent ? .red : .secondary)
+                                    .monospacedDigit()
+                            }
+                            Text(category.groupName)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            if category.showsProgressBar {
+                                CategoryProgressBar(
+                                    fraction: category.progressFraction,
+                                    state: category.progressState
+                                )
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Details for \(category.categoryName)")
+                }
+            }
+        }
+        .readableWidth()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedCategory) { category in
+            CategoryBudgetDetailSheet(category: category)
         }
     }
 }

--- a/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
+++ b/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct OverspentCategoriesView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @State private var transferContext: BudgetTransferContext?
+    @State private var editingCategory: CategoryBudget?
 
     var body: some View {
         Group {
@@ -15,10 +16,25 @@ struct OverspentCategoriesView: View {
                 List {
                     Section {
                         ForEach(budget.overspentCategories) { category in
-                            OverspentCategoryRow(category: category)
-                                // The fix, right where the problem is listed
-                                // (GH #128): swipe to cover the overspending
-                                // from To Budget or another category.
+                            VStack(alignment: .leading, spacing: 10) {
+                                OverspentCategoryRow(category: category)
+                                Button {
+                                    if budget.isTrackingBudget {
+                                        editingCategory = category
+                                    } else {
+                                        transferContext = BudgetTransferContext(category: category, budget: budget)
+                                    }
+                                } label: {
+                                    Label(
+                                        budget.isTrackingBudget ? "Increase Budget" : "Cover Overspending",
+                                        systemImage: budget.isTrackingBudget ? "plus.circle.fill" : "arrow.left.arrow.right"
+                                    )
+                                }
+                                .buttonStyle(.bordered)
+                                .accessibilityIdentifier("Resolve overspending for \(category.categoryName)")
+                            }
+                                // Keep the existing shortcut in addition to
+                                // the visible action for experienced users.
                                 .swipeActions(edge: .trailing) {
                                     Button {
                                         transferContext = BudgetTransferContext(category: category, budget: budget)
@@ -29,11 +45,14 @@ struct OverspentCategoriesView: View {
                                 }
                         }
                     } footer: {
-                        Text("Categories with a negative balance in \(MonthPicker.title(for: budget.month)). Balances include overspending rolled over from earlier months, which this month's transactions alone won't explain. Swipe a category to cover its overspending.")
+                        Text("Categories with a negative balance in \(MonthPicker.title(for: budget.month)). Balances include overspending rolled over from earlier months. Use the action under a category to resolve it, or open the category to review its transactions.")
                     }
                 }
                 .sheet(item: $transferContext) { context in
                     BudgetTransferSheet(context: context)
+                }
+                .sheet(item: $editingCategory) { category in
+                    EditBudgetAmountSheet(category: category)
                 }
             } else {
                 ContentUnavailableView(

--- a/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
+++ b/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
@@ -35,11 +35,20 @@ struct OverspentCategoriesView: View {
                             }
                                 // Keep the existing shortcut in addition to
                                 // the visible action for experienced users.
+                                // Same resolution as the button: tracking
+                                // budgets edit the amount, envelopes cover.
                                 .swipeActions(edge: .trailing) {
                                     Button {
-                                        transferContext = BudgetTransferContext(category: category, budget: budget)
+                                        if budget.isTrackingBudget {
+                                            editingCategory = category
+                                        } else {
+                                            transferContext = BudgetTransferContext(category: category, budget: budget)
+                                        }
                                     } label: {
-                                        Label("Cover", systemImage: "arrow.left.arrow.right")
+                                        Label(
+                                            budget.isTrackingBudget ? "Adjust" : "Cover",
+                                            systemImage: budget.isTrackingBudget ? "plus.circle.fill" : "arrow.left.arrow.right"
+                                        )
                                     }
                                     .tint(.green)
                                 }

--- a/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
@@ -43,6 +43,11 @@ struct BudgetMonthOverspentCountTests {
         #expect(makeMonth(availables: [0]).overspentCount == 0)
     }
 
+    @Test func overspendingAlwaysRequiresCheckIn() {
+        let month = makeMonth(availables: [-8500])
+        #expect(month.hasCheckInIssues(uncategorizedCount: 0))
+    }
+
     // MARK: - overspentCategories (the badge's explanation, GH #138)
 
     @Test func overspentCategoriesListsOnlyTheOnesInTheRed() {

--- a/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
@@ -48,6 +48,14 @@ struct BudgetMonthOverspentCountTests {
         #expect(month.hasCheckInIssues(uncategorizedCount: 0))
     }
 
+    // Money left to assign has no check-in row (the Budget summary shows
+    // it), so it must not suppress "Budget looks good" either.
+    @Test func moneyLeftToAssignAloneIsNotACheckInIssue() {
+        var month = makeMonth(availables: [5000])
+        month.toBudget = 12000
+        #expect(!month.hasCheckInIssues(uncategorizedCount: 0))
+    }
+
     // MARK: - overspentCategories (the badge's explanation, GH #138)
 
     @Test func overspentCategoriesListsOnlyTheOnesInTheRed() {

--- a/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthOverspentCountTests.swift
@@ -59,6 +59,29 @@ struct BudgetMonthOverspentCountTests {
         #expect(makeMonth(availables: [5000, 0]).overspentCategories.isEmpty)
     }
 
+    @Test func checkInSeparatesUnassignedAndApproachingCategories() {
+        var unassigned = makeCategory(id: "unassigned", available: 0)
+        unassigned.budgeted = 0
+        unassigned.spent = 0
+
+        var approaching = makeCategory(id: "approaching", available: 1000)
+        approaching.budgeted = 10000
+        approaching.spent = -9000
+
+        var healthy = makeCategory(id: "healthy", available: 6000)
+        healthy.budgeted = 10000
+        healthy.spent = -4000
+
+        let month = BudgetMonth(
+            month: "2026-07",
+            categoryBudgets: [healthy, approaching, unassigned],
+            toBudget: 5000
+        )
+
+        #expect(month.unassignedCategories.map(\.categoryId) == ["unassigned"])
+        #expect(month.approachingLimitCategories.map(\.categoryId) == ["approaching"])
+    }
+
     // MARK: - rolledOverOverspending
 
     @Test func negativeCarryoverIsRolledOverOverspending() {

--- a/Actuali/ActualiTests/BudgetMonthTrackingSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetMonthTrackingSummaryTests.swift
@@ -7,6 +7,14 @@ import Testing
 /// `total-saved` (budgeted income - budgeted expenses).
 struct BudgetMonthTrackingSummaryTests {
 
+    @Test func budgetTypeFollowsPresenceOfToBudget() {
+        let tracking = BudgetMonth(month: "2026-07", categoryBudgets: [], toBudget: nil)
+        let envelope = BudgetMonth(month: "2026-07", categoryBudgets: [], toBudget: 0)
+
+        #expect(tracking.isTrackingBudget)
+        #expect(!envelope.isTrackingBudget)
+    }
+
     private func expense(id: String, budgeted: Int, spent: Int) -> CategoryBudget {
         CategoryBudget(
             month: "2026-07",

--- a/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
+++ b/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
@@ -72,4 +72,12 @@ struct CategoryBudgetProgressTests {
         let category = makeCategory(budgeted: 0, spent: -3000, available: -3000)
         #expect(category.showsProgressBar)
     }
+
+    @Test func progressStatesDistinguishActionableCategoryConditions() {
+        #expect(makeCategory(budgeted: 0, spent: 0, available: 0).progressState == .unassigned)
+        #expect(makeCategory(budgeted: 10000, spent: 0, available: 10000).progressState == .funded)
+        #expect(makeCategory(budgeted: 10000, spent: -4000, available: 6000).progressState == .spending)
+        #expect(makeCategory(budgeted: 10000, spent: -10000, available: 0).progressState == .spent)
+        #expect(makeCategory(budgeted: 10000, spent: -12000, available: -2000).progressState == .overspent)
+    }
 }

--- a/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
+++ b/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
@@ -115,6 +115,29 @@ struct CategoryBudgetProgressTests {
         #expect(kinds.contains(.spentLastMonth))
     }
 
+    @Test func filterMatchesTheStatesItNames() {
+        let overspent = makeCategory(budgeted: 0, spent: -100, available: -100)
+        let unassigned = makeCategory(budgeted: 0, spent: 0, available: 0)
+        let funded = makeCategory(budgeted: 100, spent: 0, available: 100)
+
+        #expect(BudgetCategoryFilter.all.includes(funded))
+        #expect(BudgetCategoryFilter.overspent.includes(overspent))
+        #expect(!BudgetCategoryFilter.overspent.includes(unassigned))
+        #expect(BudgetCategoryFilter.unassigned.includes(unassigned))
+        #expect(BudgetCategoryFilter.needsAttention.includes(overspent))
+        #expect(BudgetCategoryFilter.needsAttention.includes(unassigned))
+        #expect(!BudgetCategoryFilter.needsAttention.includes(funded))
+        #expect(BudgetCategoryFilter.onTrack.includes(funded))
+        #expect(!BudgetCategoryFilter.onTrack.includes(unassigned))
+    }
+
+    @Test func monthKeysShiftAcrossTheYearBoundary() {
+        #expect(BudgetStore.shiftBudgetMonth("2026-01", by: -1) == "2025-12")
+        #expect(BudgetStore.shiftBudgetMonth("2026-12", by: 1) == "2027-01")
+        #expect(BudgetStore.shiftBudgetMonth("2026-06", by: 0) == "2026-06")
+        #expect(BudgetStore.shiftBudgetMonth("not-a-month", by: -1) == nil)
+    }
+
     @Test func coverSourcesPrioritizeFullCoverageThenSameGroup() {
         let overspent = makeCategory(id: "target", groupId: "home", budgeted: 0, spent: -5000, available: -5000)
         let partialSameGroup = makeCategory(id: "partial", groupId: "home", budgeted: 3000, spent: 0, available: 3000)

--- a/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
+++ b/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
@@ -80,4 +80,26 @@ struct CategoryBudgetProgressTests {
         #expect(makeCategory(budgeted: 10000, spent: -10000, available: 0).progressState == .spent)
         #expect(makeCategory(budgeted: 10000, spent: -12000, available: -2000).progressState == .overspent)
     }
+
+    @Test func quickAssignUsesActualHistoryAndProducesFinalAmounts() {
+        let current = makeCategory(budgeted: 10000, spent: -4000, available: 6000)
+        let history = [
+            makeCategory(budgeted: 9000, spent: -8000, available: 1000),
+            makeCategory(budgeted: 6000, spent: -4000, available: 2000),
+            makeCategory(budgeted: 3000, spent: 1000, available: 4000)
+        ]
+        let byKind = Dictionary(uniqueKeysWithValues:
+            current.quickAssignSuggestions(history: history).map { ($0.kind, $0.amount) })
+
+        #expect(byKind[.spentLastMonth] == 8000)
+        #expect(byKind[.assignedLastMonth] == 9000)
+        #expect(byKind[.averageSpent] == 4000)
+        #expect(byKind[.resetAvailable] == 4000)
+        #expect(byKind[.setToZero] == 0)
+    }
+
+    @Test func quickAssignOmitsUnavailableHistoricalChoices() {
+        let current = makeCategory(budgeted: 0, spent: 0, available: 0)
+        #expect(current.quickAssignSuggestions(history: []).isEmpty)
+    }
 }

--- a/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
+++ b/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
@@ -5,6 +5,8 @@ import Testing
 struct CategoryBudgetProgressTests {
 
     private func makeCategory(
+        id: String = "cat1",
+        groupId: String = "g1",
         budgeted: Int,
         spent: Int,
         available: Int,
@@ -12,9 +14,9 @@ struct CategoryBudgetProgressTests {
     ) -> CategoryBudget {
         CategoryBudget(
             month: "2026-07",
-            categoryId: "cat1",
+            categoryId: id,
             categoryName: "Groceries",
-            groupId: "g1",
+            groupId: groupId,
             groupName: "Everyday",
             groupSortOrder: 0,
             categorySortOrder: 0,
@@ -101,5 +103,24 @@ struct CategoryBudgetProgressTests {
     @Test func quickAssignOmitsUnavailableHistoricalChoices() {
         let current = makeCategory(budgeted: 0, spent: 0, available: 0)
         #expect(current.quickAssignSuggestions(history: []).isEmpty)
+    }
+
+    @Test func coverSourcesPrioritizeFullCoverageThenSameGroup() {
+        let overspent = makeCategory(id: "target", groupId: "home", budgeted: 0, spent: -5000, available: -5000)
+        let partialSameGroup = makeCategory(id: "partial", groupId: "home", budgeted: 3000, spent: 0, available: 3000)
+        let largeOtherGroup = makeCategory(id: "large", groupId: "other", budgeted: 12000, spent: 0, available: 12000)
+        let smallSameGroup = makeCategory(id: "small", groupId: "home", budgeted: 6000, spent: 0, available: 6000)
+        let context = BudgetTransferContext(
+            category: overspent,
+            budget: BudgetMonth(
+                month: overspent.month,
+                categoryBudgets: [partialSameGroup, largeOtherGroup, smallSameGroup],
+                toBudget: 0
+            )
+        )
+
+        #expect(BudgetTransferSheet.rankedCategories(context).map(\.categoryId)
+            == ["small", "large", "partial"])
+        #expect(!BudgetTransferSheet.canUseToBudget(context))
     }
 }

--- a/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
+++ b/Actuali/ActualiTests/CategoryBudgetProgressTests.swift
@@ -105,6 +105,16 @@ struct CategoryBudgetProgressTests {
         #expect(current.quickAssignSuggestions(history: []).isEmpty)
     }
 
+    // With one history month the average equals Spent Last Month; offering
+    // both would just duplicate the suggestion.
+    @Test func quickAssignOmitsAverageForASingleHistoryMonth() {
+        let current = makeCategory(budgeted: 10000, spent: -4000, available: 6000)
+        let history = [makeCategory(budgeted: 9000, spent: -8000, available: 1000)]
+        let kinds = current.quickAssignSuggestions(history: history).map(\.kind)
+        #expect(!kinds.contains(.averageSpent))
+        #expect(kinds.contains(.spentLastMonth))
+    }
+
     @Test func coverSourcesPrioritizeFullCoverageThenSameGroup() {
         let overspent = makeCategory(id: "target", groupId: "home", budgeted: 0, spent: -5000, available: -5000)
         let partialSameGroup = makeCategory(id: "partial", groupId: "home", budgeted: 3000, spent: 0, available: 3000)

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -22,6 +22,8 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
+        XCTAssertTrue(app.staticTexts["Budget Check-In"].exists,
+                      "the month guidance should stay visible above the category groups")
         XCTAssertTrue(budgetedCaption(in: app).waitForExistence(timeout: 10),
                       "clean rows carry a 'Budgeted:' caption")
     }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -19,7 +19,7 @@ final class BudgetDisplayStyleUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
         XCTAssertTrue(budgetedCaption(in: app).waitForExistence(timeout: 10),
@@ -63,10 +63,27 @@ final class BudgetDisplayStyleUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["All transactions for Groceries"].firstMatch
+        let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
         XCTAssertFalse(budgetedCaption(in: app).exists,
                        "detailed rows show pill cells, not 'Budgeted:' captions")
+    }
+
+    @MainActor
+    func testCategoryNameOpensActionableDetailSheet() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-budgetDisplayStyle", "clean"]
+        app.launch()
+
+        app.tabBars.buttons["Budget"].tap()
+        let groceries = app.buttons["Details for Groceries"].firstMatch
+        XCTAssertTrue(groceries.waitForExistence(timeout: 10))
+        groceries.tap()
+
+        XCTAssertTrue(app.navigationBars["Groceries"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Assign Money"].exists)
+        XCTAssertTrue(app.buttons["This Month's Transactions"].exists)
+        XCTAssertTrue(app.buttons["All Transactions"].exists)
     }
 }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -75,10 +75,11 @@ final class BudgetDisplayStyleUITests: XCTestCase {
     @MainActor
     func testCategoryNameOpensActionableDetailSheet() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-loadDemoData", "-budgetDisplayStyle", "clean"]
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "clean", "-initialTab", "1",
+        ]
         app.launch()
 
-        app.tabBars.buttons["Budget"].tap()
         let groceries = app.buttons["Details for Groceries"].firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10))
         groceries.tap()
@@ -88,5 +89,30 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         XCTAssertTrue(app.buttons["This Month's Transactions"].exists)
         XCTAssertTrue(app.buttons["All Transactions"].exists)
         XCTAssertTrue(app.staticTexts["Quick Assign"].exists)
+    }
+
+    @MainActor
+    func testCategoryActionsAndQuickAssignCanCollapse() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "clean", "-initialTab", "1",
+        ]
+        app.launch()
+
+        let groceries = app.buttons["Details for Groceries"].firstMatch
+        XCTAssertTrue(groceries.waitForExistence(timeout: 10))
+        groceries.tap()
+
+        let actions = app.buttons["Actions, expanded"]
+        XCTAssertTrue(actions.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Assign Money"].exists)
+        actions.tap()
+        XCTAssertTrue(app.buttons["Actions, collapsed"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Assign Money"].exists)
+
+        let quickAssign = app.buttons["Quick Assign, expanded"]
+        XCTAssertTrue(quickAssign.waitForExistence(timeout: 10))
+        quickAssign.tap()
+        XCTAssertTrue(app.buttons["Quick Assign, collapsed"].waitForExistence(timeout: 5))
     }
 }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -104,16 +104,30 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         groceries.tap()
 
         let actions = app.buttons["Actions, expanded"]
+        let collapsedActions = app.buttons["Actions, collapsed"]
+        if collapsedActions.waitForExistence(timeout: 2) {
+            collapsedActions.tap()
+        }
         XCTAssertTrue(actions.waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Assign Money"].exists)
         actions.tap()
-        XCTAssertTrue(app.buttons["Actions, collapsed"].waitForExistence(timeout: 5))
+        XCTAssertTrue(collapsedActions.waitForExistence(timeout: 5))
         XCTAssertFalse(app.buttons["Assign Money"].exists)
 
         let quickAssign = app.buttons["Quick Assign, expanded"]
+        let collapsedQuickAssign = app.buttons["Quick Assign, collapsed"]
+        if collapsedQuickAssign.waitForExistence(timeout: 2) {
+            collapsedQuickAssign.tap()
+        }
         XCTAssertTrue(quickAssign.waitForExistence(timeout: 10))
         quickAssign.tap()
-        XCTAssertTrue(app.buttons["Quick Assign, collapsed"].waitForExistence(timeout: 5))
+        XCTAssertTrue(collapsedQuickAssign.waitForExistence(timeout: 5))
+
+        app.navigationBars.buttons["Done"].tap()
+        XCTAssertTrue(groceries.waitForExistence(timeout: 5))
+        groceries.tap()
+        XCTAssertTrue(collapsedActions.waitForExistence(timeout: 10))
+        XCTAssertTrue(collapsedQuickAssign.waitForExistence(timeout: 10))
     }
 
     @MainActor

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -150,4 +150,43 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         XCTAssertTrue(collapsed.waitForExistence(timeout: 5))
         XCTAssertFalse(app.staticTexts["Resolve the important items before assigning the rest of the month."].exists)
     }
+
+    @MainActor
+    func testBudgetCheckInCanFundAnUnassignedCategory() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "1"]
+        app.launch()
+
+        // Parking has no activity in the demo. Clearing its budget makes it
+        // a real Not Funded check-in result through the normal write path.
+        let editParking = app.buttons["Edit budgeted amount for Parking"]
+        var scrollsLeft = 8
+        while !editParking.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(editParking.isHittable)
+        editParking.tap()
+
+        let amount = app.textFields.firstMatch
+        XCTAssertTrue(amount.waitForExistence(timeout: 5))
+        amount.tap()
+        amount.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 10))
+        app.buttons["Save"].tap()
+        XCTAssertTrue(amount.waitForNonExistence(timeout: 5))
+
+        for _ in 0..<8 { app.swipeDown() }
+        let notFunded = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'not funded'")
+        ).firstMatch
+        XCTAssertTrue(notFunded.waitForExistence(timeout: 10))
+        notFunded.tap()
+
+        let fundParking = app.buttons["Fund Parking"]
+        XCTAssertTrue(fundParking.waitForExistence(timeout: 5),
+                      "check-in result should expose a direct funding action")
+        fundParking.tap()
+        XCTAssertTrue(app.navigationBars["Parking"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Save"].exists)
+    }
 }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -85,5 +85,6 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Assign Money"].exists)
         XCTAssertTrue(app.buttons["This Month's Transactions"].exists)
         XCTAssertTrue(app.buttons["All Transactions"].exists)
+        XCTAssertTrue(app.staticTexts["Quick Assign"].exists)
     }
 }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -115,4 +115,25 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         quickAssign.tap()
         XCTAssertTrue(app.buttons["Quick Assign, collapsed"].waitForExistence(timeout: 5))
     }
+
+    @MainActor
+    func testBudgetCheckInCanCollapse() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        app.tabBars.buttons["Budget"].tap()
+        XCTAssertTrue(app.buttons["Details for Groceries"].firstMatch.waitForExistence(timeout: 10))
+
+        let expanded = app.buttons["Budget Check-In, expanded"]
+        let collapsed = app.buttons["Budget Check-In, collapsed"]
+        if collapsed.waitForExistence(timeout: 2) {
+            collapsed.tap()
+        }
+        XCTAssertTrue(expanded.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Resolve the important items before assigning the rest of the month."].exists)
+        expanded.tap()
+        XCTAssertTrue(collapsed.waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Resolve the important items before assigning the rest of the month."].exists)
+    }
 }

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -4,9 +4,9 @@ import XCTest
 ///
 /// Demo data has no overspent categories, so the notice must start hidden.
 /// Overspending Coffee through the real edit sheet must surface a
-/// "1 Overspent Category" notice at the top of the Budget screen; tapping it
-/// must list Coffee with its negative balance, and restoring the budget must
-/// clear the notice again.
+/// overspent check-in result at the top of the Budget screen; tapping it
+/// must list Coffee with its negative balance, and covering it through the
+/// visible resolution action must clear the notice again.
 final class OverspentCategoriesUITests: XCTestCase {
 
     @MainActor
@@ -19,7 +19,7 @@ final class OverspentCategoriesUITests: XCTestCase {
         XCTAssertTrue(budgetTab.waitForExistence(timeout: 10), "Budget tab not found")
 
         // Demo data is within budget everywhere: no notice at launch.
-        let notice = app.buttons["1 Overspent Category"]
+        let notice = app.buttons["budgetCheckInOverspent"]
         XCTAssertFalse(notice.exists, "overspent notice shown with nothing overspent")
 
         // Overspend Coffee by budgeting $1 against ~$19 already spent.
@@ -34,6 +34,9 @@ final class OverspentCategoriesUITests: XCTestCase {
         let coffeeRow = app.buttons.containing(NSPredicate(format: "label CONTAINS 'Coffee'")).firstMatch
         XCTAssertTrue(coffeeRow.waitForExistence(timeout: 5),
                       "Coffee missing from the overspent list")
+        let resolveButton = app.buttons["Resolve overspending for Coffee"]
+        XCTAssertTrue(resolveButton.waitForExistence(timeout: 5),
+                      "overspent category should offer a visible resolution action")
         attachScreenshot(app, name: "2-overspent-list")
 
         // Rows drill into the month's transactions.
@@ -42,13 +45,17 @@ final class OverspentCategoriesUITests: XCTestCase {
                       "tapping the overspent row did not open Coffee's transactions")
         attachScreenshot(app, name: "3-category-transactions")
 
-        // Restore a healthy budget: the notice must disappear again.
-        app.navigationBars.buttons.firstMatch.tap() // back to the list
+        // Resolving is a visible, complete action—not a hidden swipe gesture.
+        app.navigationBars.buttons.firstMatch.tap() // back to the overspent list
+        resolveButton.tap()
+        XCTAssertTrue(app.navigationBars["Cover Overspending"].waitForExistence(timeout: 5),
+                      "resolution action did not open the cover flow")
+        app.buttons["Move"].tap()
+        XCTAssertTrue(app.staticTexts["Nothing Overspent"].waitForExistence(timeout: 10),
+                      "covering the category should resolve the result immediately")
         app.navigationBars.buttons.firstMatch.tap() // back to the budget
-        setBudget(app, category: "Coffee", centsKeystrokes: "10000")
-        scrollToTop(app)
-        XCTAssertTrue(waitForNonExistence(of: notice, timeout: 10),
-                      "overspent notice still shown after restoring the budget")
+        XCTAssertTrue(waitForNotHittable(notice, timeout: 10),
+                      "overspent check-in result still shown after covering it")
         attachScreenshot(app, name: "4-notice-cleared")
     }
 
@@ -90,10 +97,10 @@ final class OverspentCategoriesUITests: XCTestCase {
     }
 
     @MainActor
-    private func waitForNonExistence(of element: XCUIElement, timeout: TimeInterval) -> Bool {
+    private func waitForNotHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if !element.exists { return true }
+            if !element.exists || !element.isHittable { return true }
             RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         }
         return false

--- a/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
+++ b/Actuali/ActualiUITests/OverspentCategoriesUITests.swift
@@ -54,7 +54,8 @@ final class OverspentCategoriesUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Nothing Overspent"].waitForExistence(timeout: 10),
                       "covering the category should resolve the result immediately")
         app.navigationBars.buttons.firstMatch.tap() // back to the budget
-        XCTAssertTrue(waitForNotHittable(notice, timeout: 10),
+        scrollToTop(app)
+        XCTAssertTrue(waitForNonExistence(of: notice, timeout: 10),
                       "overspent check-in result still shown after covering it")
         attachScreenshot(app, name: "4-notice-cleared")
     }
@@ -97,10 +98,10 @@ final class OverspentCategoriesUITests: XCTestCase {
     }
 
     @MainActor
-    private func waitForNotHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+    private func waitForNonExistence(of element: XCUIElement, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if !element.exists || !element.isHittable { return true }
+            if !element.exists { return true }
             RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         }
         return false


### PR DESCRIPTION
## Why

Actual's envelope-budget workflow needs clearer, more actionable category guidance on iOS while preserving tracking-budget behavior. This improves budgeting interactions within the existing Actual data model without changing Home, accounts, transactions, schedules, currency handling, or unrelated app areas.

Budget Check-In must reflect the budget's real financial state independently of optional presentation preferences, and it must lead to a resolution rather than stopping at a diagnostic list. Previously, disabling the optional Budget tab badge could hide overspending from Check-In, and result screens did not clearly expose the action needed to fix unfunded, near-limit, or overspent categories.

## What

- Preserves Actual's envelope and tracking-budget terminology throughout the Budget flow.
- Adds restrained status dots and spending-progress lines to category rows, with full plain-language status in category details.
- Adds compact category filters inside Budget options: All Categories, Needs Attention, Overspent/Over Budget, Not Funded/No Budget Set, and On Track/Within Budget.
- Adapts filter and action terminology for envelope and tracking budgets, indicates when filtering is active, and provides a one-tap empty-state reset.
- Adds history-based Quick Assign suggestions using existing Actual budget data.
- Adds an actionable monthly Budget Check-In that can be collapsed and remembers its state.
- Makes Actions and Quick Assign independently collapsible and preserves their state after reopening a category.
- Keeps overspending visible in Budget Check-In whenever a category has a negative available balance, regardless of the optional tab-badge setting.
- Removes the redundant Ready to Assign row from Budget Check-In because the same value and destination already appear in the Budget summary.
- Makes Check-In result screens directly actionable:
  - Not Funded categories offer **Assign Money**.
  - Tracking categories with no budget offer **Add Budget**.
  - Near-limit categories offer **Assign More** or **Increase Budget**.
  - Overspent envelope categories offer **Cover Overspending** using Actual's existing move-money flow.
  - Tracking categories over budget offer **Increase Budget**.
  - Uncategorized transactions continue to open the existing immediate category picker.
- Keeps category details and transaction review available alongside the direct resolution actions.
- Updates result lists live after changes and shows a clear resolved state when no categories still need attention.
- Covers current-month and rolled-over overspending without changing or duplicating transactions.

## How it was tested

- Ran the full unit test suite on the iPhone Air simulator before the final interaction update: 994 tests in 132 suites passed.
- Added unit coverage for envelope/tracking classification and Check-In detection of negative available balances.
- Added and ran UI coverage for collapsing and expanding Budget Check-In on iPhone Air with iOS 26.5.
- Added and ran UI coverage confirming Actions and Quick Assign remain collapsed after closing and reopening a category.
- Added and ran an iPhone Air UI test that creates a real unfunded category through the normal budget write path and verifies the direct funding action opens the amount editor.
- Updated and ran the overspending UI test end to end: create overspending, open its Check-In result, review transactions, use **Cover Overspending**, save the move, and verify the issue clears.
- Built the app successfully for the iPhone Air simulator after the final changes.
- Ran `git diff --check` successfully.

## Screenshots

<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 50 16" src="https://github.com/user-attachments/assets/57197a06-72d3-44c0-b6fe-f2849ab9cdee" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 53 56" src="https://github.com/user-attachments/assets/fcd97d5b-d72a-47e5-888c-ea2260f292b9" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 53 37" src="https://github.com/user-attachments/assets/37673273-6ddc-40fe-af79-baca0bb4b118" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 34" src="https://github.com/user-attachments/assets/1a0128db-c787-4af4-82f9-2072dd83855e" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 32" src="https://github.com/user-attachments/assets/a5251019-ceb0-4ae8-a794-f83d64da2471" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 23" src="https://github.com/user-attachments/assets/80249163-fee1-4d43-9f65-1f6fb7b76319" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 21" src="https://github.com/user-attachments/assets/87a0777b-c9da-44aa-b247-a1f4d13f35dd" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 05" src="https://github.com/user-attachments/assets/33919e44-46d6-4d99-87ec-31168bc4de4e" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 51 01" src="https://github.com/user-attachments/assets/d5592313-eac5-412a-9e16-d5de3452e114" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 50 39" src="https://github.com/user-attachments/assets/7eb47c8c-b3c2-4329-a040-1707fa6d17d5" />
<img width="250" height="500" alt="Simulator Screenshot - iPhone Air - 2026-08-15 at 12 50 27" src="https://github.com/user-attachments/assets/d4ffd644-c26b-44f7-866c-1a9dab57f87f" />
