### PR TITLE
Swap Accounts and Budgets tab order

### DIFF
--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -68,12 +68,6 @@ struct MainTabView: View {
     /// `tabItem` form in compact width.
     private var tabs: some View {
         TabView(selection: $selectedTab) {
-            Tab(value: 0) {
-                AccountsListView()
-            } label: {
-                Label("Accounts", systemImage: "banknote")
-            }
-
             Tab(value: 1) {
                 BudgetView()
             } label: {
@@ -85,6 +79,12 @@ struct MainTabView: View {
             // surfaces the value to XCUITest on iOS 26 — BudgetTabBadgeUITests
             // fails on main for that reason, unrelated to this.)
             .accessibilityValue(Text(overspentBadgeValue))
+
+            Tab(value: 0) {
+                AccountsListView()
+            } label: {
+                Label("Accounts", systemImage: "banknote")
+            }
 
             Tab(value: 2) {
                 AddTransactionTabView()

--- a/Actuali/ActualiTests/StartTabTests.swift
+++ b/Actuali/ActualiTests/StartTabTests.swift
@@ -3,7 +3,10 @@ import Testing
 
 struct StartTabTests {
 
-    @Test func tabTagsMatchMainTabViewOrder() {
+    // Tags are fixed by the persisted start page and by the tab
+    // selections in MainTabView and NotificationRouter. They do not
+    // follow the position of the tabs in the tab bar.
+    @Test func tabTagsAreStable() {
         #expect(StartTab.accounts.tabTag == 0)
         #expect(StartTab.budget.tabTag == 1)
         #expect(StartTab.addTransaction.tabTag == 2)

--- a/Actuali/ActualiUITests/MainTabOrderUITests.swift
+++ b/Actuali/ActualiUITests/MainTabOrderUITests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+/// Locks in the visual order of the bottom tab bar: Budget before Accounts.
+/// Other tests select tabs by label, so they pass regardless of position —
+/// this is the only coverage that would catch the order being swapped back.
+final class MainTabOrderUITests: XCTestCase {
+
+    @MainActor
+    func testBudgetTabPrecedesAccountsTab() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        let budgetTab = app.tabBars.buttons["Budget"]
+        let accountsTab = app.tabBars.buttons["Accounts"]
+        XCTAssertTrue(budgetTab.waitForExistence(timeout: 10), "Budget tab not found")
+        XCTAssertTrue(accountsTab.waitForExistence(timeout: 10), "Accounts tab not found")
+
+        XCTAssertLessThan(budgetTab.frame.minX, accountsTab.frame.minX,
+                          "Budget tab should appear before Accounts in the tab bar")
+    }
+}


### PR DESCRIPTION
## Summary
- Swaps the position of the Accounts and Budget tabs in the bottom tab bar — Budget now shows first, Accounts second
- Tab values/tags are unchanged, so `StartTab` persistence and `NotificationRouter` navigation (which reference tab 0/1) keep working

## Test plan
- `xcodebuild build` succeeded
- `xcodebuild test` (unit tests, ActualiUITests skipped per CI): 1212 tests passed