### PR TITLE
Add Bangladeshi Taka (BDT) to settings currency picker

### DIFF
--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     /// Every currency in Actual's loot-core currencies list, plus a few
-    /// user-requested extras Actual lacks (AMD, NOK, NZD, ZAR). Sorted by
+    /// user-requested extras Actual lacks (AMD, BDT, NOK, NZD, ZAR). Sorted by
     /// code. Display-only — all budget math is currency-agnostic integer
     /// cents, and rendering uses the system formatter for the ISO code.
     private static let currencyOptions: [(symbol: String, code: String)] = [
@@ -21,6 +21,7 @@ struct SettingsView: View {
         ("֏", "AMD"),
         ("Arg$", "ARS"),
         ("A$", "AUD"),
+        ("৳", "BDT"),
         ("R$", "BRL"),
         ("Br", "BYN"),
         ("C$", "CAD"),


### PR DESCRIPTION
## Why

Bangladeshi Taka is not currently available as a selectable currency in Settings.

Closes #244

## What

- Added Bangladeshi Taka (`৳`, `BDT`) to the Settings currency picker.
- Kept the currency list alphabetically sorted by ISO code.

## How it was tested

- Ran `git diff --check`.
- Verified that the currency codes remain alphabetically sorted.
- Verified that `৳ BDT` appears exactly once in the currency options.
- The iOS test suite was not run because Xcode was unavailable in the development environment.

## Screenshots

Not available because the development environment did not include Xcode or an iOS Simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bangladeshi Taka (BDT, ৳) as a selectable currency in Settings.
* **Documentation**
  * Updated the documented list of supported currency options to include BDT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->