### PR TITLE
Quiet down CI test logs with xcbeautify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,14 @@ jobs:
       # CODE_SIGNING_ALLOWED=NO: an unsigned test host can't reach the
       # simulator keychain (errSecMissingEntitlement in EncryptionKeyManager
       # tests).
+      # xcbeautify (preinstalled on macOS runners) keeps the log readable;
+      # pipefail preserves xcodebuild's exit code through the pipe.
       - name: Build and run unit tests
         run: |
+          set -o pipefail
           xcodebuild test \
             -project Actuali/Actuali.xcodeproj \
             -scheme Actuali \
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
-            -skip-testing:ActualiUITests
+            -skip-testing:ActualiUITests \
+            | xcbeautify


### PR DESCRIPTION
The Build and Test job logs ~12k lines (3MB) even on a green run — raw xcodebuild build-tool echo, per-test output, and app logger noise. Pipe it through xcbeautify (preinstalled on GitHub's macOS runners) for a per-test summary instead. `set -o pipefail` keeps xcodebuild's exit code authoritative so failures still fail the job, and xcbeautify prints full compiler/test errors when they happen.

No test changes — this PR itself exercises the workflow since it touches `ci.yml`.