### PR TITLE
Remove-autofocus-from-category-picker

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -1353,11 +1353,6 @@ struct CategoryPickerView: View {
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search categories")
         .searchFocused($searchFocused)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                searchFocused = true
-            }
-        }
     }
 
     private var filteredGroups: [CategoryGroup] {


### PR DESCRIPTION
**This could be considered as a preference thing**

The category search field was automatically focused when opening the category picker, causing the keyboard to appear immediately. This was unnecessary when selecting a category from the list, especially in the Uncategorized Transactions flow.

- Removed the automatic focus behavior from the category picker.
- The category list now opens normally without the keyboard.
- Users can still tap the search field to search for a category.

Tested on iphone 17 pro simulator