### PR TITLE
Add setting to open the transaction editor from Uncategorized.

### DIFF
--- a/Actuali/Actuali/Models/UncategorizedTapAction.swift
+++ b/Actuali/Actuali/Models/UncategorizedTapAction.swift
@@ -16,6 +16,14 @@ enum UncategorizedTapAction: String, CaseIterable, Identifiable {
         case .transactionEditor: return "Transaction Editor"
         }
     }
+    
+    /// Whether tapping `transaction` in the Uncategorized list should open
+    /// the full editor. Split children never do, whatever the setting says:
+    /// the edit form has no split support, which is why they carry no Edit
+    /// swipe action either (GH #260).
+    func opensEditor(for transaction: Transaction) -> Bool {
+        self == .transactionEditor && transaction.parentId == nil
+    }
 
     static let defaultsKey = "uncategorizedTapAction"
 

--- a/Actuali/Actuali/Models/UncategorizedTapAction.swift
+++ b/Actuali/Actuali/Models/UncategorizedTapAction.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// What tapping a row in the Uncategorized list opens (GH #260). Freshly
+/// imported transactions often need the payee fixed as well as the category,
+/// and the editor already carries a category field, so it can be the faster
+/// triage stop. Defaults to the category picker to keep the quick-tap flow.
+enum UncategorizedTapAction: String, CaseIterable, Identifiable {
+    case categoryPicker
+    case transactionEditor
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .categoryPicker: return "Category Picker"
+        case .transactionEditor: return "Transaction Editor"
+        }
+    }
+
+    static let defaultsKey = "uncategorizedTapAction"
+
+    static func resolved(from raw: String?) -> UncategorizedTapAction {
+        raw.flatMap(UncategorizedTapAction.init(rawValue:)) ?? .categoryPicker
+    }
+
+    static var persisted: UncategorizedTapAction {
+        resolved(from: UserDefaults.standard.string(forKey: defaultsKey))
+    }
+}

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -215,6 +215,14 @@ final class BudgetStore: ObservableObject {
             UserDefaults.standard.set(transactionDisplayMode.rawValue, forKey: TransactionDisplayMode.defaultsKey)
         }
     }
+    
+    /// What tapping a row in the Uncategorized list opens.
+    /// Persisted to UserDefaults, defaults to the category picker.
+    @Published var uncategorizedTapAction: UncategorizedTapAction = .categoryPicker {
+        didSet {
+            UserDefaults.standard.set(uncategorizedTapAction.rawValue, forKey: UncategorizedTapAction.defaultsKey)
+        }
+    }
 
     /// Whether Budget rows show a spent-vs-available progress bar.
     /// Persisted to UserDefaults, defaults to on.
@@ -766,6 +774,7 @@ final class BudgetStore: ObservableObject {
             _budgetDisplayStyle = Published(initialValue: style)
         }
         _transactionDisplayMode = Published(initialValue: TransactionDisplayMode.persisted)
+        _uncategorizedTapAction = Published(initialValue: UncategorizedTapAction.persisted)
         _showBudgetProgressBars = Published(initialValue: UserDefaults.standard
             .object(forKey: "showBudgetProgressBars") as? Bool ?? true)
         _showGroupTotals = Published(initialValue: UserDefaults.standard

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -381,6 +381,12 @@ struct SettingsView: View {
                             Text(mode.label).tag(mode)
                         }
                     }
+                    
+                    Picker("Uncategorized Tap Opens", selection: $budgetStore.uncategorizedTapAction) {
+                        ForEach(UncategorizedTapAction.allCases) { action in
+                            Text(action.label).tag(action)
+                        }
+                    }
 
                     Toggle("Budget Progress Bars", isOn: $budgetStore.showBudgetProgressBars)
 

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -381,12 +381,6 @@ struct SettingsView: View {
                             Text(mode.label).tag(mode)
                         }
                     }
-                    
-                    Picker("Uncategorized Tap Opens", selection: $budgetStore.uncategorizedTapAction) {
-                        ForEach(UncategorizedTapAction.allCases) { action in
-                            Text(action.label).tag(action)
-                        }
-                    }
 
                     Toggle("Budget Progress Bars", isOn: $budgetStore.showBudgetProgressBars)
 

--- a/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// Every transaction still needing a category, for triage (GH #26). Mirrors
 /// the WebUI's "uncategorized" pseudo-account: on-budget accounts only, split
 /// children included, transfers excluded unless the other side is off-budget.
-/// Tapping a row opens a category picker; picking one saves immediately.
+/// Tapping a row opens a category picker; picking one saves immediately. The
+/// `uncategorizedTapAction` setting swaps that for the full editor (GH #260).
 struct UncategorizedTransactionsView: View {
     @EnvironmentObject var budgetStore: BudgetStore
 
@@ -25,8 +26,14 @@ struct UncategorizedTransactionsView: View {
     @ViewBuilder
     private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
         Button {
-            pickedCategoryId = nil
-            categorizing = transaction
+            // Split children stay on the picker whatever the setting says:
+            // the edit form has no split support.
+            if budgetStore.uncategorizedTapAction == .transactionEditor, transaction.parentId == nil {
+                editingTransaction = transaction
+            } else {
+                pickedCategoryId = nil
+                categorizing = transaction
+            }
         } label: {
             // Split children keep an inert dot: their cleared state follows
             // the parent's.

--- a/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
+++ b/Actuali/Actuali/Views/Transactions/UncategorizedTransactionsView.swift
@@ -26,9 +26,7 @@ struct UncategorizedTransactionsView: View {
     @ViewBuilder
     private func transactionRow(_ transaction: Transaction, showDate: Bool) -> some View {
         Button {
-            // Split children stay on the picker whatever the setting says:
-            // the edit form has no split support.
-            if budgetStore.uncategorizedTapAction == .transactionEditor, transaction.parentId == nil {
+            if budgetStore.uncategorizedTapAction.opensEditor(for: transaction) {
                 editingTransaction = transaction
             } else {
                 pickedCategoryId = nil

--- a/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
@@ -30,4 +30,19 @@ struct BudgetStoreUncategorizedTapActionTests {
         #expect(UncategorizedTapAction.resolved(from: "somethingElse") == .categoryPicker)
         #expect(UncategorizedTapAction.resolved(from: "transactionEditor") == .transactionEditor)
     }
+    
+    @Test func routingCoversDefaultEditorAndSplitChild() {
+        func transaction(parentId: String?) -> Transaction {
+            Transaction(id: "t1", accountId: "acct", date: 20260101, amount: -1000,
+                        cleared: false, reconciled: false, isParent: false,
+                        parentId: parentId, tombstone: false)
+        }
+
+        // Default: always the picker, split child or not.
+        #expect(!UncategorizedTapAction.categoryPicker.opensEditor(for: transaction(parentId: nil)))
+        #expect(!UncategorizedTapAction.categoryPicker.opensEditor(for: transaction(parentId: "p1")))
+        // Editor setting: plain rows open the editor, split children don't.
+        #expect(UncategorizedTapAction.transactionEditor.opensEditor(for: transaction(parentId: nil)))
+        #expect(!UncategorizedTapAction.transactionEditor.opensEditor(for: transaction(parentId: "p1")))
+    }
 }

--- a/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The Uncategorized list's tap target (GH #260) defaults to the category
+/// picker and writes through to UserDefaults, like the other display settings.
+///
+/// The restore-on-launch half isn't covered here: `previewInstance()` is built
+/// by an init that skips every UserDefaults read, and the real init does file
+/// system work no unit test should trigger. `resolved(from:)` stands in for it.
+@MainActor
+struct BudgetStoreUncategorizedTapActionTests {
+
+    @Test func tapOpensCategoryPickerByDefault() {
+        #expect(BudgetStore.previewInstance().uncategorizedTapAction == .categoryPicker)
+    }
+
+    @Test func changePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.uncategorizedTapAction = .transactionEditor
+        #expect(UserDefaults.standard.string(forKey: UncategorizedTapAction.defaultsKey)
+            == UncategorizedTapAction.transactionEditor.rawValue)
+        store.uncategorizedTapAction = .categoryPicker
+        #expect(UserDefaults.standard.string(forKey: UncategorizedTapAction.defaultsKey)
+            == UncategorizedTapAction.categoryPicker.rawValue)
+    }
+
+    @Test func unsetOrUnknownValuesFallBackToCategoryPicker() {
+        #expect(UncategorizedTapAction.resolved(from: nil) == .categoryPicker)
+        #expect(UncategorizedTapAction.resolved(from: "somethingElse") == .categoryPicker)
+        #expect(UncategorizedTapAction.resolved(from: "transactionEditor") == .transactionEditor)
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreUncategorizedTapActionTests.swift
@@ -16,6 +16,17 @@ struct BudgetStoreUncategorizedTapActionTests {
     }
 
     @Test func changePersistsToUserDefaults() {
+        // Tests share the host app's UserDefaults.standard — restore whatever
+        // was there (same convention as BudgetStoreAccountMappingTests).
+        let saved = UserDefaults.standard.string(forKey: UncategorizedTapAction.defaultsKey)
+        defer {
+            if let saved {
+                UserDefaults.standard.set(saved, forKey: UncategorizedTapAction.defaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UncategorizedTapAction.defaultsKey)
+            }
+        }
+
         let store = BudgetStore.previewInstance()
         store.uncategorizedTapAction = .transactionEditor
         #expect(UserDefaults.standard.string(forKey: UncategorizedTapAction.defaultsKey)


### PR DESCRIPTION
<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->

## Why

Tapping an uncategorized transaction only opened the category picker, but a freshly imported transaction usually needs its payee corrected too — which meant an extra swipe and an Edit tap. Closes #260.

## What

- New **Settings → Uncategorized Tap Opens** picker: *Category Picker* (default, current behavior) or *Transaction Editor*.
- With *Transaction Editor* selected, tapping a row in the Uncategorized list opens the full editor instead. Nothing is lost by doing so — the editor already carries a category field.
- Split legs stay on the category picker either way: the edit form has no split support, which is why they already have no Edit swipe action.
- The setting persists to UserDefaults and restores on launch, matching the other display settings.

## How it was tested

- Added `BudgetStoreUncategorizedTapActionTests` — covers the default, the UserDefaults write-through, and the fallback for unset/unknown stored values.
- Ran the unit suite with Device Hub on iPhone 17 Pro running iOS 27:
  `xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination '...' -skip-testing:ActualiUITests`
- Manually: switched the setting to Transaction Editor, tapped a plain uncategorized row (editor opens) and a split leg (picker opens), then relaunched to confirm the setting persisted.

## Screenshots

<img width="301" alt="Screenshot iPhone 17 Pro 08-16-2026 at 10 47 26 AM" src="https://github.com/user-attachments/assets/3e7962f7-2b1c-4f6e-88a3-27fc983feefe" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-16-2026 at 10 47 34 AM" src="https://github.com/user-attachments/assets/8cde3c32-40b0-4c2b-84a1-f7e44772d2d8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preference for choosing what happens when tapping an uncategorized transaction.
  * Users can open either the category picker or transaction editor.
  * Split transactions always open the category picker.
  * The selected preference is saved and restored automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->