### PR TITLE
Skip TestFlight workflow on forks

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -22,6 +22,8 @@ concurrency:
 
 jobs:
   upload:
+    # Forks don't get secrets, so runs there always fail at cert import.
+    if: github.repository == 'MattFaz/actuali'
     runs-on: macos-26
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Forks never get repo secrets, so every TestFlight run on a fork (e.g. abhiy98/actuali) dies at cert import with an empty p12. Guard the job so it only runs on this repo.

No code touched — workflow-only change, so no tests to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted TestFlight uploads to the designated repository, preventing unsupported fork runs from attempting deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->