### PR TITLE
Fix AI review: restore id-token permission

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # claude-code-action exchanges an OIDC token for its GitHub App token.
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
The rebuilt ai-review workflow (#268) dropped `id-token: write` from the old workflow's permissions, so claude-code-action can't do its OIDC exchange and every run fails with "Could not fetch an OIDC token" (e.g. the run on #262). One line to restore it.

Workflow-only change, no tests to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow permissions to support secure authentication.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->