### PR TITLE
Add conventional amount entry

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -239,6 +239,14 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether amount fields accept conventional decimal entry. Persisted to
+    /// UserDefaults and defaults to the established calculator-style entry.
+    @Published var conventionalAmountEntry: Bool = false {
+        didSet {
+            UserDefaults.standard.set(conventionalAmountEntry, forKey: "conventionalAmountEntry")
+        }
+    }
+
     /// Whether monetary values are obscured wherever the app displays them:
     /// account balances, the budget table, reports, and transaction lists.
     /// Screens where the user is actively working with an amount (entering a
@@ -761,6 +769,8 @@ final class BudgetStore: ObservableObject {
             .object(forKey: "showGroupTotals") as? Bool ?? true)
         _showOverspentBadge = Published(initialValue: UserDefaults.standard
             .object(forKey: "showOverspentBadge") as? Bool ?? true)
+        _conventionalAmountEntry = Published(initialValue: UserDefaults.standard
+            .object(forKey: "conventionalAmountEntry") as? Bool ?? false)
         _hideBalances = Published(initialValue: UserDefaults.standard
             .object(forKey: "hideBalances") as? Bool ?? false)
         _recordPayeeLocations = Published(initialValue: UserDefaults.standard

--- a/Actuali/Actuali/Views/Accounts/AddAccountView.swift
+++ b/Actuali/Actuali/Views/Accounts/AddAccountView.swift
@@ -75,6 +75,7 @@ struct CreateLocalAccountView: View {
                     Spacer()
                     AmountInputField(
                         text: $balanceText,
+                        conventionalAmountEntry: budgetStore.conventionalAmountEntry,
                         alignment: .right,
                         allowsNegative: true
                     )

--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -50,6 +50,7 @@ struct ReconcileView: View {
                         // a negative bank balance, so the sign toggle is needed.
                         AmountInputField(
                             text: $balanceText,
+                            conventionalAmountEntry: budgetStore.conventionalAmountEntry,
                             alignment: .right,
                             allowsNegative: true,
                             weight: .semibold

--- a/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
@@ -106,7 +106,10 @@ struct BudgetTransferSheet: View {
                 }
 
                 Section {
-                    AmountInputField(text: $amountText)
+                    AmountInputField(
+                        text: $amountText,
+                        conventionalAmountEntry: budgetStore.conventionalAmountEntry
+                    )
                 } header: {
                     Text("Amount")
                 } footer: {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -940,7 +940,12 @@ struct EditBudgetAmountSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    AmountInputField(text: $amountText, allowsNegative: true, autofocus: true)
+                    AmountInputField(
+                        text: $amountText,
+                        conventionalAmountEntry: budgetStore.conventionalAmountEntry,
+                        allowsNegative: true,
+                        autofocus: true
+                    )
                 } header: {
                     Text("Budgeted in \(MonthPicker.title(for: category.month))")
                 } footer: {

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -386,6 +386,15 @@ struct SettingsView: View {
 
                     Toggle("Overspent Badge", isOn: $budgetStore.showOverspentBadge)
 
+                    Toggle(isOn: $budgetStore.conventionalAmountEntry) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Conventional amount entry")
+                            Text("When enabled, enter the decimal separator explicitly.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
                     Toggle("Hide Balances", isOn: $budgetStore.hideBalances)
 
                     // Meaningless against servers that predate payee

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -386,14 +386,7 @@ struct SettingsView: View {
 
                     Toggle("Overspent Badge", isOn: $budgetStore.showOverspentBadge)
 
-                    Toggle(isOn: $budgetStore.conventionalAmountEntry) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Conventional amount entry")
-                            Text("When enabled, enter the decimal separator explicitly.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
+                    Toggle("Conventional Amount Entry", isOn: $budgetStore.conventionalAmountEntry)
 
                     Toggle("Hide Balances", isOn: $budgetStore.hideBalances)
 
@@ -429,9 +422,9 @@ struct SettingsView: View {
                     Text("Preferences")
                 } footer: {
                     if budgetStore.currencyCode.isEmpty {
-                        Text("Hide Balances masks amounts across the app. Start Page takes effect the next time the app opens.")
+                        Text("Conventional Amount Entry types amounts whole — 324 for 324.00 — instead of filling cents first. Hide Balances masks amounts across the app. Start Page takes effect the next time the app opens.")
                     } else {
-                        Text("Symbol Only shows amounts with just the currency symbol — $ instead of NZ$. Hide Balances masks amounts across the app. Start Page takes effect the next time the app opens.")
+                        Text("Symbol Only shows amounts with just the currency symbol — $ instead of NZ$. Conventional Amount Entry types amounts whole — 324 for 324.00 — instead of filling cents first. Hide Balances masks amounts across the app. Start Page takes effect the next time the app opens.")
                     }
                 }
 

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -813,13 +813,19 @@ private struct SplitLineRow: View {
     }
 }
 
-/// Currency amount field with two input modes.
+/// Currency amount field with two digit-entry modes, picked by the
+/// `conventionalAmountEntry` setting.
 ///
-/// Default (calculator) mode: digits shift right-to-left into the cents
+/// Calculator entry (the default): digits shift right-to-left into the cents
 /// position — typing 1, 2, 0 produces 0.01, 0.12, 1.20. As soon as the user
-/// taps `.` (or `,` in comma-decimal locales), the field switches to standard
+/// taps `.` (or `,` in comma-decimal locales), the field switches to explicit
 /// decimal entry where prior digits are reinterpreted as the integer part —
 /// so 1, ., 0 produces 1.0.
+///
+/// Conventional entry: digits stand for whole units and the decimal separator
+/// is always typed — 1, 2, 0 produces 120, and 1, ., 0 produces 1.0. Nothing
+/// gains a fraction the user didn't type, so zero-decimal currencies never
+/// need a trailing ".00" (GH #211).
 ///
 /// With `allowsNegative`, a ± button joins the keyboard toolbar and flips
 /// the text's own sign. With `onToggleSign`, the same button appears but the
@@ -868,7 +874,7 @@ struct AmountInputField: UIViewRepresentable {
         let field = AutofocusTextField()
         field.wantsAutofocus = autofocus
         field.keyboardType = .decimalPad
-        field.placeholder = "0.00"
+        field.placeholder = conventionalAmountEntry ? "0" : "0.00"
         field.textAlignment = alignment
         field.delegate = context.coordinator
         field.text = text
@@ -1152,8 +1158,10 @@ struct AmountInputField: UIViewRepresentable {
             let cents = Int((abs(rounded) * 100).rounded())
             isNegative = parent.allowsNegative && rounded < 0
             integerDigits = String(cents / 100)
-            hasDecimalPoint = true
-            fractionDigits = String(format: "%02d", cents % 100)
+            // Conventional entry never adds a fraction the user didn't type,
+            // so a whole result comes back as a whole number.
+            hasDecimalPoint = !(parent.conventionalAmountEntry && cents % 100 == 0)
+            fractionDigits = hasDecimalPoint ? String(format: "%02d", cents % 100) : ""
         }
 
         private func handleCharacter(_ character: Character) {
@@ -1210,13 +1218,20 @@ struct AmountInputField: UIViewRepresentable {
                 let whole = integerDigits.isEmpty ? "0" : integerDigits
                 return sign + whole + "." + fractionDigits
             }
-            if !parent.conventionalAmountEntry {
-                let cents = Int(integerDigits) ?? 0
-                let dollars = cents / 100
-                let pennies = cents % 100
-                return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
+            if parent.conventionalAmountEntry {
+                return sign + integerDigits
             }
-            return sign + integerDigits
+            let cents = Int(integerDigits) ?? 0
+            let dollars = cents / 100
+            let pennies = cents % 100
+            return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
+        }
+
+        /// An evaluated value as the field shows it: two decimals, except in
+        /// conventional entry where a whole result stays whole.
+        private func displayValue(_ value: Double) -> String {
+            let whole = parent.conventionalAmountEntry && value == value.rounded()
+            return String(format: whole ? "%.0f" : "%.2f", value)
         }
 
         /// What the field shows: the running total and armed operator, if any,
@@ -1226,7 +1241,7 @@ struct AmountInputField: UIViewRepresentable {
             guard let pending = pendingOperator, let acc = accumulatedValue else {
                 return operandText
             }
-            let accText = String(format: "%.2f", acc)
+            let accText = displayValue(acc)
             return operandText.isEmpty
                 ? "\(accText) \(pending.rawValue) "
                 : "\(accText) \(pending.rawValue) \(operandText)"
@@ -1238,7 +1253,7 @@ struct AmountInputField: UIViewRepresentable {
             guard pendingOperator != nil, accumulatedValue != nil else {
                 return computeOperandDisplay()
             }
-            return String(format: "%.2f", normalized(resolvedValue()))
+            return displayValue(normalized(resolvedValue()))
         }
 
         private func applyDisplay(to textField: UITextField) {

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -266,7 +266,11 @@ struct AddTransactionView: View {
                         // form, so the add flow opens with the keyboard ready.
                         // Edits and prefilled amounts already have one and
                         // start with the keyboard down.
-                        AmountInputField(text: $amount, autofocus: !isEditing && amount.isEmpty)
+                        AmountInputField(
+                            text: $amount,
+                            conventionalAmountEntry: budgetStore.conventionalAmountEntry,
+                            autofocus: !isEditing && amount.isEmpty
+                        )
                     }
                 }
 
@@ -769,7 +773,11 @@ private struct SplitLineRow: View {
                 .buttonStyle(.borderless)
                 .accessibilityLabel(isOutflow ? "Outflow" : "Inflow")
                 .accessibilityHint("Flips this line's direction")
-                AmountInputField(text: $line.amount, onToggleSign: { line.isOpposite.toggle() })
+                AmountInputField(
+                    text: $line.amount,
+                    conventionalAmountEntry: budgetStore.conventionalAmountEntry,
+                    onToggleSign: { line.isOpposite.toggle() }
+                )
                     .frame(width: 110)
             }
             // No fill offer on a flipped line: the remainder is stated in the
@@ -828,6 +836,9 @@ private struct SplitLineRow: View {
 /// editing) still commits a parseable amount.
 struct AmountInputField: UIViewRepresentable {
     @Binding var text: String
+    /// When true, digits are entered as a conventional decimal amount instead
+    /// of shifting into cents.
+    var conventionalAmountEntry = false
     var alignment: NSTextAlignment = .natural
     var allowsNegative = false
     var weight: UIFont.Weight = .regular
@@ -1199,10 +1210,13 @@ struct AmountInputField: UIViewRepresentable {
                 let whole = integerDigits.isEmpty ? "0" : integerDigits
                 return sign + whole + "." + fractionDigits
             }
-            let cents = Int(integerDigits) ?? 0
-            let dollars = cents / 100
-            let pennies = cents % 100
-            return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
+            if !parent.conventionalAmountEntry {
+                let cents = Int(integerDigits) ?? 0
+                let dollars = cents / 100
+                let pennies = cents % 100
+                return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
+            }
+            return sign + integerDigits
         }
 
         /// What the field shows: the running total and armed operator, if any,

--- a/Actuali/ActualiTests/AmountInputFieldTests.swift
+++ b/Actuali/ActualiTests/AmountInputFieldTests.swift
@@ -67,30 +67,30 @@ struct AmountInputFieldTests {
         #expect(box.value == "1.20")
     }
 
-    // MARK: - Standard entry
+    // MARK: - Conventional entry
 
-    @Test func standardModeEntersWholeDigitsWithoutShiftingCents() {
+    @Test func conventionalModeEntersWholeDigitsWithoutShiftingCents() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         #expect(textField.text == "12")
         #expect(box.value == "12")
     }
 
-    @Test func standardModeKeepsExplicitDecimalEntry() {
+    @Test func conventionalModeKeepsExplicitDecimalEntry() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12.05", into: coordinator, textField)
         #expect(textField.text == "12.05")
         #expect(box.value == "12.05")
     }
 
-    @Test func standardModeLimitsFractionToTwoDigits() {
+    @Test func conventionalModeLimitsFractionToTwoDigits() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12.056", into: coordinator, textField)
         #expect(textField.text == "12.05")
         #expect(box.value == "12.05")
     }
 
-    @Test func standardModeBackspaceWorksThroughDecimalAndDigits() {
+    @Test func conventionalModeBackspaceWorksThroughDecimalAndDigits() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12.05", into: coordinator, textField)
         backspace(coordinator, textField)
@@ -103,14 +103,14 @@ struct AmountInputFieldTests {
         #expect(box.value == "1")
     }
 
-    @Test func standardModeKeepsEmptyFieldEmpty() {
+    @Test func conventionalModeKeepsEmptyFieldEmpty() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         backspace(coordinator, textField)
         #expect(textField.text == "")
         #expect(box.value == "")
     }
 
-    @Test func standardModeEditsPrefilledAmount() {
+    @Test func conventionalModeEditsPrefilledAmount() {
         let (coordinator, textField, box) = makeField(
             initial: "12.5", conventionalAmountEntry: true
         )
@@ -119,7 +119,7 @@ struct AmountInputFieldTests {
         #expect(box.value == "12.50")
     }
 
-    @Test func standardModeSupportsNegativeAmounts() {
+    @Test func conventionalModeSupportsNegativeAmounts() {
         let (coordinator, textField, box) = makeField(
             allowsNegative: true, conventionalAmountEntry: true
         )
@@ -129,43 +129,43 @@ struct AmountInputFieldTests {
         #expect(box.value == "-12.05")
     }
 
-    @Test func standardModeAdditionEvaluatesWhenEditingEnds() {
+    @Test func conventionalModeAdditionEvaluatesWhenEditingEnds() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         coordinator.addTapped()
         type("6", into: coordinator, textField)
         coordinator.textFieldDidEndEditing(textField)
-        #expect(box.value == "18.00")
+        #expect(box.value == "18")
     }
 
-    @Test func standardModeSubtractionEvaluatesWhenEditingEnds() {
+    @Test func conventionalModeSubtractionEvaluatesWhenEditingEnds() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         coordinator.subtractTapped()
         type("6", into: coordinator, textField)
         coordinator.textFieldDidEndEditing(textField)
-        #expect(box.value == "6.00")
+        #expect(box.value == "6")
     }
 
-    @Test func standardModeMultiplicationEvaluatesWhenEditingEnds() {
+    @Test func conventionalModeMultiplicationEvaluatesWhenEditingEnds() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         coordinator.multiplyTapped()
         type("6", into: coordinator, textField)
         coordinator.textFieldDidEndEditing(textField)
-        #expect(box.value == "72.00")
+        #expect(box.value == "72")
     }
 
-    @Test func standardModeDivisionEvaluatesWhenEditingEnds() {
+    @Test func conventionalModeDivisionEvaluatesWhenEditingEnds() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         coordinator.divideTapped()
         type("6", into: coordinator, textField)
         coordinator.textFieldDidEndEditing(textField)
-        #expect(box.value == "2.00")
+        #expect(box.value == "2")
     }
 
-    @Test func standardModeEvaluatesLeftToRight() {
+    @Test func conventionalModeEvaluatesLeftToRight() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("2", into: coordinator, textField)
         coordinator.addTapped()
@@ -173,17 +173,40 @@ struct AmountInputFieldTests {
         coordinator.multiplyTapped()
         type("4", into: coordinator, textField)
         coordinator.textFieldDidEndEditing(textField)
-        #expect(box.value == "20.00")
+        #expect(box.value == "20")
     }
 
-    @Test func standardModeBindingStaysValidDuringExpression() {
+    @Test func conventionalModeBindingStaysValidDuringExpression() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12", into: coordinator, textField)
         coordinator.addTapped()
         type("6", into: coordinator, textField)
-        #expect(textField.text == "12.00 + 6")
-        #expect(box.value == "18.00")
+        #expect(textField.text == "12 + 6")
+        #expect(box.value == "18")
         #expect(Double(box.value) == 18)
+    }
+
+    /// A fractional result still carries its cents — the whole-number display
+    /// is about not inventing a fraction, not about dropping one.
+    @Test func conventionalModeKeepsCentsOnFractionalResult() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("5", into: coordinator, textField)
+        coordinator.divideTapped()
+        type("2", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(textField.text == "2.50")
+        #expect(box.value == "2.50")
+    }
+
+    /// A prefilled whole amount must survive the round trip through
+    /// `sync(fromDisplay:)` — the field is handed "%.2f" strings by callers.
+    @Test func conventionalModeEditsPrefilledWholeAmount() {
+        let (coordinator, textField, box) = makeField(
+            initial: "324", conventionalAmountEntry: true
+        )
+        type("5", into: coordinator, textField)
+        #expect(textField.text == "3245")
+        #expect(box.value == "3245")
     }
 
     @Test func toggleSignNegatesAndRestores() {

--- a/Actuali/ActualiTests/AmountInputFieldTests.swift
+++ b/Actuali/ActualiTests/AmountInputFieldTests.swift
@@ -16,11 +16,13 @@ struct AmountInputFieldTests {
     /// Builds a coordinator wired to a real UITextField, mirroring makeUIView.
     private func makeField(
         initial: String = "",
-        allowsNegative: Bool = false
+        allowsNegative: Bool = false,
+        conventionalAmountEntry: Bool = false
     ) -> (coordinator: AmountInputField.Coordinator, textField: UITextField, box: TextBox) {
         let box = TextBox(initial)
         let field = AmountInputField(
             text: Binding(get: { box.value }, set: { box.value = $0 }),
+            conventionalAmountEntry: conventionalAmountEntry,
             allowsNegative: allowsNegative
         )
         let coordinator = field.makeCoordinator()
@@ -63,6 +65,125 @@ struct AmountInputFieldTests {
         type("120", into: coordinator, textField)
         #expect(textField.text == "1.20")
         #expect(box.value == "1.20")
+    }
+
+    // MARK: - Standard entry
+
+    @Test func standardModeEntersWholeDigitsWithoutShiftingCents() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        #expect(textField.text == "12")
+        #expect(box.value == "12")
+    }
+
+    @Test func standardModeKeepsExplicitDecimalEntry() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12.05", into: coordinator, textField)
+        #expect(textField.text == "12.05")
+        #expect(box.value == "12.05")
+    }
+
+    @Test func standardModeLimitsFractionToTwoDigits() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12.056", into: coordinator, textField)
+        #expect(textField.text == "12.05")
+        #expect(box.value == "12.05")
+    }
+
+    @Test func standardModeBackspaceWorksThroughDecimalAndDigits() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12.05", into: coordinator, textField)
+        backspace(coordinator, textField)
+        #expect(box.value == "12.0")
+        backspace(coordinator, textField)
+        #expect(box.value == "12.")
+        backspace(coordinator, textField)
+        #expect(box.value == "12")
+        backspace(coordinator, textField)
+        #expect(box.value == "1")
+    }
+
+    @Test func standardModeKeepsEmptyFieldEmpty() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        backspace(coordinator, textField)
+        #expect(textField.text == "")
+        #expect(box.value == "")
+    }
+
+    @Test func standardModeEditsPrefilledAmount() {
+        let (coordinator, textField, box) = makeField(
+            initial: "12.5", conventionalAmountEntry: true
+        )
+        type("0", into: coordinator, textField)
+        #expect(textField.text == "12.50")
+        #expect(box.value == "12.50")
+    }
+
+    @Test func standardModeSupportsNegativeAmounts() {
+        let (coordinator, textField, box) = makeField(
+            allowsNegative: true, conventionalAmountEntry: true
+        )
+        coordinator.toggleSign()
+        type("12.05", into: coordinator, textField)
+        #expect(textField.text == "-12.05")
+        #expect(box.value == "-12.05")
+    }
+
+    @Test func standardModeAdditionEvaluatesWhenEditingEnds() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        coordinator.addTapped()
+        type("6", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(box.value == "18.00")
+    }
+
+    @Test func standardModeSubtractionEvaluatesWhenEditingEnds() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        coordinator.subtractTapped()
+        type("6", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(box.value == "6.00")
+    }
+
+    @Test func standardModeMultiplicationEvaluatesWhenEditingEnds() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        coordinator.multiplyTapped()
+        type("6", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(box.value == "72.00")
+    }
+
+    @Test func standardModeDivisionEvaluatesWhenEditingEnds() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        coordinator.divideTapped()
+        type("6", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(box.value == "2.00")
+    }
+
+    @Test func standardModeEvaluatesLeftToRight() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("2", into: coordinator, textField)
+        coordinator.addTapped()
+        type("3", into: coordinator, textField)
+        coordinator.multiplyTapped()
+        type("4", into: coordinator, textField)
+        coordinator.textFieldDidEndEditing(textField)
+        #expect(box.value == "20.00")
+    }
+
+    @Test func standardModeBindingStaysValidDuringExpression() {
+        let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
+        type("12", into: coordinator, textField)
+        coordinator.addTapped()
+        type("6", into: coordinator, textField)
+        #expect(textField.text == "12.00 + 6")
+        #expect(box.value == "18.00")
+        #expect(Double(box.value) == 18)
     }
 
     @Test func toggleSignNegatesAndRestores() {

--- a/Actuali/ActualiTests/BudgetStoreAmountEntryPreferenceTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreAmountEntryPreferenceTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetStoreAmountEntryPreferenceTests {
+    private let key = "conventionalAmountEntry"
+
+    @Test func conventionalAmountEntryDefaultsToOff() {
+        UserDefaults.standard.removeObject(forKey: key)
+        let store = BudgetStore.previewInstance()
+        #expect(!store.conventionalAmountEntry)
+    }
+
+    @Test func conventionalAmountEntryPersistsWhenEnabled() {
+        UserDefaults.standard.removeObject(forKey: key)
+        let store = BudgetStore.previewInstance()
+        store.conventionalAmountEntry = true
+        #expect(UserDefaults.standard.object(forKey: key) as? Bool == true)
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreAmountEntryPreferenceTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreAmountEntryPreferenceTests.swift
@@ -2,21 +2,36 @@ import Foundation
 import Testing
 @testable import Actuali
 
+/// The "Conventional Amount Entry" setting must survive app launches, so the
+/// setter has to reach UserDefaults under the key `init()` reads back.
+///
+/// Only the write half is covered. `previewInstance()` goes through
+/// `init(forPreview:)`, which reads no UserDefaults at all, so a "defaults to
+/// off" assertion against it passes whatever the real `init()` does — the
+/// read stays uncovered rather than faked.
 @MainActor
 struct BudgetStoreAmountEntryPreferenceTests {
     private let key = "conventionalAmountEntry"
 
-    @Test func conventionalAmountEntryDefaultsToOff() {
+    /// Restores whatever the test host had, so the suite leaves no residue.
+    private func withCleanDefaults(_ body: () -> Void) {
+        let original = UserDefaults.standard.object(forKey: key)
         UserDefaults.standard.removeObject(forKey: key)
-        let store = BudgetStore.previewInstance()
-        #expect(!store.conventionalAmountEntry)
+        body()
+        if let original {
+            UserDefaults.standard.set(original, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
     }
 
-    @Test func conventionalAmountEntryPersistsWhenEnabled() {
-        UserDefaults.standard.removeObject(forKey: key)
-        let store = BudgetStore.previewInstance()
-        store.conventionalAmountEntry = true
-        #expect(UserDefaults.standard.object(forKey: key) as? Bool == true)
-        UserDefaults.standard.removeObject(forKey: key)
+    @Test func conventionalAmountEntryPersistsBothStates() {
+        withCleanDefaults {
+            let store = BudgetStore.previewInstance()
+            store.conventionalAmountEntry = true
+            #expect(UserDefaults.standard.object(forKey: key) as? Bool == true)
+            store.conventionalAmountEntry = false
+            #expect(UserDefaults.standard.object(forKey: key) as? Bool == false)
+        }
     }
 }


### PR DESCRIPTION
Why

Closes #211. This change gives users more flexibility when entering transaction amounts by allowing them to choose between the existing fixed-decimal currency entry and conventional number entry.

What

Added conventional number entry for transaction amounts.
Kept the existing fixed-decimal currency entry available.
Users can choose the entry method that works best for them.
Conventional entry preserves values as typed, including trailing decimals and zeros (e.g. 12. → 12., 12.0 → 12.0, 12.05 → 12.05).

How it was tested

Added/updated tests for conventional amount entry.
Manually tested both entry methods with whole numbers and decimal values.
Verified that the existing fixed-decimal currency entry continues to work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preference for conventional whole-unit amount entry.
  * Amount fields across accounts, budgets, transfers, reconciliation, and transactions now follow the selected entry mode.
  * Conventional mode treats entered digits as whole units until a decimal separator is used and improves whole-number formatting.
  * The preference is saved and restored automatically.

* **Bug Fixes**
  * Preserved calculator behavior, negative amounts, expressions, and decimal precision across supported amount fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->