### PR TITLE
Liquid Glass effect added for light mode AppIcon.icon

### DIFF
--- a/Actuali/Actuali/AppIcon.icon/icon.json
+++ b/Actuali/Actuali/AppIcon.icon/icon.json
@@ -26,11 +26,37 @@
         "kind" : "neutral",
         "opacity" : 0.5
       },
-      "specular" : true,
-      "translucency" : {
-        "enabled" : true,
-        "value" : 0.4
-      }
+      "specular-specializations" : [
+        {
+          "value" : true
+        },
+        {
+          "appearance" : "dark",
+          "value" : true
+        }
+      ],
+      "translucency-specializations" : [
+        {
+          "value" : {
+            "enabled" : true,
+            "value" : 0.4
+          }
+        },
+        {
+          "appearance" : "dark",
+          "value" : {
+            "enabled" : false,
+            "value" : 0.4
+          }
+        },
+        {
+          "appearance" : "tinted",
+          "value" : {
+            "enabled" : true,
+            "value" : 0.4
+          }
+        }
+      ]
     }
   ],
   "supported-platforms" : {

--- a/Actuali/Actuali/AppIcon.icon/icon.json
+++ b/Actuali/Actuali/AppIcon.icon/icon.json
@@ -1,52 +1,42 @@
 {
-  "fill": {
-    "linear-gradient": [
+  "fill" : {
+    "linear-gradient" : [
       "display-p3:0.42676,0.21833,0.96215,1.00000",
       "display-p3:0.19152,0.08570,0.67755,1.00000"
-    ],
-    "orientation": {
-      "start": {
-        "x": 0.5,
-        "y": 0.0
-      },
-      "stop": {
-        "x": 0.5,
-        "y": 1.0
-      }
-    }
+    ]
   },
-  "groups": [
+  "groups" : [
     {
-      "blur-material": null,
-      "hidden": false,
-      "layers": [
+      "blur-material" : null,
+      "hidden" : false,
+      "layers" : [
         {
-          "image-name": "actuali-mark-white.svg",
-          "name": "actuali-mark-white",
-          "position": {
-            "scale": 1,
-            "translation-in-points": [
+          "image-name" : "actuali-mark-white.svg",
+          "name" : "actuali-mark-white",
+          "position" : {
+            "scale" : 1,
+            "translation-in-points" : [
               0.21499616440928548,
               -11.9296875
             ]
           }
         }
       ],
-      "shadow": {
-        "kind": "neutral",
-        "opacity": 0.5
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
       },
-      "specular": true,
-      "translucency": {
-        "enabled": false,
-        "value": 0.5
+      "specular" : true,
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.4
       }
     }
   ],
-  "supported-platforms": {
-    "circles": [
+  "supported-platforms" : {
+    "circles" : [
       "watchOS"
     ],
-    "squares": "shared"
+    "squares" : "shared"
   }
 }


### PR DESCRIPTION
## Why

After the AppIcon.icon addition, Liquid Glass effect is only visible on the dark mode icon and no the light mode.

## What

I add a slight transparency to the light mode icon version in the composer file so that the light effect is visible. The gradient color was not changed at all.

## How it was tested

Viewing the rendered icon in Icon Composer tool.

## Screenshots

Before
<img width="564" height="577" alt="image" src="https://github.com/user-attachments/assets/63b68f6d-ebd1-478e-a4ab-43c9049c7f23" />

After
<img width="568" height="571" alt="image" src="https://github.com/user-attachments/assets/cbe4c820-759c-44bb-aca7-7765dca87445" />
