### PR TITLE
Add Cancel to the tab-hosted add-transaction flow

### DIFF
--- a/Actuali/Actuali/Services/NotificationRouter.swift
+++ b/Actuali/Actuali/Services/NotificationRouter.swift
@@ -40,6 +40,11 @@ final class NotificationRouter: NSObject, ObservableObject, UNUserNotificationCe
     /// `AccountsListView` consumes the id by pushing the account.
     @Published var pendingAccountNavigation: String?
 
+    /// Tab tag to select after the tab-hosted add flow cancels (the user's
+    /// Start Page, GH #281). Also not set by notifications; consumed by
+    /// `MainTabView`.
+    @Published var pendingTabNavigation: Int?
+
     /// From a tapped new-transaction notification.
     @Published var destination: NotificationDestination?
 

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -54,6 +54,13 @@ struct MainTabView: View {
         .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
             if accountId != nil { selectedTab = 0 }
         }
+        // Cancel in the tab-hosted add flow returns to the user's Start Page.
+        .onChange(of: notificationRouter.pendingTabNavigation) { _, tab in
+            if let tab {
+                selectedTab = tab
+                notificationRouter.pendingTabNavigation = nil
+            }
+        }
     }
 
     /// The `Tab` value API rather than `tabItem`: `sidebarAdaptable` above only

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -495,15 +495,16 @@ struct AddTransactionView: View {
             .listSectionSpacing(.compact)
             .scrollDismissesKeyboard(.interactively)
             .toolbar {
-                // Any presented flow (edit, account-detail "+", notification
-                // prefill) gets Cancel; the tab-hosted add flow has nothing
-                // to dismiss to, so it shows none.
-                if isEditing || isPresented {
-                    ToolbarItem(placement: .cancellationAction) {
-                        // Esc closes the form on a hardware keyboard.
-                        Button("Cancel") { dismiss() }
-                            .keyboardShortcut(.cancelAction)
+                ToolbarItem(placement: .cancellationAction) {
+                    // Any presented flow (edit, account-detail "+",
+                    // notification prefill) closes on Cancel; the tab-hosted
+                    // add flow has nothing to dismiss to, so Cancel discards
+                    // the entry in place instead (GH #281).
+                    // Esc triggers it on a hardware keyboard.
+                    Button("Cancel") {
+                        if isEditing || isPresented { dismiss() } else { resetForm() }
                     }
+                    .keyboardShortcut(.cancelAction)
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -95,6 +95,10 @@ struct AddTransactionView: View {
     }
 
     private var isEditing: Bool { editing != nil }
+    /// Presented flows (edit, account-detail "+", notification prefill) can
+    /// close themselves; the tab-hosted add flow can't. Cancel, post-save
+    /// behavior, and the header all branch on this.
+    private var canDismiss: Bool { isEditing || isPresented }
     private var isTransfer: Bool { txType == .transfer }
     private var isEditingSplitParent: Bool { editing?.isParent == true }
     private var isEditingTransfer: Bool { editing?.transferId != nil }
@@ -491,7 +495,10 @@ struct AddTransactionView: View {
                 }
             }
             .readableWidth()
-            .navigationTitle(isEditing ? "Edit Transaction" : "Add Transaction")
+            // Presented flows keep their sheet titles; the tab root shows no
+            // header, matching the Accounts and Budget tabs.
+            .navigationTitle(canDismiss ? (isEditing ? "Edit Transaction" : "Add Transaction") : "")
+            .navigationBarTitleDisplayMode(canDismiss ? .automatic : .inline)
             .listSectionSpacing(.compact)
             .scrollDismissesKeyboard(.interactively)
             .toolbar {
@@ -502,7 +509,7 @@ struct AddTransactionView: View {
                     // the entry and returns to the user's Start Page instead
                     // (GH #281). Esc triggers it on a hardware keyboard.
                     Button("Cancel") {
-                        if isEditing || isPresented {
+                        if canDismiss {
                             dismiss()
                         } else {
                             resetForm()
@@ -513,14 +520,8 @@ struct AddTransactionView: View {
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
-                    Button("Done") {
-                        payeeFocused = false
-                        UIApplication.shared.sendAction(
-                            #selector(UIResponder.resignFirstResponder),
-                            to: nil, from: nil, for: nil
-                        )
-                    }
-                    .fontWeight(.semibold)
+                    Button("Done") { dismissKeyboard() }
+                        .fontWeight(.semibold)
                 }
             }
             .disabled(isLoading)
@@ -696,7 +697,7 @@ struct AddTransactionView: View {
 
         do {
             try await budgetStore.saveTransaction(form, editing: editing)
-            if isEditing || isPresented {
+            if canDismiss {
                 // Presented flows (edit, account-detail "+", notification
                 // prefill) close; the account-detail host is already the
                 // saved transaction's list.
@@ -725,6 +726,20 @@ struct AddTransactionView: View {
         errorMessage = nil
         splitLines = []
         unsplitRequested = false
+        // A fresh form suggests categories from payee history again — a
+        // discarded manual pick must not keep suppressing the lookup.
+        userPickedCategory = false
+        // Cancel can arrive with the amount or payee field still focused;
+        // a fresh form doesn't keep the old keyboard up.
+        dismissKeyboard()
+    }
+
+    private func dismissKeyboard() {
+        payeeFocused = false
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
     }
 }
 

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -499,10 +499,15 @@ struct AddTransactionView: View {
                     // Any presented flow (edit, account-detail "+",
                     // notification prefill) closes on Cancel; the tab-hosted
                     // add flow has nothing to dismiss to, so Cancel discards
-                    // the entry in place instead (GH #281).
-                    // Esc triggers it on a hardware keyboard.
+                    // the entry and returns to the user's Start Page instead
+                    // (GH #281). Esc triggers it on a hardware keyboard.
                     Button("Cancel") {
-                        if isEditing || isPresented { dismiss() } else { resetForm() }
+                        if isEditing || isPresented {
+                            dismiss()
+                        } else {
+                            resetForm()
+                            NotificationRouter.shared.pendingTabNavigation = StartTab.persisted.tabTag
+                        }
                     }
                     .keyboardShortcut(.cancelAction)
                 }

--- a/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+/// The tab-hosted add flow must offer a Cancel that discards everything
+/// entered (issue #281). Presented flows (edit, account-detail "+") already
+/// had Cancel via dismiss; the tab flow has nothing to dismiss to, so its
+/// Cancel resets the form in place.
+final class AddTransactionCancelUITests: XCTestCase {
+
+    @MainActor
+    func testTabHostedAddFlowCancelClearsTheForm() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "2"]
+        app.launch()
+
+        let amountField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == '0.00'")
+        ).firstMatch
+        XCTAssertTrue(amountField.waitForExistence(timeout: 10), "amount field not found")
+        amountField.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5),
+                      "keyboard did not appear")
+        amountField.typeText("500")
+
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 5), "no Done bar above the decimal pad")
+        done.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
+                      "keyboard did not dismiss")
+
+        let cancel = app.navigationBars.buttons["Cancel"]
+        XCTAssertTrue(cancel.waitForExistence(timeout: 5),
+                      "tab-hosted add flow has no Cancel button")
+        cancel.tap()
+
+        // The entered amount must be gone: the field shows its placeholder
+        // again, and the form stays put (still the Add Transaction tab).
+        XCTAssertTrue(app.navigationBars["Add Transaction"].waitForExistence(timeout: 5),
+                      "cancel navigated away from the add tab")
+        let cleared = NSPredicate(format: "value == '0.00' OR value == ''")
+        expectation(for: cleared, evaluatedWith: amountField)
+        waitForExpectations(timeout: 5)
+    }
+}

--- a/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
@@ -1,17 +1,16 @@
 import XCTest
 
 /// The tab-hosted add flow must offer a Cancel that discards everything
-/// entered (issue #281). Presented flows (edit, account-detail "+") already
-/// had Cancel via dismiss; the tab flow has nothing to dismiss to, so its
-/// Cancel resets the form in place.
+/// entered and returns to the user's Start Page (issue #281). Presented
+/// flows (edit, account-detail "+") already had Cancel via dismiss; the tab
+/// flow has nothing to dismiss to, so its Cancel resets the form and routes
+/// to the Start Page tab instead.
 final class AddTransactionCancelUITests: XCTestCase {
 
+    /// Types an amount on the decimal pad and dismisses the keyboard, then
+    /// taps the nav-bar Cancel.
     @MainActor
-    func testTabHostedAddFlowCancelClearsTheForm() throws {
-        let app = XCUIApplication()
-        app.launchArguments = ["-loadDemoData", "-initialTab", "2"]
-        app.launch()
-
+    private func enterAmountAndCancel(in app: XCUIApplication) {
         let amountField = app.textFields.matching(
             NSPredicate(format: "placeholderValue == '0.00'")
         ).firstMatch
@@ -31,13 +30,50 @@ final class AddTransactionCancelUITests: XCTestCase {
         XCTAssertTrue(cancel.waitForExistence(timeout: 5),
                       "tab-hosted add flow has no Cancel button")
         cancel.tap()
+    }
 
-        // The entered amount must be gone: the field shows its placeholder
-        // again, and the form stays put (still the Add Transaction tab).
-        XCTAssertTrue(app.navigationBars["Add Transaction"].waitForExistence(timeout: 5),
-                      "cancel navigated away from the add tab")
+    /// Asserts the amount field shows its placeholder again — the entered
+    /// amount was discarded.
+    @MainActor
+    private func assertAmountCleared(in app: XCUIApplication) {
+        let amountField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == '0.00'")
+        ).firstMatch
+        XCTAssertTrue(amountField.waitForExistence(timeout: 5), "amount field not found")
         let cleared = NSPredicate(format: "value == '0.00' OR value == ''")
         expectation(for: cleared, evaluatedWith: amountField)
         waitForExpectations(timeout: 5)
+    }
+
+    @MainActor
+    func testCancelReturnsToStartPageAndClearsTheForm() throws {
+        let app = XCUIApplication()
+        // -startTab feeds UserDefaults via the argument domain, the same key
+        // the Settings Start Page picker persists.
+        app.launchArguments = ["-loadDemoData", "-initialTab", "2", "-startTab", "budget"]
+        app.launch()
+
+        enterAmountAndCancel(in: app)
+
+        XCTAssertTrue(app.navigationBars["Budget"].waitForExistence(timeout: 5),
+                      "cancel did not land on the configured Start Page")
+
+        // Back on the Add tab, the entered amount must be gone.
+        app.tabBars.buttons["Add"].tap()
+        assertAmountCleared(in: app)
+    }
+
+    @MainActor
+    func testCancelStaysPutWhenStartPageIsAddTransaction() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData", "-initialTab", "2", "-startTab", "addTransaction"]
+        app.launch()
+
+        enterAmountAndCancel(in: app)
+
+        // The Start Page is this tab: cancel stays put and just discards.
+        XCTAssertTrue(app.navigationBars["Add Transaction"].waitForExistence(timeout: 5),
+                      "cancel navigated away from its own Start Page tab")
+        assertAmountCleared(in: app)
     }
 }

--- a/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
@@ -7,8 +7,8 @@ import XCTest
 /// to the Start Page tab instead.
 final class AddTransactionCancelUITests: XCTestCase {
 
-    /// Types an amount on the decimal pad and dismisses the keyboard, then
-    /// taps the nav-bar Cancel.
+    /// Types an amount and taps Cancel with the keyboard still up — the
+    /// normal mid-entry state a cancel arrives from.
     @MainActor
     private func enterAmountAndCancel(in app: XCUIApplication) {
         let amountField = app.textFields.matching(
@@ -19,12 +19,6 @@ final class AddTransactionCancelUITests: XCTestCase {
         XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5),
                       "keyboard did not appear")
         amountField.typeText("500")
-
-        let done = app.buttons["Done"]
-        XCTAssertTrue(done.waitForExistence(timeout: 5), "no Done bar above the decimal pad")
-        done.tap()
-        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
-                      "keyboard did not dismiss")
 
         let cancel = app.navigationBars.buttons["Cancel"]
         XCTAssertTrue(cancel.waitForExistence(timeout: 5),
@@ -71,9 +65,12 @@ final class AddTransactionCancelUITests: XCTestCase {
 
         enterAmountAndCancel(in: app)
 
-        // The Start Page is this tab: cancel stays put and just discards.
-        XCTAssertTrue(app.navigationBars["Add Transaction"].waitForExistence(timeout: 5),
-                      "cancel navigated away from its own Start Page tab")
+        // The Start Page is this tab: cancel stays put, discards the entry,
+        // and dismisses the mid-entry keyboard (which covers the tab bar).
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
+                      "keyboard stayed up after cancelling in place")
         assertAmountCleared(in: app)
+        XCTAssertTrue(app.tabBars.buttons["Accounts"].isHittable,
+                      "tab bar not reachable after cancelling in place")
     }
 }

--- a/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
@@ -21,11 +21,6 @@ final class AddTransactionKeyboardUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(amountField.waitForExistence(timeout: 10), "amount field not found")
 
-        // The tab-hosted add flow is not a presentation; a Cancel button
-        // here would be a no-op and must not render.
-        XCTAssertFalse(app.navigationBars.buttons["Cancel"].exists,
-                       "Cancel button rendered in the tab-hosted add flow")
-
         amountField.tap()
         XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5),
                       "keyboard did not appear")


### PR DESCRIPTION
The Add Transaction tab had no way to back out of a half-entered transaction — the sheet-presented flows (edit, account-detail "+", notification prefill) already show Cancel, but the tab flow hid it since there's nothing to dismiss to. Now the tab flow shows the same Cancel: it discards the entry (via the existing `resetForm()`), dismisses the keyboard, and returns to the user's configured Start Page, routed through the same `NotificationRouter` channel the post-save flow uses. If the Start Page *is* Add Transaction, Cancel just clears the form and stays put. Presented flows keep dismissing as before, and Esc still triggers it on a hardware keyboard.

`resetForm()` also clears `userPickedCategory` now, so a discarded manual category pick doesn't keep suppressing payee-history suggestions on the next entry (also fixes the same latent gap in the post-save reset).

The tab-hosted flow additionally drops its 'Add Transaction' header to match the Accounts and Budget tab roots; the presented sheets keep their 'Add/Edit Transaction' titles.

One existing assertion in `AddTransactionKeyboardUITests` explicitly required that the tab flow render *no* Cancel ("would be a no-op"). This issue reverses that decision — Cancel is no longer a no-op there — so that assertion was removed; the new `AddTransactionCancelUITests` covers the tab flow's Cancel presence, the Start Page redirect, the keyboard dismissal, and the form reset instead.

Intentionally out of scope: a discard-confirmation dialog.

Verified locally on an iPhone 17 Pro sim (iOS 26.5):
- Unit suite: 1205 tests in 152 suites passed
- UI tests: AddTransactionCancelUITests, AddTransactionKeyboardUITests, AddTransactionPostSaveUITests — 7/7 passed

Fixes #281