### PR TITLE
Match the accounts summary's income and expenses to the budget tab

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -479,13 +479,20 @@ class BudgetDatabase {
         }
     }
     
-    /// Money in and out across every account for one month, for the accounts
-    /// tab's summary group (GH #256).
+    /// A month's income and spending for the accounts tab's summary group
+    /// (GH #256), on the same footing as the budget tab's Income and Spent.
     struct AccountsMonthSummary: Equatable {
         var incomeCents = 0
-        /// Positive: what left the accounts, not a signed amount.
+        /// Spending sign-flipped to read as money out, so a normal month is
+        /// positive. Net activity, like the budget tab's Spent (GH #212):
+        /// refunds offset spending, and a month whose refunds outweigh it
+        /// goes negative — the same figure the budget tab shows, so both
+        /// tabs stay in step.
         var expenseCents = 0
 
+        /// What the month kept: income less what actually went out. A net
+        /// refund makes `expenseCents` negative and so adds here, which is
+        /// the cash that stayed.
         var netCents: Int { incomeCents - expenseCents }
     }
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -500,7 +500,10 @@ class BudgetDatabase {
     /// on-budget↔on-budget transfer carries no category; a categorised leg
     /// into an off-budget account is spending, as upstream counts it).
     /// Split parents are excluded and their children counted, matching the
-    /// budget's spent query.
+    /// budget's spent query. Deleted accounts are excluded as well: upstream
+    /// tombstones an account's transactions along with it, so a live
+    /// transaction left on a tombstoned account is a sync-race orphan the
+    /// all-accounts balance above the card doesn't count either.
     func fetchAccountsMonthSummary(month: String) async throws -> AccountsMonthSummary {
         try await dbQueue.read { db in
             guard let row = try Row.fetchOne(db, sql: """
@@ -521,6 +524,7 @@ class BudgetDatabase {
                   AND (g.tombstone = 0 OR g.tombstone IS NULL)
                   AND (g.hidden = 0 OR g.hidden IS NULL)
                   AND a.offbudget = 0
+                  AND (a.tombstone = 0 OR a.tombstone IS NULL)
                   AND (t.date / 100) = ?
                 """, arguments: [Self.monthStringToInt(month)]) else {
                 return AccountsMonthSummary()

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1188,6 +1188,11 @@ class BudgetDatabase {
             //   * Only count on-budget accounts (accounts.offbudget = 0). A
             //     categorised transaction in an off-budget account is not budget
             //     spending.
+            //   * Also skip deleted accounts (accounts.tombstone = 1). Upstream
+            //     doesn't check this, because deleteAccount() tombstones or
+            //     reassigns every transaction on its way out; a live transaction
+            //     left on a deleted account is a sync-race orphan (upstream's own
+            //     TODO in accounts/app.ts) that nothing else in the app counts.
             //   * Do NOT filter transfers. On-budget↔on-budget transfers carry no
             //     category (excluded by category IS NOT NULL); a categorised leg
             //     is a transfer to an off-budget account, which Actual counts as
@@ -1216,6 +1221,7 @@ class BudgetDatabase {
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND t.category IS NOT NULL
                   AND a.offbudget = 0
+                  AND (a.tombstone = 0 OR a.tombstone IS NULL)
                   AND (t.date / 100) <= ?
                 GROUP BY (t.date / 100), COALESCE(cm.transferId, t.category)
                 """, arguments: [targetMonthInt])

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -489,32 +489,38 @@ class BudgetDatabase {
         var netCents: Int { incomeCents - expenseCents }
     }
 
-    /// Income and expenses across every account for one "yyyy-MM" month.
+    /// Income and expenses for one "yyyy-MM" month.
     ///
-    /// Scoped to all accounts, off-budget and closed included, so it
-    /// reconciles with the all-accounts balance it sits under — unlike the
-    /// budget month's income/spent, which only counts categorised
-    /// transactions in on-budget accounts. Transfer legs are excluded: a
-    /// transfer moves money inside that set, so counting it would show up as
-    /// both income and an expense (same rule as the WebUI's cash flow card).
-    /// Split parents are excluded and their children counted, matching
-    /// `fetchAccounts()`'s balance query.
+    /// Same scope as the budget month's income/spent so the two tabs agree
+    /// (GH #256): categorised transactions in on-budget accounts only, with
+    /// hidden categories and hidden groups left out the way the budget tab's
+    /// Income/Spent totals leave them out. Income is the income categories'
+    /// activity, expenses the rest — so an off-budget account's spending
+    /// doesn't land in either, and transfers need no special-casing (an
+    /// on-budget↔on-budget transfer carries no category; a categorised leg
+    /// into an off-budget account is spending, as upstream counts it).
+    /// Split parents are excluded and their children counted, matching the
+    /// budget's spent query.
     func fetchAccountsMonthSummary(month: String) async throws -> AccountsMonthSummary {
         try await dbQueue.read { db in
             guard let row = try Row.fetchOne(db, sql: """
                 SELECT
-                    COALESCE(SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END), 0) AS income,
-                    COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END), 0) AS expense
+                    COALESCE(SUM(CASE WHEN c.is_income = 1 THEN t.amount ELSE 0 END), 0) AS income,
+                    COALESCE(SUM(CASE WHEN c.is_income = 1 THEN 0 ELSE -t.amount END), 0) AS expense
                 FROM transactions t
-                LEFT JOIN payee_mapping pm ON pm.id = t.description
-                LEFT JOIN payees p ON p.id = pm.targetId
+                LEFT JOIN category_mapping cm ON cm.id = t.category
+                JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
+                JOIN category_groups g ON g.id = c.cat_group
                 JOIN accounts a ON a.id = t.acct
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
-                  AND (a.tombstone = 0 OR a.tombstone IS NULL)
-                  AND p.transfer_acct IS NULL
+                  AND (c.tombstone = 0 OR c.tombstone IS NULL)
+                  AND (c.hidden = 0 OR c.hidden IS NULL)
+                  AND (g.tombstone = 0 OR g.tombstone IS NULL)
+                  AND (g.hidden = 0 OR g.hidden IS NULL)
+                  AND a.offbudget = 0
                   AND (t.date / 100) = ?
                 """, arguments: [Self.monthStringToInt(month)]) else {
                 return AccountsMonthSummary()

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -413,10 +413,11 @@ private extension Array where Element == Account {
     }
 }
 
-/// The list's lead row: the all-accounts balance over this month's money in,
-/// money out, and the difference — the same at-a-glance group the budget tab
-/// opens with (GH #256). It's still the row that pushes the All Accounts
-/// transaction list, so the figures lead to the transactions behind them.
+/// The list's lead row: the all-accounts balance over this month's income,
+/// spending, and the difference — the same figures, on the same budgeted
+/// scope, that the budget tab opens with (GH #256). It's still the row that
+/// pushes the All Accounts transaction list, so the figures lead to the
+/// transactions behind them.
 struct AccountsSummaryCard: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let totalBalance: Int

--- a/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
@@ -110,6 +110,32 @@ struct BudgetDatabaseAccountsSummaryTests {
         #expect(summary.netCents == 250000)
     }
 
+    @Test func aMonthOfRefundsGoesNegativeLikeTheBudgetTabsSpent() async throws {
+        // Refunds net against spending rather than counting as income, so a
+        // month that got more back than it spent reports negative expenses —
+        // the same figure the budget tab's Spent shows (GH #212) — and the
+        // refund lands in Net as money kept.
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+
+                INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                    ('pay',    'acct-1', 'cat-salary', 400000, 20260803, 0),
+                    ('food',   'acct-1', 'cat-food',    -5000, 20260805, 0),
+                    ('return', 'acct-1', 'cat-rent',    80000, 20260806, 0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 400000)
+        #expect(summary.expenseCents == -75000)
+        #expect(summary.netCents == 475000)
+    }
+
     @Test func countsOnBudgetAccountsOnly() async throws {
         // The figures have to agree with the budget tab's Income/Spent, which
         // ignores off-budget accounts entirely (GH #256 follow-up). Closed

--- a/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
@@ -113,7 +113,8 @@ struct BudgetDatabaseAccountsSummaryTests {
     @Test func countsOnBudgetAccountsOnly() async throws {
         // The figures have to agree with the budget tab's Income/Spent, which
         // ignores off-budget accounts entirely (GH #256 follow-up). Closed
-        // on-budget accounts still count.
+        // on-budget accounts still count; a deleted one doesn't, so a
+        // transaction orphaned on it can't leak into every future month.
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
 
@@ -122,12 +123,14 @@ struct BudgetDatabaseAccountsSummaryTests {
                 INSERT INTO accounts (id, name, offbudget, closed, sort_order, tombstone) VALUES
                     ('acct-on',     'Checking',  0, 0, 1.0, 0),
                     ('acct-off',    'Brokerage', 1, 0, 2.0, 0),
-                    ('acct-closed', 'Old Card',  0, 1, 3.0, 0);
+                    ('acct-closed', 'Old Card',  0, 1, 3.0, 0),
+                    ('acct-dead',   'Deleted',   0, 0, 4.0, 1);
 
                 INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
                     ('salary',   'acct-on',     'cat-salary', 300000, 20260803, 0),
                     ('dividend', 'acct-off',    'cat-salary',   5000, 20260804, 0),
-                    ('fee',      'acct-closed', 'cat-food',    -1200, 20260805, 0);
+                    ('fee',      'acct-closed', 'cat-food',    -1200, 20260805, 0),
+                    ('ghost',    'acct-dead',   'cat-food',  -100000, 20260806, 0);
             """)
         }
 

--- a/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseAccountsSummaryTests.swift
@@ -4,8 +4,9 @@ import GRDB
 @testable import Actuali
 
 /// Pins the semantics of `fetchAccountsMonthSummary()`, the accounts tab's
-/// summary group (GH #256): money in and out across every account for one
-/// month, transfer legs excluded, split parents excluded, other months out.
+/// summary group (GH #256): the same income and spending the budget tab
+/// reports for the month — categorised transactions in on-budget accounts,
+/// hidden categories and groups left out, split parents excluded.
 @MainActor
 struct BudgetDatabaseAccountsSummaryTests {
 
@@ -41,17 +42,38 @@ struct BudgetDatabaseAccountsSummaryTests {
                     tombstone INTEGER DEFAULT 0
                 );
 
-                CREATE TABLE payees (
+                CREATE TABLE categories (
                     id TEXT PRIMARY KEY,
                     name TEXT,
-                    transfer_acct TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    cat_group TEXT,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
                     tombstone INTEGER DEFAULT 0
                 );
 
-                CREATE TABLE payee_mapping (
+                CREATE TABLE category_groups (
                     id TEXT PRIMARY KEY,
-                    targetId TEXT
+                    name TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
                 );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                INSERT INTO category_groups (id, name, is_income, sort_order) VALUES
+                    ('grp-income', 'Income',     1, 1.0),
+                    ('grp-usual',  'Usual',      0, 2.0);
+
+                INSERT INTO categories (id, name, is_income, cat_group, sort_order) VALUES
+                    ('cat-salary', 'Salary',   1, 'grp-income', 1.0),
+                    ('cat-rent',   'Rent',     0, 'grp-usual',  1.0),
+                    ('cat-food',   'Food',     0, 'grp-usual',  2.0);
             """)
         }
         let database = try BudgetDatabase(path: tempURL)
@@ -70,26 +92,28 @@ struct BudgetDatabaseAccountsSummaryTests {
             try conn.execute(sql: """
                 INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
 
-                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
-                    ('pay',     'acct-1', 400000, 20260803, 0),
-                    ('rent',    'acct-1', -150000, 20260805, 0),
-                    ('coffee',  'acct-1',   -450, 20260806, 0),
-                    ('void',    'acct-1',  -9999, 20260807, 1),  -- tombstoned
-                    ('lastmo',  'acct-1', -20000, 20260731, 0),  -- previous month
-                    ('nextmo',  'acct-1',  10000, 20260901, 0);  -- next month
+                INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                    ('pay',     'acct-1', 'cat-salary', 400000, 20260803, 0),
+                    ('rent',    'acct-1', 'cat-rent',  -150000, 20260805, 0),
+                    ('coffee',  'acct-1', 'cat-food',     -450, 20260806, 0),
+                    ('refund',  'acct-1', 'cat-food',      450, 20260807, 0),  -- offsets the coffee
+                    ('void',    'acct-1', 'cat-food',    -9999, 20260807, 1),  -- tombstoned
+                    ('lastmo',  'acct-1', 'cat-rent',   -20000, 20260731, 0),  -- previous month
+                    ('nextmo',  'acct-1', 'cat-salary',  10000, 20260901, 0);  -- next month
             """)
         }
 
         let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
 
         #expect(summary.incomeCents == 400000)
-        #expect(summary.expenseCents == 150450)
-        #expect(summary.netCents == 249550)
+        #expect(summary.expenseCents == 150000)
+        #expect(summary.netCents == 250000)
     }
 
-    @Test func coversOffBudgetAndClosedAccountsToo() async throws {
-        // The card sits under the all-accounts balance, which counts every
-        // account, so its month totals have to cover the same set.
+    @Test func countsOnBudgetAccountsOnly() async throws {
+        // The figures have to agree with the budget tab's Income/Spent, which
+        // ignores off-budget accounts entirely (GH #256 follow-up). Closed
+        // on-budget accounts still count.
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
 
@@ -98,57 +122,83 @@ struct BudgetDatabaseAccountsSummaryTests {
                 INSERT INTO accounts (id, name, offbudget, closed, sort_order, tombstone) VALUES
                     ('acct-on',     'Checking',  0, 0, 1.0, 0),
                     ('acct-off',    'Brokerage', 1, 0, 2.0, 0),
-                    ('acct-closed', 'Old Card',  0, 1, 3.0, 0),
-                    ('acct-dead',   'Deleted',   0, 0, 4.0, 1);
+                    ('acct-closed', 'Old Card',  0, 1, 3.0, 0);
 
-                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
-                    ('salary',   'acct-on',      300000, 20260803, 0),
-                    ('dividend', 'acct-off',       5000, 20260804, 0),
-                    ('fee',      'acct-closed',   -1200, 20260805, 0),
-                    ('ghost',    'acct-dead',   -100000, 20260806, 0);
+                INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                    ('salary',   'acct-on',     'cat-salary', 300000, 20260803, 0),
+                    ('dividend', 'acct-off',    'cat-salary',   5000, 20260804, 0),
+                    ('fee',      'acct-closed', 'cat-food',    -1200, 20260805, 0);
             """)
         }
 
         let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
 
-        #expect(summary.incomeCents == 305000)
+        #expect(summary.incomeCents == 300000)
         #expect(summary.expenseCents == 1200)
     }
 
-    @Test func excludesTransferLegs() async throws {
-        // A transfer moves money inside the set of accounts the card totals,
-        // so counting its legs would report both income and an expense that
-        // never happened (same rule as the WebUI's cash flow card).
+    @Test func ignoresUncategorisedTransactionsAndTransferLegs() async throws {
+        // Transfers between on-budget accounts carry no category, so they drop
+        // out with everything else uncategorised. A categorised leg into an
+        // off-budget account is spending, the way upstream counts it.
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
 
         try await db.dbQueueForTesting.write { conn in
             try conn.execute(sql: """
-                INSERT INTO accounts (id, name, sort_order) VALUES
-                    ('acct-checking', 'Checking', 1.0),
-                    ('acct-savings',  'Savings',  2.0);
+                INSERT INTO accounts (id, name, offbudget, sort_order) VALUES
+                    ('acct-checking', 'Checking',  0, 1.0),
+                    ('acct-savings',  'Savings',   0, 2.0),
+                    ('acct-broker',   'Brokerage', 1, 3.0);
 
-                -- Transfer payees carry no name, just the linked account.
-                INSERT INTO payees (id, name, transfer_acct) VALUES
-                    ('payee-shop',       'Shop', NULL),
-                    ('payee-to-savings', NULL,   'acct-savings'),
-                    ('payee-to-checking',NULL,   'acct-checking');
-                INSERT INTO payee_mapping (id, targetId) VALUES
-                    ('payee-shop',        'payee-shop'),
-                    ('payee-to-savings',  'payee-to-savings'),
-                    ('payee-to-checking', 'payee-to-checking');
-
-                INSERT INTO transactions (id, acct, description, amount, date, transferred_id, tombstone) VALUES
-                    ('spend',    'acct-checking', 'payee-shop',        -2500, 20260805, NULL,       0),
-                    ('leg-out',  'acct-checking', 'payee-to-savings', -50000, 20260806, 'leg-in',   0),
-                    ('leg-in',   'acct-savings',  'payee-to-checking', 50000, 20260806, 'leg-out',  0);
+                INSERT INTO transactions (id, acct, category, amount, date, transferred_id, tombstone) VALUES
+                    ('spend',     'acct-checking', 'cat-food',  -2500, 20260805, NULL,        0),
+                    ('uncat',     'acct-checking', NULL,        -7000, 20260805, NULL,        0),
+                    ('leg-out',   'acct-checking', NULL,       -50000, 20260806, 'leg-in',    0),
+                    ('leg-in',    'acct-savings',  NULL,        50000, 20260806, 'leg-out',   0),
+                    ('to-broker', 'acct-checking', 'cat-food', -30000, 20260807, 'from-chk',  0),
+                    ('from-chk',  'acct-broker',   NULL,        30000, 20260807, 'to-broker', 0);
             """)
         }
 
         let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
 
         #expect(summary.incomeCents == 0)
-        #expect(summary.expenseCents == 2500)
+        #expect(summary.expenseCents == 32500)
+    }
+
+    @Test func excludesHiddenCategoriesAndGroups() async throws {
+        // The budget tab's totals skip hidden categories and hidden groups, so
+        // these have to skip them too or the two tabs disagree.
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
+
+                INSERT INTO category_groups (id, name, is_income, sort_order, hidden) VALUES
+                    ('grp-hidden', 'Archived', 0, 3.0, 1);
+                INSERT INTO categories (id, name, is_income, cat_group, sort_order, hidden, tombstone) VALUES
+                    ('cat-hidden',   'Old Bill',   0, 'grp-usual',  3.0, 1, 0),
+                    ('cat-in-hidden','Archived',   0, 'grp-hidden', 1.0, 0, 0),
+                    ('cat-dead',     'Deleted',    0, 'grp-usual',  4.0, 0, 1),
+                    ('cat-old-pay',  'Old Salary', 1, 'grp-income', 2.0, 1, 0);
+
+                INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                    ('rent',   'acct-1', 'cat-rent',      -150000, 20260805, 0),
+                    ('pay',    'acct-1', 'cat-salary',     400000, 20260803, 0),
+                    ('hidden', 'acct-1', 'cat-hidden',      -5000, 20260805, 0),
+                    ('inhid',  'acct-1', 'cat-in-hidden',   -6000, 20260805, 0),
+                    ('dead',   'acct-1', 'cat-dead',        -7000, 20260805, 0),
+                    ('oldpay', 'acct-1', 'cat-old-pay',      8000, 20260805, 0);
+            """)
+        }
+
+        let summary = try await db.fetchAccountsMonthSummary(month: "2026-08")
+
+        #expect(summary.incomeCents == 400000)
+        #expect(summary.expenseCents == 150000)
     }
 
     @Test func countsSplitChildrenButNotTheirParent() async throws {
@@ -159,18 +209,19 @@ struct BudgetDatabaseAccountsSummaryTests {
             try conn.execute(sql: """
                 INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
 
-                -- A -$100.00 purchase split into -$60.00 and -$40.00. Counting
-                -- the parent too would report $200.00 of expenses.
-                INSERT INTO transactions (id, acct, amount, date, isParent, isChild, parent_id, tombstone) VALUES
-                    ('split-parent', 'acct-1', -10000, 20260803, 1, 0, NULL,           0),
-                    ('split-c1',     'acct-1',  -6000, 20260803, 0, 1, 'split-parent', 0),
-                    ('split-c2',     'acct-1',  -4000, 20260803, 0, 1, 'split-parent', 0);
+                -- A -$100.00 purchase split into -$60.00 and -$40.00. The
+                -- parent keeps the category it had before the split, so
+                -- counting it too would report $200.00 of expenses.
+                INSERT INTO transactions (id, acct, category, amount, date, isParent, isChild, parent_id, tombstone) VALUES
+                    ('split-parent', 'acct-1', 'cat-food', -10000, 20260803, 1, 0, NULL,           0),
+                    ('split-c1',     'acct-1', 'cat-food',  -6000, 20260803, 0, 1, 'split-parent', 0),
+                    ('split-c2',     'acct-1', 'cat-rent',  -4000, 20260803, 0, 1, 'split-parent', 0);
 
                 -- A deleted split: only the parent is tombstoned, so its
                 -- children have to be excluded through it.
-                INSERT INTO transactions (id, acct, amount, date, isParent, isChild, parent_id, tombstone) VALUES
-                    ('dead-parent', 'acct-1', -3000, 20260804, 1, 0, NULL,          1),
-                    ('orphan-c1',   'acct-1', -3000, 20260804, 0, 1, 'dead-parent', 0);
+                INSERT INTO transactions (id, acct, category, amount, date, isParent, isChild, parent_id, tombstone) VALUES
+                    ('dead-parent', 'acct-1', 'cat-food', -3000, 20260804, 1, 0, NULL,          1),
+                    ('orphan-c1',   'acct-1', 'cat-food', -3000, 20260804, 0, 1, 'dead-parent', 0);
             """)
         }
 
@@ -187,8 +238,8 @@ struct BudgetDatabaseAccountsSummaryTests {
         try await db.dbQueueForTesting.write { conn in
             try conn.execute(sql: """
                 INSERT INTO accounts (id, name, sort_order) VALUES ('acct-1', 'Checking', 1.0);
-                INSERT INTO transactions (id, acct, amount, date, tombstone) VALUES
-                    ('t1', 'acct-1', 1000, 20260701, 0);
+                INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                    ('t1', 'acct-1', 'cat-salary', 1000, 20260701, 0);
             """)
         }
 

--- a/Actuali/ActualiTests/BudgetDatabaseIncomeTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseIncomeTests.swift
@@ -160,6 +160,31 @@ struct BudgetDatabaseIncomeTests {
         #expect(june.incomeCategories.map(\.categoryId) == ["cat-salary"])
     }
 
+    @Test func transactionsOnADeletedAccountAreExcluded() async throws {
+        // Deleting an account takes its transactions with it; one left alive on
+        // a tombstoned account is a sync-race orphan, and counting it would put
+        // income and spending on the budget for an account the user can no
+        // longer see.
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try execSQL(db, """
+            INSERT INTO accounts (id, name, offbudget, sort_order, tombstone)
+            VALUES ('acct-dead', 'Deleted', 0, 2.0, 1);
+
+            INSERT INTO transactions (id, acct, category, amount, date, tombstone) VALUES
+                ('ghost-income', 'acct-dead', 'cat-salary',    77_000, 20260601, 0),
+                ('ghost-spend',  'acct-dead', 'cat-groceries', -8_000, 20260602, 0);
+            """)
+        try insertTransaction(db, date: 20260601, category: "cat-salary", amount: 100_000)
+        try insertTransaction(db, date: 20260602, category: "cat-groceries", amount: -30_000)
+
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+
+        #expect(june.totalIncome == 100_000)
+        #expect(june.totalSpent == -30_000)
+    }
+
     @Test func trackingBudgetIncludesBudgetedIncome() async throws {
         let (db, url) = try makeDatabase(envelope: false)
         defer { cleanup(url) }


### PR DESCRIPTION
The month summary on the accounts tab counted every dollar in and out of every account, so an off-budget brokerage's dividends landed in Income and its spending in Expenses — a bigger number than the budget tab shows for the same month.

Now it computes the same way the budget tab does: activity on income categories vs everything else, on-budget accounts only, hidden categories and groups excluded. Uncategorised rows drop out on their own (that includes on-budget transfer legs), and a categorised leg into an off-budget account counts as spending, matching upstream.

Expenses moved too, not just Income — otherwise Net mixes two scopes and off-budget spending keeps leaking in.

Ran: full unit suite on iPhone 17 Pro, 1203 tests passing. The summary tests were rewritten, they pinned the old all-accounts semantics.