### PR TITLE
Let an imported transaction be converted into a transfer

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2635,13 +2635,14 @@ final class BudgetStore: ObservableObject {
             importedPayee: nil
         )
 
-        let legChanges = Self.changedFields(original: original, updated: leg)
-        if !legChanges.isEmpty {
-            try await syncClient.updateTransaction(leg, changedFields: legChanges)
-        }
-        // Rules are skipped like every other transfer write — both legs are
-        // fully specified here.
-        try await syncClient.createTransaction(partner, applyRules: false)
+        // Both rows commit together: an edited row whose transferred_id
+        // outlived a failed partner insert would be a half-transfer, already
+        // on its way to the server.
+        try await syncClient.convertToTransfer(
+            leg: leg,
+            changedFields: Self.changedFields(original: original, updated: leg),
+            partner: partner
+        )
         await refreshDataOnly()
     }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -44,7 +44,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
         case .transferPartnerMissing:
             return "The other side of this transfer no longer exists"
         case .cannotConvertToTransfer:
-            return "Can't convert an existing transaction into a transfer"
+            return "Can't turn a split transaction into a transfer"
         case .cannotConvertToSplit:
             return "Can't convert an existing transaction into a split"
         case .splitNeedsTwoLines:
@@ -2236,13 +2236,15 @@ final class BudgetStore: ObservableObject {
         switch try Self.plan(for: form) {
         case .transfer(let toAccountId, let amountCents):
             if let original {
-                // Only an existing transfer can be re-saved as one. Converting
-                // a plain transaction would create a new transfer pair and
-                // orphan the original (the UI hides the Transfer option for
-                // those; this guards the path against state edge cases).
-                // Refuse rather than silently corrupt. See actios-7u6.
+                // An existing transfer re-saves both of its legs; an ordinary
+                // row is converted in place (GH #259) — pairing it into a
+                // brand new transfer would orphan it (actios-7u6).
                 guard original.transferId != nil else {
-                    throw BudgetStoreError.cannotConvertToTransfer
+                    try await convertToTransfer(
+                        original: original, form: form, otherAccountId: toAccountId,
+                        amountCents: amountCents, date: date, notes: notes
+                    )
+                    return
                 }
                 try await updateTransfer(
                     original: original,
@@ -2552,6 +2554,95 @@ final class BudgetStore: ObservableObject {
         if form.recordLocation, let payeeId {
             recordPayeeLocationIfAppropriate(payeeId: payeeId)
         }
+    }
+
+    /// Convert an ordinary transaction into one leg of a transfer (GH #259):
+    /// the row keeps its id and history (reconciled, sort order, imported
+    /// payee), its payee becomes the other account's transfer payee, and a
+    /// new partner leg is created in that account for the opposite amount.
+    /// Mirrors upstream `addTransfer` (packages/loot-core/src/server/
+    /// transactions/transfer.ts), where converting is likewise "point the
+    /// payee at another account" — the edited row itself is never replaced.
+    ///
+    /// The row keeps its direction too: an imported outflow stays an outflow,
+    /// so the amount the bank reported can't flip sign under the user. Split
+    /// parents and children are refused, matching upstream's `is_parent`
+    /// bail-out (a parent's amount is its children's, and a child has no row
+    /// of its own to pair).
+    private func convertToTransfer(
+        original: Transaction,
+        form: TransactionForm,
+        otherAccountId: String,
+        amountCents: Int,
+        date: Int,
+        notes: String?
+    ) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        guard !original.isParent, original.parentId == nil else {
+            throw BudgetStoreError.cannotConvertToTransfer
+        }
+        guard form.accountId != otherAccountId else {
+            throw BudgetStoreError.transferAccountsMatch
+        }
+        guard amountCents > 0 else {
+            throw BudgetStoreError.transferAmountNotPositive
+        }
+        guard let legTransferPayee = transferPayee(forAccountId: form.accountId),
+              let otherTransferPayee = transferPayee(forAccountId: otherAccountId) else {
+            throw BudgetStoreError.transferPayeeMissing
+        }
+
+        let signedAmount = original.amount < 0 ? -amountCents : amountCents
+        // Actual's rule: a transfer leg takes a category only when it sits in
+        // an on-budget account and the other side is off-budget. The new
+        // partner leg has no category of its own to keep either way.
+        let offBudgetIds = offBudgetAccountIds
+        let legCategoryId = !offBudgetIds.contains(form.accountId)
+            && offBudgetIds.contains(otherAccountId) ? form.categoryId : nil
+
+        let partnerId = UUID().uuidString
+        var leg = original
+        leg.accountId = form.accountId
+        leg.amount = signedAmount
+        leg.payeeId = otherTransferPayee.id
+        leg.categoryId = legCategoryId
+        leg.date = date
+        leg.notes = notes
+        leg.cleared = form.cleared
+        leg.transferId = partnerId
+
+        let partner = Transaction(
+            id: partnerId,
+            accountId: otherAccountId,
+            date: date,
+            amount: -signedAmount,
+            payeeId: legTransferPayee.id,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: notes,
+            // Upstream's addTransfer inserts the partner uncleared: it's a row
+            // the bank never reported, whatever the imported side says.
+            cleared: false,
+            reconciled: false,
+            transferId: original.id,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+
+        let legChanges = Self.changedFields(original: original, updated: leg)
+        if !legChanges.isEmpty {
+            try await syncClient.updateTransaction(leg, changedFields: legChanges)
+        }
+        // Rules are skipped like every other transfer write — both legs are
+        // fully specified here.
+        try await syncClient.createTransaction(partner, applyRules: false)
+        await refreshDataOnly()
     }
 
     /// Convert an ordinary (non-split) transaction into a split: the

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2112,6 +2112,23 @@ class BudgetDatabase {
         }
     }
 
+    /// Repoints an existing transaction at a new partner leg and inserts that
+    /// leg, with both rows' CRDT messages, in a single SQLite transaction —
+    /// a partial write would leave the edited row's `transferred_id` pointing
+    /// at a partner that was never created.
+    /// Returns the subset of messages that was actually new (see `insertMessages`).
+    func convertToTransfer(
+        leg: Transaction,
+        partner: Transaction,
+        messages: [CRDTMessage]
+    ) throws -> [CRDTMessage] {
+        try dbQueue.write { db in
+            try Self.updateTransactionRow(db, leg)
+            try Self.insertTransactionRow(db, partner)
+            return try Self.insertMessageRows(db, messages)
+        }
+    }
+
     /// Inserts a split parent, its children and their CRDT messages in a
     /// single SQLite transaction, so a failure on any row rolls back
     /// everything and no partial split can persist.
@@ -2180,28 +2197,32 @@ class BudgetDatabase {
     /// Caller is responsible for emitting CRDT messages for the same fields.
     func updateTransaction(_ transaction: Transaction) throws {
         try dbQueue.write { db in
-            try db.execute(sql: """
-                UPDATE transactions
-                SET acct = ?, date = ?, description = ?, category = ?, amount = ?,
-                    notes = ?, cleared = ?, reconciled = ?, transferred_id = ?,
-                    isParent = ?, parent_id = ?, tombstone = ?
-                WHERE id = ?
-                """, arguments: [
-                    transaction.accountId,
-                    transaction.date,
-                    transaction.payeeId,
-                    transaction.categoryId,
-                    transaction.amount,
-                    transaction.notes,
-                    transaction.cleared ? 1 : 0,
-                    transaction.reconciled ? 1 : 0,
-                    transaction.transferId,
-                    transaction.isParent ? 1 : 0,
-                    transaction.parentId,
-                    transaction.tombstone ? 1 : 0,
-                    transaction.id
-                ])
+            try Self.updateTransactionRow(db, transaction)
         }
+    }
+
+    private static func updateTransactionRow(_ db: Database, _ transaction: Transaction) throws {
+        try db.execute(sql: """
+            UPDATE transactions
+            SET acct = ?, date = ?, description = ?, category = ?, amount = ?,
+                notes = ?, cleared = ?, reconciled = ?, transferred_id = ?,
+                isParent = ?, parent_id = ?, tombstone = ?
+            WHERE id = ?
+            """, arguments: [
+                transaction.accountId,
+                transaction.date,
+                transaction.payeeId,
+                transaction.categoryId,
+                transaction.amount,
+                transaction.notes,
+                transaction.cleared ? 1 : 0,
+                transaction.reconciled ? 1 : 0,
+                transaction.transferId,
+                transaction.isParent ? 1 : 0,
+                transaction.parentId,
+                transaction.tombstone ? 1 : 0,
+                transaction.id
+            ])
     }
 
     // MARK: - Rules

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -241,6 +241,39 @@ actor SyncClient {
         scheduleAutomaticSync()
     }
 
+    /// Turn an existing transaction into one leg of a transfer and create its
+    /// partner atomically (optimistic local-first). Like `createTransfer`,
+    /// both rows and their CRDT messages commit in one SQLite transaction —
+    /// an update that landed without its partner would leave `transferred_id`
+    /// dangling, and push that dangling reference to every other device.
+    /// Rules are skipped for the same reason as `createTransfer`: the caller
+    /// builds both legs explicitly.
+    func convertToTransfer(
+        leg: Transaction,
+        changedFields: Set<String>,
+        partner: Transaction
+    ) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        logger.debug("convertToTransfer() - leg: \(leg.id, privacy: .private), partner: \(partner.id, privacy: .private)")
+
+        // 1. Generate CRDT messages for both legs up front
+        var messages = try await messageGenerator.messagesForUpdate(leg, changedFields: changedFields)
+        messages += try await messageGenerator.messagesForInsert(partner)
+        logger.debug("Generated \(messages.count, privacy: .public) CRDT messages for conversion")
+
+        // 2. Persist rows + messages in one DB transaction, then update merkle
+        for msg in try database.convertToTransfer(leg: leg, partner: partner, messages: messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+        logger.debug("Conversion stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
+
+        // 3. Push both legs to the server in the background
+        scheduleAutomaticSync()
+    }
+
     /// Create a split parent and its children atomically (optimistic
     /// local-first). Like transfers, all rows and their CRDT messages commit
     /// in one SQLite transaction and rules are skipped — the caller builds

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -164,9 +164,11 @@ struct AddTransactionView: View {
             }
     }
 
-    /// Converting keeps the edited row in its own account and on its own side
-    /// of the transfer, so the form asks for one account — the other one —
-    /// instead of the From/To pair a new transfer needs.
+    /// Converting keeps the edited row on its own side of the transfer, so
+    /// the form asks for one account — the other one — instead of the From/To
+    /// pair a new transfer needs. The account row stays editable and keeps
+    /// its usual label: moving a transaction between accounts is an ordinary
+    /// edit, and converting doesn't take that away.
     private var accountPickerLabel: String {
         isTransfer && !isConvertingToTransfer ? "From" : "Account"
     }

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -99,14 +99,28 @@ struct AddTransactionView: View {
     private var isEditingSplitParent: Bool { editing?.isParent == true }
     private var isEditingTransfer: Bool { editing?.transferId != nil }
 
+    /// Whether the edit form may offer turning this transaction into a
+    /// transfer (GH #259). Split parents and children are excluded — the
+    /// store refuses them, since a parent's amount is its children's and a
+    /// child has no row of its own to pair.
+    private var canConvertToTransfer: Bool {
+        guard let editing else { return false }
+        return editing.transferId == nil && !editing.isParent && editing.parentId == nil
+    }
+    private var isConvertingToTransfer: Bool { isTransfer && canConvertToTransfer }
+
     /// A transfer leg takes a category only when it sits in an on-budget
     /// account and the other side is off-budget — money leaving the budget
     /// still needs one (Actual's rule). Tracks the live picker selections so
     /// re-targeting the accounts shows/hides the row immediately.
     private var editedTransferLegIsCategorizable: Bool {
-        guard let editing, editing.transferId != nil else { return false }
-        let legAccountId = editing.amount < 0 ? selectedAccountId : transferToAccountId
-        let otherAccountId = editing.amount < 0 ? transferToAccountId : selectedAccountId
+        guard let editing, isTransfer else { return false }
+        // The edited row's own account is the one in the account picker,
+        // except on an existing transfer opened from its receiving leg —
+        // there the form shows the pair as From/To and the opened row is To.
+        let openedOnDestinationLeg = editing.transferId != nil && editing.amount >= 0
+        let legAccountId = openedOnDestinationLeg ? transferToAccountId : selectedAccountId
+        let otherAccountId = openedOnDestinationLeg ? selectedAccountId : transferToAccountId
         guard let leg = budgetStore.accounts.first(where: { $0.id == legAccountId }),
               let other = budgetStore.accounts.first(where: { $0.id == otherAccountId }) else {
             return false
@@ -148,6 +162,18 @@ struct AddTransactionView: View {
                 if lhs.offBudget != rhs.offBudget { return !lhs.offBudget }
                 return lhs.sortOrder < rhs.sortOrder
             }
+    }
+
+    /// Converting keeps the edited row in its own account and on its own side
+    /// of the transfer, so the form asks for one account — the other one —
+    /// instead of the From/To pair a new transfer needs.
+    private var accountPickerLabel: String {
+        isTransfer && !isConvertingToTransfer ? "From" : "Account"
+    }
+
+    private var transferPartnerLabel: String {
+        guard isConvertingToTransfer else { return "To" }
+        return (editing?.amount ?? 0) < 0 ? "Transfer to" : "Transfer from"
     }
 
     private var transferEligibleAccounts: [Account] {
@@ -247,15 +273,15 @@ struct AddTransactionView: View {
                         Picker("Type", selection: $txType) {
                             Text("Expense").tag(TransactionType.expense)
                             Text("Income").tag(TransactionType.income)
-                            if !isEditing || isEditingTransfer {
+                            if !isEditing || isEditingTransfer || canConvertToTransfer {
                                 Text("Transfer").tag(TransactionType.transfer)
                             }
                         }
                         .pickerStyle(.segmented)
                         // A split parent's sign is the children's; flipping
                         // it would have to flip every line, so it stays fixed.
-                        // A transfer stays a transfer: converting would orphan
-                        // the partner leg (the store refuses it).
+                        // A transfer stays a transfer: converting one back
+                        // would orphan the partner leg (the store refuses it).
                         .disabled(isEditingSplitParent || isEditingTransfer)
                     }
 
@@ -275,7 +301,7 @@ struct AddTransactionView: View {
                 }
 
                 Section {
-                    Picker(isTransfer ? "From" : "Account", selection: $selectedAccountId) {
+                    Picker(accountPickerLabel, selection: $selectedAccountId) {
                         ForEach(orderedOpenAccounts) { account in
                             Text(account.name).tag(account.id)
                         }
@@ -287,7 +313,7 @@ struct AddTransactionView: View {
                     }
 
                     if isTransfer {
-                        Picker("To", selection: $transferToAccountId) {
+                        Picker(transferPartnerLabel, selection: $transferToAccountId) {
                             Text("Select account").tag(String?.none)
                             ForEach(transferEligibleAccounts) { account in
                                 Text(account.name).tag(String?.some(account.id))

--- a/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseTransferAtomicityTests.swift
@@ -129,6 +129,62 @@ struct BudgetDatabaseTransferAtomicityTests {
         #expect(rows[1]["transferred_id"] == sourceId)
     }
 
+    @Test func convertingToATransferCommitsTheEditedRowAndItsNewPartner() throws {
+        let (database, path) = try makeDatabase()
+        let legId = UUID().uuidString
+        let partnerId = UUID().uuidString
+        // An ordinary transaction, before the conversion repoints it.
+        var leg = transaction(id: legId, accountId: "acct-from", amount: -1050, transferId: partnerId)
+        leg.transferId = nil
+        try database.insertTransaction(leg)
+
+        leg.transferId = partnerId
+        let partner = transaction(id: partnerId, accountId: "acct-to", amount: 1050, transferId: legId)
+        let crdtMessages = messages(for: [leg, partner])
+
+        let inserted = try database.convertToTransfer(
+            leg: leg, partner: partner, messages: crdtMessages)
+
+        #expect(inserted.count == crdtMessages.count)
+        let queue = try DatabaseQueue(path: path.path)
+        let rows = try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT id, acct, amount, transferred_id FROM transactions ORDER BY amount")
+        }
+        #expect(rows.count == 2)
+        #expect(rows[0]["id"] == legId)
+        #expect(rows[0]["transferred_id"] == partnerId)
+        #expect(rows[1]["id"] == partnerId)
+        #expect(rows[1]["transferred_id"] == legId)
+    }
+
+    @Test func partnerInsertFailureRollsBackTheEditedRowAndAllMessages() throws {
+        let (database, path) = try makeDatabase()
+        let legId = UUID().uuidString
+        var leg = transaction(id: legId, accountId: "acct-from", amount: -1050, transferId: legId)
+        leg.transferId = nil
+        try database.insertTransaction(leg)
+
+        // Same id as the row being converted: the partner INSERT violates the
+        // primary key, simulating a persistence failure on the new leg.
+        leg.transferId = legId
+        let partner = transaction(id: legId, accountId: "acct-to", amount: 1050, transferId: legId)
+
+        #expect(throws: (any Error).self) {
+            try database.convertToTransfer(
+                leg: leg, partner: partner, messages: self.messages(for: [leg, partner]))
+        }
+
+        // Atomicity: the edited row keeps no dangling link and no CRDT message
+        // escaped to be pushed to the server.
+        let queue = try DatabaseQueue(path: path.path)
+        let transferredId = try queue.read { db in
+            try String.fetchOne(db, sql: "SELECT transferred_id FROM transactions WHERE id = ?", arguments: [legId])
+        }
+        #expect(transferredId == nil)
+        #expect(try rowCount(path: path, table: "transactions") == 1)
+        #expect(try rowCount(path: path, table: "messages_crdt") == 0)
+    }
+
     @Test func secondLegFailureRollsBackFirstLegAndAllMessages() throws {
         let (database, path) = try makeDatabase()
         let sourceId = UUID().uuidString

--- a/Actuali/ActualiTests/BudgetStoreConvertToTransferTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreConvertToTransferTests.swift
@@ -1,0 +1,330 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// End-to-end coverage for turning an ordinary (often bank-imported)
+/// transaction into a transfer through `saveTransaction` → `convertToTransfer`
+/// (GH #259): the row keeps its id, account, direction and history, its payee
+/// becomes the other account's transfer payee, and a partner leg is created
+/// for the opposite amount.
+@MainActor
+struct BudgetStoreConvertToTransferTests {
+
+    /// Upstream schema for the tables the transaction writes and fetches
+    /// touch (matches BudgetStoreUpdateTransferTests).
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                );
+
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                INSERT INTO accounts (id, name, offbudget) VALUES
+                    ('acct-checking',  'Checking',  0),
+                    ('acct-card',      'Card',      0),
+                    ('acct-brokerage', 'Brokerage', 1);
+
+                -- One transfer payee per account, like Actual maintains.
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking',  NULL, 'acct-checking'),
+                    ('payee-card',      NULL, 'acct-card'),
+                    ('payee-brokerage', NULL, 'acct-brokerage');
+
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking',  'payee-checking'),
+                    ('payee-card',      'payee-card'),
+                    ('payee-brokerage', 'payee-brokerage');
+                """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    /// Store wired to a real database and sync client, with the accounts and
+    /// transfer payees mirrored into the in-memory caches the conversion
+    /// reads (`accounts` for the off-budget rule, `payees` for payee lookup).
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        store.accounts = [
+            Account(id: "acct-checking", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-card", name: "Card", type: .credit,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+            Account(id: "acct-brokerage", name: "Brokerage", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 2, balance: 0),
+        ]
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-checking", tombstone: false),
+            Payee(id: "payee-card", name: "", transferAccountId: "acct-card", tombstone: false),
+            Payee(id: "payee-brokerage", name: "", transferAccountId: "acct-brokerage", tombstone: false),
+            Payee(id: "payee-bank", name: "BANK", transferAccountId: nil, tombstone: false),
+        ]
+        return store
+    }
+
+    /// An imported transaction as a bank feed leaves it: cleared, reconciled,
+    /// with the raw memo in `imported_description` and a plain payee.
+    private func seedImported(
+        into database: BudgetDatabase,
+        accountId: String = "acct-checking",
+        amount: Int = -25000,
+        categoryId: String? = nil,
+        isParent: Bool = false,
+        parentId: String? = nil
+    ) throws -> Transaction {
+        let imported = Transaction(
+            id: "tx-imported", accountId: accountId, date: 20260610, amount: amount,
+            payeeId: "payee-bank", payeeName: "BANK", categoryId: categoryId,
+            categoryName: nil, notes: "card payment", cleared: true, reconciled: true,
+            transferId: nil, isParent: isParent, parentId: parentId, tombstone: false,
+            sortOrder: 1000, importedPayee: "RAW BANK MEMO")
+        try database.insertTransaction(imported)
+        return imported
+    }
+
+    private func form(
+        accountId: String = "acct-checking",
+        amount: String = "250.00",
+        transferToAccountId: String? = "acct-card",
+        categoryId: String? = nil,
+        notes: String = "card payment",
+        cleared: Bool = true
+    ) -> BudgetStore.TransactionForm {
+        BudgetStore.TransactionForm(
+            accountId: accountId,
+            type: .transfer,
+            amount: amount,
+            payeeName: "",
+            transferToAccountId: transferToAccountId,
+            categoryId: categoryId,
+            notes: notes,
+            date: Transaction.date(fromYYYYMMDD: 20260610),
+            cleared: cleared
+        )
+    }
+
+    private func rows(path: URL) throws -> [Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions")
+        }
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @Test func convertingAnImportedOutflowPairsItWithANewLeg() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let imported = try seedImported(into: database)
+
+        try await store.saveTransaction(form(), editing: imported)
+
+        let all = try rows(path: path)
+        #expect(all.count == 2)
+        let leg = try #require(all.first { $0["id"] as String == "tx-imported" })
+        let partner = try #require(all.first { $0["id"] as String != "tx-imported" })
+
+        // The imported row keeps its id, account, direction and history.
+        #expect(leg["acct"] == "acct-checking")
+        #expect(leg["amount"] == -25000)
+        #expect(leg["reconciled"] == 1)
+        #expect(leg["cleared"] == 1)
+        #expect(leg["imported_description"] == "RAW BANK MEMO")
+        #expect(leg["sort_order"] == 1000.0)
+        // Its payee is now the other account's transfer payee, and the pair
+        // links both ways.
+        #expect(leg["description"] == "payee-card")
+        #expect(leg["transferred_id"] == (partner["id"] as String))
+        #expect(partner["transferred_id"] == "tx-imported")
+
+        // The new leg mirrors the amount in the other account, carries the
+        // notes, and starts uncleared (upstream addTransfer).
+        #expect(partner["acct"] == "acct-card")
+        #expect(partner["amount"] == 25000)
+        #expect(partner["description"] == "payee-checking")
+        #expect(partner["notes"] == "card payment")
+        #expect(partner["cleared"] == 0)
+        #expect(partner["reconciled"] == 0)
+        #expect(partner["tombstone"] == 0)
+    }
+
+    @Test func convertingAnImportedInflowKeepsItsDirection() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        // The same card payment, imported on the card side as an inflow.
+        let imported = try seedImported(into: database, accountId: "acct-card", amount: 25000)
+
+        try await store.saveTransaction(
+            form(accountId: "acct-card", transferToAccountId: "acct-checking"),
+            editing: imported)
+
+        let all = try rows(path: path)
+        let leg = try #require(all.first { $0["id"] as String == "tx-imported" })
+        let partner = try #require(all.first { $0["id"] as String != "tx-imported" })
+        // The bank's own sign survives the conversion; the new leg takes the
+        // outflow side.
+        #expect(leg["acct"] == "acct-card")
+        #expect(leg["amount"] == 25000)
+        #expect(partner["acct"] == "acct-checking")
+        #expect(partner["amount"] == -25000)
+        #expect(leg["description"] == "payee-checking")
+        #expect(partner["description"] == "payee-card")
+    }
+
+    @Test func convertingAppliesTheFormsAmountDateAndNotes() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let imported = try seedImported(into: database)
+
+        var edit = form(amount: "300.00", notes: "fixed up")
+        edit.date = Transaction.date(fromYYYYMMDD: 20260715)
+        try await store.saveTransaction(edit, editing: imported)
+
+        let all = try rows(path: path)
+        let leg = try #require(all.first { $0["id"] as String == "tx-imported" })
+        let partner = try #require(all.first { $0["id"] as String != "tx-imported" })
+        #expect(leg["amount"] == -30000)
+        #expect(partner["amount"] == 30000)
+        #expect(leg["date"] == 20260715)
+        #expect(partner["date"] == 20260715)
+        #expect(leg["notes"] == "fixed up")
+        #expect(partner["notes"] == "fixed up")
+    }
+
+    @Test func convertingClearsTheCategoryBetweenTwoOnBudgetAccounts() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        // Imported and auto-categorized before the user reclassified it.
+        let imported = try seedImported(into: database, categoryId: "cat-bills")
+
+        var edit = form()
+        edit.categoryId = "cat-bills"
+        try await store.saveTransaction(edit, editing: imported)
+
+        let all = try rows(path: path)
+        #expect(all.allSatisfy { $0["category"] == nil })
+    }
+
+    @Test func convertingKeepsTheCategoryWhenTheOtherAccountIsOffBudget() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let imported = try seedImported(into: database)
+
+        // Money leaving the budget still needs a category on the on-budget leg.
+        var edit = form(transferToAccountId: "acct-brokerage")
+        edit.categoryId = "cat-investing"
+        try await store.saveTransaction(edit, editing: imported)
+
+        let all = try rows(path: path)
+        let leg = try #require(all.first { $0["id"] as String == "tx-imported" })
+        let partner = try #require(all.first { $0["id"] as String != "tx-imported" })
+        #expect(leg["category"] == "cat-investing")
+        #expect(partner["category"] == nil)
+    }
+
+    @Test func convertingASplitParentIsRefused() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let parent = try seedImported(into: database, isParent: true)
+
+        await #expect(throws: BudgetStoreError.cannotConvertToTransfer) {
+            try await store.saveTransaction(self.form(), editing: parent)
+        }
+        #expect(try rows(path: path).count == 1)
+    }
+
+    @Test func convertingASplitChildIsRefused() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let child = try seedImported(into: database, parentId: "tx-parent")
+
+        await #expect(throws: BudgetStoreError.cannotConvertToTransfer) {
+            try await store.saveTransaction(self.form(), editing: child)
+        }
+        #expect(try rows(path: path).count == 1)
+    }
+
+    @Test func convertingIntoTheSameAccountIsRefused() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let imported = try seedImported(into: database)
+
+        await #expect(throws: BudgetStoreError.transferAccountsMatch) {
+            try await store.saveTransaction(
+                self.form(transferToAccountId: "acct-checking"), editing: imported)
+        }
+        #expect(try rows(path: path).count == 1)
+    }
+}

--- a/Actuali/ActualiTests/BudgetStoreConvertToTransferTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreConvertToTransferTests.swift
@@ -258,6 +258,29 @@ struct BudgetStoreConvertToTransferTests {
         #expect(partner["notes"] == "fixed up")
     }
 
+    @Test func convertingHonoursAnAccountChangeMadeInTheSameEdit() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let imported = try seedImported(into: database)
+
+        // Moving a transaction between accounts is an ordinary edit, and the
+        // account picker stays live while Transfer is selected — a save that
+        // does both lands the leg in the account the form names.
+        try await store.saveTransaction(
+            form(accountId: "acct-brokerage", transferToAccountId: "acct-card"),
+            editing: imported)
+
+        let all = try rows(path: path)
+        let leg = try #require(all.first { $0["id"] as String == "tx-imported" })
+        let partner = try #require(all.first { $0["id"] as String != "tx-imported" })
+        #expect(leg["acct"] == "acct-brokerage")
+        #expect(leg["amount"] == -25000)
+        #expect(partner["acct"] == "acct-card")
+        #expect(leg["description"] == "payee-card")
+        #expect(partner["description"] == "payee-brokerage")
+    }
+
     @Test func convertingClearsTheCategoryBetweenTwoOnBudgetAccounts() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }

--- a/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreSaveTransactionTests.swift
@@ -265,16 +265,18 @@ struct BudgetStoreSaveTransactionTests {
         #expect(row["description"] == "p-1")
     }
 
-    @Test func editingIntoATransferIsRejectedAndLeavesOriginalIntact() async throws {
+    @Test func editingASplitParentIntoATransferIsRejectedAndLeavesOriginalIntact() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
 
-        let original = transaction(payeeId: "p-1", payeeName: "Grocer")
+        // An ordinary row converts in place (GH #259, covered in
+        // BudgetStoreConvertToTransferTests), but a split parent's amount is
+        // its children's sum — pairing it would orphan them (actios-7u6).
+        var original = transaction(payeeId: "p-1", payeeName: "Grocer")
+        original.isParent = true
         try database.insertTransaction(original)
 
-        // Converting an existing transaction into a transfer would create a new
-        // transfer pair and orphan the original (actios-7u6). It must be refused.
         var edit = form(type: .transfer, amount: "25.00", transferToAccountId: "acct-2")
         edit.payeeName = "Grocer"
         await #expect(throws: BudgetStoreError.cannotConvertToTransfer) {


### PR DESCRIPTION
An imported transaction (the report's example: a credit card payment) could only ever be Expense or Income — the edit form hid the Transfer segment, and `saveTransaction` threw `cannotConvertToTransfer` for any edit routed to `.transfer`. That guard came from actios-7u6, which chose "block, don't convert" for v1 because the old path created a fresh transfer pair and orphaned the original row.

Now it converts in place, the way upstream does it (`addTransfer` in `packages/loot-core/src/server/transactions/transfer.ts`, where converting is "point the payee at another account" and the edited row is never replaced):

- the edited row keeps its id, account, direction, `reconciled` flag, sort order and `imported_description`
- its payee becomes the other account's transfer payee, and both rows link through `transferred_id`
- a new partner leg is created in the other account for the opposite amount, uncleared (upstream inserts it uncleared — the bank never reported it)
- category follows Actual's rule: kept only on an on-budget leg whose partner is off-budget, cleared otherwise

Because the imported side keeps its own sign, the form asks for one account rather than a From/To pair: the account picker stays on the row's own account and the second picker reads "Transfer to" for an outflow, "Transfer from" for an inflow. Nothing flips the amount the bank reported.

Split parents and children are still refused (`cannotConvertToTransfer`) — a parent's amount is its children's sum, and a child has no row of its own to pair, matching upstream's `is_parent` bail-out. Turning an existing transfer *back* into an expense/income is unchanged and still blocked; that's the opposite direction and out of scope here.

## Verification

`xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -skip-testing:ActualiUITests`

```
✔ Test run with 1125 tests in 144 suites passed after 4.651 seconds.
** TEST SUCCEEDED **
```

New `BudgetStoreConvertToTransferTests` covers: outflow conversion pairs the row with a new leg (ids, payees, link, history preserved), inflow conversion keeps its direction, the form's amount/date/notes reach both legs, category cleared between two on-budget accounts and kept on the on-budget leg of an off-budget transfer, and split parent / split child / same-account are refused.

One existing test changed on purpose: `editingIntoATransferIsRejectedAndLeavesOriginalIntact` asserted the old block-not-convert behavior, which is exactly what this PR reverses. It's now `editingASplitParentIntoATransferIsRejectedAndLeavesOriginalIntact`, keeping the refusal path covered for the case that's still refused.

Fixes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert eligible ordinary transactions into transfers while editing.
  * Preserve the original transaction and create a linked partner transaction.
  * Select the partner account with direction-specific labels.
  * Apply appropriate category and reconciliation handling during conversion.
  * Keep transfer conversion and synchronization consistent across devices.

* **Bug Fixes**
  * Improved validation for split transactions and same-account transfers.
  * Updated transfer-conversion error messaging.
  * Ensured failed conversions leave the original transaction unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->