### PR TITLE
Remove-autofocus-from-category-picker

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -1305,7 +1305,6 @@ struct CategoryPickerView: View {
     @Binding var selectedCategoryId: String?
     var onPick: (() -> Void)? = nil
     @State private var searchText = ""
-    @FocusState private var searchFocused: Bool
 
     var body: some View {
         List {
@@ -1352,7 +1351,6 @@ struct CategoryPickerView: View {
         .navigationTitle("Category")
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search categories")
-        .searchFocused($searchFocused)
     }
 
     private var filteredGroups: [CategoryGroup] {

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -1353,11 +1353,6 @@ struct CategoryPickerView: View {
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search categories")
         .searchFocused($searchFocused)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                searchFocused = true
-            }
-        }
     }
 
     private var filteredGroups: [CategoryGroup] {


### PR DESCRIPTION
Why

The category search field was automatically focused when opening the category picker, causing the keyboard to appear immediately. This was unnecessary when selecting a category from the list, especially in the Uncategorized Transactions flow.

What

- Removed the automatic focus behavior from the category picker.
- The category list now opens normally without the keyboard.
- Users can still tap the search field to search for a category.

Tested

Tested on iphone 17 pro simulator