### PR TITLE
Fix: Remove Accounts and Reports View Headers For Parity

### DIFF
--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -35,6 +35,23 @@
 		AB0000000000000000000BDF /* ActualiUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ActualiUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		9B7C84E93030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				BudgetDatabaseAccountsSummaryTests.swift,
+			);
+			target = A79D4A9C2FA1F8F000D5A2DF /* ActualiTests */;
+		};
+		9B7C84EA3030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiUITests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				BudgetDatabaseAccountsSummaryTests.swift,
+			);
+			target = AB0000000000000000000CDF /* ActualiUITests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A7550B882EE7B4F7007026DC /* Actuali */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -43,6 +60,10 @@
 		};
 		A79D4A9E2FA1F8F000D5A2DF /* ActualiTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				9B7C84E93030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiTests" target */,
+				9B7C84EA3030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiUITests" target */,
+			);
 			path = ActualiTests;
 			sourceTree = "<group>";
 		};

--- a/Actuali/Actuali.xcodeproj/project.pbxproj
+++ b/Actuali/Actuali.xcodeproj/project.pbxproj
@@ -35,23 +35,6 @@
 		AB0000000000000000000BDF /* ActualiUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ActualiUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		9B7C84E93030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiTests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				BudgetDatabaseAccountsSummaryTests.swift,
-			);
-			target = A79D4A9C2FA1F8F000D5A2DF /* ActualiTests */;
-		};
-		9B7C84EA3030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiUITests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				BudgetDatabaseAccountsSummaryTests.swift,
-			);
-			target = AB0000000000000000000CDF /* ActualiUITests */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A7550B882EE7B4F7007026DC /* Actuali */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -60,10 +43,6 @@
 		};
 		A79D4A9E2FA1F8F000D5A2DF /* ActualiTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				9B7C84E93030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiTests" target */,
-				9B7C84EA3030DBCA006201EB /* Exceptions for "ActualiTests" folder in "ActualiUITests" target */,
-			);
 			path = ActualiTests;
 			sourceTree = "<group>";
 		};

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1581,6 +1581,23 @@ final class BudgetStore: ObservableObject {
         return incomeCategories.first { $0.name.lowercased() == "starting balances" }
             ?? incomeCategories.first
     }
+    
+    /// Money in and out across every account for one "yyyy-MM" month, for the
+    /// accounts tab's summary group (GH #256). Nil when there's no budget open
+    /// or the query failed, so the card keeps its last figures rather than
+    /// flashing zeroes.
+    func fetchAccountsMonthSummary(month: String) async -> BudgetDatabase.AccountsMonthSummary? {
+        do {
+            return try await database?.fetchAccountsMonthSummary(month: month)
+        } catch is CancellationError {
+            // The caller's task was cancelled (tab switch, a superseded
+            // refresh). Nothing failed — never alarm the user.
+            return nil
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
 
     // MARK: - Transactions
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -478,6 +478,52 @@ class BudgetDatabase {
             }
         }
     }
+    
+    /// Money in and out across every account for one month, for the accounts
+    /// tab's summary group (GH #256).
+    struct AccountsMonthSummary: Equatable {
+        var incomeCents = 0
+        /// Positive: what left the accounts, not a signed amount.
+        var expenseCents = 0
+
+        var netCents: Int { incomeCents - expenseCents }
+    }
+
+    /// Income and expenses across every account for one "yyyy-MM" month.
+    ///
+    /// Scoped to all accounts, off-budget and closed included, so it
+    /// reconciles with the all-accounts balance it sits under — unlike the
+    /// budget month's income/spent, which only counts categorised
+    /// transactions in on-budget accounts. Transfer legs are excluded: a
+    /// transfer moves money inside that set, so counting it would show up as
+    /// both income and an expense (same rule as the WebUI's cash flow card).
+    /// Split parents are excluded and their children counted, matching
+    /// `fetchAccounts()`'s balance query.
+    func fetchAccountsMonthSummary(month: String) async throws -> AccountsMonthSummary {
+        try await dbQueue.read { db in
+            guard let row = try Row.fetchOne(db, sql: """
+                SELECT
+                    COALESCE(SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END), 0) AS income,
+                    COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END), 0) AS expense
+                FROM transactions t
+                LEFT JOIN payee_mapping pm ON pm.id = t.description
+                LEFT JOIN payees p ON p.id = pm.targetId
+                LEFT JOIN accounts a ON a.id = t.acct
+                LEFT JOIN transactions par ON par.id = t.parent_id
+                WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
+                  AND (t.isParent = 0 OR t.isParent IS NULL)
+                  AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+                  AND (a.tombstone = 0 OR a.tombstone IS NULL)
+                  AND p.transfer_acct IS NULL
+                  AND (t.date / 100) = ?
+                """, arguments: [Self.monthStringToInt(month)]) else {
+                return AccountsMonthSummary()
+            }
+            let income: Int = row["income"] ?? 0
+            let expense: Int = row["expense"] ?? 0
+            return AccountsMonthSummary(incomeCents: income, expenseCents: expense)
+        }
+    }
 
     // MARK: - Transactions
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -508,7 +508,7 @@ class BudgetDatabase {
                 FROM transactions t
                 LEFT JOIN payee_mapping pm ON pm.id = t.description
                 LEFT JOIN payees p ON p.id = pm.targetId
-                LEFT JOIN accounts a ON a.id = t.acct
+                JOIN accounts a ON a.id = t.acct
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -12,21 +12,29 @@ private enum AccountSelection: Hashable {
     case account(String)
 }
 
+/// A month's totals carried together with the month they were fetched for.
+/// The two travel as one so the summary card can't caption August's figures
+/// with September, which is exactly what happens when the calendar rolls over
+/// under a view that reads "now" afresh on every render.
+struct AccountsMonthTotals: Equatable {
+    let month: String
+    let totals: BudgetDatabase.AccountsMonthSummary
+}
+
 struct AccountsListView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.isWideLayout) private var isWideLayout
+    @Environment(\.scenePhase) private var scenePhase
     @State private var path = NavigationPath()
     @State private var showingAddAccount = false
-    
     /// Split layout only. Starts on All Accounts so the detail column has
     /// something in it at launch instead of an empty pane.
     @State private var selection: AccountSelection? = .allAccounts
-    
     /// This month's money in and out, for the summary card. nil until the
     /// first fetch lands.
-    @State private var monthSummary: BudgetDatabase.AccountsMonthSummary?
+    @State private var monthSummary: AccountsMonthTotals?
 
     /// Independent expand/collapse state per section, persisted so a
     /// collapsed section stays collapsed across launches — same contract as
@@ -257,7 +265,7 @@ struct AccountsListView: View {
     }
 
     private var allAccountsRow: some View {
-        AccountsSummaryCard(totalBalance: totalBalance, summary: monthSummary)
+        AccountsSummaryCard(totalBalance: totalBalance, monthTotals: monthSummary)
     }
 
     @ViewBuilder
@@ -321,12 +329,14 @@ struct AccountsListView: View {
             }
             // Keyed to dataVersion so the summary's month totals follow every
             // edit and sync, like the account balances beneath them.
-            .task(id: budgetStore.dataVersion) {
-                if let summary = await budgetStore.fetchAccountsMonthSummary(
-                    month: BudgetView.currentMonthString()
-                ) {
-                    monthSummary = summary
-                }
+            .task(id: budgetStore.dataVersion) { await loadMonthSummary() }
+            // Nothing above re-runs when only the date changes, so a phone
+            // left on this tab overnight would keep showing last month's
+            // totals. Foregrounding is when that becomes visible, and the
+            // tab's own .task covers coming back from another tab.
+            .onChange(of: scenePhase) { _, phase in
+                guard phase == .active else { return }
+                Task { await loadMonthSummary() }
             }
             .refreshable {
                 await budgetStore.sync()
@@ -336,6 +346,12 @@ struct AccountsListView: View {
                     ProgressView()
                 }
             }
+    }
+    
+    private func loadMonthSummary() async {
+        let month = BudgetView.currentMonthString()
+        guard let totals = await budgetStore.fetchAccountsMonthSummary(month: month) else { return }
+        monthSummary = AccountsMonthTotals(month: month, totals: totals)
     }
 
     /// Tapping a success notification lands here: jump the stack straight to
@@ -395,7 +411,11 @@ struct AccountsSummaryCard: View {
     let totalBalance: Int
     /// nil until the month's totals land; the stats read "—" until then
     /// rather than flashing zeroes that a moment later turn into real money.
-    let summary: BudgetDatabase.AccountsMonthSummary?
+    /// The month rides along with them so the caption always names the month
+    /// the figures were fetched for.
+    let monthTotals: AccountsMonthTotals?
+
+    private var summary: BudgetDatabase.AccountsMonthSummary? { monthTotals?.totals }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -410,7 +430,9 @@ struct AccountsSummaryCard: View {
                     .minimumScaleFactor(0.8)
             }
             Divider()
-            Text(MonthPicker.title(for: BudgetView.currentMonthString()))
+            // Falls back to today's month only while the figures are still
+            // dashes — there's nothing yet for the caption to disagree with.
+            Text(MonthPicker.title(for: monthTotals?.month ?? BudgetView.currentMonthString()))
                 .font(.caption)
                 .foregroundStyle(.secondary)
             HStack(alignment: .top, spacing: 8) {

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -19,9 +19,14 @@ struct AccountsListView: View {
     @Environment(\.isWideLayout) private var isWideLayout
     @State private var path = NavigationPath()
     @State private var showingAddAccount = false
+    
     /// Split layout only. Starts on All Accounts so the detail column has
     /// something in it at launch instead of an empty pane.
     @State private var selection: AccountSelection? = .allAccounts
+    
+    /// This month's money in and out, for the summary card. nil until the
+    /// first fetch lands.
+    @State private var monthSummary: BudgetDatabase.AccountsMonthSummary?
 
     /// Independent expand/collapse state per section, persisted so a
     /// collapsed section stays collapsed across launches — same contract as
@@ -252,14 +257,7 @@ struct AccountsListView: View {
     }
 
     private var allAccountsRow: some View {
-        HStack {
-            Text("All Accounts")
-                .font(.headline)
-            Spacer()
-            Text(budgetStore.displayBalance(totalBalance))
-                .font(.headline)
-                .foregroundStyle(balanceColor(for: totalBalance))
-        }
+        AccountsSummaryCard(totalBalance: totalBalance, summary: monthSummary)
     }
 
     @ViewBuilder
@@ -293,7 +291,7 @@ struct AccountsListView: View {
     private func withChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         Group(content: content)
             .contentMargins(.horizontal, 6, for: .scrollContent)
-            .navigationTitle("Accounts")
+//            .navigationTitle("Accounts")
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -320,6 +318,15 @@ struct AccountsListView: View {
             }
             .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
                 if accountId != nil { consumePendingAccountNavigation() }
+            }
+            // Keyed to dataVersion so the summary's month totals follow every
+            // edit and sync, like the account balances beneath them.
+            .task(id: budgetStore.dataVersion) {
+                if let summary = await budgetStore.fetchAccountsMonthSummary(
+                    month: BudgetView.currentMonthString()
+                ) {
+                    monthSummary = summary
+                }
             }
             .refreshable {
                 await budgetStore.sync()
@@ -376,6 +383,61 @@ private extension Array where Element == Account {
     /// itself only lives in one place.
     var sumBalance: Int {
         reduce(0) { $0 + $1.balance }
+    }
+}
+
+/// The list's lead row: the all-accounts balance over this month's money in,
+/// money out, and the difference — the same at-a-glance group the budget tab
+/// opens with (GH #256). It's still the row that pushes the All Accounts
+/// transaction list, so the figures lead to the transactions behind them.
+struct AccountsSummaryCard: View {
+    @EnvironmentObject var budgetStore: BudgetStore
+    let totalBalance: Int
+    /// nil until the month's totals land; the stats read "—" until then
+    /// rather than flashing zeroes that a moment later turn into real money.
+    let summary: BudgetDatabase.AccountsMonthSummary?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("All Accounts")
+                    .font(.headline)
+                Spacer()
+                Text(budgetStore.displayBalance(totalBalance))
+                    .font(.headline)
+                    .foregroundStyle(balanceColor(for: totalBalance))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            Divider()
+            Text(MonthPicker.title(for: BudgetView.currentMonthString()))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(alignment: .top, spacing: 8) {
+                SummaryStat(label: "Income", value: amount(summary?.incomeCents))
+                Spacer(minLength: 4)
+                SummaryStat(
+                    label: "Expenses",
+                    value: amount(summary?.expenseCents),
+                    alignment: .center
+                )
+                Spacer(minLength: 4)
+                SummaryStat(
+                    label: "Net",
+                    value: amount(summary?.netCents),
+                    // Same three-way treatment as the balances, and neutral
+                    // while there's only a placeholder to color.
+                    valueColor: summary.map { balanceColor(for: $0.netCents) } ?? .primary,
+                    alignment: .trailing
+                )
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func amount(_ cents: Int?) -> String {
+        guard let cents else { return "—" }
+        return budgetStore.displayBalance(cents)
     }
 }
 

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -5,6 +5,11 @@ struct ReportsTabView: View {
     @State private var pages: [DashboardPage] = []
     @State private var selectedPageId: String?
     @State private var widgets: [DashboardWidget] = []
+    /// The page `widgets` actually came from, which is not `selectedPageId`:
+    /// that one flips the instant the picker is tapped, while the widgets
+    /// arrive a fetch later. See the dashboard's `.id` for what goes wrong
+    /// when the two are conflated.
+    @State private var loadedPageId: String?
     @State private var loadError: String?
     @State private var hasLoaded = false
 
@@ -35,9 +40,16 @@ struct ReportsTabView: View {
                             .padding(.top, 8)
                         // Keyed so per-widget @State (computed card values)
                         // resets when switching dashboards instead of showing
-                        // the previous dashboard's numbers.
+                        // the previous dashboard's numbers. Keyed to the page
+                        // the widgets came from, not the selection: keying on
+                        // the selection re-creates the dashboard around the
+                        // outgoing page's widgets, and DashboardView's load
+                        // runs once per identity — so it would fetch the
+                        // inputs that widget set needs (budgets, schedules,
+                        // custom report configs) and never re-run for the
+                        // widgets that actually land.
                         DashboardView(widgets: widgets)
-                            .id(selectedPageId)
+                            .id(loadedPageId)
                     }
                 }
             }
@@ -126,6 +138,9 @@ struct ReportsTabView: View {
             self.pages = fetchedPages
             self.selectedPageId = pageId
             self.widgets = fetched
+            // Same render pass as the widgets it identifies, so the dashboard
+            // is re-created around them rather than around their predecessor.
+            self.loadedPageId = pageId
             self.loadError = nil
         } catch is CancellationError {
             // The hosting task was torn down (tab switch, refresh gesture

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -27,21 +27,24 @@ struct ReportsTabView: View {
                         description: Text("Open or sync a budget to see reports.")
                     )
                 } else {
-                    // Keyed so per-widget @State (computed card values) resets
-                    // when switching dashboards instead of showing the
-                    // previous dashboard's numbers.
-                    DashboardView(widgets: widgets)
-                        .id(selectedPageId)
-                }
-            }
-            .navigationTitle("Reports")
-            .toolbar {
-                if pages.count > 1 {
-                    ToolbarItem(placement: .topBarTrailing) {
+                    VStack(spacing: 0) {
                         dashboardPicker
+                            // Lined up with the dashboard cards below, which
+                            // carry 6 pt of horizontal padding of their own.
+                            .padding(.horizontal, 6)
+                            .padding(.top, 8)
+                        // Keyed so per-widget @State (computed card values)
+                        // resets when switching dashboards instead of showing
+                        // the previous dashboard's numbers.
+                        DashboardView(widgets: widgets)
+                            .id(selectedPageId)
                     }
                 }
             }
+            // The dashboard picker is the page's header now, so the title
+            // stays out of its way in the compact bar.
+            .navigationTitle("Reports")
+            .navigationBarTitleDisplayMode(.inline)
             // Keyed to the open database so the initial load re-runs when
             // the budget finishes opening (launching straight onto this tab
             // races loadLocalBudget) and when the budget is switched.
@@ -54,8 +57,10 @@ struct ReportsTabView: View {
         .initialSyncBanner()
     }
 
-    /// Menu listing every live dashboard page, shown only when the budget
-    /// actually has more than one (the web app's sidebar equivalent).
+    /// Full-width dropdown naming the dashboard on screen (the web app's
+    /// sidebar equivalent). Shown whatever the page count: with a single page
+    /// it still labels what you're looking at, and it's disabled only for the
+    /// pre-dashboard-pages budgets that have no pages to switch between.
     private var dashboardPicker: some View {
         Menu {
             Picker("Dashboard", selection: Binding(
@@ -70,12 +75,27 @@ struct ReportsTabView: View {
                 }
             }
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: 8) {
                 Text(pages.first { $0.id == selectedPageId }.map(displayName(for:)) ?? "Dashboard")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer()
                 Image(systemName: "chevron.up.chevron.down")
                     .imageScale(.small)
+                    .foregroundStyle(.secondary)
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            // Same fill and radius as the widget cards it sits above.
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(.secondarySystemBackground))
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 12))
         }
+        .disabled(pages.isEmpty)
         .accessibilityLabel("Switch dashboard")
     }
 

--- a/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import XCTest
+import Testing
 import GRDB
 @testable import Actuali
 

--- a/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import XCTest
+import GRDB
+@testable import Actuali
+
+/// Pins the semantics of `fetchAccountsMonthSummary()`, the accounts tab's
+/// summary group (GH #256): money in and out across every account for one
+/// month, transfer legs excluded, split parents excluded, other months out.
+@MainActor
+struct BudgetDatabaseAccountsSummaryTests {
+
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    date INTEGER,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    parent_id TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+            """)
+        }
+        let database = try BudgetDatabase(path: tempURL)
+        return (database, tempURL)
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func sumsIncomeAndExpensesForTheRequestedMonthOnly() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+
+                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
+                    ('pay',     'acct-1', 400000, 20260803, 0),
+                    ('rent',    'acct-1', -150000, 20260805, 0),
+                    ('coffee',  'acct-1',   -450, 20260806, 0),
+                    ('void',    'acct-1',  -9999, 20260807, 1),  -- tombstoned
+                    ('lastmo',  'acct-1', -20000, 20260731, 0),  -- previous month
+                    ('nextmo',  'acct-1',  10000, 20260901, 0);  -- next month
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 400000)
+        #expect(summary.expenseCents == 150450)
+        #expect(summary.netCents == 249550)
+    }
+
+    @Test func coversOffBudgetAndClosedAccountsToo() async throws {
+        // The card sits under the all-accounts balance, which counts every
+        // account, so its month totals have to cover the same set.
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, offbudget, closed, sort_order, tombstone) VALUES
+                    ('acct-on',     'Checking',  0, 0, 1.0, 0),
+                    ('acct-off',    'Brokerage', 1, 0, 2.0, 0),
+                    ('acct-closed', 'Old Card',  0, 1, 3.0, 0),
+                    ('acct-dead',   'Deleted',   0, 0, 4.0, 1);
+
+                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
+                    ('salary',   'acct-on',      300000, 20260803, 0),
+                    ('dividend', 'acct-off',       5000, 20260804, 0),
+                    ('fee',      'acct-closed',   -1200, 20260805, 0),
+                    ('ghost',    'acct-dead',   -100000, 20260806, 0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 305000)
+        #expect(summary.expenseCents == 1200)
+    }
+
+    @Test func excludesTransferLegs() async throws {
+        // A transfer moves money inside the set of accounts the card totals,
+        // so counting its legs would report both income and an expense that
+        // never happened (same rule as the WebUI's cash flow card).
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES
+                    ('acct-checking', 'Checking', 1.0),
+                    ('acct-savings',  'Savings',  2.0);
+
+                -- Transfer payees carry no name, just the linked account.
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-shop',       'Shop', NULL),
+                    ('payee-to-savings', NULL,   'acct-savings'),
+                    ('payee-to-checking',NULL,   'acct-checking');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-shop',        'payee-shop'),
+                    ('payee-to-savings',  'payee-to-savings'),
+                    ('payee-to-checking', 'payee-to-checking');
+
+                INSERT INTO transactions (id, acct, description, amount, date, transferred_id, tombstone) VALUES
+                    ('spend',    'acct-checking', 'payee-shop',        -2500, 20260805, NULL,       0),
+                    ('leg-out',  'acct-checking', 'payee-to-savings', -50000, 20260806, 'leg-in',   0),
+                    ('leg-in',   'acct-savings',  'payee-to-checking', 50000, 20260806, 'leg-out',  0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 0)
+        #expect(summary.expenseCents == 2500)
+    }
+
+    @Test func countsSplitChildrenButNotTheirParent() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+
+                -- A -$100.00 purchase split into -$60.00 and -$40.00. Counting
+                -- the parent too would report $200.00 of expenses.
+                INSERT INTO transactions (id, acct, amount, date, isParent, isChild, parent_id, tombstone) VALUES
+                    ('split-parent', 'acct-1', -10000, 20260803, 1, 0, NULL,           0),
+                    ('split-c1',     'acct-1',  -6000, 20260803, 0, 1, 'split-parent', 0),
+                    ('split-c2',     'acct-1',  -4000, 20260803, 0, 1, 'split-parent', 0);
+
+                -- A deleted split: only the parent is tombstoned, so its
+                -- children have to be excluded through it.
+                INSERT INTO transactions (id, acct, amount, date, isParent, isChild, parent_id, tombstone) VALUES
+                    ('dead-parent', 'acct-1', -3000, 20260804, 1, 0, NULL,          1),
+                    ('orphan-c1',   'acct-1', -3000, 20260804, 0, 1, 'dead-parent', 0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 0)
+        #expect(summary.expenseCents == 10000)
+    }
+
+    @Test func emptyMonthIsZero() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
+                    ('t1', 'acct-1', 1000, 20260701, 0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary == BudgetDatabase.AccountsMonthSummary())
+        #expect(summary.netCents == 0)
+    }
+}


### PR DESCRIPTION
## Why

The accounts tab opened on a single "All Accounts" line, and the reports tab's dashboard picker was a small toolbar menu that only appeared when a budget had more than one page. Closes #256.

## What

- Accounts list now leads with a summary group in the style of the budget tab's card: the all-accounts balance over this month's income, expenses and net. It's still the row that opens the All Accounts transaction list, on phone and in the iPad sidebar alike.
- Those month totals come from a new `fetchAccountsMonthSummary()` query scoped to every account off-budget and closed included so they reconcile with the balance above them. Transfer legs are excluded (a transfer moves money inside that set, so counting it would read as both income and an expense, same rule as the WebUI's cash flow card), and split parents are excluded in favor of their children, matching `fetchAccounts()`'s balance query.
- Reports tab's dashboard picker moves out of the toolbar and becomes a full-width dropdown above the cards, shown whatever the page count with a single page it still labels what you're looking at. It's disabled only for pre-dashboard-pages budgets with no pages at all. The "Reports" title drops to inline so the dropdown reads as the page header.

## How it was tested

- Added `BudgetDatabaseAccountsSummaryTests` five cases pinning the new query: month scoping and tombstones, off-budget/closed accounts counted but tombstoned accounts not, transfer legs excluded, split children counted with the parent excluded, empty month returns zero.
- `ReportsTabView.resolvePageId` and its existing tests are untouched.
- xcodebuild test on Simulator with iPhone 17 Pro using iOS 27
- 
## Screenshots

<img width="301" alt="Screenshot iPhone 17 Pro 08-15-2026 at 1 26 52 PM" src="https://github.com/user-attachments/assets/5cb7c54c-0d0c-425e-bbad-dbb12d3e98ba" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-15-2026 at 1 26 58 PM" src="https://github.com/user-attachments/assets/05210e74-bcbc-45f0-a18b-bc4b11f28298" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-15-2026 at 1 27 04 PM" src="https://github.com/user-attachments/assets/a4fb172f-70bd-4a21-9a7d-a366c4d9d587" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a monthly summary card to All Accounts showing income, expenses, and net cash flow.
  - Summary values refresh when budget data changes and when the app becomes active.
  - Added loading placeholders while account totals are calculated.
  - Displays zero totals for months without activity.

- **UI Improvements**
  - Moved the dashboard selector into the Reports content area.
  - Improved dashboard selector spacing, typography, and card styling.
  - Disabled the selector when no dashboards are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->