### PR TITLE
Give the AI review agent a working path to post its review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -42,5 +42,11 @@ jobs:
             Post a single concise review covering: real bugs, security issues, and
             significant design problems. Skip style nits. If the PR looks fine, say
             so briefly.
+
+            Write the review to review.md, then post it with
+            `gh pr comment ${{ github.event.pull_request.number }} --body-file review.md`.
+          # Read/Write are safe here: checkout stays on the base ref, so PR-head
+          # code is never on disk. --body-file avoids heredocs/$() in the comment
+          # command, which would fail the Bash prefix match and get denied.
           claude_args: |
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_comment__*"
+            --allowedTools "Read,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
The AI review job on #265 ran green but posted nothing — the result JSON showed 13 permission denials. Two causes:

- The prompt says to read AGENTS.md, but no read tools were allowlisted, so every attempt was denied.
- There was no reliable posting path: `mcp__github_comment__*` is a no-op in this mode (that MCP server isn't configured), and `Bash(gh pr comment:*)` prefix rules don't match when the multi-line body is composed with a heredoc/`$()`, so the comment attempts were denied too. The final review text was then just discarded, and denials don't fail the job.

Fix: allow `Read`/`Write` (safe — checkout stays on the base ref, PR-head code never touches disk), have the agent write the review to a file and post with `--body-file`, and drop the dead MCP entry.

Workflow-only change, no code; validated the YAML parses. Will verify on the next PR sync.