### PR TITLE
Shorten Uncategorized Action Preference Name

### DIFF
--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -395,7 +395,7 @@ struct SettingsView: View {
                         }
                     }
                     
-                    Picker("Uncategorized Tap Opens", selection: $budgetStore.uncategorizedTapAction) {
+                    Picker("Uncategorized Action", selection: $budgetStore.uncategorizedTapAction) {
                         ForEach(UncategorizedTapAction.allCases) { action in
                             Text(action.label).tag(action)
                         }


### PR DESCRIPTION
Why

The current name, "Uncategorized Tap opens", is too long and causes the preference to wrap onto two lines.

What

The preference name was shortened so it fits on a single line:

Old: Uncategorized Tap opens
New: Uncategorized Action
How it was tested

Tested on the iPhone 17 Pro Simulator.