### PR TITLE
Animations throughout the App

### DIFF
--- a/Actuali/Actuali/ActualiApp.swift
+++ b/Actuali/Actuali/ActualiApp.swift
@@ -113,7 +113,7 @@ struct ActualiApp: App {
                             .allowsHitTesting(false)
                     }
                 }
-                .animation(.easeInOut(duration: 0.25), value: budgetStore.schedulePostNotice)
+                .animation(AppAnimation.appearance, value: budgetStore.schedulePostNotice)
         }
     }
 }

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -105,12 +105,14 @@ struct AccountDetailView: View {
     }
 
     private func breakdownRow(_ title: String, amount: Int) -> some View {
-        HStack {
+        let text = budgetStore.displayBalance(amount)
+        return HStack {
             Text(title)
                 .foregroundStyle(.secondary)
             Spacer()
-            Text(budgetStore.displayBalance(amount))
+            Text(text)
                 .foregroundStyle(.secondary)
+                .animatedAmount(text)
         }
         .font(.subheadline)
     }
@@ -122,13 +124,14 @@ struct AccountDetailView: View {
                 // split (GH #134), so the reconciled figure can be checked
                 // against a bank statement without starting a reconciliation.
                 Button {
-                    withAnimation { showingBreakdown.toggle() }
+                    withAnimation(AppAnimation.disclosure) { showingBreakdown.toggle() }
                 } label: {
                     HStack {
                         Text("Current Balance")
                         Spacer()
                         Text(budgetStore.displayBalance(currentBalance))
                             .fontWeight(.semibold)
+                            .animatedAmount(budgetStore.displayBalance(currentBalance)) 
                         if breakdown != nil {
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -298,6 +298,13 @@ struct AccountsListView: View {
     /// Shared so the two layouts can't drift apart.
     private func withChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         Group(content: content)
+            // Both layouts' section state lives in @AppStorage, and a write to
+            // that lands outside any withAnimation transaction — so the rows
+            // have to be animated from here, off the stored flags.
+            .animation(
+                AppAnimation.disclosure,
+                value: [isOnBudgetExpanded, isOffBudgetExpanded, isClosedExpanded]
+            )
             .contentMargins(.horizontal, 6, for: .scrollContent)
 //            .navigationTitle("Accounts")
             .toolbar {
@@ -430,16 +437,18 @@ struct AccountsSummaryCard: View {
     private var summary: BudgetDatabase.AccountsMonthSummary? { monthTotals?.totals }
 
     var body: some View {
+        let balance = budgetStore.displayBalance(totalBalance)
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text("All Accounts")
                     .font(.headline)
                 Spacer()
-                Text(budgetStore.displayBalance(totalBalance))
+                Text(balance)
                     .font(.headline)
                     .foregroundStyle(balanceColor(for: totalBalance))
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
+                    .animatedAmount(balance)
             }
             Divider()
             // Falls back to today's month only while the figures are still
@@ -489,24 +498,19 @@ struct AccountSectionHeader: View {
     var totalTrailingPadding: CGFloat = 24
 
     var body: some View {
+        let totalText = budgetStore.displayBalance(total)
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.toggle()
-            }
+            isExpanded.toggle()
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption)
-                    .frame(width: 12)
-                    // Decorative: the expanded/collapsed state is already
-                    // conveyed through the accessibility hint below, so this
-                    // icon would otherwise just add noise before the title.
-                    .accessibilityHidden(true)
+                DisclosureChevron(isExpanded: isExpanded)
+                                    .frame(width: 12)
                 Text(title)
                 Spacer()
-                Text(budgetStore.displayBalance(total))
+                Text(totalText)
                     .fontWeight(.regular)
                     .foregroundStyle(balanceColor(for: total))
+                    .animatedAmount(totalText)
                     // Grouped-list headers uppercase their content; fine for
                     // the title (string headers always rendered that way) but
                     // it would mangle alphabetic currency symbols ("kr"→"KR").
@@ -525,7 +529,7 @@ struct AccountSectionHeader: View {
         // be disabled outright, and a collapsed section is otherwise
         // indistinguishable from an empty one. Same convention as the budget
         // tab's group headers ("Essentials, collapsed").
-        .accessibilityLabel("\(title), \(expandedState), \(budgetStore.displayBalance(total))")
+        .accessibilityLabel("\(title), \(expandedState), \(totalText)")
         .accessibilityIdentifier("\(title), \(expandedState)")
         // Hints describe the result of the action, not the gesture itself —
         // VoiceOver already announces this as double-tap-activatable.
@@ -542,12 +546,14 @@ struct AccountRow: View {
     let account: Account
 
     var body: some View {
+        let balance = budgetStore.displayBalance(account.balance)
         HStack {
             Text(account.name)
                 .font(.body)
             Spacer()
-            Text(budgetStore.displayBalance(account.balance))
+            Text(balance)
                 .foregroundStyle(balanceColor(for: account.balance))
+                .animatedAmount(balance)
         }
     }
 }

--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -90,15 +90,13 @@ struct ReconcileView: View {
                     } else {
                         Section {
                             HStack {
+                                Text("Difference")
+                                Spacer()
                                 let text = differenceText(difference)
                                 Text(text)
                                     .fontWeight(.semibold)
                                     .foregroundStyle(.orange)
                                     .animatedAmount(text)
-                                Spacer()
-                                Text((difference > 0 ? "+" : "") + budgetStore.formatCurrency(difference))
-                                    .fontWeight(.semibold)
-                                    .foregroundStyle(.orange)
                             }
                             Button {
                                 Task { await createAdjustment(difference) }

--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -25,6 +25,11 @@ struct ReconcileView: View {
         guard let clearedBalance, let targetCents else { return nil }
         return targetCents - clearedBalance
     }
+    
+    /// Signed so a shortfall and a surplus read differently at a glance.
+    private func differenceText(_ cents: Int) -> String {
+        (cents > 0 ? "+" : "") + budgetStore.formatCurrency(cents)
+    }
 
     var body: some View {
         NavigationStack {
@@ -37,8 +42,10 @@ struct ReconcileView: View {
                             // Deliberately bypasses the hide-balances mask:
                             // comparing exact amounts against the bank is the
                             // whole point of reconciling.
-                            Text(budgetStore.formatCurrency(clearedBalance))
+                            let text = budgetStore.formatCurrency(clearedBalance)
+                            Text(text)
                                 .fontWeight(.semibold)
+                                .animatedAmount(text)
                         } else {
                             ProgressView()
                         }
@@ -83,7 +90,11 @@ struct ReconcileView: View {
                     } else {
                         Section {
                             HStack {
-                                Text("Difference")
+                                let text = differenceText(difference)
+                                Text(text)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(.orange)
+                                    .animatedAmount(text)
                                 Spacer()
                                 Text((difference > 0 ? "+" : "") + budgetStore.formatCurrency(difference))
                                     .fontWeight(.semibold)
@@ -106,6 +117,10 @@ struct ReconcileView: View {
                     }
                 }
             }
+            // Typing towards the bank's figure counts the difference down and
+            // then swaps the whole section for "All reconciled!" — the moment
+            // the numbers meet is the one thing this screen exists to show.
+            .animation(AppAnimation.appearance, value: difference)
             .navigationTitle("Reconcile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Actuali/Actuali/Views/Accounts/ReconcileView.swift
+++ b/Actuali/Actuali/Views/Accounts/ReconcileView.swift
@@ -30,6 +30,24 @@ struct ReconcileView: View {
     private func differenceText(_ cents: Int) -> String {
         (cents > 0 ? "+" : "") + budgetStore.formatCurrency(cents)
     }
+    
+    /// Which of the mutually exclusive sections below the entry fields is
+    /// showing. The section swap is animated off this rather than off
+    /// `difference`, which recomputes on every keystroke — an implicit
+    /// animation above a live text field would re-fire per character typed.
+    private enum ComparisonSection: Equatable {
+        case none
+        case invalidAmount
+        case difference
+        case reconciled
+    }
+
+    private var comparisonSection: ComparisonSection {
+        guard let difference else {
+            return clearedBalance != nil && !balanceText.isEmpty ? .invalidAmount : .none
+        }
+        return difference == 0 ? .reconciled : .difference
+    }
 
     var body: some View {
         NavigationStack {
@@ -115,10 +133,11 @@ struct ReconcileView: View {
                     }
                 }
             }
-            // Typing towards the bank's figure counts the difference down and
-            // then swaps the whole section for "All reconciled!" — the moment
-            // the numbers meet is the one thing this screen exists to show.
-            .animation(AppAnimation.appearance, value: difference)
+            // The moment the numbers meet, the difference section gives way
+            // to "All reconciled!" — the one thing this screen exists to
+            // show. The difference figure itself rolls on its own curve via
+            // `animatedAmount`, so this only has to cover the swap.
+            .animation(AppAnimation.appearance, value: comparisonSection)
             .navigationTitle("Reconcile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -243,7 +243,6 @@ struct BudgetView: View {
                         // stored value, rather than at the call site.
                         .animation(AppAnimation.disclosure, value: collapsedGroupsStorage)
                         // The clean style keeps the stock section rhythm; the
-                        // The clean style keeps the stock section rhythm; the
                         // detailed table packs its group cards tighter.
                         .listSectionSpacing(
                             budgetStore.budgetDisplayStyle == .clean ? .default : .custom(14)

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -237,6 +237,12 @@ struct BudgetView: View {
                                 }
                             }
                         }
+                        // Collapse state lives in @AppStorage, and a write to
+                        // that lands outside any withAnimation transaction —
+                        // so the rows have to be animated from here, off the
+                        // stored value, rather than at the call site.
+                        .animation(AppAnimation.disclosure, value: collapsedGroupsStorage)
+                        // The clean style keeps the stock section rhythm; the
                         // The clean style keeps the stock section rhythm; the
                         // detailed table packs its group cards tighter.
                         .listSectionSpacing(
@@ -786,6 +792,7 @@ struct SummaryStat: View {
                 .foregroundColor(valueColor)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
+                .animatedAmount(value)
         }
     }
 }
@@ -808,6 +815,7 @@ struct SummaryColumn: View {
                 .foregroundColor(valueColor)
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
+                .animatedAmount(value)
         }
         .frame(width: BudgetColumn.width, alignment: .trailing)
     }
@@ -826,6 +834,7 @@ struct BudgetAmountPill: View {
             .lineLimit(1)
             .minimumScaleFactor(0.6)
             .foregroundStyle(dimmed ? Color.secondary : color)
+            .animatedAmount(text)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .frame(width: BudgetColumn.width, alignment: .trailing)
@@ -860,9 +869,11 @@ struct BudgetGroupHeader: View {
     var body: some View {
         Button(action: onToggleCollapse) {
             HStack(spacing: BudgetColumn.spacing) {
-                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                DisclosureChevron(
+                    isExpanded: !isCollapsed,
+                    font: .caption2.weight(.semibold)
+                )
+                .foregroundStyle(.secondary)
                 if reservesTwoLines {
                     TwoLineName(
                         text: name,
@@ -954,6 +965,9 @@ struct CategoryProgressBar: View {
             }
         }
         .frame(height: 5)
+        // Budgeting a category shrinks its bar as the money lands, so the
+        // edit is visible in the row itself and not only in the pill.
+        .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
         .accessibilityLabel("Spent \(Int((fraction * 100).rounded())) percent of available")
     }

--- a/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
+++ b/Actuali/Actuali/Views/Budget/OverspentCategoriesView.swift
@@ -44,6 +44,10 @@ struct OverspentCategoriesView: View {
             }
         }
         .readableWidth()
+        // Covering a category removes its row, and covering the last one
+        // swaps the list for "Nothing Overspent" — the payoff for the swipe
+        // action, so let it play rather than blink.
+        .animation(AppAnimation.appearance, value: budgetStore.currentBudgetMonth?.overspentCount)
         .navigationTitle("Overspent Categories")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -58,6 +62,7 @@ struct OverspentCategoryRow: View {
     let category: CategoryBudget
 
     var body: some View {
+        let available = budgetStore.displayBalance(category.available)
         NavigationLink {
             CategoryTransactionsView(
                 destination: CategoryTransactionsDestination(
@@ -74,6 +79,7 @@ struct OverspentCategoryRow: View {
                     Text(budgetStore.displayBalance(category.available))
                         .foregroundStyle(.red)
                         .monospacedDigit()
+                        .animatedAmount(available)    
                 }
                 Text(category.groupName)
                     .font(.caption)

--- a/Actuali/Actuali/Views/Components/AppAnimation.swift
+++ b/Actuali/Actuali/Views/Components/AppAnimation.swift
@@ -1,0 +1,60 @@
+// Actuali/Actuali/Views/Components/AppAnimation.swift
+
+import SwiftUI
+
+/// The app's animation vocabulary. Three curves, each tied to one kind of
+/// change, so a section collapsing in the budget table and a section
+/// collapsing in the accounts list read as the same gesture rather than two
+/// screens that happen to both move.
+enum AppAnimation {
+    /// Expanding or collapsing a section. Short on purpose: the rows it
+    /// reveals are the point, not the motion getting there.
+    static let disclosure = Animation.easeInOut(duration: 0.2)
+
+    /// A figure changing under the user — a budget edit, a transfer, a sync
+    /// landing new transactions. Snappy so the new number is readable
+    /// immediately; the roll only has to say *which* number moved.
+    static let amount = Animation.snappy(duration: 0.28)
+
+    /// Something appearing or disappearing in place: a banner, a status
+    /// icon, a toast.
+    static let appearance = Animation.easeInOut(duration: 0.25)
+}
+
+extension View {
+    /// Rolls a currency figure to its new value instead of swapping it, so a
+    /// budget edit or a landed sync is visible *where* it landed rather than
+    /// only in a total the user has to go looking for.
+    ///
+    /// Takes the displayed string rather than the cents behind it, so masked
+    /// balances cross-fade on the same curve when "Hide Balances" flips.
+    func animatedAmount(_ value: String) -> some View {
+        contentTransition(.numericText())
+            .animation(AppAnimation.amount, value: value)
+    }
+}
+
+/// The rotating chevron every collapsible section header uses. One symbol
+/// turned rather than two symbols swapped: a rotation shows the header
+/// *doing* something, where `chevron.right` → `chevron.down` is a jump cut.
+///
+/// Carries its own animation so a caller that toggles state outside a
+/// `withAnimation` still gets the turn.
+struct DisclosureChevron: View {
+    let isExpanded: Bool
+    var font: Font = .caption
+
+    var body: some View {
+        Image(systemName: "chevron.right")
+            .font(font)
+            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            .animation(AppAnimation.disclosure, value: isExpanded)
+    }
+}
+
+#Preview("Chevron") {
+    VStack(spacing: 24) {
+        DisclosureChevron(isExpanded: false)
+        DisclosureChevron(isExpanded: true)
+    }
+}

--- a/Actuali/Actuali/Views/Components/InitialSyncBanner.swift
+++ b/Actuali/Actuali/Views/Components/InitialSyncBanner.swift
@@ -49,7 +49,7 @@ private struct InitialSyncBannerModifier: ViewModifier {
             }
             content
         }
-        .animation(.easeInOut(duration: 0.2), value: budgetStore.isInitialSyncing)
+        .animation(AppAnimation.appearance, value: budgetStore.isInitialSyncing)
     }
 }
 

--- a/Actuali/Actuali/Views/Components/SyncStatusView.swift
+++ b/Actuali/Actuali/Views/Components/SyncStatusView.swift
@@ -16,8 +16,8 @@ struct SyncStatusView: View {
                 // screen, so the spinner giving way to a settled icon is the
                 // only signal it finished. `.symbolEffect(.replace)` morphs
                 // one cloud glyph into the next rather than cutting.
-                Image(systemName: symbolName)
-                    .foregroundStyle(symbolColor)
+                Image(systemName: symbol.name)
+                    .foregroundStyle(symbol.color)
                     .contentTransition(.symbolEffect(.replace))
                     .transition(.scale.combined(with: .opacity))
             }
@@ -28,19 +28,11 @@ struct SyncStatusView: View {
 
     /// `.syncing` never draws a symbol (the spinner stands in for it), but
     /// the switch still has to cover it.
-    private var symbolName: String {
+    private var symbol: (name: String, color: Color) {
         switch state {
-        case .idle, .syncing: "checkmark.icloud"
-        case .offline: "icloud.slash"
-        case .error: "exclamationmark.icloud"
-        }
-    }
-
-    private var symbolColor: Color {
-        switch state {
-        case .idle, .syncing: .green
-        case .offline: .orange
-        case .error: .red
+        case .idle, .syncing: ("checkmark.icloud", .green)
+        case .offline: ("icloud.slash", .orange)
+        case .error: ("exclamationmark.icloud", .red)
         }
     }
 }

--- a/Actuali/Actuali/Views/Components/SyncStatusView.swift
+++ b/Actuali/Actuali/Views/Components/SyncStatusView.swift
@@ -7,22 +7,41 @@ struct SyncStatusView: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            switch state {
-            case .idle:
-                Image(systemName: "checkmark.icloud")
-                    .foregroundStyle(.green)
-            case .syncing:
+            if state == .syncing {
                 ProgressView()
                     .scaleEffect(0.7)
-            case .offline:
-                Image(systemName: "icloud.slash")
-                    .foregroundStyle(.orange)
-            case .error:
-                Image(systemName: "exclamationmark.icloud")
-                    .foregroundStyle(.red)
+                    .transition(.scale.combined(with: .opacity))
+            } else {
+                // A sync that lands no new data changes nothing else on
+                // screen, so the spinner giving way to a settled icon is the
+                // only signal it finished. `.symbolEffect(.replace)` morphs
+                // one cloud glyph into the next rather than cutting.
+                Image(systemName: symbolName)
+                    .foregroundStyle(symbolColor)
+                    .contentTransition(.symbolEffect(.replace))
+                    .transition(.scale.combined(with: .opacity))
             }
         }
         .font(.footnote)
+        .animation(AppAnimation.appearance, value: state)
+    }
+
+    /// `.syncing` never draws a symbol (the spinner stands in for it), but
+    /// the switch still has to cover it.
+    private var symbolName: String {
+        switch state {
+        case .idle, .syncing: "checkmark.icloud"
+        case .offline: "icloud.slash"
+        case .error: "exclamationmark.icloud"
+        }
+    }
+
+    private var symbolColor: Color {
+        switch state {
+        case .idle, .syncing: .green
+        case .offline: .orange
+        case .error: .red
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->

## Why

Nothing in the app acknowledged the user's own actions — collapsing a category group, covering an overspent category, or landing a sync all snapped between states with no motion, so it wasn't always obvious that the tap had registered or what had changed as a result.

Along the way this turned up a live bug: `AccountSectionHeader` already wrapped its toggle in `withAnimation`, but the state behind it is `@AppStorage`. A write to `@AppStorage` goes through `UserDefaults`, and the view invalidation that comes back isn't part of the transaction — so that animation had never actually run.

## What

- New `Views/Components/AppAnimation.swift`: three shared curves (`disclosure`, `amount`, `appearance`), an `.animatedAmount(_:)` modifier wrapping `contentTransition(.numericText())`, and a `DisclosureChevron` that rotates one glyph instead of swapping two.
- Collapse/expand in the budget table and the accounts list now slide their rows and turn their chevron. Because both are `@AppStorage`-backed, the animation is driven by `.animation(_:value:)` on the containers rather than `withAnimation` at the call site — that's the fix for the bug above, and it's why the accounts header loses its (inert) `withAnimation`.
- Currency figures roll to their new value instead of cutting: budget summary stats and columns, category pills and progress bars, account balances and section totals, the reconcile cleared/difference amounts. Takes the *displayed* string, so masked balances cross-fade on the same curve when Hide Balances flips.
- Sync status morphs between cloud glyphs via `.symbolEffect(.replace)` and scales the spinner in and out — a sync that lands no new data changes nothing else on screen, so that icon is the only signal it finished.
- Reconciling and covering an overspent category animate the section swapping for its "all done" state.
- Existing one-off durations in `ActualiApp` and `InitialSyncBanner` now pull from the shared constants (`InitialSyncBanner` shifts 0.2 → 0.25 as a result).

No sync-engine, database, or model code is touched — this is entirely view layer.

## How it was tested

Manually on the simulator: group collapse/expand in both budget display styles, accounts section collapse, and chevron rotation all confirmed working. The `@AppStorage` fix was validated by the chevrons animating where they previously didn't.

No new tests. These are view-layer animations with no assertable behavior change; the existing `BudgetGroupCollapseUITests` and `AccountSectionCollapseUITests` query by `accessibilityIdentifier`, which is unchanged, and `AccountSectionCollapseUITests` line 43's "collapsed header still carries the section total" assertion holds — the total is now hoisted into a local and reused by the label, producing the same string.

`xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -skip-testing:ActualiUITests` builds and runs successfully.

**The verbiage was created with assistance from AI to provide important detail and clearly define scope**