### PR TITLE
AI review: swap id-token for an explicit github_token

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,8 +11,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  # claude-code-action exchanges an OIDC token for its GitHub App token.
-  id-token: write
 
 jobs:
   review:
@@ -29,6 +27,10 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skips the OIDC → GitHub App token exchange, so the agent operates
+          # with this job's capped GITHUB_TOKEN instead of the app's broader
+          # installation token. Comments post as github-actions[bot].
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
             Fetch the diff with `gh pr diff ${{ github.event.pull_request.number }}`.


### PR DESCRIPTION
#270 unblocked the review job, but `id-token: write` makes the action exchange OIDC for a Claude GitHub App installation token — whose scopes come from the app install, not this workflow's `permissions` block. On a fork-PR trigger that's a broader credential than intended.

Passing `github_token: ${{ secrets.GITHUB_TOKEN }}` skips the exchange entirely (verified in the action source: `setupGitHubToken()` returns the override before any OIDC call), so the agent runs with exactly `contents: read` + `pull-requests: write` and `id-token` can go.

Only visible difference: review comments post as github-actions[bot] instead of the Claude app. Can't be tested until merged (`pull_request_target` runs the main-branch definition) — worth watching the first run after.