### PR TITLE
Let AI review run on fork PRs, lock PR workflows to main

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,6 +7,7 @@ name: AI Code Review
 on:
   pull_request_target:
     types: [opened, synchronize]
+    branches: [main]
 
 permissions:
   contents: read
@@ -32,6 +33,10 @@ jobs:
           # with this job's capped GITHUB_TOKEN instead of the app's broader
           # installation token. Comments post as github-actions[bot].
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The action refuses actors without write access by default, which
+          # blocks every fork PR. Safe to waive here: the job's token is the
+          # capped GITHUB_TOKEN and checkout never touches PR-head code.
+          allowed_non_write_users: "*"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
             Fetch the diff with `gh pr diff ${{ github.event.pull_request.number }}`.

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -5,6 +5,7 @@ name: CI (no app changes)
 
 on:
   pull_request:
+    branches: [main]
     paths-ignore:
       - "Actuali/**"
       - ".github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "Actuali/**"
       - ".github/workflows/ci.yml"

--- a/.github/workflows/discord-log.yml
+++ b/.github/workflows/discord-log.yml
@@ -16,6 +16,7 @@ on:
     types: [opened, closed, reopened]
   pull_request_target:
     types: [opened, closed, reopened]
+    branches: [main]
   release:
     types: [published]
 


### PR DESCRIPTION
AI review was triggering on fork PRs (#276) but dying instantly: claude-code-action refuses actors without write access, which is every external contributor. Added `allowed_non_write_users: "*"` — safe here since the job never checks out PR-head code, uses the capped `GITHUB_TOKEN`, and the agent's tools are limited to reading the diff and commenting.

Also added `branches: [main]` to the PR triggers in ai-review, ci, ci-noop, and discord-log so workflows (and review credits) only spend on PRs actually targeting main. testflight already had it.

Workflow-only change, nothing to build or test. Failing runs for reference: [PR #274](https://github.com/MattFaz/actuali/actions/runs/32009354601), [patch-13](https://github.com/MattFaz/actuali/actions/runs/32092356154).