### PR TITLE
Rules

### DIFF
--- a/Actuali/Actuali/Models/Rule.swift
+++ b/Actuali/Actuali/Models/Rule.swift
@@ -1,26 +1,18 @@
 import Foundation
 
-/// Mirrors loot-core's rule model. Conditions and actions are stored as JSON
-/// blobs in the `rules` table; field names use the *internal* schema names
-/// (e.g. `description` for payee, `imported_description` for imported_payee,
-/// `acct` for account). They are translated to public names on parse.
-///
-/// Subset of upstream support:
-/// - Stages: `pre`, default (nil), `post` — runs in that order.
-/// - Condition ops: is, isNot, contains, doesNotContain, oneOf, notOneOf,
-///   matches, gt, gte, lt, lte, isbetween, isapprox.
-/// - Action ops: set, prepend-notes, append-notes.
-/// - Skipped (logged + treated as no-op): link-schedule, set-split-amount,
-///   delete-transaction, formula/handlebars templates, hasTags,
-///   recurring-date conditions, onBudget/offBudget.
-struct Rule: Identifiable {
+/// Mirrors loot-core's rule model (`types/models/rule.ts`). Conditions and
+/// actions are stored as JSON blobs in the `rules` table using the *internal*
+/// schema names (`description` for payee, `acct` for account); `RuleSchema`
+/// translates them on the way in and out.
+struct Rule: Identifiable, Equatable, Hashable {
     let id: String
-    let stage: Stage
-    let conditionsOp: ConditionsOp
-    let conditions: [Condition]
-    let actions: [Action]
+    var stage: Stage
+    var conditionsOp: ConditionsOp
+    var conditions: [Condition]
+    var actions: [Action]
+    var tombstone: Bool = false
 
-    enum Stage: Int, Comparable {
+    enum Stage: Int, Comparable, CaseIterable {
         case pre = 0
         case `default` = 1
         case post = 2
@@ -34,29 +26,54 @@ struct Rule: Identifiable {
             default: self = .default
             }
         }
+
+        /// The value written to the `stage` column — NULL for the default stage,
+        /// same as upstream.
+        var storedValue: String? {
+            switch self {
+            case .pre: return "pre"
+            case .post: return "post"
+            case .default: return nil
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .pre: return "Pre"
+            case .default: return "Default"
+            case .post: return "Post"
+            }
+        }
     }
 
-    enum ConditionsOp: String {
+    enum ConditionsOp: String, CaseIterable {
         case and
         case or
 
         init(raw: String?) {
             self = raw?.lowercased() == "or" ? .or : .and
         }
+
+        var label: String { self == .and ? "all" : "any" }
     }
 
-    struct Condition {
-        let op: String
-        let field: String   // public field name (e.g. "imported_payee")
-        let value: Any?
-        let options: [String: Any]?
+    struct Condition: Equatable, Hashable {
+        var op: String
+        var field: String        // public field name, e.g. "imported_payee"
+        var value: RuleValue
+        var options: [String: RuleValue]?
     }
 
-    struct Action {
-        let op: String
-        let field: String?  // nil for ops without a field (e.g. link-schedule)
-        let value: Any?
-        let options: [String: Any]?
+    struct Action: Equatable, Hashable {
+        var op: String
+        var field: String?       // nil for ops without a field (link-schedule, …)
+        var value: RuleValue
+        var options: [String: RuleValue]?
+    }
+
+    /// A rule with nothing filled in, for the "new rule" editor.
+    static func empty(id: String = UUID().uuidString) -> Rule {
+        Rule(id: id, stage: .default, conditionsOp: .and, conditions: [], actions: [])
     }
 }
 
@@ -67,25 +84,8 @@ enum RuleParseError: Error {
     case notArray
 }
 
-/// Internal-to-public field-name translation, mirroring
-/// `schemaConfig.views.transactions.fields` in loot-core.
-private let internalToPublicField: [String: String] = [
-    "isParent": "is_parent",
-    "isChild": "is_child",
-    "acct": "account",
-    "financial_id": "imported_id",
-    "imported_description": "imported_payee",
-    "transferred_id": "transfer_id",
-    "description": "payee",
-]
-
-private func publicField(from internalField: String) -> String {
-    internalToPublicField[internalField] ?? internalField
-}
-
 extension Rule {
-    /// Parse a single rule row from the `rules` table.
-    /// `conditionsJSON` and `actionsJSON` are the raw JSON text columns.
+    /// Parse a single row of the `rules` table.
     static func parse(
         id: String,
         stage: String?,
@@ -93,54 +93,137 @@ extension Rule {
         conditionsJSON: String?,
         actionsJSON: String?
     ) throws -> Rule {
-        let conditions = try parseConditions(conditionsJSON)
-        let actions = try parseActions(actionsJSON)
-        return Rule(
+        Rule(
             id: id,
             stage: Stage(raw: stage),
             conditionsOp: ConditionsOp(raw: conditionsOp),
-            conditions: conditions,
-            actions: actions
+            conditions: try parseConditions(conditionsJSON),
+            actions: try parseActions(actionsJSON)
         )
     }
 
     private static func parseConditions(_ json: String?) throws -> [Condition] {
-        let items = try parseArray(json)
-        return items.compactMap { item -> Condition? in
-            guard
-                let op = item["op"] as? String,
-                let internalField = item["field"] as? String
-            else { return nil }
+        try parseArray(json).compactMap { item in
+            guard let op = item["op"] as? String,
+                  let field = item["field"] as? String else { return nil }
             return Condition(
                 op: op,
-                field: publicField(from: internalField),
-                value: item["value"] ?? nil,
-                options: item["options"] as? [String: Any]
+                field: RuleSchema.publicField(from: field),
+                value: RuleValue(json: item["value"] ?? nil),
+                options: options(from: item["options"])
             )
         }
     }
 
     private static func parseActions(_ json: String?) throws -> [Action] {
-        let items = try parseArray(json)
-        return items.compactMap { item -> Action? in
+        try parseArray(json).compactMap { item in
             guard let op = item["op"] as? String else { return nil }
-            let internalField = item["field"] as? String
             return Action(
                 op: op,
-                field: internalField.map(publicField(from:)),
-                value: item["value"] ?? nil,
-                options: item["options"] as? [String: Any]
+                field: (item["field"] as? String).map(RuleSchema.publicField(from:)),
+                value: RuleValue(json: item["value"] ?? nil),
+                options: options(from: item["options"])
             )
         }
+    }
+
+    private static func options(from any: Any?) -> [String: RuleValue]? {
+        guard let dict = any as? [String: Any], !dict.isEmpty else { return nil }
+        return dict.mapValues(RuleValue.init(json:))
     }
 
     private static func parseArray(_ json: String?) throws -> [[String: Any]] {
         guard let json, let data = json.data(using: .utf8) else { return [] }
         let any = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
-        guard let arr = any as? [[String: Any]] else {
+        guard let array = any as? [[String: Any]] else {
             if any is NSNull { return [] }
             throw RuleParseError.notArray
         }
-        return arr
+        return array
+    }
+}
+
+// MARK: - JSON serialization
+
+extension Rule.Condition {
+    /// Upstream `Condition.serialize()` + `toInternalField`.
+    var jsonObject: [String: Any] {
+        var object: [String: Any] = [
+            "op": op,
+            "field": RuleSchema.internalField(from: field),
+            "value": value.jsonObject
+        ]
+        if let type = RuleSchema.fieldType(field)?.rawValue {
+            object["type"] = type
+        }
+        if let options, !options.isEmpty {
+            object["options"] = options.mapValues(\.jsonObject)
+        }
+        return object
+    }
+}
+
+extension Rule.Action {
+    /// Upstream `Action.serialize()`: `set` carries the field and its type,
+    /// `set-split-amount`/`link-schedule`/notes ops carry a null field with a
+    /// fixed type, and `delete-transaction` carries neither (JS leaves both
+    /// `undefined`, which `JSON.stringify` drops).
+    var jsonObject: [String: Any] {
+        var object: [String: Any] = ["op": op, "value": value.jsonObject]
+
+        switch op {
+        case "set":
+            if let field {
+                object["field"] = RuleSchema.internalField(from: field)
+                if let type = RuleSchema.fieldType(field)?.rawValue { object["type"] = type }
+            }
+        case "set-split-amount":
+            object["field"] = NSNull()
+            object["type"] = RuleFieldType.number.rawValue
+        case "link-schedule":
+            object["field"] = NSNull()
+            object["type"] = RuleFieldType.id.rawValue
+        case "prepend-notes", "append-notes":
+            // Upstream really does tag these `id`; kept for byte parity.
+            object["field"] = "notes"
+            object["type"] = RuleFieldType.id.rawValue
+        default:
+            break
+        }
+
+        if let options, !options.isEmpty {
+            object["options"] = options.mapValues(\.jsonObject)
+        }
+        return object
+    }
+}
+
+extension Rule {
+    var conditionsJSON: String { Self.encode(conditions.map(\.jsonObject)) }
+    var actionsJSON: String { Self.encode(actions.map(\.jsonObject)) }
+
+    private static func encode(_ array: [[String: Any]]) -> String {
+        // .sortedKeys so a rule that round-trips through the editor unchanged
+        // produces the same bytes, keeping CRDT writes idempotent-looking in
+        // review and in tests.
+        guard let data = try? JSONSerialization.data(withJSONObject: array, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else { return "[]" }
+        return json
+    }
+}
+
+// MARK: - CRDTSyncable
+
+extension Rule: CRDTSyncable {
+    static var datasetName: String { "rules" }
+
+    var syncableFields: [String: Any?] {
+        [
+            "stage": stage.storedValue,
+            "conditions_op": conditionsOp.rawValue,
+            "conditions": conditionsJSON,
+            "actions": actionsJSON,
+            "tombstone": tombstone ? 1 : 0
+        ]
     }
 }

--- a/Actuali/Actuali/Models/Rule.swift
+++ b/Actuali/Actuali/Models/Rule.swift
@@ -1,5 +1,7 @@
 import Foundation
+import os
 
+private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "Rule")
 /// Mirrors loot-core's rule model (`types/models/rule.ts`). Conditions and
 /// actions are stored as JSON blobs in the `rules` table using the *internal*
 /// schema names (`description` for payee, `acct` for account); `RuleSchema`
@@ -82,6 +84,8 @@ struct Rule: Identifiable, Equatable, Hashable {
 enum RuleParseError: Error {
     case invalidJSON
     case notArray
+    case invalidCondition
+    case invalidAction
 }
 
 extension Rule {
@@ -103,9 +107,15 @@ extension Rule {
     }
 
     private static func parseConditions(_ json: String?) throws -> [Condition] {
-        try parseArray(json).compactMap { item in
+        try parseArray(json).map { item in
+            // Upstream drops the *whole rule* when any condition fails to parse
+            // (`makeRule` returns null). Dropping just the bad condition would
+            // leave an `and` rule matching on fewer conditions than its author
+            // wrote — firing more broadly, not less.
             guard let op = item["op"] as? String,
-                  let field = item["field"] as? String else { return nil }
+                  let field = item["field"] as? String else {
+                throw RuleParseError.invalidCondition
+            }
             return Condition(
                 op: op,
                 field: RuleSchema.publicField(from: field),
@@ -116,8 +126,8 @@ extension Rule {
     }
 
     private static func parseActions(_ json: String?) throws -> [Action] {
-        try parseArray(json).compactMap { item in
-            guard let op = item["op"] as? String else { return nil }
+        try parseArray(json).map { item in
+            guard let op = item["op"] as? String else { throw RuleParseError.invalidAction }
             return Action(
                 op: op,
                 field: (item["field"] as? String).map(RuleSchema.publicField(from:)),
@@ -206,9 +216,24 @@ extension Rule {
         // .sortedKeys so a rule that round-trips through the editor unchanged
         // produces the same bytes, keeping CRDT writes idempotent-looking in
         // review and in tests.
-        guard let data = try? JSONSerialization.data(withJSONObject: array, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else { return "[]" }
-        return json
+        do {
+            let data = try JSONSerialization.data(withJSONObject: array, options: [.sortedKeys])
+            if let json = String(data: data, encoding: .utf8) { return json }
+        } catch {
+            logger.error("Rule serialization failed: \(error.localizedDescription, privacy: .public)")
+        }
+        // Unreachable once every RuleValue is JSON-legal (see RuleValue.jsonObject).
+        // Returning "[]" would sync a blanked rule to every device, so callers
+        // that write must check `isSerializable` first — see BudgetStore.validate.
+        logger.error("Rule serialization produced no JSON; refusing to blank the rule")
+        return "[]"
+    }
+    
+    /// Whether both blobs will survive a round trip to JSON. Checked before a
+    /// save so a rule can never be written to the server as an empty one.
+    var isSerializable: Bool {
+        JSONSerialization.isValidJSONObject(conditions.map(\.jsonObject))
+            && JSONSerialization.isValidJSONObject(actions.map(\.jsonObject))
     }
 }
 

--- a/Actuali/Actuali/Models/RuleValue.swift
+++ b/Actuali/Actuali/Models/RuleValue.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A JSON value carried by a rule condition or action. Rules live as JSON blobs
+/// in the `rules` table, so every value is a JSON primitive — modelling that
+/// explicitly instead of `Any?` keeps the model `Equatable` (SwiftUI state) and
+/// makes the round trip back out to JSON exact.
+enum RuleValue: Equatable, Hashable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case list([RuleValue])
+    case object([String: RuleValue])
+    case null
+
+    /// Wrap a value produced by `JSONSerialization`.
+    init(json: Any?) {
+        switch json {
+        case nil, is NSNull:
+            self = .null
+        case let value as String:
+            self = .string(value)
+        case let value as NSNumber:
+            // NSNumber erases Bool; CFBoolean is the only way to tell them apart.
+            self = CFGetTypeID(value) == CFBooleanGetTypeID()
+                ? .bool(value.boolValue)
+                : .number(value.doubleValue)
+        case let value as [Any]:
+            self = .list(value.map(RuleValue.init(json:)))
+        case let value as [String: Any]:
+            self = .object(value.mapValues(RuleValue.init(json:)))
+        default:
+            self = .null
+        }
+    }
+
+    /// The `JSONSerialization`-compatible representation for writing back.
+    /// Whole numbers serialize as integers so amounts round-trip as the cents
+    /// upstream wrote (`1050`, not `1050.0`).
+    var jsonObject: Any {
+        switch self {
+        case .string(let value): return value
+        case .number(let value):
+            guard value.rounded() == value, abs(value) < 9_007_199_254_740_992 else { return value }
+            return Int(value)
+        case .bool(let value): return value
+        case .list(let items): return items.map(\.jsonObject)
+        case .object(let dict): return dict.mapValues(\.jsonObject)
+        case .null: return NSNull()
+        }
+    }
+
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var numberValue: Double? {
+        if case .number(let value) = self { return value }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    var listValue: [RuleValue]? {
+        if case .list(let items) = self { return items }
+        return nil
+    }
+
+    /// The `{num1, num2}` payload an `isbetween` condition carries.
+    var betweenValue: (num1: Double, num2: Double)? {
+        guard case .object(let dict) = self,
+              let num1 = dict["num1"]?.numberValue,
+              let num2 = dict["num2"]?.numberValue else { return nil }
+        return (num1, num2)
+    }
+
+    var isNull: Bool {
+        if case .null = self { return true }
+        return false
+    }
+}

--- a/Actuali/Actuali/Models/RuleValue.swift
+++ b/Actuali/Actuali/Models/RuleValue.swift
@@ -40,6 +40,10 @@ enum RuleValue: Equatable, Hashable {
         switch self {
         case .string(let value): return value
         case .number(let value):
+            // JSON has no NaN or infinity, so these can only arrive from code —
+            // but JSONSerialization refuses to encode them, and the whole rule
+            // would serialize to "[]".
+            guard value.isFinite else { return NSNull() }
             guard value.rounded() == value, abs(value) < 9_007_199_254_740_992 else { return value }
             return Int(value)
         case .bool(let value): return value

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -22,6 +22,13 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case splitAmountMismatch
     case invalidAccountName
     case accountCreationFailed(String)
+    case ruleNeedsCondition
+    case ruleNeedsAction
+    case ruleInvalidCondition(field: String, op: String)
+    case ruleInvalidAction
+    case ruleEmptyValue(field: String)
+    case ruleInvalidPattern(pattern: String)
+    case ruleOwnedBySchedule
 
     var errorDescription: String? {
         switch self {
@@ -55,6 +62,20 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "Enter an account name"
         case .accountCreationFailed(let message):
             return "Failed to create account: \(message)"
+        case .ruleNeedsCondition: 
+            return "Add at least one condition."
+        case .ruleNeedsAction: 
+            return "Add at least one action."
+        case .ruleInvalidCondition(let field, let op):
+            return "\"\(RuleSchema.label(op: op))\" can't be used with \(RuleSchema.label(field: field))."
+        case .ruleInvalidAction: 
+            return "Choose a field for every action."
+        case .ruleEmptyValue(let field): 
+            return "\(RuleSchema.label(field: field).capitalized) needs a value."
+        case .ruleInvalidPattern(let pattern): 
+            return "\"\(pattern)\" isn't a valid regular expression."
+        case .ruleOwnedBySchedule: 
+            return "This rule belongs to a schedule. Delete the schedule instead."
         }
     }
 }
@@ -3242,6 +3263,106 @@ final class BudgetStore: ObservableObject {
         }
         try await syncClient.setNote(id: id, note: note)
     }
+    
+    // MARK: - Rules
+
+    /// Live rules in engine order (GH #222). Loaded on demand by the Rules
+    /// screen rather than at budget load — most sessions never open it.
+    @Published private(set) var rules: [Rule] = []
+    /// Rules a schedule owns: editable, but not deletable, same as upstream.
+    @Published private(set) var scheduleOwnedRuleIds: Set<String> = []
+    /// False when the open budget file predates the `rules` table, which hides
+    /// the whole feature rather than failing at save time.
+    @Published private(set) var rulesSupported = false
+
+    func loadRules() async {
+        guard let database else {
+            rules = []
+            scheduleOwnedRuleIds = []
+            rulesSupported = false
+            return
+        }
+        do {
+            rulesSupported = try database.rulesTableExists()
+            rules = rulesSupported ? try await database.fetchRulesRanked() : []
+            scheduleOwnedRuleIds = (try? database.scheduleOwnedRuleIds()) ?? []
+        } catch {
+            logger.error("loadRules failed: \(error.localizedDescription, privacy: .public)")
+            rules = []
+        }
+    }
+
+    /// Create or update a rule. Validation mirrors upstream `rule-validate`:
+    /// a rule needs at least one condition and one action, and every condition
+    /// must use an operator its field supports.
+    func saveRule(_ rule: Rule) async throws {
+        guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
+        try Self.validate(rule)
+        try await syncClient.saveRule(rule)
+        await loadRules()
+    }
+
+    /// Delete a rule. Refuses when a schedule owns it, like upstream's
+    /// `deleteRule`, which returns false rather than orphaning the schedule.
+    func deleteRule(_ rule: Rule) async throws {
+        guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
+        guard !scheduleOwnedRuleIds.contains(rule.id) else {
+            throw BudgetStoreError.ruleOwnedBySchedule
+        }
+        try await syncClient.deleteRule(rule)
+        await loadRules()
+    }
+
+    static func validate(_ rule: Rule) throws {
+        guard !rule.conditions.isEmpty else { throw BudgetStoreError.ruleNeedsCondition }
+        guard !rule.actions.isEmpty else { throw BudgetStoreError.ruleNeedsAction }
+
+        for condition in rule.conditions {
+            guard RuleSchema.isValidOp(field: condition.field, op: condition.op) else {
+                throw BudgetStoreError.ruleInvalidCondition(field: condition.field, op: condition.op)
+            }
+            // Upstream's Condition constructor rejects empty values for
+            // non-nullable types, and empty arrays for oneOf/notOneOf.
+            switch condition.op {
+            case "oneOf", "notOneOf":
+                guard condition.value.listValue?.isEmpty == false else {
+                    throw BudgetStoreError.ruleEmptyValue(field: condition.field)
+                }
+            case "onBudget", "offBudget":
+                break
+            default:
+                let type = RuleSchema.fieldType(condition.field)
+                if type == .number || type == .date || type == .boolean {
+                    guard !condition.value.isNull else {
+                        throw BudgetStoreError.ruleEmptyValue(field: condition.field)
+                    }
+                }
+                if ["contains", "doesNotContain", "matches", "hasTags", "hasAnyTag"].contains(condition.op) {
+                    guard let text = condition.value.stringValue, !text.isEmpty else {
+                        throw BudgetStoreError.ruleEmptyValue(field: condition.field)
+                    }
+                    // Upstream doesn't check this — a bad pattern just fails
+                    // silently at apply time. Catching it here is the one place
+                    // the user can still do something about it. Compile the
+                    // lowercased pattern, which is what the engine will run.
+                    if condition.op == "matches",
+                       (try? NSRegularExpression(pattern: text.lowercased())) == nil {
+                        throw BudgetStoreError.ruleInvalidPattern(pattern: text)
+                    }
+                }
+            }
+        }
+
+        for action in rule.actions where action.op == "set" {
+            guard let field = action.field, RuleSchema.fieldType(field) != nil else {
+                throw BudgetStoreError.ruleInvalidAction
+            }
+            // Upstream: `account` may never be set to nothing.
+            if field == "account", action.value.stringValue?.isEmpty != false {
+                throw BudgetStoreError.ruleEmptyValue(field: field)
+            }
+        }
+    }
 
     // MARK: - Currency Formatting
 
@@ -3272,3 +3393,4 @@ final class BudgetStore: ObservableObject {
         Self.yearMonthFormatter.string(from: Date())
     }
 }
+

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -63,22 +63,22 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "Enter an account name"
         case .accountCreationFailed(let message):
             return "Failed to create account: \(message)"
-        case .ruleNeedsCondition: 
+        case .ruleNeedsCondition:
             return "Add at least one condition."
-        case .ruleNeedsAction: 
+        case .ruleNeedsAction:
             return "Add at least one action."
         case .ruleInvalidCondition(let field, let op):
             return "\"\(RuleSchema.label(op: op))\" can't be used with \(RuleSchema.label(field: field))."
-        case .ruleInvalidAction: 
+        case .ruleInvalidAction:
             return "Choose a field for every action."
-        case .ruleEmptyValue(let field): 
+        case .ruleEmptyValue(let field):
             return "\(RuleSchema.label(field: field).capitalized) needs a value."
-        case .ruleInvalidPattern(let pattern): 
+        case .ruleInvalidPattern(let pattern):
             return "\"\(pattern)\" isn't a valid regular expression."
-        case .ruleOwnedBySchedule: 
+        case .ruleOwnedBySchedule:
             return "This rule belongs to a schedule. Delete the schedule instead."
         case .ruleNotSerializable:
-                    return "This rule contains a value that can't be saved. Check the amounts."
+            return "This rule contains a value that can't be saved. Check the amounts."
         }
     }
 }
@@ -3296,6 +3296,7 @@ final class BudgetStore: ObservableObject {
         } catch {
             logger.error("loadRules failed: \(error.localizedDescription, privacy: .public)")
             rules = []
+            scheduleOwnedRuleIds = []
         }
     }
 
@@ -3338,6 +3339,13 @@ final class BudgetStore: ObservableObject {
                 }
             case "onBudget", "offBudget":
                 break
+            case "isbetween":
+                // Upstream's parse asserts a `{num1, num2}` payload; anything
+                // else makes `makeRule` return null and the whole rule vanish
+                // from the web client.
+                guard condition.value.betweenValue != nil else {
+                    throw BudgetStoreError.ruleEmptyValue(field: condition.field)
+                }
             default:
                 let type = RuleSchema.fieldType(condition.field)
                 if type == .number || type == .date || type == .boolean {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3363,6 +3363,20 @@ final class BudgetStore: ObservableObject {
             }
         }
     }
+    
+    /// Names for everything a rule summary might reference.
+    var ruleSummary: RuleSummary {
+        let categories = categoryGroups.flatMap(\.categories)
+        return RuleSummary(
+            names: .init(
+                payees: Dictionary(payees.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first }),
+                categories: Dictionary(categories.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first }),
+                categoryGroups: Dictionary(categoryGroups.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first }),
+                accounts: Dictionary(accounts.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first })
+            ),
+            formatAmount: { [weak self] cents in self?.formatCurrency(cents) ?? "\(cents)" }
+        )
+    }
 
     // MARK: - Currency Formatting
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -29,6 +29,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case ruleEmptyValue(field: String)
     case ruleInvalidPattern(pattern: String)
     case ruleOwnedBySchedule
+    case ruleNotSerializable
 
     var errorDescription: String? {
         switch self {
@@ -76,6 +77,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "\"\(pattern)\" isn't a valid regular expression."
         case .ruleOwnedBySchedule: 
             return "This rule belongs to a schedule. Delete the schedule instead."
+        case .ruleNotSerializable:
+                    return "This rule contains a value that can't be saved. Check the amounts."
         }
     }
 }
@@ -1732,6 +1735,10 @@ final class BudgetStore: ObservableObject {
             throw BudgetStoreError.syncNotConfigured
         }
         var existing = try database.existingFinancialIds(accountId: accountId)
+        
+        // One rules/context fetch for the whole import, not one per row.
+        let prepared = await syncClient.prepareRules()
+        
         var imported = 0
         var skipped = 0
         for candidate in candidates {
@@ -1762,7 +1769,7 @@ final class BudgetStore: ObservableObject {
                 importedPayee: payeeName,
                 financialId: candidate.id
             )
-            try await syncClient.createTransaction(transaction)
+            try await syncClient.createTransaction(transaction, prepared: prepared)
             imported += 1
         }
         await refreshDataOnly()
@@ -3316,6 +3323,7 @@ final class BudgetStore: ObservableObject {
     static func validate(_ rule: Rule) throws {
         guard !rule.conditions.isEmpty else { throw BudgetStoreError.ruleNeedsCondition }
         guard !rule.actions.isEmpty else { throw BudgetStoreError.ruleNeedsAction }
+        guard rule.isSerializable else { throw BudgetStoreError.ruleNotSerializable }
 
         for condition in rule.conditions {
             guard RuleSchema.isValidOp(field: condition.field, op: condition.op) else {
@@ -3337,6 +3345,17 @@ final class BudgetStore: ObservableObject {
                         throw BudgetStoreError.ruleEmptyValue(field: condition.field)
                     }
                 }
+                // A date condition needs a full YYYY-MM-DD for the comparison
+                // ops; `is` also accepts a month or a year, matching upstream's
+                // parseDateString.
+                if type == .date {
+                    let digits = (condition.value.stringValue ?? "")
+                        .replacingOccurrences(of: "-", with: "")
+                    let allowed = condition.op == "is" ? [4, 6, 8] : [8]
+                    guard allowed.contains(digits.count), Int(digits) != nil else {
+                        throw BudgetStoreError.ruleEmptyValue(field: condition.field)
+                    }
+                }
                 if ["contains", "doesNotContain", "matches", "hasTags", "hasAnyTag"].contains(condition.op) {
                     guard let text = condition.value.stringValue, !text.isEmpty else {
                         throw BudgetStoreError.ruleEmptyValue(field: condition.field)
@@ -3345,9 +3364,18 @@ final class BudgetStore: ObservableObject {
                     // silently at apply time. Catching it here is the one place
                     // the user can still do something about it. Compile the
                     // lowercased pattern, which is what the engine will run.
-                    if condition.op == "matches",
-                       (try? NSRegularExpression(pattern: text.lowercased())) == nil {
-                        throw BudgetStoreError.ruleInvalidPattern(pattern: text)
+                    if condition.op == "matches" {
+                        // No timeout exists for NSRegularExpression, so a
+                        // pathological pattern would wedge the sync actor it
+                        // runs on. A length bound doesn't make that impossible,
+                        // but it rules out the pasted-blob case; the web app has
+                        // the same exposure.
+                        guard text.count <= 500 else {
+                            throw BudgetStoreError.ruleInvalidPattern(pattern: text)
+                        }
+                        guard (try? NSRegularExpression(pattern: text.lowercased())) != nil else {
+                            throw BudgetStoreError.ruleInvalidPattern(pattern: text)
+                        }
                     }
                 }
             }
@@ -3376,36 +3404,6 @@ final class BudgetStore: ObservableObject {
             ),
             formatAmount: { [weak self] cents in self?.formatCurrency(cents) ?? "\(cents)" }
         )
-    }
-
-    /// Run every rule over the given transactions and save what changed —
-    /// upstream's "Run rules on selected transactions" (Account.tsx `onRunRules`).
-    /// Returns the number of transactions actually updated.
-    @discardableResult
-    func runRules(on transactions: [Transaction]) async throws -> Int {
-        guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
-
-        let rules = try database.fetchRules()
-        let context = try database.ruleContext()
-        var updated = 0
-
-        for original in transactions {
-            let result = RulesEngine.apply(original, rules: rules, context: context)
-            guard !result.changedFields.isEmpty || result.pendingPayeeName != nil else { continue }
-
-            var transaction = result.transaction
-            if let name = result.pendingPayeeName {
-                transaction.payeeId = try await findOrCreatePayee(name: name).id
-            }
-            try await syncClient.updateTransaction(
-                transaction,
-                changedFields: Self.changedFields(original: original, updated: transaction)
-            )
-            updated += 1
-        }
-
-        await refreshData()
-        return updated
     }
 
     // MARK: - Currency Formatting

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3378,6 +3378,36 @@ final class BudgetStore: ObservableObject {
         )
     }
 
+    /// Run every rule over the given transactions and save what changed —
+    /// upstream's "Run rules on selected transactions" (Account.tsx `onRunRules`).
+    /// Returns the number of transactions actually updated.
+    @discardableResult
+    func runRules(on transactions: [Transaction]) async throws -> Int {
+        guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
+
+        let rules = try database.fetchRules()
+        let context = try database.ruleContext()
+        var updated = 0
+
+        for original in transactions {
+            let result = RulesEngine.apply(original, rules: rules, context: context)
+            guard !result.changedFields.isEmpty || result.pendingPayeeName != nil else { continue }
+
+            var transaction = result.transaction
+            if let name = result.pendingPayeeName {
+                transaction.payeeId = try await findOrCreatePayee(name: name).id
+            }
+            try await syncClient.updateTransaction(
+                transaction,
+                changedFields: Self.changedFields(original: original, updated: transaction)
+            )
+            updated += 1
+        }
+
+        await refreshData()
+        return updated
+    }
+
     // MARK: - Currency Formatting
 
     /// Format an amount in cents to a currency string using the budget's currency

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2235,6 +2235,56 @@ class BudgetDatabase {
             }
         }
     }
+    
+    /// Budget-level context the rules engine needs for conditions it can't
+    /// answer from the transaction row (upstream `prepareTransactionForRules`).
+    func ruleContext() throws -> RuleContext {
+        try dbQueue.read { db in
+            let offBudget = try Set(String.fetchAll(
+                db, sql: "SELECT id FROM accounts WHERE offbudget = 1"
+            ))
+
+            var groups: [String: String] = [:]
+            for row in try Row.fetchAll(db, sql: """
+                SELECT id, cat_group FROM categories
+                WHERE tombstone = 0 OR tombstone IS NULL
+                """) {
+                if let id: String = row["id"], let group: String = row["cat_group"] {
+                    groups[id] = group
+                }
+            }
+
+            var payeeNames: [String: String] = [:]
+            for row in try Row.fetchAll(db, sql: """
+                SELECT id, name FROM payees
+                WHERE tombstone = 0 OR tombstone IS NULL
+                """) {
+                if let id: String = row["id"], let name: String = row["name"] {
+                    payeeNames[id] = name
+                }
+            }
+
+            return RuleContext(
+                offBudgetAccountIds: offBudget,
+                categoryGroupIds: groups,
+                payeeNames: payeeNames
+            )
+        }
+    }
+
+    /// The live payee with this name, case-insensitively — how a `payee_name`
+    /// action resolves to an id before we fall back to creating one.
+    func payee(named name: String) throws -> Payee? {
+        try dbQueue.read { db in
+            let row = try Row.fetchOne(db, sql: """
+                SELECT id, name, transfer_acct FROM payees
+                WHERE (tombstone = 0 OR tombstone IS NULL) AND name = ? COLLATE NOCASE
+                LIMIT 1
+                """, arguments: [name])
+            guard let row, let id: String = row["id"] else { return nil }
+            return Payee(id: id, name: row["name"] ?? name, transferAccountId: row["transfer_acct"])
+        }
+    }
 
     // MARK: - Schedules
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2206,34 +2206,8 @@ class BudgetDatabase {
 
     // MARK: - Rules
 
-    /// Fetch all non-tombstoned rules from the rules table.
-    /// Returns an empty array if the rules table doesn't exist.
-    func fetchRules() throws -> [Rule] {
-        try dbQueue.read { db in
-            guard try db.tableExists("rules") else { return [] }
-
-            let rows = try Row.fetchAll(db, sql: """
-                SELECT id, stage, conditions_op, conditions, actions
-                FROM rules
-                WHERE tombstone = 0 OR tombstone IS NULL
-                """)
-
-            return rows.compactMap { row in
-                let id: String? = row["id"]
-                guard let id else { return nil }
-                do {
-                    return try Rule.parse(
-                        id: id,
-                        stage: row["stage"],
-                        conditionsOp: row["conditions_op"],
-                        conditionsJSON: row["conditions"],
-                        actionsJSON: row["actions"]
-                    )
-                } catch {
-                    return nil
-                }
-            }
-        }
+    func rulesTableExists() throws -> Bool {
+        try dbQueue.read { db in try db.tableExists("rules") }
     }
     
     /// Budget-level context the rules engine needs for conditions it can't
@@ -2283,6 +2257,53 @@ class BudgetDatabase {
                 """, arguments: [name])
             guard let row, let id: String = row["id"] else { return nil }
             return Payee(id: id, name: row["name"] ?? name, transferAccountId: row["transfer_acct"])
+        }
+    }
+
+    /// All live rules. Returns [] when the budget file has no `rules` table.
+    func fetchRules() throws -> [Rule] {
+        try dbQueue.read { db in try Self.liveRules(db) }
+    }
+
+    /// Live rules in the order the engine runs them — what the Rules screen shows,
+    /// matching upstream's `rules-get` (which returns `rankRules(...)`).
+    func fetchRulesRanked() async throws -> [Rule] {
+        try await dbQueue.read { db in RuleRanker.rank(try Self.liveRules(db)) }
+    }
+
+    private static func liveRules(_ db: Database) throws -> [Rule] {
+        guard try db.tableExists("rules") else { return [] }
+
+        let rows = try Row.fetchAll(db, sql: """
+            SELECT id, stage, conditions_op, conditions, actions
+            FROM rules
+            WHERE tombstone = 0 OR tombstone IS NULL
+            """)
+
+        return rows.compactMap { row in
+            guard let id: String = row["id"] else { return nil }
+            // A rule we can't parse is a rule we must not silently half-apply:
+            // upstream drops invalid rules on load too (`makeRule` returns null).
+            return try? Rule.parse(
+                id: id,
+                stage: row["stage"],
+                conditionsOp: row["conditions_op"],
+                conditionsJSON: row["conditions"],
+                actionsJSON: row["actions"]
+            )
+        }
+    }
+
+    /// Rule ids a schedule owns. Upstream refuses to delete these
+    /// (`deleteRule` returns false when a schedule points at the rule), and the
+    /// list badges them so it's clear why.
+    func scheduleOwnedRuleIds() throws -> Set<String> {
+        try dbQueue.read { db in
+            guard try db.tableExists("schedules") else { return [] }
+            return try Set(String.fetchAll(db, sql: """
+                SELECT rule FROM schedules
+                WHERE rule IS NOT NULL AND (tombstone = 0 OR tombstone IS NULL)
+                """))
         }
     }
 

--- a/Actuali/Actuali/Services/Reports/ConditionsFilter.swift
+++ b/Actuali/Actuali/Services/Reports/ConditionsFilter.swift
@@ -139,26 +139,10 @@ enum ConditionsFilter {
     /// Transactions store dates as YYYYMMDD ints. Recurring-date conditions
     /// (objects with a frequency) are not supported and pass through.
     private static func matchDate(_ tx: Transaction, _ c: WidgetRuleCondition) -> Bool {
-        guard let s = decodeString(c.value) else { return true }
-        let digits = s.replacingOccurrences(of: "-", with: "")
-        guard let value = Int(digits) else { return true }
-
-        switch (c.op, digits.count) {
-        case ("is", 8): return tx.date == value
-        case ("is", 6): return tx.date / 100 == value      // month
-        case ("is", 4): return tx.date / 10000 == value    // year
-        case ("isapprox", 8):
-            guard let target = ymdToDate(value), let txDate = ymdToDate(tx.date) else { return false }
-            return abs(txDate.timeIntervalSince(target)) <= 2 * 86_400 + 1
-        case ("gt", 8): return tx.date > value
-        case ("gte", 8): return tx.date >= value
-        case ("lt", 8): return tx.date < value
-        case ("lte", 8): return tx.date <= value
-        default:
-            // Upstream rejects month/year values for comparison ops at parse
-            // time, dropping the condition entirely.
-            return true
-        }
+        guard let value = decodeString(c.value) else { return true }
+        // An unevaluable date condition is a dropped condition here, matching
+        // upstream's filter builder — the report shows everything else.
+        return RuleDateMatcher.matches(transactionDate: tx.date, op: c.op, value: value) ?? true
     }
 
     // MARK: - Id conditions (category / account / payee)
@@ -324,11 +308,5 @@ enum ConditionsFilter {
             return AmountOptions(inflow: nil, outflow: nil)
         }
         return opts
-    }
-
-    private static func ymdToDate(_ ymd: Int) -> Date? {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
-        return cal.date(from: DateComponents(year: ymd / 10000, month: (ymd % 10000) / 100, day: ymd % 100))
     }
 }

--- a/Actuali/Actuali/Services/Rules/RuleDateMatcher.swift
+++ b/Actuali/Actuali/Services/Rules/RuleDateMatcher.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Date-condition semantics shared by the rules engine and the report filters.
+/// Condition values are strings (`"2026-05-03"`, `"2026-05"`, `"2026"`);
+/// transactions store dates as YYYYMMDD ints.
+///
+/// Returns `nil` when the condition can't be evaluated (unparseable value, or
+/// an op/precision combination upstream rejects at parse time). Callers decide
+/// what that means: the engine treats it as "no match", the report filters as
+/// "condition dropped", which is what each does upstream.
+enum RuleDateMatcher {
+
+    static func matches(transactionDate: Int, op: String, value: String) -> Bool? {
+        let digits = value.replacingOccurrences(of: "-", with: "")
+        guard let target = Int(digits) else { return nil }
+
+        switch (op, digits.count) {
+        case ("is", 8): return transactionDate == target
+        case ("is", 6): return transactionDate / 100 == target        // YYYY-MM
+        case ("is", 4): return transactionDate / 10000 == target      // YYYY
+        case ("isapprox", 8):
+            // Upstream widens an exact date by ±2 days.
+            guard let targetDate = date(from: target),
+                  let txDate = date(from: transactionDate) else { return nil }
+            return abs(txDate.timeIntervalSince(targetDate)) <= 2 * 86_400 + 1
+        case ("gt", 8): return transactionDate > target
+        case ("gte", 8): return transactionDate >= target
+        case ("lt", 8): return transactionDate < target
+        case ("lte", 8): return transactionDate <= target
+        default:
+            // Comparison ops require an exact date upstream; month/year values
+            // fail `Condition`'s parse assertions and the rule never loads.
+            return nil
+        }
+    }
+
+    private static func date(from yyyymmdd: Int) -> Date? {
+        var components = DateComponents()
+        components.year = yyyymmdd / 10000
+        components.month = (yyyymmdd % 10000) / 100
+        components.day = yyyymmdd % 100
+        return Calendar.current.date(from: components)
+    }
+}

--- a/Actuali/Actuali/Services/Rules/RuleDateMatcher.swift
+++ b/Actuali/Actuali/Services/Rules/RuleDateMatcher.swift
@@ -34,11 +34,21 @@ enum RuleDateMatcher {
         }
     }
 
+    /// Fixed UTC Gregorian calendar, not `Calendar.current`: the ±2 day window
+    /// has to be exactly 2 × 86,400s. A local calendar makes a DST day 23 or 25
+    /// hours long, which pushes a legitimately-two-days-apart pair over the
+    /// threshold, and makes results depend on the device's timezone.
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar
+    }()
+
     private static func date(from yyyymmdd: Int) -> Date? {
         var components = DateComponents()
         components.year = yyyymmdd / 10000
         components.month = (yyyymmdd % 10000) / 100
         components.day = yyyymmdd % 100
-        return Calendar.current.date(from: components)
+        return calendar.date(from: components)
     }
 }

--- a/Actuali/Actuali/Services/Rules/RuleRanker.swift
+++ b/Actuali/Actuali/Services/Rules/RuleRanker.swift
@@ -25,8 +25,11 @@ enum RuleRanker {
         var total = 0
         for condition in rule.conditions {
             guard let score = opScores[condition.op] else {
+                // Upstream's reducer returns 0 for the unknown op, which resets
+                // the running total but keeps accumulating later conditions.
                 logger.debug("Found invalid operation while ranking: \(condition.op, privacy: .public)")
-                return 0
+                total = 0
+                continue
             }
             total += score
         }

--- a/Actuali/Actuali/Services/Rules/RuleRanker.swift
+++ b/Actuali/Actuali/Services/Rules/RuleRanker.swift
@@ -38,11 +38,19 @@ enum RuleRanker {
     }
 
     static func rank(_ rules: [Rule]) -> [Rule] {
-        Rule.Stage.allCases.flatMap { stage in
+        // Score once per rule, not once per comparison — upstream keeps the same
+        // scores map for the same reason.
+        var scores: [String: Int] = [:]
+        for rule in rules where scores[rule.id] == nil {
+            scores[rule.id] = score(rule)
+        }
+
+        return Rule.Stage.allCases.flatMap { stage in
             rules
                 .filter { $0.stage == stage }
                 .sorted { lhs, rhs in
-                    let (left, right) = (score(lhs), score(rhs))
+                    let left = scores[lhs.id] ?? 0
+                    let right = scores[rhs.id] ?? 0
                     return left == right ? lhs.id < rhs.id : left < right
                 }
         }

--- a/Actuali/Actuali/Services/Rules/RuleRanker.swift
+++ b/Actuali/Actuali/Services/Rules/RuleRanker.swift
@@ -1,0 +1,50 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "RuleRanker")
+
+/// Port of loot-core `rankRules` (server/rules/rule-utils.ts). Rules run
+/// `pre` → default → `post`, and within a stage in *ascending* score order so
+/// the most specific rule applies last and wins. Ties break on id, so every
+/// client orders an identical rule set identically.
+enum RuleRanker {
+
+    private static let opScores: [String: Int] = [
+        "is": 10, "isNot": 10,
+        "oneOf": 9, "notOneOf": 9,
+        "isapprox": 5, "isbetween": 5,
+        "gt": 1, "gte": 1, "lt": 1, "lte": 1,
+        "contains": 0, "doesNotContain": 0, "matches": 0,
+        "hasTags": 0, "hasAnyTag": 0,
+        "onBudget": 0, "offBudget": 0
+    ]
+
+    private static let doublingOps: Set<String> = ["is", "isNot", "isapprox", "oneOf", "notOneOf"]
+
+    static func score(_ rule: Rule) -> Int {
+        var total = 0
+        for condition in rule.conditions {
+            guard let score = opScores[condition.op] else {
+                logger.debug("Found invalid operation while ranking: \(condition.op, privacy: .public)")
+                return 0
+            }
+            total += score
+        }
+        // A rule made purely of exact-match conditions is twice as specific.
+        if !rule.conditions.isEmpty, rule.conditions.allSatisfy({ doublingOps.contains($0.op) }) {
+            return total * 2
+        }
+        return total
+    }
+
+    static func rank(_ rules: [Rule]) -> [Rule] {
+        Rule.Stage.allCases.flatMap { stage in
+            rules
+                .filter { $0.stage == stage }
+                .sorted { lhs, rhs in
+                    let (left, right) = (score(lhs), score(rhs))
+                    return left == right ? lhs.id < rhs.id : left < right
+                }
+        }
+    }
+}

--- a/Actuali/Actuali/Services/Rules/RuleSchema.swift
+++ b/Actuali/Actuali/Services/Rules/RuleSchema.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Field metadata for rules, ported from loot-core `shared/rules.ts` (FIELD_INFO,
+/// TYPE_INFO, isValidOp) plus the label maps in `desktop-client/src/util/rule.ts`.
+/// One place so the engine, the validator and the editor can't drift apart.
+enum RuleFieldType: String {
+    case id, string, number, date, boolean
+}
+
+enum RuleSchema {
+
+    // MARK: - Types and operators
+
+    /// Public field name -> type. `saved` (saved-filter references) is
+    /// deliberately absent: upstream drops those conditions before evaluating.
+    static let fieldTypes: [String: RuleFieldType] = [
+        "imported_payee": .string,
+        "payee": .id,
+        "payee_name": .string,
+        "date": .date,
+        "notes": .string,
+        "amount": .number,
+        "category": .id,
+        "category_group": .id,
+        "account": .id,
+        "cleared": .boolean,
+        "reconciled": .boolean,
+        "transfer": .boolean,
+        "parent": .boolean
+    ]
+
+    private static let opsByType: [RuleFieldType: [String]] = [
+        .date: ["is", "isapprox", "gt", "gte", "lt", "lte"],
+        .id: ["is", "isNot", "oneOf", "notOneOf", "contains", "doesNotContain",
+              "matches", "onBudget", "offBudget"],
+        .string: ["is", "isNot", "oneOf", "notOneOf", "contains", "doesNotContain",
+                  "matches", "hasTags", "hasAnyTag"],
+        .number: ["is", "isapprox", "isbetween", "gt", "gte", "lt", "lte"],
+        .boolean: ["is"]
+    ]
+
+    private static let disallowedOps: [String: Set<String>] = [
+        "imported_payee": ["hasTags", "hasAnyTag"],
+        "payee": ["onBudget", "offBudget"],
+        "category": ["onBudget", "offBudget"],
+        "category_group": ["onBudget", "offBudget"],
+        "notes": ["oneOf", "notOneOf"]
+    ]
+
+    static func fieldType(_ field: String) -> RuleFieldType? {
+        fieldTypes[field]
+    }
+
+    /// Ops the editor offers for `field`, in upstream's declaration order.
+    static func validOps(for field: String) -> [String] {
+        guard let type = fieldTypes[field] else { return [] }
+        let disallowed = disallowedOps[field] ?? []
+        return (opsByType[type] ?? []).filter { !disallowed.contains($0) }
+    }
+
+    static func isValidOp(field: String, op: String) -> Bool {
+        validOps(for: field).contains(op)
+    }
+
+    // MARK: - Editor field lists (upstream RuleEditor.tsx)
+
+    static let conditionFields = [
+        "imported_payee", "account", "category", "category_group",
+        "date", "payee", "notes", "amount"
+    ]
+
+    static let actionFields = [
+        "category", "payee", "payee_name", "notes", "cleared", "account", "date", "amount"
+    ]
+
+    // MARK: - Internal <-> public column names
+
+    /// Mirrors `schemaConfig.views.transactions.fields` in loot-core.
+    private static let internalToPublic: [String: String] = [
+        "isParent": "is_parent",
+        "isChild": "is_child",
+        "acct": "account",
+        "financial_id": "imported_id",
+        "imported_description": "imported_payee",
+        "transferred_id": "transfer_id",
+        "description": "payee"
+    ]
+
+    private static let publicToInternal: [String: String] =
+        Dictionary(uniqueKeysWithValues: internalToPublic.map { ($0.value, $0.key) })
+
+    static func publicField(from internalField: String) -> String {
+        internalToPublic[internalField] ?? internalField
+    }
+
+    static func internalField(from publicField: String) -> String {
+        publicToInternal[publicField] ?? publicField
+    }
+
+    // MARK: - Labels (util/rule.ts mapField / friendlyOp)
+
+    static func label(field: String, options: [String: RuleValue]? = nil) -> String {
+        switch field {
+        case "imported_payee": return "imported payee"
+        case "payee_name": return "payee (name)"
+        case "amount":
+            if options?["inflow"]?.boolValue == true { return "amount (inflow)" }
+            if options?["outflow"]?.boolValue == true { return "amount (outflow)" }
+            return "amount"
+        case "category_group": return "category group"
+        default: return field
+        }
+    }
+
+    static func label(op: String, type: RuleFieldType? = nil) -> String {
+        switch op {
+        case "is": return "is"
+        case "isNot": return "is not"
+        case "oneOf": return "one of"
+        case "notOneOf": return "not one of"
+        case "isapprox": return "is approx"
+        case "isbetween": return "is between"
+        case "contains": return "contains"
+        case "doesNotContain": return "does not contain"
+        case "matches": return "matches"
+        case "hasTags": return "has all tags"
+        case "hasAnyTag": return "has any tag"
+        case "onBudget": return "is on budget"
+        case "offBudget": return "is off budget"
+        case "gt": return type == .date ? "is after" : "is greater than"
+        case "gte": return type == .date ? "is after or equals" : "is greater than or equals"
+        case "lt": return type == .date ? "is before" : "is less than"
+        case "lte": return type == .date ? "is before or equals" : "is less than or equals"
+        case "set": return "set"
+        case "set-split-amount": return "allocate"
+        case "link-schedule": return "link schedule"
+        case "prepend-notes": return "prepend to notes"
+        case "append-notes": return "append to notes"
+        case "delete-transaction": return "delete transaction"
+        default: return op
+        }
+    }
+}

--- a/Actuali/Actuali/Services/Rules/RuleSummary.swift
+++ b/Actuali/Actuali/Services/Rules/RuleSummary.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Human-readable rule text, ported from `desktop-client/src/components/rules/
+/// {Condition,Action}Expression.tsx` and `ManageRules.tsx`'s `ruleToString`
+/// (which is also what the web's rule search matches against).
+struct RuleSummary {
+    /// Names for the ids a rule references, so the summary reads
+    /// "Groceries" rather than a UUID.
+    struct Names {
+        var payees: [String: String] = [:]
+        var categories: [String: String] = [:]
+        var categoryGroups: [String: String] = [:]
+        var accounts: [String: String] = [:]
+
+        static let empty = Names()
+    }
+
+    let names: Names
+    /// Formats cents the way the rest of the app does (`BudgetStore.formatCurrency`).
+    let formatAmount: (Int) -> String
+
+    func condition(_ condition: Rule.Condition) -> String {
+        let field = RuleSchema.label(field: condition.field, options: condition.options)
+        let op = RuleSchema.label(op: condition.op, type: RuleSchema.fieldType(condition.field))
+        switch condition.op {
+        case "onBudget", "offBudget":
+            return "\(field) \(op)"
+        default:
+            return "\(field) \(op) \(value(condition.value, field: condition.field))"
+        }
+    }
+
+    func action(_ action: Rule.Action) -> String {
+        switch action.op {
+        case "set":
+            guard let field = action.field else { return RuleSchema.label(op: action.op) }
+            if let template = action.options?["template"]?.stringValue {
+                return "set \(RuleSchema.label(field: field)) to template \(template)"
+            }
+            if let formula = action.options?["formula"]?.stringValue {
+                return "set \(RuleSchema.label(field: field)) to formula \(formula)"
+            }
+            return "set \(RuleSchema.label(field: field)) to \(value(action.value, field: field))"
+        case "prepend-notes", "append-notes":
+            return "\(RuleSchema.label(op: action.op)) \(action.value.stringValue ?? "")"
+        case "link-schedule":
+            return "link schedule"
+        case "delete-transaction":
+            return "delete transaction"
+        case "set-split-amount":
+            return "allocate a split amount"
+        default:
+            return RuleSchema.label(op: action.op)
+        }
+    }
+
+    /// Everything a rule says, in one line — the string the search box filters on.
+    func searchText(_ rule: Rule) -> String {
+        (rule.conditions.map(condition) + rule.actions.map(action))
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private func value(_ value: RuleValue, field: String) -> String {
+        switch value {
+        case .null:
+            return "nothing"
+        case .bool(let flag):
+            return flag ? "yes" : "no"
+        case .list(let items):
+            let rendered = items.map { self.value($0, field: field) }
+            return rendered.isEmpty ? "nothing" : rendered.joined(separator: ", ")
+        case .object:
+            guard let between = value.betweenValue else { return "" }
+            return "\(formatAmount(Int(between.num1))) and \(formatAmount(Int(between.num2)))"
+        case .number(let number):
+            guard RuleSchema.fieldType(field) == .number else { return "\(Int(number))" }
+            return formatAmount(Int(number))
+        case .string(let text):
+            switch field {
+            case "payee": return names.payees[text] ?? text
+            case "category": return names.categories[text] ?? text
+            case "category_group": return names.categoryGroups[text] ?? text
+            case "account": return names.accounts[text] ?? text
+            default: return text.isEmpty ? "nothing" : text
+            }
+        }
+    }
+}

--- a/Actuali/Actuali/Services/Rules/RulesEngine.swift
+++ b/Actuali/Actuali/Services/Rules/RulesEngine.swift
@@ -3,32 +3,67 @@ import os
 
 private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "RulesEngine")
 
-/// Evaluates Actual Budget rules against a Transaction before insert.
-/// Mirrors a subset of loot-core's `runRules` — see Rule.swift for scope.
+/// Budget-level context for conditions that can't be answered from the
+/// transaction row alone. Mirrors what upstream's `prepareTransactionForRules`
+/// hangs off the transaction before the rules run.
+struct RuleContext {
+    var offBudgetAccountIds: Set<String> = []
+    var categoryGroupIds: [String: String] = [:]   // category id -> group id
+    var payeeNames: [String: String] = [:]         // payee id -> name
+
+    static let empty = RuleContext()
+}
+
+/// What a rules pass produced.
+struct RuleRunResult {
+    var transaction: Transaction
+    /// Public rule field names the rules changed ("payee", "category", …), for
+    /// logging and for deciding whether a write is needed at all. The CRDT
+    /// column set for an update still comes from `BudgetStore.changedFields`,
+    /// which speaks the internal column names.
+    var changedFields: Set<String>
+    /// Set when an action assigned `payee_name`: the caller resolves it to a
+    /// payee id, creating the payee if necessary, like upstream's
+    /// `resolvePayeeNameForRules`.
+    var pendingPayeeName: String?
+    /// A `delete-transaction` action fired.
+    var isDeleted: Bool = false
+}
+
+/// Evaluates Actual Budget rules against a Transaction.
+/// Port of loot-core `runRules` (server/transactions/transaction-rules.ts) with
+/// the condition/action semantics of `server/rules/{condition,action}.ts`.
+///
+/// Not supported (logged, treated as a no-op): `set-split-amount`, Handlebars
+/// templates and formula actions, and recurring-date conditions. See the
+/// deferred-work section of the rules plan.
 enum RulesEngine {
 
-    /// Apply all non-tombstoned rules to `transaction` in stage order
-    /// (pre → default → post). Returns the (possibly-updated) transaction
-    /// and the set of public field names that changed.
-    static func apply(_ transaction: Transaction, rules: [Rule]) -> (Transaction, Set<String>) {
-        var bag = TransactionBag(transaction)
+    static func apply(
+        _ transaction: Transaction,
+        rules: [Rule],
+        context: RuleContext = .empty
+    ) -> RuleRunResult {
+        var bag = TransactionBag(transaction, context: context)
         let original = bag.snapshot()
 
-        let ordered = rules.sorted { $0.stage < $1.stage }
-        for rule in ordered {
-            if evalConditions(rule, bag: bag) {
-                for action in rule.actions {
-                    apply(action, bag: &bag, ruleId: rule.id)
-                }
+        for rule in RuleRanker.rank(rules) where evalConditions(rule, bag: bag) {
+            for action in rule.actions {
+                apply(action, bag: &bag, ruleId: rule.id)
             }
         }
 
-        let updated = bag.toTransaction(base: transaction)
         let changed = bag.changedFields(comparedTo: original)
         if !changed.isEmpty {
             logger.info("Rules applied: changed fields \(changed.sorted().joined(separator: ", "), privacy: .public)")
         }
-        return (updated, changed)
+
+        return RuleRunResult(
+            transaction: bag.toTransaction(base: transaction),
+            changedFields: changed,
+            pendingPayeeName: bag.pendingPayeeName,
+            isDeleted: bag.isDeleted
+        )
     }
 
     // MARK: - Condition evaluation
@@ -37,58 +72,113 @@ enum RulesEngine {
         guard !rule.conditions.isEmpty else { return false }
         switch rule.conditionsOp {
         case .and: return rule.conditions.allSatisfy { eval($0, bag: bag) }
-        case .or:  return rule.conditions.contains { eval($0, bag: bag) }
+        case .or: return rule.conditions.contains { eval($0, bag: bag) }
         }
     }
 
-    private static func eval(_ cond: Rule.Condition, bag: TransactionBag) -> Bool {
-        let raw = bag.value(for: cond.field)
+    private static func eval(_ condition: Rule.Condition, bag: TransactionBag) -> Bool {
+        let type = RuleSchema.fieldType(condition.field)
 
-        switch cond.op {
-        case "is":          return isEqual(raw, to: cond.value, options: cond.options)
-        case "isNot":       return !isEqual(raw, to: cond.value, options: cond.options)
-        case "contains":    return containsString(raw, cond.value)
-        case "doesNotContain":
-            guard let s = stringValue(raw) else { return false }
-            guard let q = stringValue(cond.value) else { return false }
-            return !s.lowercased().contains(q.lowercased())
-        case "oneOf":       return inList(raw, cond.value)
-        case "notOneOf":
-            guard raw != nil else { return false }
-            return !inList(raw, cond.value)
-        case "matches":
-            guard let s = stringValue(raw), let pattern = stringValue(cond.value) else { return false }
-            return (try? NSRegularExpression(pattern: pattern, options: .caseInsensitive))
-                .map { $0.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil } ?? false
-        case "gt", "gte", "lt", "lte":
-            return compareNumeric(raw, cond.value, op: cond.op, options: cond.options)
-        case "isbetween":
-            guard let n = numericValue(raw, options: cond.options) else { return false }
-            guard let dict = cond.value as? [String: Any],
-                  let a = numericValue(dict["num1"]),
-                  let b = numericValue(dict["num2"]) else { return false }
-            let (lo, hi) = a <= b ? (a, b) : (b, a)
-            return n >= lo && n <= hi
+        // onBudget/offBudget read the account, not the field value.
+        switch condition.op {
+        case "onBudget": return bag.isOnBudget == true
+        case "offBudget": return bag.isOnBudget == false
+        default: break
+        }
+
+        switch type {
+        case .date:
+            guard let date = bag.date, let value = condition.value.stringValue else { return false }
+            return RuleDateMatcher.matches(transactionDate: date, op: condition.op, value: value) ?? false
+        case .number:
+            return evalNumber(condition, bag: bag)
+        case .boolean:
+            guard condition.op == "is",
+                  let expected = condition.value.boolValue,
+                  let actual = bag.bool(for: condition.field) else { return false }
+            return actual == expected
+        case .string, .id, .none:
+            return evalText(condition, bag: bag, type: type)
+        }
+    }
+
+    private static func evalNumber(_ condition: Rule.Condition, bag: TransactionBag) -> Bool {
+        // Upstream applies inflow/outflow before the switch, so it gates every
+        // numeric op, `isbetween` included.
+        guard var amount = bag.number(for: condition.field).map(Double.init) else { return false }
+        if condition.options?["outflow"]?.boolValue == true {
+            guard amount <= 0 else { return false }
+            amount = -amount
+        } else if condition.options?["inflow"]?.boolValue == true {
+            guard amount >= 0 else { return false }
+        }
+
+        if condition.op == "isbetween" {
+            guard let between = condition.value.betweenValue else { return false }
+            let low = min(between.num1, between.num2)
+            let high = max(between.num1, between.num2)
+            return amount >= low && amount <= high
+        }
+
+        guard let target = condition.value.numberValue else { return false }
+        switch condition.op {
+        case "is": return amount == target
         case "isapprox":
-            guard let n = numericValue(raw, options: cond.options),
-                  let target = numericValue(cond.value) else { return false }
-            // Upstream: getApproxNumberThreshold returns floor(|n| * 7.5%).
-            let threshold = floor(abs(target) * 0.075)
-            return n >= target - threshold && n <= target + threshold
-        case "hasTags", "hasAnyTag":
-            // Upstream lowercases both the string field value and each tag, so
-            // rule-engine tag matching is case-insensitive (unlike AQL filters).
-            guard let s = stringValue(raw), let condValue = stringValue(cond.value) else { return false }
-            let tags = TagFilter.extractTags(condValue)
-            let hit = { (tag: String) in
-                TagFilter.notesContainTag(s, tag: tag, caseSensitive: false)
+            // getApproxNumberThreshold: Math.round(|n| * 0.075).
+            let threshold = (abs(target) * 0.075).rounded()
+            return amount >= target - threshold && amount <= target + threshold
+        case "gt": return amount > target
+        case "gte": return amount >= target
+        case "lt": return amount < target
+        case "lte": return amount <= target
+        default: return false
+        }
+    }
+
+    private static func evalText(_ condition: Rule.Condition, bag: TransactionBag, type: RuleFieldType?) -> Bool {
+        // Upstream coerces a missing string field to "" before comparing; id
+        // fields keep their nil so `isNot` still matches an empty payee.
+        var fieldValue = bag.string(for: condition.field)
+        if type == .string { fieldValue = fieldValue ?? "" }
+
+        switch condition.op {
+        case "is":
+            guard let condValue = condition.value.stringValue else { return fieldValue == nil }
+            return fieldValue?.lowercased() == condValue.lowercased()
+        case "isNot":
+            guard let condValue = condition.value.stringValue else { return fieldValue != nil }
+            return fieldValue?.lowercased() != condValue.lowercased()
+        case "contains":
+            guard let fieldValue, let condValue = condition.value.stringValue else { return false }
+            return fieldValue.lowercased().contains(condValue.lowercased())
+        case "doesNotContain":
+            guard let fieldValue, let condValue = condition.value.stringValue else { return false }
+            return !fieldValue.lowercased().contains(condValue.lowercased())
+        case "oneOf", "notOneOf":
+            guard let fieldValue, let list = condition.value.listValue else { return false }
+            let hit = list.compactMap(\.stringValue)
+                .contains { $0.lowercased() == fieldValue.lowercased() }
+            return condition.op == "oneOf" ? hit : !hit
+        case "matches":
+            guard let fieldValue, let pattern = condition.value.stringValue else { return false }
+            // Lowercased, not case-insensitive: upstream's string parse does
+            // `value.toLowerCase()` on the pattern itself, so `\D` becomes `\d`
+            // there and inverts its meaning. Using a case-insensitive match on
+            // the raw pattern would be more correct and would make a rule that
+            // works on the web behave differently here, so we copy the quirk.
+            // Worth an upstream fix in condition.ts; not one to make client-side.
+            guard let regex = try? NSRegularExpression(pattern: pattern.lowercased()) else {
+                logger.debug("invalid regexp in matches condition")
+                return false
             }
-            return cond.op == "hasTags" ? tags.allSatisfy(hit) : tags.contains(where: hit)
-        case "onBudget", "offBudget":
-            logger.debug("Skipping unsupported condition op '\(cond.op, privacy: .public)' on field '\(cond.field, privacy: .public)'")
-            return false
+            return regex.firstMatch(in: fieldValue, range: NSRange(fieldValue.startIndex..., in: fieldValue)) != nil
+        case "hasTags", "hasAnyTag":
+            guard let fieldValue, let condValue = condition.value.stringValue else { return false }
+            let tags = TagFilter.extractTags(condValue)
+            let hit = { (tag: String) in TagFilter.notesContainTag(fieldValue, tag: tag, caseSensitive: false) }
+            return condition.op == "hasTags" ? tags.allSatisfy(hit) : tags.contains(where: hit)
         default:
-            logger.debug("Unknown condition op '\(cond.op, privacy: .public)'")
+            logger.debug("Unknown condition op '\(condition.op, privacy: .public)'")
             return false
         }
     }
@@ -100,178 +190,148 @@ enum RulesEngine {
         case "set":
             guard let field = action.field else { return }
             if action.options?["template"] != nil || action.options?["formula"] != nil {
-                logger.notice("Rule \(ruleId, privacy: .public): skipping set on '\(field, privacy: .public)' — formula/template actions not supported on iOS")
+                logger.notice("Rule \(ruleId, privacy: .public): skipping set on '\(field, privacy: .public)' — template/formula actions aren't supported on iOS")
+                return
+            }
+            if action.options?["splitIndex"]?.numberValue.map({ $0 > 0 }) == true {
+                logger.notice("Rule \(ruleId, privacy: .public): skipping split action on '\(field, privacy: .public)'")
                 return
             }
             bag.set(field, to: action.value)
 
         case "prepend-notes":
-            guard let s = stringValue(action.value) else { return }
-            let existing = stringValue(bag.value(for: "notes")) ?? ""
-            bag.set("notes", to: existing.isEmpty ? s : s + existing)
+            guard let value = action.value.stringValue else { return }
+            let existing = bag.string(for: "notes") ?? ""
+            bag.set("notes", to: .string(existing.isEmpty ? value : value + existing))
 
         case "append-notes":
-            guard let s = stringValue(action.value) else { return }
-            let existing = stringValue(bag.value(for: "notes")) ?? ""
-            bag.set("notes", to: existing.isEmpty ? s : existing + s)
+            guard let value = action.value.stringValue else { return }
+            let existing = bag.string(for: "notes") ?? ""
+            bag.set("notes", to: .string(existing.isEmpty ? value : existing + value))
 
-        case "link-schedule", "set-split-amount", "delete-transaction":
-            logger.notice("Rule \(ruleId, privacy: .public): skipping unsupported action op '\(action.op, privacy: .public)'")
+        case "link-schedule":
+            guard let value = action.value.stringValue else { return }
+            bag.set("schedule", to: .string(value))
+
+        case "delete-transaction":
+            bag.isDeleted = true
+
+        case "set-split-amount":
+            logger.notice("Rule \(ruleId, privacy: .public): skipping unsupported action op 'set-split-amount'")
 
         default:
             logger.notice("Rule \(ruleId, privacy: .public): unknown action op '\(action.op, privacy: .public)'")
         }
     }
-
-    // MARK: - Helpers
-
-    private static func stringValue(_ any: Any?) -> String? {
-        if let s = any as? String { return s }
-        if any is NSNull { return nil }
-        return nil
-    }
-
-    private static func numericValue(_ any: Any?, options: [String: Any]? = nil) -> Double? {
-        let n: Double?
-        if let d = any as? Double { n = d }
-        else if let i = any as? Int { n = Double(i) }
-        else if let n2 = any as? NSNumber { n = n2.doubleValue }
-        else { n = nil }
-
-        guard var v = n else { return nil }
-        if let options {
-            if options["outflow"] as? Bool == true {
-                if v > 0 { return nil }
-                v = -v
-            } else if options["inflow"] as? Bool == true {
-                if v < 0 { return nil }
-            }
-        }
-        return v
-    }
-
-    private static func isEqual(_ a: Any?, to b: Any?, options: [String: Any]?) -> Bool {
-        // Numeric comparison preferred when both sides are numeric
-        if let na = numericValue(a, options: options), let nb = numericValue(b) {
-            return na == nb
-        }
-        // String — case-insensitive (matches upstream which lowercases)
-        if let sa = stringValue(a), let sb = stringValue(b) {
-            return sa.lowercased() == sb.lowercased()
-        }
-        // Bool
-        if let ba = a as? Bool, let bb = b as? Bool { return ba == bb }
-        // Both nil
-        if a == nil && b == nil { return true }
-        if a is NSNull && b == nil { return true }
-        if a == nil && b is NSNull { return true }
-        return false
-    }
-
-    private static func containsString(_ haystack: Any?, _ needle: Any?) -> Bool {
-        guard let s = stringValue(haystack), let q = stringValue(needle) else { return false }
-        return s.lowercased().contains(q.lowercased())
-    }
-
-    private static func inList(_ value: Any?, _ list: Any?) -> Bool {
-        guard let arr = list as? [Any] else { return false }
-        return arr.contains { isEqual(value, to: $0, options: nil) }
-    }
-
-    private static func compareNumeric(_ a: Any?, _ b: Any?, op: String, options: [String: Any]?) -> Bool {
-        guard let na = numericValue(a, options: options), let nb = numericValue(b) else { return false }
-        switch op {
-        case "gt": return na > nb
-        case "gte": return na >= nb
-        case "lt": return na < nb
-        case "lte": return na <= nb
-        default: return false
-        }
-    }
 }
 
-/// Mutable key-value view of a Transaction keyed by *public* field names.
-/// Lets the rule engine read/write fields uniformly without hard-coding
-/// every Transaction property.
+/// Mutable key-value view of a Transaction keyed by *public* rule field names.
 struct TransactionBag {
-    private var fields: [String: Any?]
+    private var strings: [String: String?] = [:]
+    private var numbers: [String: Int?] = [:]
+    private var bools: [String: Bool] = [:]
 
-    init(_ t: Transaction) {
-        fields = [
-            "id": t.id,
-            "account": t.accountId,
-            "date": t.date,
-            "amount": t.amount,
-            "payee": t.payeeId as Any?,
-            "category": t.categoryId as Any?,
-            "notes": t.notes as Any?,
-            "cleared": t.cleared,
-            "reconciled": t.reconciled,
-            "transfer_id": t.transferId as Any?,
-            "is_parent": t.isParent,
-            "is_child": t.parentId != nil,
-            "parent_id": t.parentId as Any?,
-            "tombstone": t.tombstone,
-            "imported_payee": t.importedPayee as Any?,
+    /// nil when the transaction's account isn't known to the context.
+    let isOnBudget: Bool?
+    /// Set when a rule assigned `payee_name`; upstream parks `payee = 'new'` and
+    /// resolves the name to an id after every rule has run.
+    private(set) var pendingPayeeName: String?
+    var isDeleted = false
+
+    init(_ transaction: Transaction, context: RuleContext = .empty) {
+        strings = [
+            "account": transaction.accountId,
+            "payee": transaction.payeeId,
+            "payee_name": transaction.payeeId.flatMap { context.payeeNames[$0] } ?? transaction.payeeName,
+            "category": transaction.categoryId,
+            "category_group": transaction.categoryId.flatMap { context.categoryGroupIds[$0] },
+            "notes": transaction.notes,
+            "imported_payee": transaction.importedPayee,
+            "transfer_id": transaction.transferId,
+            "parent_id": transaction.parentId,
+            "schedule": transaction.schedule
         ]
+        numbers = ["date": transaction.date, "amount": transaction.amount]
+        // `cleared` and `reconciled` only. `transfer` and `parent` are absent on
+        // purpose: they are not keys of upstream's prepared transaction either,
+        // so `Condition.eval` hits `fieldValue === undefined` and returns false
+        // for them. Only the query path (`conditionsToAQL`, mirrored by
+        // ConditionsFilter) maps them to real columns.
+        bools = [
+            "cleared": transaction.cleared,
+            "reconciled": transaction.reconciled
+        ]
+        // Upstream reads `_account.offbudget`, and an unknown account means the
+        // condition can't match either way.
+        isOnBudget = transaction.accountId.isEmpty
+            ? nil
+            : !context.offBudgetAccountIds.contains(transaction.accountId)
     }
 
-    func value(for field: String) -> Any? {
-        guard let v = fields[field] else { return nil }
-        return v ?? nil
-    }
+    var date: Int? { numbers["date"] ?? nil }
 
-    mutating func set(_ field: String, to value: Any?) {
-        fields[field] = value
-    }
+    func string(for field: String) -> String? { strings[field] ?? nil }
+    func number(for field: String) -> Int? { numbers[field] ?? nil }
+    func bool(for field: String) -> Bool? { bools[field] }
 
-    func snapshot() -> [String: String?] {
-        // Use a string-coerced snapshot for change detection — sidesteps Any
-        // equality. Good enough since we only care about which fields changed.
-        var out: [String: String?] = [:]
-        for (k, v) in fields {
-            out[k] = describe(v)
+    mutating func set(_ field: String, to value: RuleValue) {
+        switch RuleSchema.fieldType(field) {
+        case .number:
+            // Garbage in a rule (a non-finite or out-of-range amount) is not a
+            // change: skip the write so the original amount survives and
+            // `changedFields` doesn't claim an edit that didn't happen. See
+            // RulesEngineTests.setAmountNonFiniteLeavesAmountUnchanged.
+            if let number = value.numberValue, let cents = Int(exactly: number.rounded()) {
+                numbers[field] = cents
+            }
+        case .boolean:
+            if let flag = value.boolValue { bools[field] = flag }
+        case .date:
+            // A `set date` action carries "yyyy-MM-dd"; the column is YYYYMMDD.
+            if let text = value.stringValue,
+               let day = Int(text.replacingOccurrences(of: "-", with: "")), day > 9_999_999 {
+                numbers["date"] = day
+            }
+        default:
+            strings[field] = value.stringValue
+            if field == "payee_name" {
+                // Upstream: setting payee_name parks payee = 'new'.
+                pendingPayeeName = value.stringValue
+                strings["payee"] = nil
+            }
+            if field == "payee" {
+                pendingPayeeName = nil
+            }
         }
+    }
+
+    func snapshot() -> [String: String] {
+        var out: [String: String] = [:]
+        for (key, value) in strings { out[key] = value.map { "s:" + $0 } ?? "nil" }
+        for (key, value) in numbers { out[key] = value.map { "i:\($0)" } ?? "nil" }
+        for (key, value) in bools { out[key] = "b:\(value)" }
         return out
     }
 
-    func changedFields(comparedTo prior: [String: String?]) -> Set<String> {
-        var changed: Set<String> = []
-        for (k, v) in fields {
-            let now = describe(v)
-            let then = prior[k] ?? nil
-            if now != then { changed.insert(k) }
-        }
-        return changed
+    func changedFields(comparedTo prior: [String: String]) -> Set<String> {
+        Set(snapshot().compactMap { key, value in prior[key] == value ? nil : key })
     }
 
     func toTransaction(base: Transaction) -> Transaction {
-        var t = base
-        if let v = fields["account"] as? String { t.accountId = v }
-        if let v = fields["date"] as? Int { t.date = v }
-        if let v = fields["amount"] as? Int { t.amount = v }
-        else if let d = fields["amount"] as? Double,
-                let v = Int(exactly: d.rounded()) { t.amount = v }
-        t.payeeId = fields["payee"].flatMap { $0 as? String }
-        t.categoryId = fields["category"].flatMap { $0 as? String }
-        t.notes = fields["notes"].flatMap { $0 as? String }
-        if let v = fields["cleared"] as? Bool { t.cleared = v }
-        if let v = fields["reconciled"] as? Bool { t.reconciled = v }
-        t.transferId = fields["transfer_id"].flatMap { $0 as? String }
-        if let v = fields["is_parent"] as? Bool { t.isParent = v }
-        t.parentId = fields["parent_id"].flatMap { $0 as? String }
-        if let v = fields["tombstone"] as? Bool { t.tombstone = v }
-        t.importedPayee = fields["imported_payee"].flatMap { $0 as? String }
-        return t
-    }
-
-    private func describe(_ any: Any?) -> String? {
-        guard let any else { return nil }
-        if any is NSNull { return nil }
-        if let s = any as? String { return "s:" + s }
-        if let i = any as? Int { return "i:\(i)" }
-        if let d = any as? Double { return "d:\(d)" }
-        if let b = any as? Bool { return "b:\(b)" }
-        return "x:\(any)"
+        var transaction = base
+        if let accountId = string(for: "account") { transaction.accountId = accountId }
+        if let date = number(for: "date") { transaction.date = date }
+        if let amount = number(for: "amount") { transaction.amount = amount }
+        transaction.payeeId = string(for: "payee")
+        transaction.categoryId = string(for: "category")
+        transaction.notes = string(for: "notes")
+        transaction.importedPayee = string(for: "imported_payee")
+        transaction.transferId = string(for: "transfer_id")
+        transaction.parentId = string(for: "parent_id")
+        transaction.schedule = string(for: "schedule")
+        transaction.cleared = bool(for: "cleared") ?? base.cleared
+        transaction.reconciled = bool(for: "reconciled") ?? base.reconciled
+        transaction.tombstone = isDeleted || base.tombstone
+        return transaction
     }
 }

--- a/Actuali/Actuali/Services/Rules/RulesEngine.swift
+++ b/Actuali/Actuali/Services/Rules/RulesEngine.swift
@@ -161,17 +161,21 @@ enum RulesEngine {
             return condition.op == "oneOf" ? hit : !hit
         case "matches":
             guard let fieldValue, let pattern = condition.value.stringValue else { return false }
-            // Lowercased, not case-insensitive: upstream's string parse does
-            // `value.toLowerCase()` on the pattern itself, so `\D` becomes `\d`
-            // there and inverts its meaning. Using a case-insensitive match on
-            // the raw pattern would be more correct and would make a rule that
-            // works on the web behave differently here, so we copy the quirk.
-            // Worth an upstream fix in condition.ts; not one to make client-side.
+            // Both sides lowercased, not a case-insensitive match: upstream
+            // lowercases the pattern in condition.ts's string parse and the
+            // field value at the top of eval. Copying both is what makes a
+            // rule written on the web behave identically here — including the
+            // quirk that `\D` becomes `\d` and inverts its meaning. Worth an
+            // upstream fix in condition.ts; not one to make client-side.
+            let haystack = fieldValue.lowercased()
             guard let regex = try? NSRegularExpression(pattern: pattern.lowercased()) else {
                 logger.debug("invalid regexp in matches condition")
                 return false
             }
-            return regex.firstMatch(in: fieldValue, range: NSRange(fieldValue.startIndex..., in: fieldValue)) != nil
+            return regex.firstMatch(
+                in: haystack,
+                range: NSRange(haystack.startIndex..., in: haystack)
+            ) != nil
         case "hasTags", "hasAnyTag":
             guard let fieldValue, let condValue = condition.value.stringValue else { return false }
             let tags = TagFilter.extractTags(condValue)

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -15,6 +15,7 @@ enum SyncError: LocalizedError, Equatable {
     case serverError(String)
     case budgetTableMissing
     case notesTableMissing
+    case rulesTableMissing
 
     var errorDescription: String? {
         switch self {
@@ -32,6 +33,8 @@ enum SyncError: LocalizedError, Equatable {
             return "This budget file has no budget table to write to."
         case .notesTableMissing:
             return "This budget file has no notes table to write to."
+        case .rulesTableMissing:
+            return "This budget file has no rules table to write to."
         }
     }
 }
@@ -651,6 +654,62 @@ actor SyncClient {
 
         // 4. Push in the background — the Save button awaits this write, and
         //    an unreachable server must not hold the sheet open (issue #125).
+        scheduleAutomaticSync()
+    }
+    
+    /// Create or update a rule (optimistic local-first). Mirrors upstream
+    /// `rule-add` / `rule-update` (loot-core server/rules/app.ts): the whole row
+    /// is written every time — stage, conditionsOp, conditions and actions — so
+    /// a rule edited on two devices converges on one client's complete rule
+    /// rather than an interleaving of both, which is what upstream's `db.update`
+    /// of the same four columns produces.
+    ///
+    /// Requires the `rules` table: without it `applyMessages` would skip the
+    /// local apply as unknown schema and the save would look like it worked.
+    func saveRule(_ rule: Rule) async throws {
+        guard let database else { throw SyncError.notConfigured }
+        guard try database.rulesTableExists() else { throw SyncError.rulesTableMissing }
+
+        logger.debug("saveRule() - id: \(rule.id, privacy: .private), conditions: \(rule.conditions.count, privacy: .public), actions: \(rule.actions.count, privacy: .public)")
+
+        // 1. Generate CRDT messages (before any DB write, so an HLC failure
+        //    leaves nothing stranded)
+        let messages = try await messageGenerator.messagesForInsert(rule)
+
+        // 2. Apply locally (optimistic) through the same LWW upsert incoming
+        //    messages use, so a local edit and the identical edit arriving from
+        //    another device converge byte-for-byte.
+        try database.applyMessages(messages)
+
+        // 3. Store messages and update merkle
+        for msg in try database.insertMessages(messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
+    }
+
+    /// Tombstone a rule (optimistic local-first), upstream `rule-delete`.
+    /// The caller is responsible for refusing to delete a schedule's rule —
+    /// see `BudgetStore.deleteRule`.
+    func deleteRule(_ rule: Rule) async throws {
+        guard let database else { throw SyncError.notConfigured }
+        guard try database.rulesTableExists() else { throw SyncError.rulesTableMissing }
+
+        logger.debug("deleteRule() - id: \(rule.id, privacy: .private)")
+
+        let message = try await messageGenerator.messageForDelete(rule)
+        try database.applyMessages([message])
+
+        for msg in try database.insertMessages([message]) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
         scheduleAutomaticSync()
     }
 

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -182,16 +182,27 @@ actor SyncClient {
         //    Skip for transfers — upstream runs rules on the transfer leg, but our
         //    transfer flow already builds both legs explicitly and we don't want
         //    rules rewriting the linked payee/account.
-        let finalTransaction: Transaction
+        var finalTransaction = transaction
         if applyRules, transaction.transferId == nil {
             let rules = (try? database.fetchRules()) ?? []
-            let (updated, changed) = RulesEngine.apply(transaction, rules: rules)
-            if !changed.isEmpty {
-                logger.info("Rules updated \(changed.count, privacy: .public) field(s) on new transaction")
+            let context = (try? database.ruleContext()) ?? .empty
+            let result = RulesEngine.apply(transaction, rules: rules, context: context)
+
+            if result.isDeleted {
+                // A `delete-transaction` rule matched. Upstream tombstones the
+                // row; for a transaction that doesn't exist yet, not creating it
+                // is the same outcome with less to sync.
+                logger.notice("Rules deleted the incoming transaction — skipping insert")
+                return
             }
-            finalTransaction = updated
-        } else {
-            finalTransaction = transaction
+
+            finalTransaction = result.transaction
+            if let name = result.pendingPayeeName {
+                finalTransaction.payeeId = try await resolvePayee(named: name)
+            }
+            if !result.changedFields.isEmpty {
+                logger.info("Rules updated \(result.changedFields.count, privacy: .public) field(s) on new transaction")
+            }
         }
 
         // 1. Insert locally (optimistic)
@@ -364,6 +375,20 @@ actor SyncClient {
         try saveClock()
 
         // Note: Don't schedule sync here - let the transaction sync handle it
+    }
+    
+    /// Turn a `payee_name` a rule set into a payee id, creating the payee when
+    /// it's new — upstream `resolvePayeeNameForRules`.
+    private func resolvePayee(named name: String) async throws -> String? {
+        guard let database else { throw SyncError.notConfigured }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let existing = try database.payee(named: trimmed) { return existing.id }
+
+        let payee = Payee(id: UUID().uuidString, name: trimmed, transferAccountId: nil)
+        try await createPayee(payee)
+        return payee.id
     }
 
     /// Create a new account, its transfer payee (the empty-named payee every

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -170,13 +170,33 @@ actor SyncClient {
             }
         }
     }
+    
+    /// Everything a rules pass needs, fetched once. The import path builds this
+    /// before its loop instead of paying for a full categories/payees/accounts
+    /// scan per transaction.
+    struct PreparedRules {
+        let rules: [Rule]
+        let context: RuleContext
+    }
+
+    func prepareRules() -> PreparedRules {
+        guard let database else { return PreparedRules(rules: [], context: .empty) }
+        return PreparedRules(
+            rules: (try? database.fetchRules()) ?? [],
+            context: (try? database.ruleContext()) ?? .empty
+        )
+    }
 
     // MARK: - Public API
 
     /// Create a transaction (optimistic local-first).
     /// `applyRules: false` skips the rules pass — used for split children,
     /// whose every field the caller spelled out explicitly (like `createSplit`).
-    func createTransaction(_ transaction: Transaction, applyRules: Bool = true) async throws {
+    func createTransaction(
+        _ transaction: Transaction,
+        applyRules: Bool = true,
+        prepared: PreparedRules? = nil
+    ) async throws {
         guard let database else { throw SyncError.notConfigured }
 
         logger.debug("createTransaction() - id: \(transaction.id, privacy: .private)")
@@ -187,9 +207,8 @@ actor SyncClient {
         //    rules rewriting the linked payee/account.
         var finalTransaction = transaction
         if applyRules, transaction.transferId == nil {
-            let rules = (try? database.fetchRules()) ?? []
-            let context = (try? database.ruleContext()) ?? .empty
-            let result = RulesEngine.apply(transaction, rules: rules, context: context)
+            let prepared = prepared ?? prepareRules()
+            let result = RulesEngine.apply(transaction, rules: prepared.rules, context: prepared.context)
 
             if result.isDeleted {
                 // A `delete-transaction` rule matched. Upstream tombstones the

--- a/Actuali/Actuali/Views/Rules/RuleEditorView.swift
+++ b/Actuali/Actuali/Views/Rules/RuleEditorView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Create or edit a rule. Same shape as the web editor: a stage, an
+/// all/any combinator, a list of conditions and a list of actions.
+struct RuleEditorView: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    /// Conditions and actions need stable identities for `ForEach` while the
+    /// user edits them, and two identical rows are legitimate — so the editor
+    /// carries its own ids instead of making the model rows `Identifiable`.
+    private struct Row<Value>: Identifiable {
+        let id = UUID()
+        var value: Value
+    }
+
+    private let ruleId: String
+    private let isNew: Bool
+    @State private var stage: Rule.Stage
+    @State private var conditionsOp: Rule.ConditionsOp
+    @State private var conditions: [Row<Rule.Condition>]
+    @State private var actions: [Row<Rule.Action>]
+    @State private var failureMessage: String?
+    @State private var isSaving = false
+
+    init(rule: Rule) {
+        ruleId = rule.id
+        isNew = rule.conditions.isEmpty && rule.actions.isEmpty
+        _stage = State(initialValue: rule.stage)
+        _conditionsOp = State(initialValue: rule.conditionsOp)
+        _conditions = State(initialValue: rule.conditions.map { Row(value: $0) })
+        _actions = State(initialValue: rule.actions.map { Row(value: $0) })
+    }
+
+    private var draft: Rule {
+        Rule(id: ruleId, stage: stage, conditionsOp: conditionsOp,
+             conditions: conditions.map(\.value), actions: actions.map(\.value))
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Stage", selection: $stage) {
+                    ForEach(Rule.Stage.allCases, id: \.self) { stage in
+                        Text(stage.label).tag(stage)
+                    }
+                }
+                .pickerStyle(.segmented)
+            } footer: {
+                Text("Pre rules run before everything else, Post rules run last. Most rules belong in Default.")
+            }
+
+            Section {
+                Picker("Match", selection: $conditionsOp) {
+                    Text("all conditions").tag(Rule.ConditionsOp.and)
+                    Text("any condition").tag(Rule.ConditionsOp.or)
+                }
+
+                ForEach($conditions) { $row in
+                    RuleConditionEditor(condition: $row.value)
+                }
+                .onDelete { conditions.remove(atOffsets: $0) }
+
+                Button {
+                    conditions.append(Row(value: .init(op: "is", field: "imported_payee",
+                                                       value: .string(""), options: nil)))
+                } label: {
+                    Label("Add Condition", systemImage: "plus")
+                }
+            } header: {
+                Text("If")
+            }
+
+            Section {
+                ForEach($actions) { $row in
+                    RuleActionEditor(action: $row.value)
+                }
+                .onDelete { actions.remove(atOffsets: $0) }
+
+                Button {
+                    actions.append(Row(value: .init(op: "set", field: "category",
+                                                    value: .null, options: nil)))
+                } label: {
+                    Label("Add Action", systemImage: "plus")
+                }
+            } header: {
+                Text("Then")
+            }
+        }
+        .navigationTitle(isNew ? "New Rule" : "Edit Rule")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(isSaving || conditions.isEmpty || actions.isEmpty)
+            }
+        }
+        .alert("Couldn't Save Rule", isPresented: Binding(
+            get: { failureMessage != nil },
+            set: { if !$0 { failureMessage = nil } }
+        )) {
+            Button("OK") { failureMessage = nil }
+        } message: {
+            Text(failureMessage ?? "")
+        }
+    }
+
+    private func save() {
+        isSaving = true
+        Task {
+            do {
+                try await budgetStore.saveRule(draft)
+                dismiss()
+            } catch {
+                failureMessage = error.localizedDescription
+            }
+            isSaving = false
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
+++ b/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+
+/// One condition row: field, operator, and a value editor chosen by the field's
+/// type. Field/op lists come from `RuleSchema`, which is the same metadata the
+/// engine validates against.
+struct RuleConditionEditor: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @Binding var condition: Rule.Condition
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Picker("Field", selection: fieldBinding) {
+                    ForEach(RuleSchema.conditionFields, id: \.self) { field in
+                        Text(RuleSchema.label(field: field).capitalized).tag(field)
+                    }
+                }
+                .labelsHidden()
+
+                Picker("Operator", selection: opBinding) {
+                    ForEach(RuleSchema.validOps(for: condition.field), id: \.self) { op in
+                        Text(RuleSchema.label(op: op, type: RuleSchema.fieldType(condition.field))).tag(op)
+                    }
+                }
+                .labelsHidden()
+            }
+
+            RuleValueEditor(
+                value: $condition.value,
+                field: condition.field,
+                op: condition.op,
+                options: $condition.options
+            )
+        }
+    }
+
+    /// Changing the field can invalidate the operator and the value shape, so
+    /// both reset the way the web editor does.
+    private var fieldBinding: Binding<String> {
+        Binding(
+            get: { condition.field },
+            set: { field in
+                condition.field = field
+                if !RuleSchema.isValidOp(field: field, op: condition.op) {
+                    condition.op = RuleSchema.validOps(for: field).first ?? "is"
+                }
+                condition.value = RuleValueEditor.defaultValue(field: field, op: condition.op)
+            }
+        )
+    }
+
+    private var opBinding: Binding<String> {
+        Binding(
+            get: { condition.op },
+            set: { op in
+                let wasMulti = ["oneOf", "notOneOf"].contains(condition.op)
+                let isMulti = ["oneOf", "notOneOf"].contains(op)
+                let wasBetween = condition.op == "isbetween"
+                condition.op = op
+                if wasMulti != isMulti || wasBetween != (op == "isbetween") {
+                    condition.value = RuleValueEditor.defaultValue(field: condition.field, op: op)
+                }
+            }
+        )
+    }
+}
+
+/// One action row: `set <field> to <value>`, plus the note ops.
+struct RuleActionEditor: View {
+    @Binding var action: Rule.Action
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Action", selection: opBinding) {
+                ForEach(["set", "prepend-notes", "append-notes", "delete-transaction"], id: \.self) { op in
+                    Text(RuleSchema.label(op: op).capitalized).tag(op)
+                }
+            }
+            .labelsHidden()
+
+            if action.op == "set" {
+                Picker("Field", selection: fieldBinding) {
+                    ForEach(RuleSchema.actionFields, id: \.self) { field in
+                        Text(RuleSchema.label(field: field).capitalized).tag(field)
+                    }
+                }
+                .labelsHidden()
+
+                RuleValueEditor(value: $action.value, field: action.field ?? "category",
+                                op: "is", options: $action.options)
+            } else if action.op != "delete-transaction" {
+                TextField("Text", text: Binding(
+                    get: { action.value.stringValue ?? "" },
+                    set: { action.value = .string($0) }
+                ))
+            }
+        }
+    }
+
+    private var opBinding: Binding<String> {
+        Binding(
+            get: { action.op },
+            set: { op in
+                action.op = op
+                switch op {
+                case "set":
+                    action.field = action.field ?? "category"
+                    action.value = .null
+                case "delete-transaction":
+                    action.field = nil
+                    action.value = .null
+                default:
+                    action.field = "notes"
+                    action.value = .string("")
+                }
+            }
+        )
+    }
+
+    private var fieldBinding: Binding<String> {
+        Binding(
+            get: { action.field ?? "category" },
+            set: { field in
+                action.field = field
+                action.value = RuleValueEditor.defaultValue(field: field, op: "is")
+            }
+        )
+    }
+}
+
+/// The value half of a condition or action, shaped by the field's type.
+struct RuleValueEditor: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @Binding var value: RuleValue
+    let field: String
+    let op: String
+    @Binding var options: [String: RuleValue]?
+
+    /// The empty value for a freshly chosen field/op pair.
+    static func defaultValue(field: String, op: String) -> RuleValue {
+        if ["oneOf", "notOneOf"].contains(op) { return .list([]) }
+        if op == "isbetween" { return .object(["num1": .number(0), "num2": .number(0)]) }
+        switch RuleSchema.fieldType(field) {
+        case .number: return .number(0)
+        case .boolean: return .bool(true)
+        case .date, .string: return .string("")
+        case .id, .none: return .null
+        }
+    }
+
+    var body: some View {
+        switch RuleSchema.fieldType(field) {
+        case .id:
+            idPicker
+        case .number:
+            amountEditor
+        case .date:
+            datePicker
+        case .boolean:
+            Toggle("Value", isOn: Binding(
+                get: { value.boolValue ?? false },
+                set: { value = .bool($0) }
+            ))
+        case .string, .none:
+            VStack(alignment: .leading, spacing: 4) {
+                TextField(placeholder, text: Binding(
+                    get: { value.stringValue ?? "" },
+                    set: { value = .string($0) }
+                ))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+                if op == "matches" {
+                    // The engine lowercases the pattern to match upstream, which
+                    // silently turns `\D` into `\d`. We can't warn about that
+                    // without promising a fix we're not making, but saying the
+                    // match is case-insensitive is true, is the part that
+                    // actually surprises people, and is the reason `\D` behaves
+                    // the way it does.
+                    Text("Patterns are matched case-insensitively.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var placeholder: String {
+        if op == "matches" { return "Regular expression" }
+        return ["oneOf", "notOneOf"].contains(op) ? "Comma-separated values" : "Value"
+    }
+
+    /// Payee / category / category group / account. Multi-select ops keep a
+    /// list; single ops keep a plain string.
+    @ViewBuilder
+    private var idPicker: some View {
+        if ["oneOf", "notOneOf"].contains(op) {
+            NavigationLink {
+                RuleIdMultiPicker(field: field, value: $value)
+            } label: {
+                LabeledContent("Values", value: "\(value.listValue?.count ?? 0) selected")
+            }
+        } else {
+            Picker("Value", selection: Binding(
+                get: { value.stringValue ?? "" },
+                set: { value = $0.isEmpty ? .null : .string($0) }
+            )) {
+                Text("Nothing").tag("")
+                ForEach(choices, id: \.id) { choice in
+                    Text(choice.name).tag(choice.id)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var amountEditor: some View {
+        // `AmountInputField` (declared in AddTransactionView.swift) is the
+        // app's shared cents entry field; reuse it so rule amounts format and
+        // validate like every other amount in the app.
+        HStack {
+            Text("Amount")
+            Spacer()
+            AmountInputField(text: Binding(
+                get: { value.numberValue.map { String(format: "%.2f", $0 / 100) } ?? "" },
+                set: { text in
+                    value = .number(Double(Transaction.cents(fromDollars: Double(text) ?? 0) ?? 0))
+                }
+            ), allowsNegative: true)
+            .frame(maxWidth: 140)
+        }
+        // Upstream exposes amount (inflow) / amount (outflow) as separate
+        // fields; here they're a segmented direction on the amount row.
+        Picker("Direction", selection: directionBinding) {
+            Text("Any").tag("any")
+            Text("Inflow").tag("inflow")
+            Text("Outflow").tag("outflow")
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var datePicker: some View {
+        DatePicker("Date", selection: Binding(
+            get: {
+                guard let text = value.stringValue,
+                      let day = Int(text.replacingOccurrences(of: "-", with: "")), day > 9_999_999
+                else { return Date() }
+                return Transaction.date(fromYYYYMMDD: day)
+            },
+            set: { date in
+                let ymd = Transaction.yyyymmdd(from: date)
+                value = .string(String(format: "%04d-%02d-%02d", ymd / 10000, (ymd % 10000) / 100, ymd % 100))
+            }
+        ), displayedComponents: .date)
+    }
+
+    private var directionBinding: Binding<String> {
+        Binding(
+            get: {
+                if options?["inflow"]?.boolValue == true { return "inflow" }
+                if options?["outflow"]?.boolValue == true { return "outflow" }
+                return "any"
+            },
+            set: { direction in
+                switch direction {
+                case "inflow": options = ["inflow": .bool(true)]
+                case "outflow": options = ["outflow": .bool(true)]
+                default: options = nil
+                }
+            }
+        )
+    }
+
+    private var choices: [(id: String, name: String)] {
+        switch field {
+        case "payee": return budgetStore.payees.map { ($0.id, $0.name) }
+        case "category": return budgetStore.categoryGroups.flatMap(\.categories).map { ($0.id, $0.name) }
+        case "category_group": return budgetStore.categoryGroups.map { ($0.id, $0.name) }
+        case "account": return budgetStore.accounts.filter { !$0.closed }.map { ($0.id, $0.name) }
+        default: return []
+        }
+    }
+}
+
+/// Multi-select for `oneOf` / `notOneOf` id conditions.
+struct RuleIdMultiPicker: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    let field: String
+    @Binding var value: RuleValue
+
+    private var selected: Set<String> {
+        Set((value.listValue ?? []).compactMap(\.stringValue))
+    }
+
+    var body: some View {
+        List(choices, id: \.id) { choice in
+            Button {
+                toggle(choice.id)
+            } label: {
+                HStack {
+                    Text(choice.name)
+                    Spacer()
+                    if selected.contains(choice.id) {
+                        Image(systemName: "checkmark").foregroundStyle(.tint)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .navigationTitle(RuleSchema.label(field: field).capitalized)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func toggle(_ id: String) {
+        var ids = selected
+        if ids.contains(id) { ids.remove(id) } else { ids.insert(id) }
+        // Preserve the choice list's order so the rule reads the same every
+        // time it round-trips through the editor.
+        value = .list(choices.map(\.id).filter(ids.contains).map(RuleValue.string))
+    }
+
+    private var choices: [(id: String, name: String)] {
+        switch field {
+        case "payee": return budgetStore.payees.map { ($0.id, $0.name) }
+        case "category": return budgetStore.categoryGroups.flatMap(\.categories).map { ($0.id, $0.name) }
+        case "category_group": return budgetStore.categoryGroups.map { ($0.id, $0.name) }
+        case "account": return budgetStore.accounts.filter { !$0.closed }.map { ($0.id, $0.name) }
+        default: return []
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
+++ b/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
@@ -1,10 +1,41 @@
 import SwiftUI
 
+/// The pickable rows for an id-typed rule field. Transfer payees (the
+/// empty-named payee each account owns) and hidden categories are filtered out
+/// the same way the transaction form filters them — they aren't things a user
+/// writes a rule against.
+/// `@MainActor` because it reads `BudgetStore`, which is main-actor isolated;
+/// every caller is a View member and already on the main actor.
+@MainActor
+private func ruleChoices(for field: String, in store: BudgetStore) -> [(id: String, name: String)] {
+    switch field {
+    case "payee":
+        return store.payees
+            .filter { !$0.tombstone && $0.transferAccountId == nil }
+            .map { ($0.id, $0.name) }
+    case "category":
+        return store.categoryGroups
+            .filter { !$0.hidden }
+            .flatMap(\.categories)
+            .filter { !$0.hidden }
+            .map { ($0.id, $0.name) }
+    case "category_group":
+        return store.categoryGroups
+            .filter { !$0.hidden }
+            .map { ($0.id, $0.name) }
+    case "account":
+        return store.accounts
+            .filter { !$0.closed }
+            .map { ($0.id, $0.name) }
+    default:
+        return []
+    }
+}
+
 /// One condition row: field, operator, and a value editor chosen by the field's
 /// type. Field/op lists come from `RuleSchema`, which is the same metadata the
 /// engine validates against.
 struct RuleConditionEditor: View {
-    @EnvironmentObject var budgetStore: BudgetStore
     @Binding var condition: Rule.Condition
 
     var body: some View {
@@ -29,7 +60,8 @@ struct RuleConditionEditor: View {
                 value: $condition.value,
                 field: condition.field,
                 op: condition.op,
-                options: $condition.options
+                options: $condition.options,
+                showsDirection: true
             )
         }
     }
@@ -45,6 +77,10 @@ struct RuleConditionEditor: View {
                     condition.op = RuleSchema.validOps(for: field).first ?? "is"
                 }
                 condition.value = RuleValueEditor.defaultValue(field: field, op: condition.op)
+                // Inflow/outflow only means anything on an amount.
+                if RuleSchema.fieldType(field) != .number {
+                    condition.options = nil
+                }
             }
         )
     }
@@ -86,8 +122,15 @@ struct RuleActionEditor: View {
                 }
                 .labelsHidden()
 
-                RuleValueEditor(value: $action.value, field: action.field ?? "category",
-                                op: "is", options: $action.options)
+                // `op: "is"` because an action's value is always a single one —
+                // the multi-value and between shapes are condition-only. No
+                // direction either: a `set amount` has no inflow/outflow.
+                RuleValueEditor(
+                    value: $action.value,
+                    field: action.field ?? "category",
+                    op: "is",
+                    options: $action.options
+                )
             } else if action.op != "delete-transaction" {
                 TextField("Text", text: Binding(
                     get: { action.value.stringValue ?? "" },
@@ -135,6 +178,9 @@ struct RuleValueEditor: View {
     let field: String
     let op: String
     @Binding var options: [String: RuleValue]?
+    /// Inflow/outflow is a condition-only concept — a `set amount` action has no
+    /// direction. Defaults off so callers opt in.
+    var showsDirection: Bool = false
 
     /// The empty value for a freshly chosen field/op pair.
     static func defaultValue(field: String, op: String) -> RuleValue {
@@ -162,39 +208,73 @@ struct RuleValueEditor: View {
                 set: { value = .bool($0) }
             ))
         case .string, .none:
-            VStack(alignment: .leading, spacing: 4) {
+            textEditor
+        }
+    }
+
+    private var isMultiValue: Bool { ["oneOf", "notOneOf"].contains(op) }
+
+    private var choices: [(id: String, name: String)] {
+        ruleChoices(for: field, in: budgetStore)
+    }
+
+    private var placeholder: String {
+        if op == "matches" { return "Regular expression" }
+        return isMultiValue ? "Comma-separated values" : "Value"
+    }
+
+    // MARK: - Text
+
+    @ViewBuilder
+    private var textEditor: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if isMultiValue {
+                // oneOf/notOneOf carry a list, not a string. Editing it as
+                // comma-separated text keeps the row a single field while still
+                // producing the shape the engine matches on — a plain string
+                // here would never match and couldn't be saved.
+                TextField(placeholder, text: Binding(
+                    get: { (value.listValue ?? []).compactMap(\.stringValue).joined(separator: ", ") },
+                    set: { text in
+                        value = .list(
+                            text.split(separator: ",")
+                                .map { $0.trimmingCharacters(in: .whitespaces) }
+                                .filter { !$0.isEmpty }
+                                .map(RuleValue.string)
+                        )
+                    }
+                ))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            } else {
                 TextField(placeholder, text: Binding(
                     get: { value.stringValue ?? "" },
                     set: { value = .string($0) }
                 ))
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
+            }
 
-                if op == "matches" {
-                    // The engine lowercases the pattern to match upstream, which
-                    // silently turns `\D` into `\d`. We can't warn about that
-                    // without promising a fix we're not making, but saying the
-                    // match is case-insensitive is true, is the part that
-                    // actually surprises people, and is the reason `\D` behaves
-                    // the way it does.
-                    Text("Patterns are matched case-insensitively.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+            if op == "matches" {
+                // The engine lowercases the pattern to match upstream, which
+                // silently turns `\D` into `\d`. We can't warn about that
+                // without promising a fix we're not making, but saying the match
+                // is case-insensitive is true, is the part that actually
+                // surprises people, and is the reason `\D` behaves as it does.
+                Text("Patterns are matched case-insensitively.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
     }
 
-    private var placeholder: String {
-        if op == "matches" { return "Regular expression" }
-        return ["oneOf", "notOneOf"].contains(op) ? "Comma-separated values" : "Value"
-    }
+    // MARK: - Ids
 
     /// Payee / category / category group / account. Multi-select ops keep a
     /// list; single ops keep a plain string.
     @ViewBuilder
     private var idPicker: some View {
-        if ["oneOf", "notOneOf"].contains(op) {
+        if isMultiValue {
             NavigationLink {
                 RuleIdMultiPicker(field: field, value: $value)
             } label: {
@@ -213,45 +293,22 @@ struct RuleValueEditor: View {
         }
     }
 
+    // MARK: - Amounts
+
     @ViewBuilder
     private var amountEditor: some View {
-        // `AmountInputField` (declared in AddTransactionView.swift) is the
-        // app's shared cents entry field; reuse it so rule amounts format and
-        // validate like every other amount in the app.
-        HStack {
-            Text("Amount")
-            Spacer()
-            AmountInputField(text: Binding(
-                get: { value.numberValue.map { String(format: "%.2f", $0 / 100) } ?? "" },
-                set: { text in
-                    value = .number(Double(Transaction.cents(fromDollars: Double(text) ?? 0) ?? 0))
-                }
-            ), allowsNegative: true)
-            .frame(maxWidth: 140)
-        }
-        // Upstream exposes amount (inflow) / amount (outflow) as separate
-        // fields; here they're a segmented direction on the amount row.
-        Picker("Direction", selection: directionBinding) {
-            Text("Any").tag("any")
-            Text("Inflow").tag("inflow")
-            Text("Outflow").tag("outflow")
-        }
-        .pickerStyle(.segmented)
-    }
+        RuleAmountField(value: $value)
 
-    private var datePicker: some View {
-        DatePicker("Date", selection: Binding(
-            get: {
-                guard let text = value.stringValue,
-                      let day = Int(text.replacingOccurrences(of: "-", with: "")), day > 9_999_999
-                else { return Date() }
-                return Transaction.date(fromYYYYMMDD: day)
-            },
-            set: { date in
-                let ymd = Transaction.yyyymmdd(from: date)
-                value = .string(String(format: "%04d-%02d-%02d", ymd / 10000, (ymd % 10000) / 100, ymd % 100))
+        if showsDirection {
+            // Upstream exposes amount (inflow) / amount (outflow) as separate
+            // fields; here they're a segmented direction on the amount row.
+            Picker("Direction", selection: directionBinding) {
+                Text("Any").tag("any")
+                Text("Inflow").tag("inflow")
+                Text("Outflow").tag("outflow")
             }
-        ), displayedComponents: .date)
+            .pickerStyle(.segmented)
+        }
     }
 
     private var directionBinding: Binding<String> {
@@ -271,13 +328,49 @@ struct RuleValueEditor: View {
         )
     }
 
-    private var choices: [(id: String, name: String)] {
-        switch field {
-        case "payee": return budgetStore.payees.map { ($0.id, $0.name) }
-        case "category": return budgetStore.categoryGroups.flatMap(\.categories).map { ($0.id, $0.name) }
-        case "category_group": return budgetStore.categoryGroups.map { ($0.id, $0.name) }
-        case "account": return budgetStore.accounts.filter { !$0.closed }.map { ($0.id, $0.name) }
-        default: return []
+    // MARK: - Dates
+
+    private var datePicker: some View {
+        DatePicker("Date", selection: Binding(
+            get: {
+                guard let text = value.stringValue,
+                      let day = Int(text.replacingOccurrences(of: "-", with: "")), day > 9_999_999
+                else { return Date() }
+                return Transaction.date(fromYYYYMMDD: day)
+            },
+            set: { date in
+                let ymd = Transaction.yyyymmdd(from: date)
+                value = .string(String(format: "%04d-%02d-%02d", ymd / 10000, (ymd % 10000) / 100, ymd % 100))
+            }
+        ), displayedComponents: .date)
+    }
+}
+
+/// Cents entry for a rule amount. Holds its own text the way the rest of the app
+/// does (`AddTransactionView`) and commits through `AmountParser`, so partial
+/// input ("10.", "1,50") isn't destroyed mid-keystroke — a binding that reparsed
+/// on every character would zero the value as the user typed.
+private struct RuleAmountField: View {
+    @Binding var value: RuleValue
+    @State private var text = ""
+
+    var body: some View {
+        HStack {
+            Text("Amount")
+            Spacer()
+            AmountInputField(text: $text, allowsNegative: true)
+                .frame(maxWidth: 140)
+        }
+        .onAppear {
+            guard text.isEmpty, let cents = value.numberValue else { return }
+            text = String(format: "%.2f", cents / 100)
+        }
+        .onChange(of: text) { _, newText in
+            // An unparseable partial entry leaves the stored value alone; Save
+            // is what ultimately validates it.
+            guard let dollars = AmountParser.parse(newText),
+                  let cents = Transaction.cents(fromDollars: dollars) else { return }
+            value = .number(Double(cents))
         }
     }
 }
@@ -290,6 +383,10 @@ struct RuleIdMultiPicker: View {
 
     private var selected: Set<String> {
         Set((value.listValue ?? []).compactMap(\.stringValue))
+    }
+
+    private var choices: [(id: String, name: String)] {
+        ruleChoices(for: field, in: budgetStore)
     }
 
     var body: some View {
@@ -314,18 +411,8 @@ struct RuleIdMultiPicker: View {
     private func toggle(_ id: String) {
         var ids = selected
         if ids.contains(id) { ids.remove(id) } else { ids.insert(id) }
-        // Preserve the choice list's order so the rule reads the same every
-        // time it round-trips through the editor.
+        // Preserve the choice list's order so the rule reads the same every time
+        // it round-trips through the editor.
         value = .list(choices.map(\.id).filter(ids.contains).map(RuleValue.string))
-    }
-
-    private var choices: [(id: String, name: String)] {
-        switch field {
-        case "payee": return budgetStore.payees.map { ($0.id, $0.name) }
-        case "category": return budgetStore.categoryGroups.flatMap(\.categories).map { ($0.id, $0.name) }
-        case "category_group": return budgetStore.categoryGroups.map { ($0.id, $0.name) }
-        case "account": return budgetStore.accounts.filter { !$0.closed }.map { ($0.id, $0.name) }
-        default: return []
-        }
     }
 }

--- a/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
+++ b/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
@@ -56,15 +56,21 @@ struct RuleConditionEditor: View {
                 .labelsHidden()
             }
 
-            RuleValueEditor(
-                value: $condition.value,
-                field: condition.field,
-                op: condition.op,
-                options: $condition.options,
-                showsDirection: true
-            )
+            // onBudget/offBudget read the account, not a value; upstream hides
+            // the value input for them.
+            if !Self.valuelessOps.contains(condition.op) {
+                RuleValueEditor(
+                    value: $condition.value,
+                    field: condition.field,
+                    op: condition.op,
+                    options: $condition.options,
+                    showsDirection: true
+                )
+            }
         }
     }
+
+    private static let valuelessOps: Set<String> = ["onBudget", "offBudget"]
 
     /// Changing the field can invalidate the operator and the value shape, so
     /// both reset the way the web editor does.
@@ -92,8 +98,12 @@ struct RuleConditionEditor: View {
                 let wasMulti = ["oneOf", "notOneOf"].contains(condition.op)
                 let isMulti = ["oneOf", "notOneOf"].contains(op)
                 let wasBetween = condition.op == "isbetween"
+                let wasValueless = Self.valuelessOps.contains(condition.op)
+                let isValueless = Self.valuelessOps.contains(op)
                 condition.op = op
-                if wasMulti != isMulti || wasBetween != (op == "isbetween") {
+                if isValueless {
+                    condition.value = .null
+                } else if wasMulti != isMulti || wasBetween != (op == "isbetween") || wasValueless {
                     condition.value = RuleValueEditor.defaultValue(field: condition.field, op: op)
                 }
             }
@@ -297,7 +307,15 @@ struct RuleValueEditor: View {
 
     @ViewBuilder
     private var amountEditor: some View {
-        RuleAmountField(value: $value)
+        if op == "isbetween" {
+            // A between value is a `{num1, num2}` object; feeding it to the
+            // single-amount field would clobber it with a scalar the engine
+            // can't evaluate and the web client refuses to load.
+            RuleAmountField(label: "From", value: betweenBinding("num1"))
+            RuleAmountField(label: "To", value: betweenBinding("num2"))
+        } else {
+            RuleAmountField(value: $value)
+        }
 
         if showsDirection {
             // Upstream exposes amount (inflow) / amount (outflow) as separate
@@ -309,6 +327,26 @@ struct RuleValueEditor: View {
             }
             .pickerStyle(.segmented)
         }
+    }
+
+    /// One endpoint of a `{num1, num2}` between value. Writing an endpoint
+    /// rebuilds the object so a malformed value self-heals into the shape the
+    /// engine and the web client require.
+    private func betweenBinding(_ key: String) -> Binding<RuleValue> {
+        Binding(
+            get: {
+                guard case .object(let dict) = value, let endpoint = dict[key] else { return .null }
+                return endpoint
+            },
+            set: { newValue in
+                var dict: [String: RuleValue] = [:]
+                if case .object(let existing) = value { dict = existing }
+                dict[key] = newValue
+                if dict["num1"] == nil { dict["num1"] = .number(0) }
+                if dict["num2"] == nil { dict["num2"] = .number(0) }
+                value = .object(dict)
+            }
+        )
     }
 
     private var directionBinding: Binding<String> {
@@ -351,12 +389,13 @@ struct RuleValueEditor: View {
 /// input ("10.", "1,50") isn't destroyed mid-keystroke — a binding that reparsed
 /// on every character would zero the value as the user typed.
 private struct RuleAmountField: View {
+    var label = "Amount"
     @Binding var value: RuleValue
     @State private var text = ""
 
     var body: some View {
         HStack {
-            Text("Amount")
+            Text(label)
             Spacer()
             AmountInputField(text: $text, allowsNegative: true)
                 .frame(maxWidth: 140)
@@ -409,10 +448,20 @@ struct RuleIdMultiPicker: View {
     }
 
     private func toggle(_ id: String) {
-        var ids = selected
+        value = Self.toggling(id, in: value, visibleIds: choices.map(\.id))
+    }
+
+    /// Toggle `id`, keeping visible ids in the choice list's order so the rule
+    /// reads the same every time it round-trips through the editor — and
+    /// keeping ids the picker can't display (hidden categories, closed
+    /// accounts, rules authored on another client), which toggling an
+    /// unrelated item must not silently drop.
+    static func toggling(_ id: String, in value: RuleValue, visibleIds: [String]) -> RuleValue {
+        var ids = Set((value.listValue ?? []).compactMap(\.stringValue))
         if ids.contains(id) { ids.remove(id) } else { ids.insert(id) }
-        // Preserve the choice list's order so the rule reads the same every time
-        // it round-trips through the editor.
-        value = .list(choices.map(\.id).filter(ids.contains).map(RuleValue.string))
+        let visible = visibleIds.filter(ids.contains)
+        let hidden = (value.listValue ?? []).compactMap(\.stringValue)
+            .filter { ids.contains($0) && !visibleIds.contains($0) }
+        return .list((visible + hidden).map(RuleValue.string))
     }
 }

--- a/Actuali/Actuali/Views/Rules/RulesListView.swift
+++ b/Actuali/Actuali/Views/Rules/RulesListView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// Manage the rules Actual applies to incoming transactions (GH #222).
+/// Mirrors the web's mobile rules page: stage badge, an IF/THEN summary per
+/// rule, search over that summary text, and swipe to delete.
+struct RulesListView: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    @State private var searchText = ""
+    @State private var editingRule: Rule?
+    @State private var isCreating = false
+    @State private var failureMessage: String?
+    @State private var hasLoaded = false
+
+    private var summary: RuleSummary { budgetStore.ruleSummary }
+
+    private var filteredRules: [Rule] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return budgetStore.rules }
+        return budgetStore.rules.filter { summary.searchText($0).contains(query) }
+    }
+
+    var body: some View {
+        Group {
+            if !budgetStore.rulesSupported && hasLoaded {
+                ContentUnavailableView(
+                    "Rules Unavailable",
+                    systemImage: "slider.horizontal.3",
+                    description: Text("This budget file has no rules table. Open it in Actual once to add one.")
+                )
+            } else if budgetStore.rules.isEmpty && hasLoaded {
+                ContentUnavailableView {
+                    Label("No Rules", systemImage: "slider.horizontal.3")
+                } description: {
+                    Text("Rules rewrite transactions as they're added — renaming payees, setting categories, and more.")
+                } actions: {
+                    Button("Create Rule") { isCreating = true }
+                }
+            } else if hasLoaded {
+                List {
+                    Section {
+                        ForEach(filteredRules) { rule in
+                            Button {
+                                editingRule = rule
+                            } label: {
+                                RuleRow(rule: rule, summary: summary,
+                                        isOwnedBySchedule: budgetStore.scheduleOwnedRuleIds.contains(rule.id))
+                            }
+                            .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing) {
+                                if !budgetStore.scheduleOwnedRuleIds.contains(rule.id) {
+                                    Button("Delete", role: .destructive) { delete(rule) }
+                                }
+                            }
+                        }
+                    } footer: {
+                        Text("Rules run in stage order — Pre, then Default, then Post — and within a stage the most specific rule runs last.")
+                    }
+                }
+                .searchable(text: $searchText, prompt: "Search rules")
+            } else {
+                ProgressView()
+            }
+        }
+        .navigationTitle("Rules")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if budgetStore.rulesSupported {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isCreating = true
+                    } label: {
+                        Label("Add Rule", systemImage: "plus")
+                    }
+                }
+            }
+        }
+        .sheet(item: $editingRule) { rule in
+            NavigationStack { RuleEditorView(rule: rule) }
+        }
+        .sheet(isPresented: $isCreating) {
+            NavigationStack { RuleEditorView(rule: .empty()) }
+        }
+        .alert("Couldn't Delete Rule", isPresented: Binding(
+            get: { failureMessage != nil },
+            set: { if !$0 { failureMessage = nil } }
+        )) {
+            Button("OK") { failureMessage = nil }
+        } message: {
+            Text(failureMessage ?? "")
+        }
+        .task {
+            await budgetStore.loadRules()
+            hasLoaded = true
+        }
+        .refreshable { await budgetStore.loadRules() }
+    }
+
+    private func delete(_ rule: Rule) {
+        Task {
+            do {
+                try await budgetStore.deleteRule(rule)
+            } catch {
+                failureMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+/// One rule: stage badge, the conditions under IF, the actions under THEN.
+private struct RuleRow: View {
+    let rule: Rule
+    let summary: RuleSummary
+    let isOwnedBySchedule: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(rule.stage.label.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(stageColor.opacity(0.18), in: RoundedRectangle(cornerRadius: 4))
+                    .foregroundStyle(stageColor)
+                if isOwnedBySchedule {
+                    Label("Schedule", systemImage: "calendar")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            labelled("IF", lines: rule.conditions.map(summary.condition),
+                     joiner: rule.conditionsOp == .and ? "and" : "or")
+            labelled("THEN", lines: rule.actions.map(summary.action), joiner: nil)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var stageColor: Color {
+        switch rule.stage {
+        case .pre: return .blue
+        case .default: return .secondary
+        case .post: return .orange
+        }
+    }
+
+    /// `joiner` prefixes every line but the first ("and"/"or"), the way
+    /// `RuleRow.tsx` renders `prefix={i > 0 ? conditionsOp : null}`.
+    private func labelled(_ title: String, lines: [String], joiner: String?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                Text(index > 0 ? "\(joiner.map { $0 + " " } ?? "")\(line)" : line)
+                    .font(.subheadline)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Rules/RulesListView.swift
+++ b/Actuali/Actuali/Views/Rules/RulesListView.swift
@@ -21,13 +21,15 @@ struct RulesListView: View {
 
     var body: some View {
         Group {
-            if !budgetStore.rulesSupported && hasLoaded {
+            if !hasLoaded {
+                ProgressView()
+            } else if !budgetStore.rulesSupported {
                 ContentUnavailableView(
                     "Rules Unavailable",
                     systemImage: "slider.horizontal.3",
                     description: Text("This budget file has no rules table. Open it in Actual once to add one.")
                 )
-            } else if budgetStore.rules.isEmpty && hasLoaded {
+            } else if budgetStore.rules.isEmpty {
                 ContentUnavailableView {
                     Label("No Rules", systemImage: "slider.horizontal.3")
                 } description: {
@@ -35,30 +37,8 @@ struct RulesListView: View {
                 } actions: {
                     Button("Create Rule") { isCreating = true }
                 }
-            } else if hasLoaded {
-                List {
-                    Section {
-                        ForEach(filteredRules) { rule in
-                            Button {
-                                editingRule = rule
-                            } label: {
-                                RuleRow(rule: rule, summary: summary,
-                                        isOwnedBySchedule: budgetStore.scheduleOwnedRuleIds.contains(rule.id))
-                            }
-                            .buttonStyle(.plain)
-                            .swipeActions(edge: .trailing) {
-                                if !budgetStore.scheduleOwnedRuleIds.contains(rule.id) {
-                                    Button("Delete", role: .destructive) { delete(rule) }
-                                }
-                            }
-                        }
-                    } footer: {
-                        Text("Rules run in stage order: Pre, then Default, then Post, within a stage the most specific rule runs last.")
-                    }
-                }
-                .searchable(text: $searchText, prompt: "Search rules")
             } else {
-                ProgressView()
+                rulesList
             }
         }
         .navigationTitle("Rules")
@@ -95,6 +75,45 @@ struct RulesListView: View {
         .refreshable { await budgetStore.loadRules() }
     }
 
+    private var rulesList: some View {
+        List {
+            if filteredRules.isEmpty {
+                // Searching past every rule shouldn't leave a blank screen.
+                ContentUnavailableView.search(text: searchText)
+                    .listRowBackground(Color.clear)
+            } else {
+                Section {
+                    ForEach(filteredRules) { rule in
+                        Button {
+                            editingRule = rule
+                        } label: {
+                            RuleRow(
+                                rule: rule,
+                                summary: summary,
+                                isOwnedBySchedule: budgetStore.scheduleOwnedRuleIds.contains(rule.id)
+                            )
+                        }
+                        // Without an explicit shape, a plain-styled button only
+                        // takes taps on the text itself, not the empty width
+                        // beside it.
+                        .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                        .swipeActions(edge: .trailing) {
+                            // A schedule's rule can't be deleted — the schedule
+                            // owns it, same as upstream's `deleteRule`.
+                            if !budgetStore.scheduleOwnedRuleIds.contains(rule.id) {
+                                Button("Delete", role: .destructive) { delete(rule) }
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("Rules run in stage order: Pre, then Default, then Post. Within a stage, the most specific rule runs last.")
+                }
+            }
+        }
+        .searchable(text: $searchText, prompt: "Search rules")
+    }
+
     private func delete(_ rule: Rule) {
         Task {
             do {
@@ -121,6 +140,7 @@ private struct RuleRow: View {
                     .padding(.vertical, 2)
                     .background(stageColor.opacity(0.18), in: RoundedRectangle(cornerRadius: 4))
                     .foregroundStyle(stageColor)
+
                 if isOwnedBySchedule {
                     Label("Schedule", systemImage: "calendar")
                         .font(.caption2)
@@ -150,11 +170,19 @@ private struct RuleRow: View {
             Text(title)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
+
             ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
                 Text(index > 0 ? "\(joiner.map { $0 + " " } ?? "")\(line)" : line)
                     .font(.subheadline)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RulesListView()
+            .environmentObject(BudgetStore.previewInstance())
     }
 }

--- a/Actuali/Actuali/Views/Rules/RulesListView.swift
+++ b/Actuali/Actuali/Views/Rules/RulesListView.swift
@@ -53,7 +53,7 @@ struct RulesListView: View {
                             }
                         }
                     } footer: {
-                        Text("Rules run in stage order — Pre, then Default, then Post — and within a stage the most specific rule runs last.")
+                        Text("Rules run in stage order: Pre, then Default, then Post, within a stage the most specific rule runs last.")
                     }
                 }
                 .searchable(text: $searchText, prompt: "Search rules")

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -425,7 +425,7 @@ struct SettingsView: View {
                             }
                         }
                     }
-                    
+
                     if budgetStore.currentBudgetId != nil {
                         NavigationLink {
                             RulesListView()

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -425,6 +425,14 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    
+                    if budgetStore.currentBudgetId != nil {
+                        NavigationLink {
+                            RulesListView()
+                        } label: {
+                            Text("Rules")
+                        }
+                    }
                 } header: {
                     Text("Preferences")
                 } footer: {

--- a/Actuali/ActualiTests/BudgetDatabaseRulesTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseRulesTests.swift
@@ -24,9 +24,106 @@ struct BudgetDatabaseRulesTests {
 
     private func cleanup(_ url: URL) { try? FileManager.default.removeItem(at: url) }
 
-    @Test func fetchesLiveRulesOnly() throws { /* tombstone = 1 row excluded */ }
-    @Test func returnsEmptyWithoutRulesTable() throws { /* includeRulesTable: false */ }
-    @Test func rankedFetchOrdersLeastSpecificFirst() async throws { /* mirrors RuleRankerTests via SQL */ }
-    @Test func schedulesOwningRulesAreReported() throws { /* schedules table with rule = 'r-1' */ }
-    @Test func ruleContextMapsCategoriesAccountsAndPayees() throws { /* categories/accounts/payees seeds */ }
+    @Test func fetchesLiveRulesOnly() throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO rules (id, stage, conditions_op, conditions, actions, tombstone) VALUES
+              ('r-live', NULL, 'and',
+               '[{"op":"is","field":"description","value":"payee-1","type":"id"}]',
+               '[{"op":"set","field":"category","value":"cat-1","type":"id"}]', 0),
+              ('r-dead', NULL, 'and',
+               '[{"op":"is","field":"description","value":"payee-2","type":"id"}]',
+               '[{"op":"set","field":"category","value":"cat-2","type":"id"}]', 1);
+            """)
+        defer { cleanup(path) }
+
+        let rules = try database.fetchRules()
+
+        #expect(rules.map(\.id) == ["r-live"])
+        // Internal column names come back out as public rule field names.
+        #expect(rules[0].conditions[0].field == "payee")
+    }
+
+    @Test func returnsEmptyWithoutRulesTable() throws {
+        let (database, path) = try makeDatabase(includeRulesTable: false)
+        defer { cleanup(path) }
+
+        #expect(try database.rulesTableExists() == false)
+        #expect(try database.fetchRules().isEmpty)
+    }
+
+    /// `fetchRulesRanked` mirrors upstream `rules-get`: least specific first
+    /// within a stage, and `post` after `default`.
+    @Test func rankedFetchOrdersLeastSpecificFirst() async throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            INSERT INTO rules (id, stage, conditions_op, conditions, actions, tombstone) VALUES
+              ('r-exact', NULL, 'and',
+               '[{"op":"is","field":"imported_description","value":"coffee co","type":"string"}]',
+               '[{"op":"set","field":"category","value":"cat-1","type":"id"}]', 0),
+              ('r-broad', NULL, 'and',
+               '[{"op":"contains","field":"imported_description","value":"coffee","type":"string"}]',
+               '[{"op":"set","field":"category","value":"cat-2","type":"id"}]', 0),
+              ('r-post', 'post', 'and',
+               '[{"op":"contains","field":"imported_description","value":"coffee","type":"string"}]',
+               '[{"op":"set","field":"category","value":"cat-3","type":"id"}]', 0);
+            """)
+        defer { cleanup(path) }
+
+        let ranked = try await database.fetchRulesRanked()
+
+        #expect(ranked.map(\.id) == ["r-broad", "r-exact", "r-post"])
+    }
+
+    @Test func schedulesOwningRulesAreReported() throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            CREATE TABLE IF NOT EXISTS schedules
+              (id TEXT PRIMARY KEY, rule TEXT, tombstone INTEGER DEFAULT 0);
+            INSERT INTO schedules (id, rule, tombstone) VALUES
+              ('s-1', 'r-owned', 0),
+              ('s-dead', 'r-was-owned', 1),
+              ('s-norule', NULL, 0);
+            """)
+        defer { cleanup(path) }
+
+        #expect(try database.scheduleOwnedRuleIds() == ["r-owned"])
+    }
+
+    @Test func ruleContextMapsCategoriesAccountsAndPayees() throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            CREATE TABLE IF NOT EXISTS accounts
+              (id TEXT PRIMARY KEY, name TEXT, offbudget INTEGER DEFAULT 0,
+               closed INTEGER DEFAULT 0, tombstone INTEGER DEFAULT 0);
+            CREATE TABLE IF NOT EXISTS categories
+              (id TEXT PRIMARY KEY, name TEXT, cat_group TEXT, tombstone INTEGER DEFAULT 0);
+            CREATE TABLE IF NOT EXISTS payees
+              (id TEXT PRIMARY KEY, name TEXT, transfer_acct TEXT, tombstone INTEGER DEFAULT 0);
+            INSERT INTO accounts (id, name, offbudget) VALUES
+              ('acct-on', 'Checking', 0), ('acct-off', 'Mortgage', 1);
+            INSERT INTO categories (id, name, cat_group) VALUES ('cat-food', 'Food', 'grp-daily');
+            INSERT INTO payees (id, name) VALUES ('payee-1', 'Woolworths');
+            """)
+        defer { cleanup(path) }
+
+        let context = try database.ruleContext()
+
+        #expect(context.offBudgetAccountIds == ["acct-off"])
+        #expect(context.categoryGroupIds["cat-food"] == "grp-daily")
+        #expect(context.payeeNames["payee-1"] == "Woolworths")
+    }
+
+    /// `payee(named:)` backs the `set payee_name` action, which must reuse an
+    /// existing payee rather than creating a second one that differs by case.
+    @Test func findsPayeeByNameCaseInsensitively() throws {
+        let (database, path) = try makeDatabase(seedSQL: """
+            CREATE TABLE IF NOT EXISTS payees
+              (id TEXT PRIMARY KEY, name TEXT, transfer_acct TEXT, tombstone INTEGER DEFAULT 0);
+            INSERT INTO payees (id, name, tombstone) VALUES
+              ('payee-1', 'Woolworths', 0), ('payee-dead', 'Aldi', 1);
+            """)
+        defer { cleanup(path) }
+
+        #expect(try database.payee(named: "woolworths")?.id == "payee-1")
+        #expect(try database.payee(named: "WOOLWORTHS")?.id == "payee-1")
+        #expect(try database.payee(named: "Aldi") == nil)
+        #expect(try database.payee(named: "Nowhere") == nil)
+    }
 }

--- a/Actuali/ActualiTests/BudgetDatabaseRulesTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseRulesTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+struct BudgetDatabaseRulesTests {
+
+    private func makeDatabase(includeRulesTable: Bool = true, seedSQL: String = "") throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            if includeRulesTable {
+                try db.execute(sql: """
+                    CREATE TABLE rules (id TEXT PRIMARY KEY, stage TEXT, conditions TEXT,
+                                        actions TEXT, tombstone INTEGER DEFAULT 0,
+                                        conditions_op TEXT DEFAULT 'and');
+                    """)
+            }
+            if !seedSQL.isEmpty { try db.execute(sql: seedSQL) }
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func cleanup(_ url: URL) { try? FileManager.default.removeItem(at: url) }
+
+    @Test func fetchesLiveRulesOnly() throws { /* tombstone = 1 row excluded */ }
+    @Test func returnsEmptyWithoutRulesTable() throws { /* includeRulesTable: false */ }
+    @Test func rankedFetchOrdersLeastSpecificFirst() async throws { /* mirrors RuleRankerTests via SQL */ }
+    @Test func schedulesOwningRulesAreReported() throws { /* schedules table with rule = 'r-1' */ }
+    @Test func ruleContextMapsCategoriesAccountsAndPayees() throws { /* categories/accounts/payees seeds */ }
+}

--- a/Actuali/ActualiTests/BudgetStoreRulesTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreRulesTests.swift
@@ -45,6 +45,25 @@ struct BudgetStoreRulesTests {
         }
     }
 
+    @Test func rejectsIsBetweenWithoutARange() {
+        // A scalar here makes upstream's parse assert and the whole rule
+        // vanish from the web client — it must never save.
+        let scalar = rule(conditions: [
+            .init(op: "isbetween", field: "amount", value: .number(500), options: nil)
+        ])
+        #expect(throws: BudgetStoreError.ruleEmptyValue(field: "amount")) {
+            try BudgetStore.validate(scalar)
+        }
+    }
+
+    @Test func acceptsIsBetweenWithARange() throws {
+        let ranged = rule(conditions: [
+            .init(op: "isbetween", field: "amount",
+                  value: .object(["num1": .number(1000), "num2": .number(2000)]), options: nil)
+        ])
+        try BudgetStore.validate(ranged)
+    }
+
     @Test func rejectsEmptyMultiValue() {
         #expect(throws: BudgetStoreError.ruleEmptyValue(field: "payee")) {
             try BudgetStore.validate(rule(conditions: [

--- a/Actuali/ActualiTests/BudgetStoreRulesTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreRulesTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import Actuali
+
+/// Rule validation, mirroring upstream `rule-validate` (loot-core
+/// server/rules/app.ts): a rule the editor accepts must be one the engine can
+/// actually run.
+@MainActor
+struct BudgetStoreRulesTests {
+
+    private func rule(
+        conditions: [Rule.Condition],
+        actions: [Rule.Action] = [.init(op: "set", field: "category",
+                                        value: .string("cat-1"), options: nil)]
+    ) -> Rule {
+        Rule(id: "r-1", stage: .default, conditionsOp: .and,
+             conditions: conditions, actions: actions)
+    }
+
+    @Test func acceptsAWellFormedRule() throws {
+        try BudgetStore.validate(rule(conditions: [
+            .init(op: "contains", field: "imported_payee", value: .string("woolworths"), options: nil)
+        ]))
+    }
+
+    @Test func rejectsRuleWithoutConditions() {
+        #expect(throws: BudgetStoreError.ruleNeedsCondition) {
+            try BudgetStore.validate(rule(conditions: []))
+        }
+    }
+
+    @Test func rejectsRuleWithoutActions() {
+        #expect(throws: BudgetStoreError.ruleNeedsAction) {
+            try BudgetStore.validate(rule(
+                conditions: [.init(op: "is", field: "payee", value: .string("p"), options: nil)],
+                actions: []))
+        }
+    }
+
+    /// `notes` disallows oneOf/notOneOf upstream (FIELD_INFO.disallowedOps).
+    @Test func rejectsOperatorTheFieldDoesNotSupport() {
+        #expect(throws: BudgetStoreError.ruleInvalidCondition(field: "notes", op: "oneOf")) {
+            try BudgetStore.validate(rule(conditions: [
+                .init(op: "oneOf", field: "notes", value: .list([.string("a")]), options: nil)
+            ]))
+        }
+    }
+
+    @Test func rejectsEmptyMultiValue() {
+        #expect(throws: BudgetStoreError.ruleEmptyValue(field: "payee")) {
+            try BudgetStore.validate(rule(conditions: [
+                .init(op: "oneOf", field: "payee", value: .list([]), options: nil)
+            ]))
+        }
+    }
+
+    @Test func rejectsEmptyContainsValue() {
+        #expect(throws: BudgetStoreError.ruleEmptyValue(field: "imported_payee")) {
+            try BudgetStore.validate(rule(conditions: [
+                .init(op: "contains", field: "imported_payee", value: .string(""), options: nil)
+            ]))
+        }
+    }
+
+    /// A date condition saved with no date would sync to every client and
+    /// silently never match.
+    @Test func rejectsIncompleteDateValue() {
+        for value in ["", "2026", "2026-05"] {
+            #expect(throws: BudgetStoreError.ruleEmptyValue(field: "date")) {
+                try BudgetStore.validate(rule(conditions: [
+                    .init(op: "gt", field: "date", value: .string(value), options: nil)
+                ]))
+            }
+        }
+    }
+
+    @Test func acceptsFullDateValue() throws {
+        try BudgetStore.validate(rule(conditions: [
+            .init(op: "is", field: "date", value: .string("2026-05-03"), options: nil)
+        ]))
+    }
+
+    @Test func rejectsUncompilableRegex() {
+        #expect(throws: BudgetStoreError.ruleInvalidPattern(pattern: "[")) {
+            try BudgetStore.validate(rule(conditions: [
+                .init(op: "matches", field: "notes", value: .string("["), options: nil)
+            ]))
+        }
+    }
+
+    @Test func rejectsSetAccountToNothing() {
+        #expect(throws: BudgetStoreError.ruleEmptyValue(field: "account")) {
+            try BudgetStore.validate(rule(
+                conditions: [.init(op: "is", field: "payee", value: .string("p"), options: nil)],
+                actions: [.init(op: "set", field: "account", value: .null, options: nil)]))
+        }
+    }
+}

--- a/Actuali/ActualiTests/ConditionsFilterTests.swift
+++ b/Actuali/ActualiTests/ConditionsFilterTests.swift
@@ -299,6 +299,16 @@ struct ConditionsFilterTests {
         #expect(ConditionsFilter.matches(transaction: makeTransaction(category: "groceries"), conditions: [cond], op: "and", context: groupContext))
         #expect(!ConditionsFilter.matches(transaction: makeTransaction(category: "rent"), conditions: [cond], op: "and", context: groupContext))
     }
+    
+    /// Two days either side of a US DST change must still be "approximately"
+    /// the same date — the bug a local calendar reintroduces.
+    @Test func approxDateSpansDaylightSavingBoundaries() {
+        // 2026-11-01 is a US fall-back date.
+        #expect(RuleDateMatcher.matches(transactionDate: 20261101, op: "isapprox",
+                                        value: "2026-10-30") == true)
+        #expect(RuleDateMatcher.matches(transactionDate: 20260308, op: "isapprox",
+                                        value: "2026-03-10") == true)
+    }
 }
 
 /// Test helper to build WidgetRuleCondition values from primitives.

--- a/Actuali/ActualiTests/RuleModelTests.swift
+++ b/Actuali/ActualiTests/RuleModelTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import Actuali
+
+/// Round-tripping rules through the JSON blobs Actual stores them in. Field
+/// names must come back out internal (`description`, `acct`) or the web app and
+/// the sync engine will read a rule we wrote as a different rule.
+struct RuleModelTests {
+
+    @Test func parsesInternalFieldNamesToPublicOnes() throws {
+        let rule = try Rule.parse(
+            id: "r-1", stage: "pre", conditionsOp: "or",
+            conditionsJSON: #"[{"op":"is","field":"description","value":"payee-1","type":"id"}]"#,
+            actionsJSON: #"[{"op":"set","field":"acct","value":"acct-1","type":"id"}]"#
+        )
+
+        #expect(rule.stage == .pre)
+        #expect(rule.conditionsOp == .or)
+        #expect(rule.conditions[0].field == "payee")
+        #expect(rule.conditions[0].value == .string("payee-1"))
+        #expect(rule.actions[0].field == "account")
+    }
+
+    @Test func serializesBackToInternalFieldNames() throws {
+        let rule = Rule(
+            id: "r-1", stage: .default, conditionsOp: .and,
+            conditions: [.init(op: "contains", field: "imported_payee",
+                               value: .string("woolworths"), options: nil)],
+            actions: [.init(op: "set", field: "payee", value: .string("payee-1"), options: nil)]
+        )
+
+        #expect(rule.conditionsJSON.contains(#""field":"imported_description""#))
+        #expect(rule.actionsJSON.contains(#""field":"description""#))
+        #expect(rule.conditionsJSON.contains(#""type":"string""#))
+    }
+
+    @Test func roundTripsUnchanged() throws {
+        let conditions = #"[{"field":"amount","op":"isbetween","type":"number","value":{"num1":-5000,"num2":-1000}}]"#
+        let actions = #"[{"field":"category","op":"set","type":"id","value":"cat-1"}]"#
+        let rule = try Rule.parse(id: "r-1", stage: nil, conditionsOp: "and",
+                                  conditionsJSON: conditions, actionsJSON: actions)
+
+        #expect(rule.conditionsJSON == conditions)
+        #expect(rule.actionsJSON == actions)
+    }
+
+    @Test func amountsSerializeAsIntegerCents() {
+        #expect(RuleValue.number(1050).jsonObject as? Int == 1050)
+    }
+
+    @Test func defaultStageWritesNullStage() {
+        let rule = Rule.empty(id: "r-1")
+        #expect(rule.syncableFields["stage"] as? String == nil)
+        #expect(rule.syncableFields["conditions_op"] as? String == "and")
+    }
+}

--- a/Actuali/ActualiTests/RuleModelTests.swift
+++ b/Actuali/ActualiTests/RuleModelTests.swift
@@ -52,4 +52,15 @@ struct RuleModelTests {
         #expect(rule.syncableFields["stage"] as? String == nil)
         #expect(rule.syncableFields["conditions_op"] as? String == "and")
     }
+    
+    /// Upstream drops a rule whose conditions don't parse rather than running a
+    /// weakened version of it.
+    @Test func rejectsRuleWithAMalformedCondition() {
+        #expect(throws: RuleParseError.self) {
+            try Rule.parse(
+                id: "r-1", stage: nil, conditionsOp: "and",
+                conditionsJSON: #"[{"op":"is","field":"description","value":"p"},{"value":"orphan"}]"#,
+                actionsJSON: #"[{"op":"set","field":"category","value":"cat-1"}]"#)
+        }
+    }
 }

--- a/Actuali/ActualiTests/RuleRankerTests.swift
+++ b/Actuali/ActualiTests/RuleRankerTests.swift
@@ -25,10 +25,11 @@ struct RuleRankerTests {
         #expect(RuleRanker.score(rule(id: "r", ops: ["is", "contains"])) == 10)
     }
 
-    /// Upstream bails to 0 for a rule containing an operator it doesn't know,
-    /// which sends the rule to the front (least specific).
-    @Test func unknownOperatorScoresZero() {
+    /// Upstream's reducer returns 0 for an unknown operator, resetting the
+    /// running total — but conditions after it still accumulate.
+    @Test func unknownOperatorResetsScoreAndKeepsAccumulating() {
         #expect(RuleRanker.score(rule(id: "r", ops: ["is", "bogus"])) == 0)
+        #expect(RuleRanker.score(rule(id: "r", ops: ["bogus", "is", "gt"])) == 11)
     }
 
     @Test func ordersByStageThenScoreThenId() {

--- a/Actuali/ActualiTests/RuleRankerTests.swift
+++ b/Actuali/ActualiTests/RuleRankerTests.swift
@@ -1,0 +1,52 @@
+import Testing
+@testable import Actuali
+
+/// Port fidelity for `rankRules` (loot-core server/rules/rule-utils.ts). Order
+/// decides which of two matching rules wins, so the score table is behaviour,
+/// not an implementation detail.
+struct RuleRankerTests {
+
+    private func rule(id: String, stage: Rule.Stage = .default, ops: [String]) -> Rule {
+        Rule(
+            id: id,
+            stage: stage,
+            conditionsOp: .and,
+            conditions: ops.map { .init(op: $0, field: "notes", value: .string("x"), options: nil) },
+            actions: [.init(op: "set", field: "category", value: .string("cat"), options: nil)]
+        )
+    }
+
+    @Test func scoresMatchUpstreamTable() {
+        #expect(RuleRanker.score(rule(id: "r", ops: ["contains"])) == 0)
+        #expect(RuleRanker.score(rule(id: "r", ops: ["gt"])) == 1)
+        // All-exact conditions double: is(10) + is(10) = 20, doubled to 40.
+        #expect(RuleRanker.score(rule(id: "r", ops: ["is", "is"])) == 40)
+        // A single non-exact condition cancels the doubling: 10 + 0.
+        #expect(RuleRanker.score(rule(id: "r", ops: ["is", "contains"])) == 10)
+    }
+
+    /// Upstream bails to 0 for a rule containing an operator it doesn't know,
+    /// which sends the rule to the front (least specific).
+    @Test func unknownOperatorScoresZero() {
+        #expect(RuleRanker.score(rule(id: "r", ops: ["is", "bogus"])) == 0)
+    }
+
+    @Test func ordersByStageThenScoreThenId() {
+        let ranked = RuleRanker.rank([
+            rule(id: "post", stage: .post, ops: ["is"]),
+            rule(id: "b-broad", ops: ["contains"]),
+            rule(id: "a-broad", ops: ["contains"]),
+            rule(id: "exact", ops: ["is"]),
+            rule(id: "pre", stage: .pre, ops: ["contains"])
+        ])
+
+        // pre first; inside default, equal scores tie-break on id, then the
+        // higher-scoring exact rule runs last so it wins; post last of all.
+        #expect(ranked.map(\.id) == ["pre", "a-broad", "b-broad", "exact", "post"])
+    }
+
+    @Test func rankingIsStableForIdenticalInput() {
+        let rules = [rule(id: "b", ops: ["is"]), rule(id: "a", ops: ["is"])]
+        #expect(RuleRanker.rank(rules).map(\.id) == RuleRanker.rank(rules.reversed()).map(\.id))
+    }
+}

--- a/Actuali/ActualiTests/RuleSummaryTests.swift
+++ b/Actuali/ActualiTests/RuleSummaryTests.swift
@@ -1,0 +1,52 @@
+import Testing
+@testable import Actuali
+
+/// The IF/THEN text on the rules list, and the string its search box matches.
+struct RuleSummaryTests {
+
+    private let summary = RuleSummary(
+        names: .init(
+            payees: ["payee-1": "Woolworths"],
+            categories: ["cat-1": "Groceries"],
+            categoryGroups: ["grp-1": "Daily"],
+            accounts: ["acct-1": "Checking"]
+        ),
+        formatAmount: { cents in "$\(Double(cents) / 100)" }
+    )
+
+    @Test func namesIdsInsteadOfShowingUUIDs() {
+        let condition = Rule.Condition(op: "is", field: "payee",
+                                       value: .string("payee-1"), options: nil)
+        #expect(summary.condition(condition) == "payee is Woolworths")
+    }
+
+    @Test func labelsAmountDirectionFromOptions() {
+        let condition = Rule.Condition(op: "gt", field: "amount", value: .number(5000),
+                                       options: ["outflow": .bool(true)])
+        #expect(summary.condition(condition).hasPrefix("amount (outflow) is greater than"))
+    }
+
+    @Test func rendersOpsWithoutAValue() {
+        let condition = Rule.Condition(op: "offBudget", field: "account",
+                                       value: .null, options: nil)
+        #expect(summary.condition(condition) == "account is off budget")
+    }
+
+    @Test func describesActions() {
+        let action = Rule.Action(op: "set", field: "category",
+                                 value: .string("cat-1"), options: nil)
+        #expect(summary.action(action) == "set category to Groceries")
+    }
+
+    @Test func searchTextCoversConditionsAndActions() {
+        let rule = Rule(
+            id: "r-1", stage: .default, conditionsOp: .and,
+            conditions: [.init(op: "contains", field: "imported_payee",
+                               value: .string("WOOLIES"), options: nil)],
+            actions: [.init(op: "set", field: "category", value: .string("cat-1"), options: nil)])
+
+        let text = summary.searchText(rule)
+        #expect(text.contains("woolies"))
+        #expect(text.contains("groceries"))
+    }
+}

--- a/Actuali/ActualiTests/RuleValueEditorsTests.swift
+++ b/Actuali/ActualiTests/RuleValueEditorsTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Actuali
+
+/// The multi-picker's toggle logic. The picker only lists live, visible
+/// entities, but a rule can reference hidden categories, closed accounts, or
+/// ids authored on another client — toggling one item must never drop them.
+struct RuleValueEditorsTests {
+
+    private let visible = ["cat-a", "cat-b", "cat-c"]
+
+    @Test func togglingAddsAndRemovesAVisibleId() {
+        let added = RuleIdMultiPicker.toggling("cat-b", in: .list([]), visibleIds: visible)
+        #expect(added == .list([.string("cat-b")]))
+
+        let removed = RuleIdMultiPicker.toggling("cat-b", in: added, visibleIds: visible)
+        #expect(removed == .list([]))
+    }
+
+    @Test func togglingKeepsVisibleIdsInChoiceOrder() {
+        var value = RuleValue.list([])
+        for id in ["cat-c", "cat-a"] {
+            value = RuleIdMultiPicker.toggling(id, in: value, visibleIds: visible)
+        }
+        #expect(value == .list([.string("cat-a"), .string("cat-c")]))
+    }
+
+    @Test func togglingPreservesIdsThePickerCannotDisplay() {
+        let webAuthored = RuleValue.list([.string("hidden-cat"), .string("cat-a")])
+
+        let toggled = RuleIdMultiPicker.toggling("cat-b", in: webAuthored, visibleIds: visible)
+        #expect(toggled == .list([.string("cat-a"), .string("cat-b"), .string("hidden-cat")]))
+
+        // A hidden id can still be removed explicitly.
+        let removed = RuleIdMultiPicker.toggling("hidden-cat", in: toggled, visibleIds: visible)
+        #expect(removed == .list([.string("cat-a"), .string("cat-b")]))
+    }
+}

--- a/Actuali/ActualiTests/RulesEngineTests.swift
+++ b/Actuali/ActualiTests/RulesEngineTests.swift
@@ -1,6 +1,14 @@
 import Testing
 @testable import Actuali
 
+/// Rule evaluation against a single transaction — the port of loot-core's
+/// `runRules` (server/transactions/transaction-rules.ts) plus the condition and
+/// action semantics of `server/rules/{condition,action}.ts`.
+///
+/// Rules are written here as the JSON blobs Actual actually stores, internal
+/// column names and all (`description` for payee, `imported_description` for
+/// imported payee, `acct` for account), so a test that passes is evidence the
+/// engine reads what the web app writes.
 struct RulesEngineTests {
 
     // MARK: - Helpers
@@ -48,6 +56,18 @@ struct RulesEngineTests {
         )
     }
 
+    /// The pair most of these tests care about. `RulesEngine.apply` returns the
+    /// full `RuleRunResult`; the delete and payee-name channels are asserted
+    /// against the result directly in the tests that exercise them.
+    private func applied(
+        _ transaction: Transaction,
+        rules: [Rule],
+        context: RuleContext = .empty
+    ) -> (Transaction, Set<String>) {
+        let result = RulesEngine.apply(transaction, rules: rules, context: context)
+        return (result.transaction, result.changedFields)
+    }
+
     // MARK: - The user's actual scenario
 
     @Test func importedPayeeContainsTriggersRenameRule() {
@@ -64,7 +84,7 @@ struct RulesEngineTests {
         )
 
         let tx = makeTransaction(importedPayee: "Woolworths 3029", payeeId: "payee-other-id")
-        let (updated, changed) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, changed) = applied(tx, rules: [rule])
 
         #expect(updated.payeeId == "payee-woolworths-id")
         #expect(changed.contains("payee"))
@@ -81,7 +101,7 @@ struct RulesEngineTests {
         )
 
         let tx = makeTransaction(importedPayee: nil, payeeId: "payee-other-id")
-        let (updated, changed) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, changed) = applied(tx, rules: [rule])
 
         #expect(updated.payeeId == "payee-other-id")
         #expect(changed.isEmpty)
@@ -97,7 +117,7 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "woolworths #4")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.payeeId == "payee-w")
     }
 
@@ -113,8 +133,21 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(payeeId: "payee-coffee")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-food")
+    }
+
+    @Test func isNotOpMatchesEverythingElse() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"isNot","field":"description","value":"payee-coffee"}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-other"}]
+            """
+        )
+        #expect(applied(makeTransaction(payeeId: "payee-tea"), rules: [rule]).0.categoryId == "cat-other")
+        #expect(applied(makeTransaction(payeeId: "payee-coffee"), rules: [rule]).0.categoryId == nil)
     }
 
     @Test func oneOfMatchesAnyValue() {
@@ -127,8 +160,36 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(payeeId: "payee-b")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-x")
+    }
+
+    @Test func notOneOfExcludesListedValues() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"notOneOf","field":"description","value":["payee-a","payee-b"]}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-rest"}]
+            """
+        )
+        #expect(applied(makeTransaction(payeeId: "payee-c"), rules: [rule]).0.categoryId == "cat-rest")
+        #expect(applied(makeTransaction(payeeId: "payee-a"), rules: [rule]).0.categoryId == nil)
+        // Upstream returns false for a null field value on notOneOf too.
+        #expect(applied(makeTransaction(payeeId: nil), rules: [rule]).0.categoryId == nil)
+    }
+
+    @Test func doesNotContainExcludesMatchingText() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"doesNotContain","field":"imported_description","value":"refund"}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-spend"}]
+            """
+        )
+        #expect(applied(makeTransaction(importedPayee: "Shop Co"), rules: [rule]).0.categoryId == "cat-spend")
+        #expect(applied(makeTransaction(importedPayee: "Shop Co REFUND"), rules: [rule]).0.categoryId == nil)
     }
 
     @Test func gtComparesAmount() {
@@ -141,8 +202,35 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(amount: 1500)
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-big")
+    }
+
+    @Test func isBetweenMatchesInclusiveRange() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"isbetween","field":"amount","value":{"num1":-2000,"num2":-1000}}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-mid"}]
+            """
+        )
+        #expect(applied(makeTransaction(amount: -1500), rules: [rule]).0.categoryId == "cat-mid")
+        // Bounds are inclusive, and the stored order of num1/num2 doesn't matter.
+        #expect(applied(makeTransaction(amount: -1000), rules: [rule]).0.categoryId == "cat-mid")
+        #expect(applied(makeTransaction(amount: -2000), rules: [rule]).0.categoryId == "cat-mid")
+        #expect(applied(makeTransaction(amount: -500), rules: [rule]).0.categoryId == nil)
+    }
+
+    /// `getApproxNumberThreshold` rounds (1000 × 0.075 = 75). Flooring instead
+    /// made amounts inside the web app's window miss the rule here.
+    @Test func approxAmountUsesRoundedThreshold() {
+        let rule = parseRule(
+            conditions: #"[{"op":"isapprox","field":"amount","value":-1000}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-approx"}]"#)
+
+        #expect(applied(makeTransaction(amount: -1075), rules: [rule]).0.categoryId == "cat-approx")
+        #expect(applied(makeTransaction(amount: -1076), rules: [rule]).0.categoryId == nil)
     }
 
     @Test func outflowOptionInvertsAmountSign() {
@@ -156,12 +244,25 @@ struct RulesEngineTests {
             """
         )
         let outflowTx = makeTransaction(amount: -1500)
-        let (updated, _) = RulesEngine.apply(outflowTx, rules: [rule])
+        let (updated, _) = applied(outflowTx, rules: [rule])
         #expect(updated.categoryId == "cat-big-spend")
 
         let inflowTx = makeTransaction(amount: 1500)
-        let (notUpdated, _) = RulesEngine.apply(inflowTx, rules: [rule])
+        let (notUpdated, _) = applied(inflowTx, rules: [rule])
         #expect(notUpdated.categoryId == nil)
+    }
+
+    @Test func inflowOptionRequiresPositiveAmount() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"gt","field":"amount","value":1000,"options":{"inflow":true}}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-income"}]
+            """
+        )
+        #expect(applied(makeTransaction(amount: 1500), rules: [rule]).0.categoryId == "cat-income")
+        #expect(applied(makeTransaction(amount: -1500), rules: [rule]).0.categoryId == nil)
     }
 
     @Test func matchesUsesRegex() {
@@ -174,8 +275,29 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "Starbucks #1234")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-coffee")
+    }
+
+    /// Upstream lowercases the pattern itself at parse time, so `\D` runs as
+    /// `\d`. A rule written on the web has to behave the same here, quirk
+    /// included — see the comment in RulesEngine.evalText.
+    @Test func matchesLowercasesThePatternLikeUpstream() {
+        let rule = parseRule(
+            conditions: #"[{"op":"matches","field":"notes","value":"\\D+"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-digits"}]"#)
+        // "1234" contains no non-digits, but \D lowercases to \d and matches.
+        let tx = makeTransaction(notes: "1234")
+        let (updated, _) = applied(tx, rules: [rule])
+        #expect(updated.categoryId == "cat-digits")
+    }
+
+    @Test func invalidRegexNeverMatches() {
+        let rule = parseRule(
+            conditions: #"[{"op":"matches","field":"notes","value":"["}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-bad"}]"#)
+        let (updated, _) = applied(makeTransaction(notes: "anything"), rules: [rule])
+        #expect(updated.categoryId == nil)
     }
 
     @Test func conditionsOpOrMatchesEither() {
@@ -192,8 +314,157 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "Local Cafe")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-coffee")
+    }
+
+    /// Upstream coerces a missing string field to "" before comparing
+    /// (`fieldValue ??= ''`), so a note-less transaction matches `is ""`.
+    @Test func emptyNotesMatchesIsEmptyString() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"notes","value":"","type":"string"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-empty"}]"#)
+        let (updated, _) = applied(makeTransaction(notes: nil), rules: [rule])
+        #expect(updated.categoryId == "cat-empty")
+    }
+
+    // MARK: - Date conditions
+
+    @Test func exactDateConditionMatches() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"date","value":"2026-05-03","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-day"}]"#)
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == "cat-day")
+    }
+
+    @Test func monthDateConditionMatches() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"date","value":"2026-05","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-month"}]"#)
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == "cat-month")
+    }
+
+    @Test func yearDateConditionMatches() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"date","value":"2026","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-year"}]"#)
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == "cat-year")
+    }
+
+    /// Upstream widens an exact date by ±2 days.
+    @Test func approxDateMatchesWithinTwoDays() {
+        let rule = parseRule(
+            conditions: #"[{"op":"isapprox","field":"date","value":"2026-05-05","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-near"}]"#)
+        // The transaction is dated 20260503 — two days out, inclusive.
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == "cat-near")
+    }
+
+    @Test func approxDateMissesOutsideTwoDays() {
+        let rule = parseRule(
+            conditions: #"[{"op":"isapprox","field":"date","value":"2026-05-07","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-far"}]"#)
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == nil)
+    }
+
+    @Test func dateComparisonOps() {
+        func category(forOp op: String, value: String) -> String? {
+            let rule = parseRule(
+                conditions: #"[{"op":"\#(op)","field":"date","value":"\#(value)","type":"date"}]"#,
+                actions: #"[{"op":"set","field":"category","value":"cat-hit"}]"#)
+            return applied(makeTransaction(), rules: [rule]).0.categoryId
+        }
+
+        // The transaction is dated 20260503.
+        #expect(category(forOp: "gt", value: "2026-05-02") == "cat-hit")
+        #expect(category(forOp: "gt", value: "2026-05-03") == nil)
+        #expect(category(forOp: "gte", value: "2026-05-03") == "cat-hit")
+        #expect(category(forOp: "lt", value: "2026-05-04") == "cat-hit")
+        #expect(category(forOp: "lt", value: "2026-05-03") == nil)
+        #expect(category(forOp: "lte", value: "2026-05-03") == "cat-hit")
+    }
+
+    /// A month or year value fails `Condition`'s parse assertions upstream, so
+    /// the rule never loads there. Here the condition simply can't match.
+    @Test func dateComparisonRejectsMonthPrecision() {
+        let rule = parseRule(
+            conditions: #"[{"op":"gt","field":"date","value":"2026-04","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-month"}]"#)
+        let (updated, _) = applied(makeTransaction(), rules: [rule])
+        #expect(updated.categoryId == nil)
+    }
+
+    // MARK: - Conditions that need budget context
+
+    /// `category_group` is not a transaction column; it's resolved from the
+    /// category through `RuleContext`, the way upstream's
+    /// `prepareTransactionForRules` hangs it off the transaction.
+    @Test func categoryGroupConditionUsesContext() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"category_group","value":"grp-daily","type":"id"}]"#,
+            actions: #"[{"op":"set","field":"notes","value":"daily"}]"#)
+        var tx = makeTransaction()
+        tx.categoryId = "cat-food"
+
+        let context = RuleContext(categoryGroupIds: ["cat-food": "grp-daily"])
+        #expect(applied(tx, rules: [rule], context: context).0.notes == "daily")
+        // Without the context the group is unknown and the rule can't match.
+        #expect(applied(tx, rules: [rule]).0.notes == nil)
+    }
+
+    @Test func payeeNameConditionUsesContext() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"payee_name","value":"wool","type":"string"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-groceries"}]"#)
+        let tx = makeTransaction(payeeId: "payee-1")
+
+        let context = RuleContext(payeeNames: ["payee-1": "Woolworths"])
+        #expect(applied(tx, rules: [rule], context: context).0.categoryId == "cat-groceries")
+        #expect(applied(tx, rules: [rule]).0.categoryId == nil)
+    }
+
+    @Test func offBudgetConditionMatchesOffBudgetAccount() {
+        let rule = parseRule(
+            conditions: #"[{"op":"offBudget","field":"acct","value":null,"type":"id"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-off"}]"#)
+        let tx = makeTransaction()   // account is "acct-1"
+
+        #expect(applied(tx, rules: [rule],
+                        context: RuleContext(offBudgetAccountIds: ["acct-1"])).0.categoryId == "cat-off")
+        #expect(applied(tx, rules: [rule],
+                        context: RuleContext(offBudgetAccountIds: ["acct-other"])).0.categoryId == nil)
+    }
+
+    @Test func onBudgetConditionMatchesBudgetedAccount() {
+        let rule = parseRule(
+            conditions: #"[{"op":"onBudget","field":"acct","value":null,"type":"id"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-on"}]"#)
+        let tx = makeTransaction()
+
+        #expect(applied(tx, rules: [rule],
+                        context: RuleContext(offBudgetAccountIds: ["acct-other"])).0.categoryId == "cat-on")
+        #expect(applied(tx, rules: [rule],
+                        context: RuleContext(offBudgetAccountIds: ["acct-1"])).0.categoryId == nil)
+    }
+
+    /// Upstream's live `Condition.eval` can never match `transfer` or `parent`:
+    /// the prepared transaction has no such keys, so it hits
+    /// `fieldValue === undefined` and returns false. Only the query path
+    /// (`conditionsToAQL`, mirrored by ConditionsFilter) maps them to columns.
+    @Test func transferConditionsNeverMatchInTheEngine() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"transfer","value":true,"type":"boolean"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-transfer"}]"#)
+        var tx = makeTransaction()
+        tx.transferId = "tx-2"
+
+        let (updated, _) = applied(tx, rules: [rule])
+        #expect(updated.categoryId == nil)
     }
 
     // MARK: - Actions
@@ -208,7 +479,7 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "X-Co", notes: "lunch")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.notes == "lunch [auto]")
     }
 
@@ -222,7 +493,7 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "X-Co", notes: "lunch")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.notes == "[auto] lunch")
     }
 
@@ -236,8 +507,55 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "X-Co", notes: nil)
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.notes == "auto")
+    }
+
+    /// `set payee_name` parks the name for the caller to resolve to an id
+    /// (creating the payee if it's new), matching upstream's
+    /// `resolvePayeeNameForRules`.
+    @Test func setPayeeNameReportsPendingPayee() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"imported_description","value":"woolies"}]"#,
+            actions: #"[{"op":"set","field":"payee_name","value":"Woolworths"}]"#)
+
+        let result = RulesEngine.apply(makeTransaction(importedPayee: "WOOLIES 123"), rules: [rule])
+
+        #expect(result.pendingPayeeName == "Woolworths")
+        #expect(result.transaction.payeeId == nil)
+    }
+
+    @Test func linkScheduleActionSetsSchedule() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"imported_description","value":"rent"}]"#,
+            actions: #"[{"op":"link-schedule","value":"sched-1"}]"#)
+
+        let (updated, changed) = applied(makeTransaction(importedPayee: "RENT JUNE"), rules: [rule])
+
+        #expect(updated.schedule == "sched-1")
+        #expect(changed.contains("schedule"))
+    }
+
+    @Test func deleteTransactionActionMarksResultDeleted() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"imported_description","value":"spam"}]"#,
+            actions: #"[{"op":"delete-transaction","value":null}]"#)
+
+        let result = RulesEngine.apply(makeTransaction(importedPayee: "SPAM CO"), rules: [rule])
+
+        #expect(result.isDeleted)
+        #expect(result.transaction.tombstone)
+    }
+
+    @Test func deleteTransactionLeavesNonMatchingTransactionsAlone() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"imported_description","value":"spam"}]"#,
+            actions: #"[{"op":"delete-transaction","value":null}]"#)
+
+        let result = RulesEngine.apply(makeTransaction(importedPayee: "Coffee Co"), rules: [rule])
+
+        #expect(!result.isDeleted)
+        #expect(!result.transaction.tombstone)
     }
 
     // MARK: - Amount conversion guards
@@ -252,7 +570,7 @@ struct RulesEngineTests {
             """
         )
         let tx = makeTransaction(importedPayee: "X-Co", amount: -500)
-        let (updated, changed) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, changed) = applied(tx, rules: [rule])
         #expect(updated.amount == 820)
         #expect(changed.contains("amount"))
     }
@@ -273,14 +591,15 @@ struct RulesEngineTests {
                 ]
             )
             let tx = makeTransaction(importedPayee: "X-Co", amount: -500)
-            // Must not trap; garbage values are dropped and the original
-            // amount is preserved.
-            let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+            // Must not trap; garbage values are dropped, the original amount
+            // survives, and no change is reported for a write that never landed.
+            let (updated, changed) = applied(tx, rules: [rule])
             #expect(updated.amount == -500)
+            #expect(!changed.contains("amount"))
         }
     }
 
-    // MARK: - Stage ordering
+    // MARK: - Ordering
 
     @Test func preStageRunsBeforeDefault() {
         // pre rule sets imported_payee → payee mapping
@@ -308,42 +627,127 @@ struct RulesEngineTests {
 
         let tx = makeTransaction(importedPayee: "Woolworths 3029")
         // Pass in default-then-pre order; engine must run pre first.
-        let (updated, _) = RulesEngine.apply(tx, rules: [def, pre])
+        let (updated, _) = applied(tx, rules: [def, pre])
         #expect(updated.payeeId == "payee-w")
         #expect(updated.categoryId == "cat-groceries")
     }
 
-    // MARK: - Unsupported ops
+    @Test func postStageRunsLast() {
+        let normal = parseRule(
+            id: "def-1",
+            conditions: #"[{"op":"contains","field":"imported_description","value":"coffee"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-normal"}]"#)
+        let post = parseRule(
+            id: "post-1",
+            stage: "post",
+            conditions: #"[{"op":"contains","field":"imported_description","value":"coffee"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-post"}]"#)
 
-    @Test func unsupportedActionDoesNotChangeFields() {
+        let tx = makeTransaction(importedPayee: "Coffee Co")
+        #expect(applied(tx, rules: [post, normal]).0.categoryId == "cat-post")
+    }
+
+    /// Within a stage, upstream ranks ascending by score so the most specific
+    /// rule applies last and wins — whatever order the rules arrive in.
+    @Test func moreSpecificRuleWinsRegardlessOfInputOrder() {
+        let broad = parseRule(
+            id: "r-b",
+            conditions: #"[{"op":"contains","field":"imported_description","value":"coffee"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-broad"}]"#)
+        let exact = parseRule(
+            id: "r-a",
+            conditions: #"[{"op":"is","field":"imported_description","value":"coffee co"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-exact"}]"#)
+
+        let tx = makeTransaction(importedPayee: "Coffee Co")
+
+        #expect(applied(tx, rules: [broad, exact]).0.categoryId == "cat-exact")
+        #expect(applied(tx, rules: [exact, broad]).0.categoryId == "cat-exact")
+    }
+
+    // MARK: - Unsupported and malformed rules
+
+    /// Splits aren't supported yet. The action is skipped, and skipping it must
+    /// not corrupt the parent transaction's amount.
+    @Test func splitActionsAreSkippedNotApplied() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"contains","field":"imported_description","value":"shop"}]
+            """,
+            actions: """
+            [{"op":"set-split-amount","value":500,"options":{"splitIndex":1,"method":"fixed-amount"}}]
+            """
+        )
+        let (updated, changed) = applied(makeTransaction(importedPayee: "SHOP CO", amount: -2000),
+                                        rules: [rule])
+
+        #expect(updated.amount == -2000)
+        #expect(changed.isEmpty)
+    }
+
+    /// A `set` carrying a Handlebars template or a formula is skipped whole —
+    /// neither engine exists on iOS, and a half-applied template would be worse
+    /// than no rule at all.
+    @Test func templateAndFormulaActionsAreSkipped() {
+        for options in [#"{"template":"{{payee}} auto"}"#, #"{"formula":"=amount*2"}"#] {
+            let rule = parseRule(
+                conditions: """
+                [{"op":"contains","field":"imported_description","value":"X"}]
+                """,
+                actions: """
+                [{"op":"set","field":"notes","value":"","options":\(options)}]
+                """
+            )
+            let (updated, changed) = applied(makeTransaction(importedPayee: "X-Co", notes: "keep"),
+                                             rules: [rule])
+            #expect(updated.notes == "keep")
+            #expect(changed.isEmpty)
+        }
+    }
+
+    @Test func unknownActionOpIsIgnored() {
         let rule = parseRule(
             conditions: """
             [{"op":"contains","field":"imported_description","value":"X"}]
             """,
             actions: """
-            [{"op":"link-schedule","value":"sched-1"}]
+            [{"op":"teleport-transaction","value":"elsewhere"}]
             """
         )
         let tx = makeTransaction(importedPayee: "X-Co", payeeId: "payee-original")
-        let (updated, changed) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, changed) = applied(tx, rules: [rule])
         #expect(updated.payeeId == "payee-original")
         #expect(changed.isEmpty)
     }
 
-    @Test func malformedRuleJSONIsIgnored() {
-        // RulesEngine should keep going if a rule has bad JSON — we test the
-        // engine's resilience to empty conditions arrays here. (BudgetDatabase
-        // filters out parse errors before they reach the engine.)
+    @Test func unknownConditionOpNeverMatches() {
+        let rule = parseRule(
+            conditions: """
+            [{"op":"soundsLike","field":"imported_description","value":"X"}]
+            """,
+            actions: """
+            [{"op":"set","field":"category","value":"cat-never"}]
+            """
+        )
+        let (updated, _) = applied(makeTransaction(importedPayee: "X-Co"), rules: [rule])
+        #expect(updated.categoryId == nil)
+    }
+
+    /// A rule with no conditions matches nothing — upstream's `evalConditions`
+    /// returns false for an empty list rather than treating it as "always".
+    @Test func ruleWithoutConditionsNeverFires() {
         let rule = Rule(
             id: "bad",
             stage: .default,
             conditionsOp: .and,
             conditions: [],
-            actions: []
+            actions: [
+                Rule.Action(op: "set", field: "category", value: .string("cat-x"), options: nil)
+            ]
         )
         let tx = makeTransaction(importedPayee: "X")
-        let (updated, changed) = RulesEngine.apply(tx, rules: [rule])
-        #expect(updated.importedPayee == "X")
+        let (updated, changed) = applied(tx, rules: [rule])
+        #expect(updated.categoryId == nil)
         #expect(changed.isEmpty)
     }
 
@@ -363,21 +767,21 @@ struct RulesEngineTests {
     @Test func hasTagsMatchesAllTagsCaseInsensitively() {
         let rule = tagRule(op: "hasTags", value: "#work #urgent")
         let tx = makeTransaction(notes: "errand #Work also #URGENT")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-tagged")
     }
 
     @Test func hasTagsDoesNotFireWhenATagIsMissing() {
         let rule = tagRule(op: "hasTags", value: "#work #urgent")
         let tx = makeTransaction(notes: "#work only")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == nil)
     }
 
     @Test func hasAnyTagFiresOnAnySingleMatch() {
         let rule = tagRule(op: "hasAnyTag", value: "#work #urgent")
         let tx = makeTransaction(notes: "#urgent errand")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == "cat-tagged")
     }
 
@@ -386,108 +790,14 @@ struct RulesEngineTests {
         // count as a word-boundary match for #work.
         let rule = tagRule(op: "hasAnyTag", value: "#work")
         let tx = makeTransaction(notes: "##work #workout")
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == nil)
     }
 
     @Test func hasAnyTagDoesNotFireWithoutNotes() {
         let rule = tagRule(op: "hasAnyTag", value: "#work")
         let tx = makeTransaction(notes: nil)
-        let (updated, _) = RulesEngine.apply(tx, rules: [rule])
+        let (updated, _) = applied(tx, rules: [rule])
         #expect(updated.categoryId == nil)
     }
-    
-    // MARK: - Ranking
-
-    /// Two matching rules: the less specific one (contains, score 0) applies
-    /// first and the exact match (is, score 20) overwrites it, whatever order
-    /// they come out of the database in.
-    @Test func moreSpecificRuleWinsRegardlessOfInputOrder() {
-        let broad = parseRule(
-            id: "r-b",
-            conditions: #"[{"op":"contains","field":"imported_description","value":"coffee"}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-broad"}]"#)
-        let exact = parseRule(
-            id: "r-a",
-            conditions: #"[{"op":"is","field":"imported_description","value":"coffee co"}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-exact"}]"#)
-
-        let tx = makeTransaction(importedPayee: "Coffee Co")
-
-        #expect(RulesEngine.apply(tx, rules: [broad, exact]).transaction.categoryId == "cat-exact")
-        #expect(RulesEngine.apply(tx, rules: [exact, broad]).transaction.categoryId == "cat-exact")
-    }
-
-    @Test func preStageRunsBeforeDefault() { /* pre sets payee, default keys off it */ }
-
-    // MARK: - Dates (regression: these never matched before)
-
-    @Test func exactDateConditionMatches() {
-        let rule = parseRule(
-            conditions: #"[{"op":"is","field":"date","value":"2026-05-03","type":"date"}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-day"}]"#)
-        #expect(RulesEngine.apply(makeTransaction(), rules: [rule]).transaction.categoryId == "cat-day")
-    }
-
-    @Test func monthDateConditionMatches() { /* value "2026-05" */ }
-    @Test func approxDateMatchesWithinTwoDays() { /* "2026-05-05" matches 20260503 */ }
-    @Test func approxDateMissesOutsideTwoDays() { /* "2026-05-07" doesn't */ }
-    @Test func dateComparisonOps() { /* gt/gte/lt/lte */ }
-
-    // MARK: - isapprox rounding
-
-    /// getApproxNumberThreshold rounds (100 * 0.075 = 7.5 -> 8); flooring to 7
-    /// made -1092 miss a rule the web app applies.
-    @Test func approxAmountUsesRoundedThreshold() {
-        let rule = parseRule(
-            conditions: #"[{"op":"isapprox","field":"amount","value":-1000}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-approx"}]"#)
-        let tx = makeTransaction(amount: -1075)
-        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == "cat-approx")
-    }
-
-    // MARK: - New fields and ops
-
-    @Test func categoryGroupConditionUsesContext() { /* RuleContext.categoryGroupIds */ }
-    @Test func payeeNameConditionUsesContext() { /* RuleContext.payeeNames */ }
-    @Test func offBudgetConditionMatchesOffBudgetAccount() { /* RuleContext.offBudgetAccountIds */ }
-    @Test func emptyNotesMatchesIsEmptyString() { /* notes nil, `is ""` -> true */ }
-
-    // MARK: - New actions
-
-    @Test func setPayeeNameReportsPendingPayee() {
-        let rule = parseRule(
-            conditions: #"[{"op":"contains","field":"imported_description","value":"woolies"}]"#,
-            actions: #"[{"op":"set","field":"payee_name","value":"Woolworths"}]"#)
-        let result = RulesEngine.apply(makeTransaction(importedPayee: "WOOLIES 123"), rules: [rule])
-        #expect(result.pendingPayeeName == "Woolworths")
-        #expect(result.transaction.payeeId == nil)
-    }
-
-    /// Upstream's live path can't see `transfer`/`parent` — only its query path
-    /// maps them — so a filter-derived rule using them must not fire here
-    /// either, however tempting it is to make it work.
-    @Test func transferConditionsNeverMatchInTheEngine() {
-        let rule = parseRule(
-            conditions: #"[{"op":"is","field":"transfer","value":true,"type":"boolean"}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-transfer"}]"#)
-        var tx = makeTransaction()
-        tx.transferId = "tx-2"
-        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == nil)
-    }
-
-    /// Upstream lowercases the pattern, so `\D` runs as `\d`. A rule written on
-    /// the web has to behave the same here, quirk included.
-    @Test func matchesLowercasesThePatternLikeUpstream() {
-        let rule = parseRule(
-            conditions: #"[{"op":"matches","field":"notes","value":"\\D+"}]"#,
-            actions: #"[{"op":"set","field":"category","value":"cat-digits"}]"#)
-        // "1234" has no non-digits, but \D lowercases to \d and matches.
-        let tx = makeTransaction(notes: "1234")
-        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == "cat-digits")
-    }
-
-    @Test func deleteTransactionActionMarksResultDeleted() { /* result.isDeleted */ }
-    @Test func linkScheduleActionSetsSchedule() { /* transaction.schedule */ }
-    @Test func splitActionsAreSkippedNotApplied() { /* set-split-amount leaves the tx alone */ }
 }

--- a/Actuali/ActualiTests/RulesEngineTests.swift
+++ b/Actuali/ActualiTests/RulesEngineTests.swift
@@ -264,10 +264,12 @@ struct RulesEngineTests {
                 stage: .default,
                 conditionsOp: .and,
                 conditions: [
-                    Rule.Condition(op: "contains", field: "imported_payee", value: "X", options: nil)
+                    Rule.Condition(op: "contains", field: "imported_payee",
+                                   value: .string("X"), options: nil)
                 ],
                 actions: [
-                    Rule.Action(op: "set", field: "amount", value: bad, options: nil)
+                    Rule.Action(op: "set", field: "amount",
+                                value: .number(bad), options: nil)
                 ]
             )
             let tx = makeTransaction(importedPayee: "X-Co", amount: -500)

--- a/Actuali/ActualiTests/RulesEngineTests.swift
+++ b/Actuali/ActualiTests/RulesEngineTests.swift
@@ -396,4 +396,98 @@ struct RulesEngineTests {
         let (updated, _) = RulesEngine.apply(tx, rules: [rule])
         #expect(updated.categoryId == nil)
     }
+    
+    // MARK: - Ranking
+
+    /// Two matching rules: the less specific one (contains, score 0) applies
+    /// first and the exact match (is, score 20) overwrites it, whatever order
+    /// they come out of the database in.
+    @Test func moreSpecificRuleWinsRegardlessOfInputOrder() {
+        let broad = parseRule(
+            id: "r-b",
+            conditions: #"[{"op":"contains","field":"imported_description","value":"coffee"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-broad"}]"#)
+        let exact = parseRule(
+            id: "r-a",
+            conditions: #"[{"op":"is","field":"imported_description","value":"coffee co"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-exact"}]"#)
+
+        let tx = makeTransaction(importedPayee: "Coffee Co")
+
+        #expect(RulesEngine.apply(tx, rules: [broad, exact]).transaction.categoryId == "cat-exact")
+        #expect(RulesEngine.apply(tx, rules: [exact, broad]).transaction.categoryId == "cat-exact")
+    }
+
+    @Test func preStageRunsBeforeDefault() { /* pre sets payee, default keys off it */ }
+
+    // MARK: - Dates (regression: these never matched before)
+
+    @Test func exactDateConditionMatches() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"date","value":"2026-05-03","type":"date"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-day"}]"#)
+        #expect(RulesEngine.apply(makeTransaction(), rules: [rule]).transaction.categoryId == "cat-day")
+    }
+
+    @Test func monthDateConditionMatches() { /* value "2026-05" */ }
+    @Test func approxDateMatchesWithinTwoDays() { /* "2026-05-05" matches 20260503 */ }
+    @Test func approxDateMissesOutsideTwoDays() { /* "2026-05-07" doesn't */ }
+    @Test func dateComparisonOps() { /* gt/gte/lt/lte */ }
+
+    // MARK: - isapprox rounding
+
+    /// getApproxNumberThreshold rounds (100 * 0.075 = 7.5 -> 8); flooring to 7
+    /// made -1092 miss a rule the web app applies.
+    @Test func approxAmountUsesRoundedThreshold() {
+        let rule = parseRule(
+            conditions: #"[{"op":"isapprox","field":"amount","value":-1000}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-approx"}]"#)
+        let tx = makeTransaction(amount: -1075)
+        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == "cat-approx")
+    }
+
+    // MARK: - New fields and ops
+
+    @Test func categoryGroupConditionUsesContext() { /* RuleContext.categoryGroupIds */ }
+    @Test func payeeNameConditionUsesContext() { /* RuleContext.payeeNames */ }
+    @Test func offBudgetConditionMatchesOffBudgetAccount() { /* RuleContext.offBudgetAccountIds */ }
+    @Test func emptyNotesMatchesIsEmptyString() { /* notes nil, `is ""` -> true */ }
+
+    // MARK: - New actions
+
+    @Test func setPayeeNameReportsPendingPayee() {
+        let rule = parseRule(
+            conditions: #"[{"op":"contains","field":"imported_description","value":"woolies"}]"#,
+            actions: #"[{"op":"set","field":"payee_name","value":"Woolworths"}]"#)
+        let result = RulesEngine.apply(makeTransaction(importedPayee: "WOOLIES 123"), rules: [rule])
+        #expect(result.pendingPayeeName == "Woolworths")
+        #expect(result.transaction.payeeId == nil)
+    }
+
+    /// Upstream's live path can't see `transfer`/`parent` — only its query path
+    /// maps them — so a filter-derived rule using them must not fire here
+    /// either, however tempting it is to make it work.
+    @Test func transferConditionsNeverMatchInTheEngine() {
+        let rule = parseRule(
+            conditions: #"[{"op":"is","field":"transfer","value":true,"type":"boolean"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-transfer"}]"#)
+        var tx = makeTransaction()
+        tx.transferId = "tx-2"
+        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == nil)
+    }
+
+    /// Upstream lowercases the pattern, so `\D` runs as `\d`. A rule written on
+    /// the web has to behave the same here, quirk included.
+    @Test func matchesLowercasesThePatternLikeUpstream() {
+        let rule = parseRule(
+            conditions: #"[{"op":"matches","field":"notes","value":"\\D+"}]"#,
+            actions: #"[{"op":"set","field":"category","value":"cat-digits"}]"#)
+        // "1234" has no non-digits, but \D lowercases to \d and matches.
+        let tx = makeTransaction(notes: "1234")
+        #expect(RulesEngine.apply(tx, rules: [rule]).transaction.categoryId == "cat-digits")
+    }
+
+    @Test func deleteTransactionActionMarksResultDeleted() { /* result.isDeleted */ }
+    @Test func linkScheduleActionSetsSchedule() { /* transaction.schedule */ }
+    @Test func splitActionsAreSkippedNotApplied() { /* set-split-amount leaves the tx alone */ }
 }


### PR DESCRIPTION
## Why

Closes #222. Actuali already evaluated rules when a transaction was created, but there was no way to see or change them from the app and the evaluation had real gaps: rules weren't ranked, so with two matching rules whichever SQLite returned last won instead of the most specific one, and date conditions never matched at all (the bag holds `date` as a `YYYYMMDD` int, rule values are `"2026-05-03"` strings).

## What

- **Rules screen** under Settings → Rules: list every rule with its stage and an IF/THEN summary, search across that summary, and add, edit or delete. Rules a schedule owns are badged and can't be deleted, matching upstream's `deleteRule`, which refuses rather than orphaning the schedule.
- **Rules are written back through CRDT sync**  one message per column of the `rules` row, applied locally through the same LWW upsert incoming messages use, so a rule created on the phone shows up in the web app and vice versa. Conditions and actions serialize with Actual's *internal* column names (`description`, `acct`, `imported_description`) and carry the same `type` field upstream writes.
- **Engine parity fixes**  each one changed behaviour that was previously wrong:
  - rule ranking (`rankRules`): stage order, then ascending score within a stage, tie-broken on id
  - date conditions work at all now, including `is` on a month/year and `isapprox`'s ±2 day window
  - `isapprox` on amounts rounds its threshold instead of flooring (`getApproxNumberThreshold`)
  - `matches` lowercases both the pattern and the field value, like upstream's parse + eval
  - new fields and ops: `payee_name`, `category_group`, `onBudget`/`offBudget`
  - new actions: `set payee_name` (resolving to a payee id, creating one if new), `delete-transaction`, `link-schedule`
- `Rule` gained a typed value model (`RuleValue`) so conditions round-trip to JSON exactly, and the date
  matching shared with report filters moved into `RuleDateMatcher`  using a fixed UTC calendar, so a
  ±2 day window isn't 25 hours long across a DST boundary.

Upstream references for the sync-engine parts, so the behaviour can be checked:
`packages/loot-core/src/server/rules/{condition,action,rule,rule-utils}.ts`,
`server/transactions/transaction-rules.ts` (`ruleModel`, `insertRule`, `deleteRule`, `runRules`),
`shared/rules.ts` for the field/op table, and migrations `1597756566448_rules.sql` /
`1679728867040_rules_conditions.sql` for the row shape.

Deferred on purpose, and noted rather than half-done: `set-split-amount` (split rules), Handlebars templates and formula actions, recurring-date conditions, and re-running rules on register edits. Rules using them load and save fine; the unsupported action is skipped and logged.

## How it was tested

- `xcodebuild build` and the full unit suite on the iOS simulator, `-skip-testing:ActualiUITests`, same as CI.
- Rules engine coverage went from 18 tests to 47, plus new suites for ranking, the database layer, rule validation and the summary text. Adding them found a live bug: `matches` was lowercasing the pattern but not the field value, so `^STARBUCKS` never matched `Starbucks #1234`.
- Round-tripped a rule against a real server: created it on device, synced, confirmed the web app renders it with the same field, operator and value, edited it there, synced back.
- Imported Wallet transactions with a rename rule live to check rules still apply on import.

## Screenshots

<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 16 44 PM" src="https://github.com/user-attachments/assets/1cfd0553-3bc8-45b4-b083-3f28b9f20a8c" />
<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 16 50 PM" src="https://github.com/user-attachments/assets/dadd0fdf-1560-4e2c-a1f7-7d45896d008c" />
<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 16 58 PM" src="https://github.com/user-attachments/assets/5441701f-905a-49b8-93f9-4584e5e9f15a" />
<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 17 13 PM" src="https://github.com/user-attachments/assets/af33495c-fa9a-420b-8da3-1e8e25b9a17c" />
<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 17 30 PM" src="https://github.com/user-attachments/assets/77c72b90-197c-4e49-8c10-0bd1b280158f" />
<img width="301" height="655" alt="Screenshot iPhone 17 Pro 08-14-2026 at 8 17 36 PM" src="https://github.com/user-attachments/assets/cfa7e46b-4700-43ee-aba6-5cb34a83175f" />
