### PR TITLE
Add fallback server address

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -108,6 +108,12 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    @Published var fallbackServerURL: String = "" {
+        didSet {
+            UserDefaults.standard.set(fallbackServerURL, forKey: "fallbackServerURL")
+        }
+    }
+
     /// Extra HTTP headers the user wants stamped onto every server request
     /// (e.g. Cloudflare Access service-token headers). Persisted in the Keychain
     /// because values may be secrets. Assigning re-persists and pushes the live
@@ -813,6 +819,8 @@ final class BudgetStore: ObservableObject {
         // `-startTab budget` from test runs (actios-96wa).
         _serverURL = Published(
             initialValue: UserDefaults.standard.string(forKey: "serverURL") ?? "")
+        _fallbackServerURL = Published(
+            initialValue: UserDefaults.standard.string(forKey: "fallbackServerURL") ?? "")
         // customHeaders intentionally assigns through the property: its
         // didSet also pushes the headers onto the live network client.
         customHeaders = Self.loadPersistedCustomHeaders()
@@ -880,7 +888,10 @@ final class BudgetStore: ObservableObject {
 
     /// Configure server URL and token for sync to work on launch and app resume
     private func configureSavedSession(token: String) async {
-        try? await serverClient.configure(serverURL: serverURL)
+        try? await serverClient.configure(
+            serverURL: serverURL,
+            fallbackServerURL: fallbackServerURL
+        )
         await serverClient.setToken(token)
         isConnected = true
     }
@@ -933,6 +944,7 @@ final class BudgetStore: ObservableObject {
 
     func connect() async {
         let normalized = Self.normalizedServerURL(serverURL)
+        let normalizedFallback = Self.normalizedServerURL(fallbackServerURL)
         guard !normalized.isEmpty else {
             error = "Please enter a server URL"
             return
@@ -940,12 +952,18 @@ final class BudgetStore: ObservableObject {
         if normalized != serverURL {
             serverURL = normalized
         }
+        if normalizedFallback != fallbackServerURL {
+            fallbackServerURL = normalizedFallback
+        }
 
         isLoading = true
         error = nil
 
         do {
-            try await serverClient.configure(serverURL: normalized)
+            try await serverClient.configure(
+                serverURL: normalized,
+                fallbackServerURL: normalizedFallback
+            )
             // Ensure the client carries the user's headers before any probe/login,
             // so servers behind an auth proxy are reachable from the first request.
             applyCustomHeadersToClient()

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -888,9 +888,12 @@ final class BudgetStore: ObservableObject {
 
     /// Configure server URL and token for sync to work on launch and app resume
     private func configureSavedSession(token: String) async {
+        // Normalize here too: the field persists raw text per keystroke, and
+        // only connect() normalizes — a value saved between connect and login
+        // would otherwise fail validation on every subsequent launch.
         try? await serverClient.configure(
             serverURL: serverURL,
-            fallbackServerURL: fallbackServerURL
+            fallbackServerURL: Self.normalizedServerURL(fallbackServerURL)
         )
         await serverClient.setToken(token)
         isConnected = true
@@ -3004,6 +3007,10 @@ final class BudgetStore: ObservableObject {
     /// Sync when app enters foreground - only if a budget is loaded
     /// Uses rate-limited automatic sync to avoid redundant syncs
     func syncOnForeground() async {
+        // After a failover, probe whether the primary recovered while we were
+        // backgrounded. Fire-and-forget: the sync below proceeds on whichever
+        // address is currently active and never waits on the probe.
+        Task { await serverClient.retryPrimaryIfRecovered() }
         guard let client = syncClient else {
             logger.debug("syncOnForeground() skipped - no budget loaded")
             return

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -259,19 +259,25 @@ actor ActualServerClient {
     /// `ActualServerError.networkError` so callers surface actionable guidance
     /// instead of CFNetwork's raw description.
     private func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        // Capture the base that produced this request before suspension. Another
+        // request may fail over the actor while this one is awaiting its response.
+        let requestServerURL = serverURL
         do {
             return try await session.data(for: request)
         } catch let urlError as URLError where urlError.code != .cancelled {
             if let fallbackServerURL,
                let requestURL = request.url,
-               let primaryServerURL = serverURL,
-               requestURL.host == primaryServerURL.host {
+               let primaryServerURL = requestServerURL,
+               requestURL.host == primaryServerURL.host,
+               urlError.code != .notConnectedToInternet,
+               let fallbackURL = Self.fallbackRequestURL(
+                   requestURL: requestURL,
+                   primaryServerURL: primaryServerURL,
+                   fallbackServerURL: fallbackServerURL
+               ),
+               fallbackURL != requestURL {
                 var fallbackRequest = request
-                fallbackRequest.url = Self.fallbackRequestURL(
-                    requestURL: requestURL,
-                    primaryServerURL: primaryServerURL,
-                    fallbackServerURL: fallbackServerURL
-                )
+                fallbackRequest.url = fallbackURL
                 do {
                     let result = try await session.data(for: fallbackRequest)
                     // Keep using the reachable address for the rest of this

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -264,19 +264,19 @@ actor ActualServerClient {
         } catch let urlError as URLError where urlError.code != .cancelled {
             if let fallbackServerURL,
                let requestURL = request.url,
-               let serverURL,
-               requestURL.host == serverURL.host {
+               let primaryServerURL = serverURL,
+               requestURL.host == primaryServerURL.host {
                 var fallbackRequest = request
                 fallbackRequest.url = Self.fallbackRequestURL(
                     requestURL: requestURL,
-                    primaryServerURL: serverURL,
+                    primaryServerURL: primaryServerURL,
                     fallbackServerURL: fallbackServerURL
                 )
                 do {
                     let result = try await session.data(for: fallbackRequest)
                     // Keep using the reachable address for the rest of this
                     // session instead of waiting for the primary on every request.
-                    serverURL = fallbackServerURL
+                    self.serverURL = fallbackServerURL
                     return result
                 } catch let fallbackError as URLError where fallbackError.code != .cancelled {
                     throw ActualServerError.networkError(fallbackError)

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -201,6 +201,9 @@ actor ActualServerClient {
     private let session: URLSession
     private var serverURL: URL?
     private var fallbackServerURL: URL?
+    /// The primary as the user configured it, unaffected by failover swaps,
+    /// so a recovery probe knows which address to check.
+    private var configuredPrimaryURL: URL?
     private var token: String?
 
     /// User-supplied headers stamped onto every outgoing request, in order.
@@ -229,19 +232,20 @@ actor ActualServerClient {
         guard let url = URL(string: serverURL) else {
             throw ActualServerError.invalidURL
         }
-        let fallbackURL: URL?
-        if fallbackServerURL.isEmpty {
-            fallbackURL = nil
-        } else {
-            guard let url = URL(string: fallbackServerURL),
-                  url.scheme != nil,
-                  url.host != nil else {
+        // Set the primary before validating the fallback: configureSavedSession
+        // swallows this method's errors with try?, and a bad fallback must not
+        // leave the client without a working primary.
+        self.serverURL = url
+        self.configuredPrimaryURL = url
+        self.fallbackServerURL = nil
+        if !fallbackServerURL.isEmpty {
+            guard let fallbackURL = URL(string: fallbackServerURL),
+                  fallbackURL.scheme != nil,
+                  fallbackURL.host != nil else {
                 throw ActualServerError.invalidFallbackURL
             }
-            fallbackURL = url
+            self.fallbackServerURL = fallbackURL
         }
-        self.serverURL = url
-        self.fallbackServerURL = fallbackURL
     }
 
     func setToken(_ token: String?) {
@@ -267,13 +271,14 @@ actor ActualServerClient {
     /// `ActualServerError.networkError` so callers surface actionable guidance
     /// instead of CFNetwork's raw description.
     private func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
-        // Capture the base that produced this request before suspension. Another
-        // request may fail over the actor while this one is awaiting its response.
+        // Capture both bases that apply to this request before suspension. Another
+        // request may swap them on the actor while this one is awaiting its response.
         let requestServerURL = serverURL
+        let requestFallbackURL = fallbackServerURL
         do {
             return try await session.data(for: request)
         } catch let urlError as URLError where urlError.code != .cancelled {
-            if let fallbackServerURL,
+            if let requestFallbackURL,
                let requestURL = request.url,
                let primaryServerURL = requestServerURL,
                requestURL.host == primaryServerURL.host,
@@ -281,15 +286,23 @@ actor ActualServerClient {
                let fallbackURL = Self.fallbackRequestURL(
                    requestURL: requestURL,
                    primaryServerURL: primaryServerURL,
-                   fallbackServerURL: fallbackServerURL
+                   fallbackServerURL: requestFallbackURL
                ),
                fallbackURL != requestURL {
                 var fallbackRequest = request
                 fallbackRequest.url = fallbackURL
                 do {
                     let result = try await session.data(for: fallbackRequest)
+                    // Stick with the address that answered: swap the roles so
+                    // subsequent requests skip the dead address's timeout. A
+                    // later failure retries the old primary through this same
+                    // path, so a recovered primary swaps straight back.
+                    if serverURL == requestServerURL {
+                        serverURL = requestFallbackURL
+                        fallbackServerURL = requestServerURL
+                    }
                     logger.notice(
-                        "Primary server was unreachable; used the configured fallback for this request"
+                        "Server was unreachable; switched to the configured alternate address"
                     )
                     return result
                 } catch let fallbackError as URLError where fallbackError.code != .cancelled {
@@ -299,6 +312,26 @@ actor ActualServerClient {
             // Cancellation is ordinary control flow (a superseded refresh, a
             // screen the user left), so it propagates untouched.
             throw ActualServerError.networkError(urlError)
+        }
+    }
+
+    /// After a failover, check whether the configured primary is reachable
+    /// again and swap back if so. Safe to fire-and-forget on foreground: the
+    /// short probe timeout never blocks callers' own requests, and a no-op
+    /// when the session is already on the primary.
+    func retryPrimaryIfRecovered() async {
+        guard let configuredPrimaryURL,
+              let current = serverURL,
+              current != configuredPrimaryURL else { return }
+        var request = makeRequest(configuredPrimaryURL.appendingPathComponent("/info"))
+        request.timeoutInterval = 5
+        guard let (_, response) = try? await session.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+        // Re-check after the await: a concurrent request may have swapped.
+        if serverURL == current {
+            fallbackServerURL = current
+            serverURL = configuredPrimaryURL
+            logger.notice("Primary server is reachable again; switched back to it")
         }
     }
 
@@ -320,7 +353,7 @@ actor ActualServerClient {
         } else {
             endpointPath = requestPath[...]
         }
-    
+
         var components = URLComponents(
             url: fallbackServerURL,
             resolvingAgainstBaseURL: false

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -1,7 +1,11 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "ServerNetwork")
 
 enum ActualServerError: LocalizedError {
     case invalidURL
+    case invalidFallbackURL
     case invalidResponse
     case httpError(statusCode: Int, message: String?)
     case unauthorized
@@ -14,6 +18,8 @@ enum ActualServerError: LocalizedError {
         switch self {
         case .invalidURL:
             return "Invalid server URL"
+        case .invalidFallbackURL:
+            return "Invalid fallback server URL"
         case .invalidResponse:
             return "Invalid response from server"
         case .authProxyBlocked:
@@ -227,8 +233,10 @@ actor ActualServerClient {
         if fallbackServerURL.isEmpty {
             fallbackURL = nil
         } else {
-            guard let url = URL(string: fallbackServerURL) else {
-                throw ActualServerError.invalidURL
+            guard let url = URL(string: fallbackServerURL),
+                  url.scheme != nil,
+                  url.host != nil else {
+                throw ActualServerError.invalidFallbackURL
             }
             fallbackURL = url
         }
@@ -280,9 +288,9 @@ actor ActualServerClient {
                 fallbackRequest.url = fallbackURL
                 do {
                     let result = try await session.data(for: fallbackRequest)
-                    // Keep using the reachable address for the rest of this
-                    // session instead of waiting for the primary on every request.
-                    self.serverURL = fallbackServerURL
+                    logger.notice(
+                        "Primary server was unreachable; used the configured fallback for this request"
+                    )
                     return result
                 } catch let fallbackError as URLError where fallbackError.code != .cancelled {
                     throw ActualServerError.networkError(fallbackError)

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -194,6 +194,7 @@ enum ServerVersion {
 actor ActualServerClient {
     private let session: URLSession
     private var serverURL: URL?
+    private var fallbackServerURL: URL?
     private var token: String?
 
     /// User-supplied headers stamped onto every outgoing request, in order.
@@ -218,11 +219,21 @@ actor ActualServerClient {
 
     // MARK: - Configuration
 
-    func configure(serverURL: String) throws {
+    func configure(serverURL: String, fallbackServerURL: String = "") throws {
         guard let url = URL(string: serverURL) else {
             throw ActualServerError.invalidURL
         }
+        let fallbackURL: URL?
+        if fallbackServerURL.isEmpty {
+            fallbackURL = nil
+        } else {
+            guard let url = URL(string: fallbackServerURL) else {
+                throw ActualServerError.invalidURL
+            }
+            fallbackURL = url
+        }
         self.serverURL = url
+        self.fallbackServerURL = fallbackURL
     }
 
     func setToken(_ token: String?) {
@@ -251,6 +262,25 @@ actor ActualServerClient {
         do {
             return try await session.data(for: request)
         } catch let urlError as URLError where urlError.code != .cancelled {
+            if let fallbackServerURL,
+               let requestURL = request.url,
+               requestURL.host == serverURL?.host {
+                var fallbackRequest = request
+                fallbackRequest.url = URL(
+                    string: requestURL.path(percentEncoded: true)
+                        + (requestURL.query.map { "?" + $0 } ?? ""),
+                    relativeTo: fallbackServerURL
+                )?.absoluteURL
+                do {
+                    let result = try await session.data(for: fallbackRequest)
+                    // Keep using the reachable address for the rest of this
+                    // session instead of waiting for the primary on every request.
+                    serverURL = fallbackServerURL
+                    return result
+                } catch let fallbackError as URLError where fallbackError.code != .cancelled {
+                    throw ActualServerError.networkError(fallbackError)
+                }
+            }
             // Cancellation is ordinary control flow (a superseded refresh, a
             // screen the user left), so it propagates untouched.
             throw ActualServerError.networkError(urlError)
@@ -380,7 +410,7 @@ actor ActualServerClient {
         var request = makeRequest(url)
         request.httpMethod = "GET"
 
-        guard let (data, response) = try? await session.data(for: request),
+        guard let (data, response) = try? await send(request),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let created = try? JSONDecoder().decode(Bool.self, from: data) else {
@@ -405,7 +435,7 @@ actor ActualServerClient {
         var request = makeRequest(url)
         request.httpMethod = "GET"
 
-        guard let (data, response) = try? await session.data(for: request),
+        guard let (data, response) = try? await send(request),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let info = try? JSONDecoder().decode(ServerInfoResponse.self, from: data) else {

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -306,7 +306,13 @@ actor ActualServerClient {
                     )
                     return result
                 } catch let fallbackError as URLError where fallbackError.code != .cancelled {
-                    throw ActualServerError.networkError(fallbackError)
+                    logger.error(
+                        "Fallback address also failed: \(fallbackError.code.rawValue, privacy: .public)"
+                    )
+                    // The primary is the address the user thinks of as "the
+                    // server", so its error is the one that tells them what
+                    // to fix; the fallback's failure lives in the log above.
+                    throw ActualServerError.networkError(urlError)
                 }
             }
             // Cancellation is ordinary control flow (a superseded refresh, a
@@ -325,8 +331,13 @@ actor ActualServerClient {
               current != configuredPrimaryURL else { return }
         var request = makeRequest(configuredPrimaryURL.appendingPathComponent("/info"))
         request.timeoutInterval = 5
+        // Older servers and route-stripping reverse proxies don't answer
+        // /info (see fetchServerVersion), so any client-side status proves
+        // the primary is reachable; 5xx means a proxy whose backend is down,
+        // so stay on the fallback.
         guard let (_, response) = try? await session.data(for: request),
-              (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+              let status = (response as? HTTPURLResponse)?.statusCode,
+              (200..<500).contains(status) else { return }
         // Re-check after the await: a concurrent request may have swapped.
         if serverURL == current {
             fallbackServerURL = current

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -264,13 +264,14 @@ actor ActualServerClient {
         } catch let urlError as URLError where urlError.code != .cancelled {
             if let fallbackServerURL,
                let requestURL = request.url,
-               requestURL.host == serverURL?.host {
+               let serverURL,
+               requestURL.host == serverURL.host {
                 var fallbackRequest = request
-                fallbackRequest.url = URL(
-                    string: requestURL.path(percentEncoded: true)
-                        + (requestURL.query.map { "?" + $0 } ?? ""),
-                    relativeTo: fallbackServerURL
-                )?.absoluteURL
+                fallbackRequest.url = Self.fallbackRequestURL(
+                    requestURL: requestURL,
+                    primaryServerURL: serverURL,
+                    fallbackServerURL: fallbackServerURL
+                )
                 do {
                     let result = try await session.data(for: fallbackRequest)
                     // Keep using the reachable address for the rest of this
@@ -285,6 +286,43 @@ actor ActualServerClient {
             // screen the user left), so it propagates untouched.
             throw ActualServerError.networkError(urlError)
         }
+    }
+
+    /// Rebase an API request from the primary server onto the fallback while
+    /// preserving path prefixes on either address (for example `/actual`).
+    private static func fallbackRequestURL(
+        requestURL: URL,
+        primaryServerURL: URL,
+        fallbackServerURL: URL
+    ) -> URL? {
+        let primaryPath = primaryServerURL.path(percentEncoded: true)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let requestPath = requestURL.path(percentEncoded: true)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let endpointPath: Substring
+        if !primaryPath.isEmpty,
+           requestPath == primaryPath || requestPath.hasPrefix(primaryPath + "/") {
+            endpointPath = requestPath.dropFirst(primaryPath.count)
+        } else {
+            endpointPath = requestPath[...]
+        }
+    
+        var components = URLComponents(
+            url: fallbackServerURL,
+            resolvingAgainstBaseURL: false
+        )
+        let fallbackPath = fallbackServerURL.path(percentEncoded: true)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let endpoint = String(endpointPath)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components?.percentEncodedPath = "/" + [fallbackPath, endpoint]
+            .filter { !$0.isEmpty }
+            .joined(separator: "/")
+        components?.percentEncodedQuery = URLComponents(
+            url: requestURL,
+            resolvingAgainstBaseURL: false
+        )?.percentEncodedQuery
+        return components?.url
     }
 
     /// Whether a response looks like an auth proxy's login page rather than the

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -188,6 +188,13 @@ struct SettingsView: View {
                         .disabled(budgetStore.isConnected)
                         .accessibilityHint("Example: https://actual.example.com")
 
+                    TextField("Fallback server URL (optional)", text: $budgetStore.fallbackServerURL)
+                        .textContentType(.URL)
+                        .autocapitalization(.none)
+                        .keyboardType(.URL)
+                        .disabled(budgetStore.isConnected)
+                        .accessibilityHint("Used when the primary server cannot be reached")
+
                     if !budgetStore.isConnected {
                         // Show the password field before probing, when password
                         // login is active, or when the first OpenID sign-in needs

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+private final class FallbackTransport: URLProtocol {
+    nonisolated(unsafe) static var requestedHosts: [String] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let host = request.url?.host ?? ""
+        Self.requestedHosts.append(host)
+
+        if host == "primary.example.com" {
+            client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(
+            self,
+            didLoad: Data(#"{"status":"ok","data":{"token":"fallback-token"}}"#.utf8)
+        )
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite(.serialized)
+struct ActualServerClientFallbackTests {
+    private func makeClient(fallbackServerURL: String = "https://fallback.example.com") async throws
+        -> ActualServerClient {
+        FallbackTransport.requestedHosts = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FallbackTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: configuration))
+        try await client.configure(
+            serverURL: "https://primary.example.com",
+            fallbackServerURL: fallbackServerURL
+        )
+        return client
+    }
+
+    @Test func retriesAtFallbackWhenPrimaryCannotBeReached() async throws {
+        let client = try await makeClient()
+
+        let token = try await client.login(password: "password")
+        _ = try await client.login(password: "password")
+
+        #expect(token == "fallback-token")
+        #expect(FallbackTransport.requestedHosts == [
+            "primary.example.com",
+            "fallback.example.com",
+            "fallback.example.com"
+        ])
+    }
+
+    @Test func doesNotRetryWithoutAFallbackAddress() async throws {
+        let client = try await makeClient(fallbackServerURL: "")
+
+        await #expect(throws: ActualServerError.self) {
+            _ = try await client.login(password: "password")
+        }
+        #expect(FallbackTransport.requestedHosts == ["primary.example.com"])
+    }
+}

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -3,14 +3,14 @@ import Testing
 @testable import Actuali
 
 private final class FallbackTransport: URLProtocol {
-    nonisolated(unsafe) static var requestedHosts: [String] = []
+    nonisolated(unsafe) static var requestedURLs: [URL] = []
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         let host = request.url?.host ?? ""
-        Self.requestedHosts.append(host)
+        Self.requestedURLs.append(request.url!)
 
         if host == "primary.example.com" {
             client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
@@ -38,7 +38,7 @@ private final class FallbackTransport: URLProtocol {
 struct ActualServerClientFallbackTests {
     private func makeClient(fallbackServerURL: String = "https://fallback.example.com") async throws
         -> ActualServerClient {
-        FallbackTransport.requestedHosts = []
+        FallbackTransport.requestedURLs = []
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [FallbackTransport.self]
         let client = ActualServerClient(session: URLSession(configuration: configuration))
@@ -56,10 +56,8 @@ struct ActualServerClientFallbackTests {
         _ = try await client.login(password: "password")
 
         #expect(token == "fallback-token")
-        #expect(FallbackTransport.requestedHosts == [
-            "primary.example.com",
-            "fallback.example.com",
-            "fallback.example.com"
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com", "fallback.example.com"
         ])
     }
 
@@ -69,6 +67,16 @@ struct ActualServerClientFallbackTests {
         await #expect(throws: ActualServerError.self) {
             _ = try await client.login(password: "password")
         }
-        #expect(FallbackTransport.requestedHosts == ["primary.example.com"])
+        #expect(FallbackTransport.requestedURLs.map(\.host) == ["primary.example.com"])
+    }
+
+    @Test func preservesFallbackAddressPathPrefix() async throws {
+        let client = try await makeClient(
+            fallbackServerURL: "https://fallback.example.com/actual"
+        )
+    
+        _ = try await client.login(password: "password")
+    
+        #expect(FallbackTransport.requestedURLs.last?.path == "/actual/account/login")
     }
 }

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -5,6 +5,7 @@ import Testing
 private final class FallbackTransport: URLProtocol {
     nonisolated(unsafe) static var requestedURLs: [URL] = []
     nonisolated(unsafe) static var failures: [String: URLError] = [:]
+    nonisolated(unsafe) static var statuses: [String: Int] = [:]
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -20,7 +21,7 @@ private final class FallbackTransport: URLProtocol {
 
         let response = HTTPURLResponse(
             url: request.url!,
-            statusCode: 200,
+            statusCode: Self.statuses[host] ?? 200,
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "application/json"]
         )!
@@ -40,6 +41,7 @@ struct ActualServerClientFallbackTests {
     private func makeSession() -> URLSession {
         FallbackTransport.requestedURLs = []
         FallbackTransport.failures = ["primary.example.com": URLError(.cannotConnectToHost)]
+        FallbackTransport.statuses = [:]
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [FallbackTransport.self]
         return URLSession(configuration: configuration)
@@ -132,6 +134,59 @@ struct ActualServerClientFallbackTests {
     @Test func foregroundProbeKeepsFallbackWhilePrimaryIsDown() async throws {
         let client = try await makeClient()
         _ = try await client.login(password: "password")
+
+        await client.retryPrimaryIfRecovered()
+        _ = try await client.login(password: "password")
+
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com",
+            "primary.example.com", "fallback.example.com"
+        ])
+    }
+
+    @Test func surfacesPrimaryErrorWhenBothAddressesFail() async throws {
+        let client = try await makeClient()
+        FallbackTransport.failures = [
+            "primary.example.com": URLError(.secureConnectionFailed),
+            "fallback.example.com": URLError(.cannotFindHost),
+        ]
+
+        do {
+            _ = try await client.login(password: "password")
+            Issue.record("Expected the request to fail")
+        } catch let error as ActualServerError {
+            guard case .networkError(let underlying) = error,
+                  let urlError = underlying as? URLError else {
+                Issue.record("Expected a networkError, got \(error)")
+                return
+            }
+            // The primary's error is the actionable one; the fallback's
+            // failure is only logged.
+            #expect(urlError.code == .secureConnectionFailed)
+        }
+    }
+
+    @Test func foregroundProbeAcceptsPrimariesWithoutAnInfoRoute() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+        FallbackTransport.failures = [:]
+        FallbackTransport.statuses = ["primary.example.com": 404]
+
+        await client.retryPrimaryIfRecovered()
+        FallbackTransport.statuses = [:]
+        _ = try await client.login(password: "password")
+
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com",
+            "primary.example.com", "primary.example.com"
+        ])
+    }
+
+    @Test func foregroundProbeStaysOnFallbackWhenPrimaryAnswers5xx() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+        FallbackTransport.failures = [:]
+        FallbackTransport.statuses = ["primary.example.com": 502]
 
         await client.retryPrimaryIfRecovered()
         _ = try await client.login(password: "password")

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 private final class FallbackTransport: URLProtocol {
     nonisolated(unsafe) static var requestedURLs: [URL] = []
-    nonisolated(unsafe) static var primaryFailure = URLError(.cannotConnectToHost)
-    nonisolated(unsafe) static var fallbackFailure: URLError?
+    nonisolated(unsafe) static var primaryFailure: URLError? = URLError(.cannotConnectToHost)
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -14,12 +13,8 @@ private final class FallbackTransport: URLProtocol {
         let host = request.url?.host ?? ""
         Self.requestedURLs.append(request.url!)
 
-        if host == "primary.example.com" {
-            client?.urlProtocol(self, didFailWithError: Self.primaryFailure)
-            return
-        }
-        if let fallbackFailure = Self.fallbackFailure {
-            client?.urlProtocol(self, didFailWithError: fallbackFailure)
+        if host == "primary.example.com", let primaryFailure = Self.primaryFailure {
+            client?.urlProtocol(self, didFailWithError: primaryFailure)
             return
         }
 
@@ -46,7 +41,6 @@ struct ActualServerClientFallbackTests {
         -> ActualServerClient {
         FallbackTransport.requestedURLs = []
         FallbackTransport.primaryFailure = URLError(.cannotConnectToHost)
-        FallbackTransport.fallbackFailure = nil
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [FallbackTransport.self]
         let client = ActualServerClient(session: URLSession(configuration: configuration))
@@ -65,7 +59,8 @@ struct ActualServerClientFallbackTests {
 
         #expect(token == "fallback-token")
         #expect(FallbackTransport.requestedURLs.map(\.host) == [
-            "primary.example.com", "fallback.example.com", "fallback.example.com"
+            "primary.example.com", "fallback.example.com",
+            "primary.example.com", "fallback.example.com"
         ])
     }
 
@@ -88,17 +83,15 @@ struct ActualServerClientFallbackTests {
         #expect(FallbackTransport.requestedURLs.last?.path == "/actual/account/login")
     }
 
-    @Test func doesNotRetryFallbackAgainstItselfAfterFailover() async throws {
+    @Test func triesPrimaryAgainAfterUsingFallback() async throws {
         let client = try await makeClient()
         _ = try await client.login(password: "password")
-        FallbackTransport.fallbackFailure = URLError(.cannotConnectToHost)
+        FallbackTransport.primaryFailure = nil
     
-        await #expect(throws: ActualServerError.self) {
-            _ = try await client.login(password: "password")
-        }
+        _ = try await client.login(password: "password")
     
         #expect(FallbackTransport.requestedURLs.map(\.host) == [
-            "primary.example.com", "fallback.example.com", "fallback.example.com"
+            "primary.example.com", "fallback.example.com", "primary.example.com"
         ])
     }
     
@@ -111,5 +104,19 @@ struct ActualServerClientFallbackTests {
         }
     
         #expect(FallbackTransport.requestedURLs.map(\.host) == ["primary.example.com"])
+    }
+
+    @Test func malformedFallbackHasSpecificError() async {
+        let client = ActualServerClient()
+    
+        do {
+            try await client.configure(
+                serverURL: "https://primary.example.com",
+                fallbackServerURL: "https://"
+            )
+            Issue.record("Expected malformed fallback URL to be rejected")
+        } catch {
+            #expect(error.localizedDescription == "Invalid fallback server URL")
+        }
     }
 }

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -4,6 +4,8 @@ import Testing
 
 private final class FallbackTransport: URLProtocol {
     nonisolated(unsafe) static var requestedURLs: [URL] = []
+    nonisolated(unsafe) static var primaryFailure = URLError(.cannotConnectToHost)
+    nonisolated(unsafe) static var fallbackFailure: URLError?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -13,7 +15,11 @@ private final class FallbackTransport: URLProtocol {
         Self.requestedURLs.append(request.url!)
 
         if host == "primary.example.com" {
-            client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+            client?.urlProtocol(self, didFailWithError: Self.primaryFailure)
+            return
+        }
+        if let fallbackFailure = Self.fallbackFailure {
+            client?.urlProtocol(self, didFailWithError: fallbackFailure)
             return
         }
 
@@ -39,6 +45,8 @@ struct ActualServerClientFallbackTests {
     private func makeClient(fallbackServerURL: String = "https://fallback.example.com") async throws
         -> ActualServerClient {
         FallbackTransport.requestedURLs = []
+        FallbackTransport.primaryFailure = URLError(.cannotConnectToHost)
+        FallbackTransport.fallbackFailure = nil
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [FallbackTransport.self]
         let client = ActualServerClient(session: URLSession(configuration: configuration))
@@ -78,5 +86,30 @@ struct ActualServerClientFallbackTests {
         _ = try await client.login(password: "password")
     
         #expect(FallbackTransport.requestedURLs.last?.path == "/actual/account/login")
+    }
+
+    @Test func doesNotRetryFallbackAgainstItselfAfterFailover() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+        FallbackTransport.fallbackFailure = URLError(.cannotConnectToHost)
+    
+        await #expect(throws: ActualServerError.self) {
+            _ = try await client.login(password: "password")
+        }
+    
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com", "fallback.example.com"
+        ])
+    }
+    
+    @Test func offlineDeviceDoesNotAttemptFallback() async throws {
+        let client = try await makeClient()
+        FallbackTransport.primaryFailure = URLError(.notConnectedToInternet)
+    
+        await #expect(throws: ActualServerError.self) {
+            _ = try await client.login(password: "password")
+        }
+    
+        #expect(FallbackTransport.requestedURLs.map(\.host) == ["primary.example.com"])
     }
 }

--- a/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
+++ b/Actuali/ActualiTests/ActualServerClientFallbackTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 private final class FallbackTransport: URLProtocol {
     nonisolated(unsafe) static var requestedURLs: [URL] = []
-    nonisolated(unsafe) static var primaryFailure: URLError? = URLError(.cannotConnectToHost)
+    nonisolated(unsafe) static var failures: [String: URLError] = [:]
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -13,8 +13,8 @@ private final class FallbackTransport: URLProtocol {
         let host = request.url?.host ?? ""
         Self.requestedURLs.append(request.url!)
 
-        if host == "primary.example.com", let primaryFailure = Self.primaryFailure {
-            client?.urlProtocol(self, didFailWithError: primaryFailure)
+        if let failure = Self.failures[host] {
+            client?.urlProtocol(self, didFailWithError: failure)
             return
         }
 
@@ -37,13 +37,17 @@ private final class FallbackTransport: URLProtocol {
 
 @Suite(.serialized)
 struct ActualServerClientFallbackTests {
-    private func makeClient(fallbackServerURL: String = "https://fallback.example.com") async throws
-        -> ActualServerClient {
+    private func makeSession() -> URLSession {
         FallbackTransport.requestedURLs = []
-        FallbackTransport.primaryFailure = URLError(.cannotConnectToHost)
+        FallbackTransport.failures = ["primary.example.com": URLError(.cannotConnectToHost)]
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [FallbackTransport.self]
-        let client = ActualServerClient(session: URLSession(configuration: configuration))
+        return URLSession(configuration: configuration)
+    }
+
+    private func makeClient(fallbackServerURL: String = "https://fallback.example.com") async throws
+        -> ActualServerClient {
+        let client = ActualServerClient(session: makeSession())
         try await client.configure(
             serverURL: "https://primary.example.com",
             fallbackServerURL: fallbackServerURL
@@ -55,11 +59,9 @@ struct ActualServerClientFallbackTests {
         let client = try await makeClient()
 
         let token = try await client.login(password: "password")
-        _ = try await client.login(password: "password")
 
         #expect(token == "fallback-token")
         #expect(FallbackTransport.requestedURLs.map(\.host) == [
-            "primary.example.com", "fallback.example.com",
             "primary.example.com", "fallback.example.com"
         ])
     }
@@ -77,38 +79,92 @@ struct ActualServerClientFallbackTests {
         let client = try await makeClient(
             fallbackServerURL: "https://fallback.example.com/actual"
         )
-    
+
         _ = try await client.login(password: "password")
-    
+
         #expect(FallbackTransport.requestedURLs.last?.path == "/actual/account/login")
     }
 
-    @Test func triesPrimaryAgainAfterUsingFallback() async throws {
+    @Test func sticksWithFallbackOnceItSucceeds() async throws {
         let client = try await makeClient()
         _ = try await client.login(password: "password")
-        FallbackTransport.primaryFailure = nil
-    
+        // Even with the primary healthy again, the session keeps using the
+        // address that answered instead of paying a probe on every request.
+        FallbackTransport.failures = [:]
+
         _ = try await client.login(password: "password")
-    
+
         #expect(FallbackTransport.requestedURLs.map(\.host) == [
-            "primary.example.com", "fallback.example.com", "primary.example.com"
+            "primary.example.com", "fallback.example.com", "fallback.example.com"
         ])
     }
-    
+
+    @Test func returnsToPrimaryWhenFallbackFailsLater() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+        FallbackTransport.failures = ["fallback.example.com": URLError(.cannotConnectToHost)]
+
+        _ = try await client.login(password: "password")
+        _ = try await client.login(password: "password")
+
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com",
+            "fallback.example.com", "primary.example.com",
+            "primary.example.com"
+        ])
+    }
+
+    @Test func foregroundProbeSwapsBackWhenPrimaryRecovers() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+        FallbackTransport.failures = [:]
+
+        await client.retryPrimaryIfRecovered()
+        _ = try await client.login(password: "password")
+
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com",
+            "primary.example.com", "primary.example.com"
+        ])
+        #expect(FallbackTransport.requestedURLs[2].path == "/info")
+    }
+
+    @Test func foregroundProbeKeepsFallbackWhilePrimaryIsDown() async throws {
+        let client = try await makeClient()
+        _ = try await client.login(password: "password")
+
+        await client.retryPrimaryIfRecovered()
+        _ = try await client.login(password: "password")
+
+        #expect(FallbackTransport.requestedURLs.map(\.host) == [
+            "primary.example.com", "fallback.example.com",
+            "primary.example.com", "fallback.example.com"
+        ])
+    }
+
+    @Test func foregroundProbeIsANoOpBeforeAnyFailover() async throws {
+        let client = try await makeClient()
+        FallbackTransport.failures = [:]
+
+        await client.retryPrimaryIfRecovered()
+
+        #expect(FallbackTransport.requestedURLs.isEmpty)
+    }
+
     @Test func offlineDeviceDoesNotAttemptFallback() async throws {
         let client = try await makeClient()
-        FallbackTransport.primaryFailure = URLError(.notConnectedToInternet)
-    
+        FallbackTransport.failures = ["primary.example.com": URLError(.notConnectedToInternet)]
+
         await #expect(throws: ActualServerError.self) {
             _ = try await client.login(password: "password")
         }
-    
+
         #expect(FallbackTransport.requestedURLs.map(\.host) == ["primary.example.com"])
     }
 
     @Test func malformedFallbackHasSpecificError() async {
         let client = ActualServerClient()
-    
+
         do {
             try await client.configure(
                 serverURL: "https://primary.example.com",
@@ -118,5 +174,23 @@ struct ActualServerClientFallbackTests {
         } catch {
             #expect(error.localizedDescription == "Invalid fallback server URL")
         }
+    }
+
+    @Test func badFallbackStillConfiguresPrimary() async throws {
+        // configureSavedSession swallows configure errors with try?; a bad
+        // fallback must degrade to "no fallback", not an unconfigured client.
+        let client = ActualServerClient(session: makeSession())
+        FallbackTransport.failures = [:]
+        await #expect(throws: ActualServerError.self) {
+            try await client.configure(
+                serverURL: "https://primary.example.com",
+                fallbackServerURL: "no-scheme.example.com"
+            )
+        }
+
+        let token = try await client.login(password: "password")
+
+        #expect(token == "fallback-token")
+        #expect(FallbackTransport.requestedURLs.map(\.host) == ["primary.example.com"])
     }
 }

--- a/Actuali/ActualiTests/BudgetStoreFallbackServerTests.swift
+++ b/Actuali/ActualiTests/BudgetStoreFallbackServerTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@Suite(.serialized)
+@MainActor
+struct BudgetStoreFallbackServerTests {
+    @Test func connectNormalizesAndPersistsTheFallbackAddress() async {
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(ActualServerClient())
+        store.serverURL = "budget.example.com"
+        store.fallbackServerURL = "  fallback.example.com  "
+
+        await store.connect()
+
+        #expect(store.fallbackServerURL == "https://fallback.example.com")
+        #expect(
+            UserDefaults.standard.string(forKey: "fallbackServerURL")
+                == "https://fallback.example.com"
+        )
+    }
+
+    @Test func connectSurfacesAMalformedFallbackInsteadOfFailingSilently() async {
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(ActualServerClient())
+        store.serverURL = "budget.example.com"
+        store.fallbackServerURL = "https://"
+
+        await store.connect()
+
+        #expect(store.error == "Invalid fallback server URL")
+    }
+}


### PR DESCRIPTION
## Why

Allow Actuali to connect through a secondary server address when the primary address is unreachable.

Closes #285.

## What

- Added an optional fallback server URL to the connection settings.
- Retry transport failures against the fallback URL (skipped when the device is offline).
- Stick with the fallback for the session once it succeeds, so requests don't re-pay the dead primary's timeout.
- Swap back to the primary automatically: on the next transport error at the fallback, via a short non-blocking `/info` probe when the app returns to the foreground, or at next launch.
- Preserve reverse-proxy path prefixes (e.g. `/actual`) on either address.
- Persist and restore the fallback URL between launches.

## How it was tested

- Full unit suite (`xcodebuild test … -skip-testing:ActualiUITests`) passes locally on an iPhone 17 Pro simulator: 1228 tests, 0 failures.
- `ActualServerClientFallbackTests` covers failover, sticky behavior, recovery (fallback failure, foreground probe incl. servers without `/info`), path prefixes, offline short-circuit, error surfacing when both addresses fail, and malformed-fallback validation.
- `BudgetStoreFallbackServerTests` covers normalization, persistence, and error surfacing through `connect()`.
