### PR TITLE
Hide half-applied CRDT rows from transaction lists and balances

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -463,7 +463,7 @@ class BudgetDatabase {
                 WHERE t.acct IS NOT NULL
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "p"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 GROUP BY t.acct
                 """)
@@ -533,7 +533,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "par"))
                   AND (c.tombstone = 0 OR c.tombstone IS NULL)
                   AND (c.hidden = 0 OR c.hidden IS NULL)
                   AND (g.tombstone = 0 OR g.tombstone IS NULL)
@@ -551,6 +551,15 @@ class BudgetDatabase {
     }
 
     // MARK: - Transactions
+
+    /// Alive-child filter for every query that counts split children:
+    /// mirrors upstream v_transactions_internal_alive, which joins the
+    /// parent row of every is_child = 1 row and requires it to exist with
+    /// tombstone = 0, so children of tombstoned or never-materialized
+    /// parents count nowhere. `parent` is the joined parent row's alias.
+    private static func aliveChildPredicate(parent: String) -> String {
+        "(t.isChild = 0 OR t.isChild IS NULL OR (\(parent).id IS NOT NULL AND (\(parent).tombstone = 0 OR \(parent).tombstone IS NULL)))"
+    }
 
     /// SELECT + display-name joins + liveness filter shared by the
     /// creation-detection and single-id transaction queries. The list query
@@ -832,7 +841,7 @@ class BudgetDatabase {
                   AND t.cleared = 1
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "p"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 """, arguments: [accountId]) ?? 0
         }
@@ -856,7 +865,7 @@ class BudgetDatabase {
                 WHERE t.acct = ?
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "p"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 """, arguments: [accountId])
             return AccountBalanceBreakdown(
@@ -887,7 +896,7 @@ class BudgetDatabase {
                   AND t.date IS NOT NULL
                   AND (t.reconciled = 0 OR t.reconciled IS NULL)
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "p"))
                 ORDER BY t.date DESC, t.sort_order DESC
                 """, arguments: [accountId])
 
@@ -936,7 +945,7 @@ class BudgetDatabase {
         WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
           AND t.date IS NOT NULL
           AND (t.isParent = 0 OR t.isParent IS NULL)
-          AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
+          AND \(aliveChildPredicate(parent: "par"))
           AND t.category IS NULL
           AND (a.offbudget = 0 OR a.offbudget IS NULL)
           AND (a.tombstone = 0 OR a.tombstone IS NULL)
@@ -1041,7 +1050,7 @@ class BudgetDatabase {
                 LEFT JOIN category_mapping cm ON cm.id = t.category
                 LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "par"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND COALESCE(cm.transferId, t.category) = ?
                   AND a.offbudget = 0
@@ -1240,7 +1249,7 @@ class BudgetDatabase {
                 LEFT JOIN accounts a ON a.id = t.acct
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "p"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND t.category IS NOT NULL
                   AND a.offbudget = 0
@@ -1647,7 +1656,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
-                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
+                  AND \(Self.aliveChildPredicate(parent: "par"))
                   AND t.date IS NOT NULL
                   AND t.acct IS NOT NULL
                 """)
@@ -2786,6 +2795,8 @@ class BudgetDatabase {
                 LEFT JOIN categories c ON c.id = t.category
                 WHERE t.schedule = ?
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
+                  AND t.date IS NOT NULL
+                  AND t.acct IS NOT NULL
                 ORDER BY t.date DESC, t.sort_order DESC
                 LIMIT ?
                 """, arguments: [scheduleId, limit])

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -444,11 +444,13 @@ class BudgetDatabase {
             // to the parent. We must exclude parents (isParent = 0) or every
             // split would be counted twice — matching Actual's own aggregate
             // semantics and fetchTransactionsForReports(). We must also exclude
-            // children whose parent is tombstoned: deleting a split tombstones
-            // the parent but leaves the child rows with tombstone = 0, so a
-            // per-row tombstone check alone would still count those orphans
-            // (matching Actual's alive view). Transfer legs still count;
-            // accounts with no transactions get 0.
+            // children whose parent is tombstoned or missing: deleting a split
+            // tombstones the parent but leaves the child rows with tombstone =
+            // 0, so a per-row tombstone check alone would still count those
+            // orphans, and upstream's alive view joins the parent row itself,
+            // so a child whose parent row never materialized doesn't count
+            // either. Transfer legs still count; accounts with no transactions
+            // get 0.
             //
             // date IS NOT NULL mirrors upstream v_transactions_internal: a
             // CRDT update for a row whose insert messages are gone (e.g.
@@ -461,7 +463,7 @@ class BudgetDatabase {
                 WHERE t.acct IS NOT NULL
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 GROUP BY t.acct
                 """)
@@ -531,7 +533,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
-                  AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
                   AND (c.tombstone = 0 OR c.tombstone IS NULL)
                   AND (c.hidden = 0 OR c.hidden IS NULL)
                   AND (g.tombstone = 0 OR g.tombstone IS NULL)
@@ -830,7 +832,7 @@ class BudgetDatabase {
                   AND t.cleared = 1
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 """, arguments: [accountId]) ?? 0
         }
@@ -854,7 +856,7 @@ class BudgetDatabase {
                 WHERE t.acct = ?
                   AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                 """, arguments: [accountId])
             return AccountBalanceBreakdown(
@@ -885,7 +887,7 @@ class BudgetDatabase {
                   AND t.date IS NOT NULL
                   AND (t.reconciled = 0 OR t.reconciled IS NULL)
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
                 ORDER BY t.date DESC, t.sort_order DESC
                 """, arguments: [accountId])
 
@@ -934,7 +936,7 @@ class BudgetDatabase {
         WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
           AND t.date IS NOT NULL
           AND (t.isParent = 0 OR t.isParent IS NULL)
-          AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+          AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
           AND t.category IS NULL
           AND (a.offbudget = 0 OR a.offbudget IS NULL)
           AND (a.tombstone = 0 OR a.tombstone IS NULL)
@@ -1039,7 +1041,7 @@ class BudgetDatabase {
                 LEFT JOIN category_mapping cm ON cm.id = t.category
                 LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND COALESCE(cm.transferId, t.category) = ?
                   AND a.offbudget = 0
@@ -1238,7 +1240,7 @@ class BudgetDatabase {
                 LEFT JOIN accounts a ON a.id = t.acct
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
-                  AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (p.id IS NOT NULL AND (p.tombstone = 0 OR p.tombstone IS NULL)))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND t.category IS NOT NULL
                   AND a.offbudget = 0
@@ -1645,7 +1647,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions par ON par.id = t.parent_id
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
-                  AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+                  AND (t.isChild = 0 OR t.isChild IS NULL OR (par.id IS NOT NULL AND (par.tombstone = 0 OR par.tombstone IS NULL)))
                   AND t.date IS NOT NULL
                   AND t.acct IS NOT NULL
                 """)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -449,11 +449,17 @@ class BudgetDatabase {
             // per-row tombstone check alone would still count those orphans
             // (matching Actual's alive view). Transfer legs still count;
             // accounts with no transactions get 0.
+            //
+            // date IS NOT NULL mirrors upstream v_transactions_internal: a
+            // CRDT update for a row whose insert messages are gone (e.g.
+            // after a sync reset) materializes a half-applied row with no
+            // date, which official clients never show or count (GH #275).
             let balanceRows = try Row.fetchAll(db, sql: """
                 SELECT t.acct AS acct, COALESCE(SUM(t.amount), 0) AS balance
                 FROM transactions t
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE t.acct IS NOT NULL
+                  AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
@@ -568,6 +574,8 @@ class BudgetDatabase {
         LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
         WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
           AND (t.isChild = 0 OR t.isChild IS NULL)
+          AND t.date IS NOT NULL
+          AND t.acct IS NOT NULL
         """
 
     private static func mapTransaction(_ row: Row) -> Transaction {
@@ -667,6 +675,8 @@ class BudgetDatabase {
                 LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isChild = 0 OR t.isChild IS NULL)
+                  AND t.date IS NOT NULL
+                  AND t.acct IS NOT NULL
                 """
 
             var arguments: [(any DatabaseValueConvertible)?] = []
@@ -818,6 +828,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE t.acct = ?
                   AND t.cleared = 1
+                  AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
@@ -841,6 +852,7 @@ class BudgetDatabase {
                 FROM transactions t
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE t.acct = ?
+                  AND t.date IS NOT NULL
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
@@ -870,6 +882,7 @@ class BudgetDatabase {
                 LEFT JOIN transactions p ON p.id = t.parent_id
                 WHERE t.acct = ?
                   AND t.cleared = 1
+                  AND t.date IS NOT NULL
                   AND (t.reconciled = 0 OR t.reconciled IS NULL)
                   AND (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.parent_id IS NULL OR p.tombstone = 0 OR p.tombstone IS NULL)
@@ -919,6 +932,7 @@ class BudgetDatabase {
 
     private static let uncategorizedWhere = """
         WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
+          AND t.date IS NOT NULL
           AND (t.isParent = 0 OR t.isParent IS NULL)
           AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
           AND t.category IS NULL
@@ -1632,6 +1646,8 @@ class BudgetDatabase {
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND (t.parent_id IS NULL OR par.tombstone = 0 OR par.tombstone IS NULL)
+                  AND t.date IS NOT NULL
+                  AND t.acct IS NOT NULL
                 """)
 
             return rows.map { row in

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1050,6 +1050,7 @@ class BudgetDatabase {
                 LEFT JOIN category_mapping cm ON cm.id = t.category
                 LEFT JOIN categories c ON c.id = COALESCE(cm.transferId, t.category)
                 WHERE (t.tombstone = 0 OR t.tombstone IS NULL)
+                  AND t.date IS NOT NULL
                   AND \(Self.aliveChildPredicate(parent: "par"))
                   AND (t.isParent = 0 OR t.isParent IS NULL)
                   AND COALESCE(cm.transferId, t.category) = ?

--- a/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
@@ -134,6 +134,33 @@ struct BudgetDatabaseHalfAppliedRowTests {
         #expect(breakdown.uncleared == 0)
     }
 
+    /// Upstream's alive view joins the parent row of every child (is_child =
+    /// 1) and requires it to exist with tombstone = 0, so a child whose
+    /// parent row never materialized — or that lost its parent_id cell —
+    /// counts nowhere.
+    @Test func balancesExcludeChildrenOfMissingParents() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, amount, date, isChild, parent_id, cleared) VALUES
+                    ('c-missing-parent', 'acct-a', -1000, 20251102, 1, 'never-arrived', 1),
+                    ('c-null-parent',    'acct-a', -2000, 20251103, 1, NULL,            1);
+            """)
+        }
+
+        let account = try #require(try await db.fetchAccounts().first { $0.id == "acct-a" })
+        #expect(account.balance == -275425)
+
+        let breakdown = try await db.balanceBreakdown(accountId: "acct-a")
+        #expect(breakdown.cleared == -275425)
+
+        let reportRows = try await db.fetchTransactionsForReports()
+        #expect(reportRows.map(\.id) == ["t-real"])
+    }
+
     @Test func singleFetchAndReportsHideHalfAppliedRows() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }

--- a/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+import GRDB
+@testable import Actuali
+
+/// Pins the upstream `v_transactions_internal` validity filter (GH #275):
+/// a CRDT update message for a row whose insert messages are gone from the
+/// server's history (e.g. after a sync reset) materializes a half-applied
+/// transaction row with a NULL `date` or `acct`. Upstream hides those rows
+/// behind `date IS NOT NULL AND acct IS NOT NULL` in every view, so the
+/// official client neither lists them nor counts them in balances — Actuali
+/// must do the same or the row shows up as a phantom duplicate with a
+/// garbage date and skews the account balance.
+@MainActor
+struct BudgetDatabaseHalfAppliedRowTests {
+
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    transfer_acct TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE payee_mapping (
+                    id TEXT PRIMARY KEY,
+                    targetId TEXT
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    parent_id TEXT,
+                    tombstone INTEGER DEFAULT 0
+                );
+            """)
+        }
+        let database = try BudgetDatabase(path: tempURL)
+        return (database, tempURL)
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// One healthy transfer leg plus a half-applied row (no date cell ever
+    /// arrived) on the same account — the exact shape reported in GH #275.
+    private func seed(_ db: BudgetDatabase) async throws {
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, sort_order) VALUES
+                    ('acct-a', 'Bank', 1.0);
+
+                INSERT INTO transactions (id, acct, amount, date, notes, cleared) VALUES
+                    ('t-real', 'acct-a', -275425, 20251030, NULL, 1);
+
+                -- Half-applied: update messages recreated the row without its
+                -- date cell. Official clients hide it (date IS NOT NULL).
+                INSERT INTO transactions (id, acct, amount, date, notes, cleared) VALUES
+                    ('t-phantom', 'acct-a', -275425, NULL, 'VOTRE PAIEMENT', 1);
+
+                -- Half-applied the other way round: no acct cell.
+                INSERT INTO transactions (id, acct, amount, date, notes) VALUES
+                    ('t-orphan', NULL, -5000, 20251101, 'stray');
+            """)
+        }
+    }
+
+    @Test func listHidesRowsWithoutDateOrAccount() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        let accountRows = try await db.fetchTransactions(accountId: "acct-a")
+        #expect(accountRows.map(\.id) == ["t-real"])
+
+        let allRows = try await db.fetchTransactions()
+        #expect(allRows.map(\.id) == ["t-real"])
+    }
+
+    @Test func balancesExcludeRowsWithoutDate() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        let account = try #require(try await db.fetchAccounts().first { $0.id == "acct-a" })
+        #expect(account.balance == -275425)
+
+        let cleared = try await db.clearedBalance(accountId: "acct-a")
+        #expect(cleared == -275425)
+
+        let breakdown = try await db.balanceBreakdown(accountId: "acct-a")
+        #expect(breakdown.cleared == -275425)
+        #expect(breakdown.uncleared == 0)
+    }
+
+    @Test func singleFetchAndReportsHideHalfAppliedRows() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        #expect(try await db.fetchTransaction(id: "t-phantom") == nil)
+        #expect(try await db.fetchTransaction(id: "t-real") != nil)
+
+        let reportRows = try await db.fetchTransactionsForReports()
+        #expect(reportRows.map(\.id) == ["t-real"])
+    }
+}

--- a/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
@@ -188,4 +188,22 @@ struct BudgetDatabaseHalfAppliedRowTests {
         let rows = try db.fetchTransactions(scheduleId: "sched-1")
         #expect(rows.map(\.id) == ["t-real"])
     }
+
+    /// The "All Time" category drill-down has no month window, so it can't
+    /// rely on `(date / 100) = ?` to drop NULL-date rows as a side effect.
+    @Test func allTimeCategoryListHidesHalfAppliedRows() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                UPDATE transactions SET category = 'cat-1'
+                WHERE id IN ('t-real', 't-phantom');
+            """)
+        }
+
+        let rows = try await db.fetchCategoryTransactions(categoryId: "cat-1", month: nil)
+        #expect(rows.map(\.id) == ["t-real"])
+    }
 }

--- a/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseHalfAppliedRowTests.swift
@@ -172,4 +172,20 @@ struct BudgetDatabaseHalfAppliedRowTests {
         let reportRows = try await db.fetchTransactionsForReports()
         #expect(reportRows.map(\.id) == ["t-real"])
     }
+
+    @Test func scheduleLinkedListHidesHalfAppliedRows() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seed(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                UPDATE transactions SET schedule = 'sched-1'
+                WHERE id IN ('t-real', 't-phantom');
+            """)
+        }
+
+        let rows = try db.fetchTransactions(scheduleId: "sched-1")
+        #expect(rows.map(\.id) == ["t-real"])
+    }
 }


### PR DESCRIPTION
The duplicate transfer in #275 is a half-applied CRDT row: the server's message history contains update messages (memo, cleared, amount, acct) for a transaction whose original insert messages are gone — the classic leftover after an upstream sync reset. Every client materializes that row with a NULL `date`, but the official client never shows it because `v_transactions_internal` filters `date IS NOT NULL AND acct IS NOT NULL` on every read. We didn't, so the row showed up in the account list with a garbage date (NULL date renders as "30 Nov 2" — exactly the screenshot) and its amount was counted into the balance. Deleting/recreating the transfer in the official client can't help because official can't even see the row.

Two commits, same parity concern:

1. Mirror the `date IS NOT NULL AND acct IS NOT NULL` filter in our transaction reads: account balances, the transaction list, single-transaction fetch, cleared/uncleared/reconciled breakdowns, the reconcile-lock fetch, the uncategorized filter, and the reports fetch.
2. Match upstream's alive view for split children: upstream joins the parent row for every `is_child = 1` row and requires it to exist with `tombstone = 0`. Our old predicate keyed on `parent_id`, so a child whose parent row never materialized (or that lost its `parent_id` cell) still counted toward balances and reports.

Upstream reference: `packages/loot-core/src/server/aql/schema/index.ts` (`v_transactions_internal` / `v_transactions_internal_alive`) and `migrations/1614782639336_trans_views2.sql`.

New `BudgetDatabaseHalfAppliedRowTests` seeds the exact shape from the report (a healthy transfer leg plus a date-less duplicate on the same account, plus children with missing/absent parents) and pins that lists, balances and reports hide them. All four tests fail without their fix (balance doubled, list showed the phantom, orphan children counted).

Ran the full unit suite locally: 1209 tests in 153 suites, all passing, on iPhone 17 Pro / iOS 26.2 sim.

Fixes #275