### PR TITLE
Skip automation workflows on forks

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   review:
+    if: github.repository == 'MattFaz/actuali'
     runs-on: ubuntu-latest
     concurrency:
       group: ai-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/app-store-reviews.yml
+++ b/.github/workflows/app-store-reviews.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   poll:
+    if: github.repository == 'MattFaz/actuali'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/assign-issue.yaml
+++ b/.github/workflows/assign-issue.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   assign:
+    if: github.repository == 'MattFaz/actuali'
     runs-on: ubuntu-latest
     steps:
       - uses: takanome-dev/assign-issue-action@v3.1.0

--- a/.github/workflows/discord-log.yml
+++ b/.github/workflows/discord-log.yml
@@ -23,6 +23,7 @@ permissions: {}
 
 jobs:
   notify:
+    if: github.repository == 'MattFaz/actuali'
     runs-on: ubuntu-latest
     steps:
       - name: Send Discord message

--- a/.github/workflows/redeploy-website-on-release.yml
+++ b/.github/workflows/redeploy-website-on-release.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   trigger-build:
+    if: github.repository == 'MattFaz/actuali'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Cloudflare deploy hook


### PR DESCRIPTION
Forks don't have the secrets these workflows need, so runs there just fail (App Store review polling, AI review, Discord notifications, etc). Adds the same `if: github.repository == 'MattFaz/actuali'` guard testflight.yml already uses to the other automation workflows.

CI is deliberately left unguarded so fork PRs can still build and test.

No code changes — workflow YAML only, nothing to run locally.