### PR TITLE
Add an option to hide closed accounts

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -331,11 +331,28 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether the Accounts list drops its Closed Accounts section, for
+    /// budgets that have accumulated closed accounts over the years
+    /// (GH #277). Persisted to UserDefaults, defaults to off.
+    @Published var hideClosedAccounts: Bool = false {
+        didSet {
+            UserDefaults.standard.set(hideClosedAccounts, forKey: "hideClosedAccounts")
+        }
+    }
+
     /// Categories the Budget list should show. With the hide toggle on, only
     /// exactly-zero available drops out: overspent (negative) categories stay
     /// visible so problems that need fixing are never masked.
     func visibleCategoryBudgets(_ categories: [CategoryBudget]) -> [CategoryBudget] {
         hideZeroBudgetCategories ? categories.filter { $0.available != 0 } : categories
+    }
+
+    /// Closed accounts the Accounts list should show — none when the hide
+    /// toggle is on. A view filter only: the All Accounts total still counts
+    /// closed accounts, so hiding them can't quietly change the net worth on
+    /// screen.
+    var visibleClosedAccounts: [Account] {
+        hideClosedAccounts ? [] : accounts.filter(\.closed)
     }
 
     /// One consistent-width replacement keeps masked amounts visually stable
@@ -833,6 +850,8 @@ final class BudgetStore: ObservableObject {
             .bool(forKey: "hideZeroBudgetCategories"))
         _hideClearedTransactions = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideClearedTransactions"))
+        _hideClosedAccounts = Published(initialValue: UserDefaults.standard
+            .bool(forKey: "hideClosedAccounts"))
         _postScheduledTransactions = Published(initialValue: UserDefaults.standard
             .bool(forKey: "postScheduledTransactions"))
 

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -64,7 +64,7 @@ struct AccountsListView: View {
     }
 
     var closedAccounts: [Account] {
-        budgetStore.accounts.filter { $0.closed }
+        budgetStore.visibleClosedAccounts
     }
 
     var onBudgetTotal: Int { onBudgetAccounts.sumBalance }
@@ -308,6 +308,17 @@ struct AccountsListView: View {
                         Image(systemName: "plus")
                     }
                     .accessibilityLabel("Add Account")
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Toggle(isOn: $budgetStore.hideClosedAccounts) {
+                            Label("Hide Closed Accounts", systemImage: "archivebox")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                    .accessibilityLabel("Accounts options")
+                    .accessibilityHint("Account list display options")
                 }
                 ToolbarItem(placement: .primaryAction) {
                     SyncStatusView(state: budgetStore.syncState)

--- a/Actuali/ActualiTests/BudgetStoreHideClosedAccountsTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreHideClosedAccountsTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// The "hide closed accounts" toggle (GH #277) must default to off, persist
+/// like the other display settings, and drop only closed accounts — open ones
+/// stay visible whatever the toggle says.
+@MainActor
+struct BudgetStoreHideClosedAccountsTests {
+
+    private func makeAccounts() -> [Account] {
+        [
+            Account(id: "a1", name: "Checking", type: .checking, offBudget: false, closed: false, sortOrder: 0, balance: 5000),
+            Account(id: "a2", name: "Old Savings", type: .savings, offBudget: false, closed: true, sortOrder: 1, balance: 0),
+            Account(id: "a3", name: "Old Card", type: .credit, offBudget: true, closed: true, sortOrder: 2, balance: -100)
+        ]
+    }
+
+    @Test func defaultsToFalse() {
+        UserDefaults.standard.removeObject(forKey: "hideClosedAccounts")
+        let store = BudgetStore.previewInstance()
+        #expect(store.hideClosedAccounts == false)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.hideClosedAccounts = true
+        #expect(UserDefaults.standard.bool(forKey: "hideClosedAccounts") == true)
+        store.hideClosedAccounts = false
+        #expect(UserDefaults.standard.bool(forKey: "hideClosedAccounts") == false)
+        UserDefaults.standard.removeObject(forKey: "hideClosedAccounts")
+    }
+
+    @Test func hidesClosedAccountsWhenEnabled() {
+        let store = BudgetStore.previewInstance()
+        store.accounts = makeAccounts()
+        store.hideClosedAccounts = true
+        defer { UserDefaults.standard.removeObject(forKey: "hideClosedAccounts") }
+
+        #expect(store.visibleClosedAccounts.isEmpty)
+    }
+
+    @Test func showsClosedAccountsWhenDisabled() {
+        let store = BudgetStore.previewInstance()
+        store.accounts = makeAccounts()
+        store.hideClosedAccounts = false
+        defer { UserDefaults.standard.removeObject(forKey: "hideClosedAccounts") }
+
+        #expect(store.visibleClosedAccounts.map(\.id) == ["a2", "a3"])
+    }
+}


### PR DESCRIPTION
Closed accounts stick around in the accounts list forever, and for anyone who's closed a few over the years that's a permanently cluttered view. This adds a "Hide Closed Accounts" toggle in a new options menu on the Accounts toolbar (the ellipsis button, next to +), matching how the Budget tab and transaction lists already expose their hide-filters.

## What changed

- `BudgetStore.hideClosedAccounts` — persisted to UserDefaults, defaults to off, same shape as `hideZeroBudgetCategories` / `hideClearedTransactions`.
- `BudgetStore.visibleClosedAccounts` — the filter lives on the store (mirroring `visibleCategoryBudgets`) so the phone stack layout and the iPad split layout can't drift; both already gate the section on it being non-empty.
- An options menu on the Accounts toolbar holding the toggle, shared by both layouts via `withChrome`.

## Out of scope

- The All Accounts total still counts closed accounts. This is a list filter, not a net-worth change — a display toggle silently moving the headline balance would be worse than the clutter.
- No duplicate toggle in Settings; the filter belongs with the list it filters.
- Account pickers elsewhere (transactions, schedules, rules, wallet import) already exclude closed accounts, so nothing there needed touching.

## Verification

New `BudgetStoreHideClosedAccountsTests` covers the default, UserDefaults persistence, and that the filter drops closed accounts only when enabled. Red first — `hideClosedAccounts` and `visibleClosedAccounts` didn't exist, so it failed to compile.

Full unit suite on iPhone 17 Pro:

```
xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali \
  -destination 'id=C39AF42C-...' -skip-testing:ActualiUITests

◇ Suite BudgetStoreHideClosedAccountsTests started.
✔ Test defaultsToFalse() passed after 4.097 seconds.
✔ Test togglePersistsToUserDefaults() passed after 4.155 seconds.
✔ Test hidesClosedAccountsWhenEnabled() passed after 4.098 seconds.
✔ Test showsClosedAccountsWhenDisabled() passed after 4.176 seconds.
✔ Suite BudgetStoreHideClosedAccountsTests passed after 4.288 seconds.

✔ Test run with 1202 tests in 152 suites passed after 4.979 seconds.
** TEST SUCCEEDED **
```

Fixes #277
