### PR TITLE
Show expenses as negative in notifications

### DIFF
--- a/Actuali/Actuali/Services/NewTransactionNotifier.swift
+++ b/Actuali/Actuali/Services/NewTransactionNotifier.swift
@@ -113,7 +113,7 @@ enum NewTransactionNotifier {
                              narrowSymbol: Bool,
                              accountNames: [String: String],
                              offBudgetAccountIds: Set<String>) -> String {
-        var line = CurrencyAmountFormat.string(cents: abs(transaction.amount),
+        var line = CurrencyAmountFormat.string(cents: transaction.amount,
                                                currencyCode: currencyCode,
                                                narrowSymbol: narrowSymbol)
         if let payee = transaction.payeeName, !payee.isEmpty {

--- a/Actuali/Actuali/Services/TransactionLogNotifier.swift
+++ b/Actuali/Actuali/Services/TransactionLogNotifier.swift
@@ -101,7 +101,7 @@ enum TransactionLogNotifier {
                             locale: Locale = .autoupdatingCurrent) -> String {
         var parts: [String] = []
         if let amountCents {
-            let amountString = CurrencyAmountFormat.string(cents: abs(amountCents),
+            let amountString = CurrencyAmountFormat.string(cents: amountCents,
                                                            currencyCode: currencyCode,
                                                            narrowSymbol: narrowSymbol,
                                                            locale: locale)
@@ -117,7 +117,7 @@ enum TransactionLogNotifier {
     static func composeSuccessBody(payee: String, amountCents: Int, currencyCode: String,
                                    narrowSymbol: Bool, synced: Bool = true,
                                    locale: Locale = .autoupdatingCurrent) -> String {
-        let amountString = CurrencyAmountFormat.string(cents: abs(amountCents),
+        let amountString = CurrencyAmountFormat.string(cents: amountCents,
                                                        currencyCode: currencyCode,
                                                        narrowSymbol: narrowSymbol,
                                                        locale: locale)

--- a/Actuali/ActualiTests/NewTransactionNotifierTests.swift
+++ b/Actuali/ActualiTests/NewTransactionNotifierTests.swift
@@ -31,6 +31,27 @@ struct NewTransactionNotifierTests {
         #expect(content?.body.localizedCaseInsensitiveContains("category") == false)
     }
 
+    /// Expenses are negative cents; the notification line must carry that
+    /// sign so outflows read distinctly from income (GH #258). Uses
+    /// narrowSymbol like narrowSymbolDropsCurrencyPrefixFromLines above —
+    /// locale-robust, since narrow presentation never carries the ISO prefix.
+    @Test func expenseLineShowsNegativeAmount() {
+        let content = NewTransactionNotifier.makeContent(
+            for: [makeTransaction(id: "t1", payeeName: "Starbucks", categoryId: "food", amount: -1250)],
+            currencyCode: "USD", narrowSymbol: true)
+
+        #expect(content?.body.contains("-$12.50") == true)
+    }
+
+    @Test func incomeLineShowsPositiveAmount() {
+        let content = NewTransactionNotifier.makeContent(
+            for: [makeTransaction(id: "t1", payeeName: "Employer", categoryId: "income", amount: 1250)],
+            currencyCode: "USD", narrowSymbol: true)
+
+        #expect(content?.body.contains("-") == false)
+        #expect(content?.body.contains("$12.50") == true)
+    }
+
     @Test func singleUncategorizedTransactionAsksForCategory() {
         let content = NewTransactionNotifier.makeContent(
             for: [makeTransaction(id: "t1", payeeName: "Starbucks")],

--- a/Actuali/ActualiTests/TransactionLogNotifierTests.swift
+++ b/Actuali/ActualiTests/TransactionLogNotifierTests.swift
@@ -62,6 +62,30 @@ struct TransactionLogNotifierTests {
         #expect(bodyGBP == "£5.00 at Tesco")
     }
 
+    /// Expenses are negative cents (Actual's sign convention); the notification
+    /// must show that sign so outflows read distinctly from income (GH #258).
+    @Test func composeSuccessBodyShowsExpenseAsNegative() {
+        let body = TransactionLogNotifier.composeSuccessBody(
+            payee: "Starbucks",
+            amountCents: -1250,
+            currencyCode: "USD",
+            narrowSymbol: false,
+            locale: enUS
+        )
+        #expect(body == "-$12.50 at Starbucks")
+    }
+
+    @Test func composeSuccessBodyShowsIncomeAsPositive() {
+        let body = TransactionLogNotifier.composeSuccessBody(
+            payee: "Employer",
+            amountCents: 1250,
+            currencyCode: "USD",
+            narrowSymbol: false,
+            locale: enUS
+        )
+        #expect(body == "$12.50 at Employer")
+    }
+
     /// A write that never reached the server must not read as a plain success —
     /// the transaction exists only on the phone until the next sync (issue #139).
     @Test func composeSuccessBodySaysWhenTheRowIsOnlyLocal() {

--- a/Actuali/ActualiTests/TransactionLogNotifierTests.swift
+++ b/Actuali/ActualiTests/TransactionLogNotifierTests.swift
@@ -30,6 +30,19 @@ struct TransactionLogNotifierTests {
         #expect(bodyGBP.contains("£5.00 at Tesco"))
     }
 
+    /// Expenses are negative cents; the failure body must carry that sign too
+    /// (composeSuccessBody is covered separately below, GH #258).
+    @Test func composeFailureBodyShowsExpenseAsNegative() {
+        let body = TransactionLogNotifier.composeBody(
+            message: "Error message",
+            payee: "Starbucks",
+            amountCents: -1250,
+            currencyCode: "USD",
+            locale: enUS
+        )
+        #expect(body == "-$12.50 at Starbucks. Error message")
+    }
+
     @Test func composeFailureBodyHonorsNarrowSymbol() {
         let bodyNarrow = TransactionLogNotifier.composeBody(
             message: "Error message",


### PR DESCRIPTION
## Summary
Expenses and income showed as the same positive amount in notifications (new-transaction sync banners and log-transaction confirmations). `CurrencyAmountFormat.string` already formats signed cents correctly (e.g. `-$12.50`), matching the pattern used in the transaction list, but all three notification call sites wrapped the amount in `abs()` first, discarding the sign. Removed the `abs()` calls so notifications carry the same sign convention as the rest of the app.

## Test plan
- Added failing tests first (`expenseLineShowsNegativeAmount`/`incomeLineShowsPositiveAmount` in `NewTransactionNotifierTests`, `composeSuccessBodyShowsExpenseAsNegative`/`composeSuccessBodyShowsIncomeAsPositive` in `TransactionLogNotifierTests`), confirmed they failed against the old `abs()` code, then applied the fix and confirmed they pass.
- Ran the full unit test suite: `xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -skip-testing:ActualiUITests` — 996 tests passed.

Fixes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction notifications now correctly display negative amounts for expenses.
  * Income amounts continue to appear as positive values.
  * Currency formatting preserves minus signs in success and failure messages.

* **Tests**
  * Added coverage for expense and income notification amount formatting.
  * Added validation for narrow currency symbols and USD-formatted notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->