### PR TITLE
income category tx

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -225,7 +225,8 @@ struct BudgetView: View {
                                             income: income,
                                             // Only tracking budgets budget income;
                                             // envelope budgets just receive it.
-                                            showsBudgeted: budget.toBudget == nil
+                                            showsBudgeted: budget.toBudget == nil,
+                                            onShowTransactions: showTransactions
                                         )
                                     }
                                 } header: {
@@ -401,6 +402,14 @@ struct BudgetView: View {
         transactionsDestination = CategoryTransactionsDestination(
             categoryId: category.categoryId,
             categoryName: category.categoryName,
+            month: month
+        )
+    }
+
+    private func showTransactions(_ income: IncomeCategory, month: String?) {
+        transactionsDestination = CategoryTransactionsDestination(
+            categoryId: income.categoryId,
+            categoryName: income.categoryName,
             month: month
         )
     }
@@ -918,14 +927,29 @@ struct IncomeCategoryRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let income: IncomeCategory
     var showsBudgeted = false
+    var onShowTransactions: (IncomeCategory, String?) -> Void = { _, _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                TwoLineName(text: income.categoryName, font: .body)
+                Button {
+                    onShowTransactions(income, nil)
+                } label: {
+                    TwoLineName(text: income.categoryName, font: .body)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("All transactions for \(income.categoryName)")
+
                 Spacer()
-                Text(budgetStore.displayBalance(income.received))
-                    .foregroundColor(income.received > 0 ? .green : .secondary)
+
+                Button {
+                    onShowTransactions(income, income.month)
+                } label: {
+                    Text(budgetStore.displayBalance(income.received))
+                        .foregroundColor(income.received > 0 ? .green : .secondary)
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Transactions for \(income.categoryName) in \(MonthPicker.title(for: income.month))")
             }
             if showsBudgeted {
                 Text("Budgeted: \(budgetStore.displayBalance(income.budgeted))")

--- a/Actuali/ActualiTests/BudgetDatabaseCategoryTransactionsTests.swift
+++ b/Actuali/ActualiTests/BudgetDatabaseCategoryTransactionsTests.swift
@@ -244,4 +244,30 @@ struct BudgetDatabaseCategoryTransactionsTests {
         let ids = try await db.fetchCategoryTransactions(categoryId: "cat-food", month: nil).map(\.id)
         #expect(ids == ["t-new", "t-mid-late", "t-mid-early", "t-old"])
     }
+
+    @Test func fetchesIncomeCategoryTransactions() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO accounts (id, name, offbudget) VALUES ('acct-1', 'Checking', 0);
+
+                INSERT INTO categories (id, name) VALUES ('cat-salary', 'Salary');
+                INSERT INTO category_mapping (id, transferId) VALUES ('cat-salary', NULL);
+
+                INSERT INTO transactions (id, acct, category, amount, date) VALUES
+                    ('t-may-salary',  'acct-1', 'cat-salary', 500_000, 20260531),
+                    ('t-june-salary', 'acct-1', 'cat-salary', 500_000, 20260615);
+            """)
+        }
+
+        let juneTxns = try await db.fetchCategoryTransactions(categoryId: "cat-salary", month: "2026-06")
+        #expect(juneTxns.map(\.id) == ["t-june-salary"])
+        #expect(juneTxns.first?.amount == 500_000)
+        #expect(juneTxns.first?.categoryName == "Salary")
+
+        let allTxns = try await db.fetchCategoryTransactions(categoryId: "cat-salary", month: nil)
+        #expect(allTxns.map(\.id) == ["t-june-salary", "t-may-salary"])
+    }
 }


### PR DESCRIPTION
## Why

Tapping the received amount or category name on income categories previously did nothing. Closes #298.

## What

- Made income category rows tappable in `BudgetView`:
  - Tapping the received amount opens `CategoryTransactionsView` scoped to that month.
  - Tapping the category name opens `CategoryTransactionsView` scoped to all time (matching regular budget categories).
- Added unit test in `BudgetDatabaseCategoryTransactionsTests` covering all-time and month-scoped income category queries.

## How it was tested

- Added unit test `BudgetDatabaseCategoryTransactionsTests.fetchesIncomeCategoryTransactions` to verify income transaction querying.