### PR TITLE
Add Transaction: Cancel under the save button, one-line Notes box

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -515,6 +515,10 @@ struct AddTransactionView: View {
                 }
             }
             .readableWidth()
+            // The form's default ~35pt top inset is dead space on a screen
+            // with no header; 8pt keeps the first section off the status bar
+            // without it.
+            .contentMargins(.top, 8, for: .scrollContent)
             // Presented flows keep their sheet titles; the tab root shows no
             // header, matching the Accounts and Budget tabs.
             .navigationTitle(canDismiss ? (isEditing ? "Edit Transaction" : "Add Transaction") : "")

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -450,8 +450,11 @@ struct AddTransactionView: View {
                 }
 
                 Section {
+                    // One line while the note is short — an empty three-line
+                    // box only pushes Cleared and the save button off screen —
+                    // growing as the text needs it, up to six.
                     TextField("Notes", text: $notes, axis: .vertical)
-                        .lineLimit(3...6)
+                        .lineLimit(1...6)
                     // Links in the note stay openable while the text is a
                     // TextField (GH #190) — this form doubles as the only
                     // full view of a transaction's note.
@@ -493,6 +496,23 @@ struct AddTransactionView: View {
                     // whole form. Inert while the save is disabled.
                     .keyboardShortcut(.return, modifiers: .command)
                 }
+
+                // Cancel sits under the save button rather than in the
+                // navigation bar: the two decisions belong together at the
+                // end of the form, and its own section makes it the same
+                // full-width row as the save button.
+                Section {
+                    Button(role: .destructive, action: cancelEntry) {
+                        HStack {
+                            Spacer()
+                            Text("Cancel")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                    }
+                    // Esc still cancels on a hardware keyboard.
+                    .keyboardShortcut(.cancelAction)
+                }
             }
             .readableWidth()
             // Presented flows keep their sheet titles; the tab root shows no
@@ -502,22 +522,6 @@ struct AddTransactionView: View {
             .listSectionSpacing(.compact)
             .scrollDismissesKeyboard(.interactively)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    // Any presented flow (edit, account-detail "+",
-                    // notification prefill) closes on Cancel; the tab-hosted
-                    // add flow has nothing to dismiss to, so Cancel discards
-                    // the entry and returns to the user's Start Page instead
-                    // (GH #281). Esc triggers it on a hardware keyboard.
-                    Button("Cancel") {
-                        if canDismiss {
-                            dismiss()
-                        } else {
-                            resetForm()
-                            NotificationRouter.shared.pendingTabNavigation = StartTab.persisted.tabTag
-                        }
-                    }
-                    .keyboardShortcut(.cancelAction)
-                }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()
                     Button("Done") { dismissKeyboard() }
@@ -531,6 +535,19 @@ struct AddTransactionView: View {
                 // to them, mirroring Actual's cascade rule.
                 await loadSplitChildren()
             }
+        }
+    }
+
+    /// Any presented flow (edit, account-detail "+", notification prefill)
+    /// closes on Cancel; the tab-hosted add flow has nothing to dismiss to, so
+    /// Cancel discards the entry and returns to the user's Start Page instead
+    /// (GH #281).
+    private func cancelEntry() {
+        if canDismiss {
+            dismiss()
+        } else {
+            resetForm()
+            NotificationRouter.shared.pendingTabNavigation = StartTab.persisted.tabTag
         }
     }
 

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -510,15 +510,19 @@ struct AddTransactionView: View {
                             Spacer()
                         }
                     }
-                    // Esc still cancels on a hardware keyboard.
+                    // Esc cancels on a hardware keyboard while the row is on
+                    // screen. A Form row is lazy, so on a form long enough to
+                    // scroll the shortcut isn't registered until the row is
+                    // reached — the same reachability the tap has.
                     .keyboardShortcut(.cancelAction)
                 }
             }
             .readableWidth()
-            // The form's default ~35pt top inset is dead space on a screen
-            // with no header; 8pt keeps the first section off the status bar
-            // without it.
-            .contentMargins(.top, 8, for: .scrollContent)
+            // The form's default ~35pt top inset is dead space on the
+            // header-less tab root; 8pt keeps the first section off the status
+            // bar without it. Presented flows have a title up there and keep
+            // the stock inset.
+            .contentMargins(.top, canDismiss ? nil : 8, for: .scrollContent)
             // Presented flows keep their sheet titles; the tab root shows no
             // header, matching the Accounts and Budget tabs.
             .navigationTitle(canDismiss ? (isEditing ? "Edit Transaction" : "Add Transaction") : "")
@@ -750,8 +754,9 @@ struct AddTransactionView: View {
         // A fresh form suggests categories from payee history again — a
         // discarded manual pick must not keep suppressing the lookup.
         userPickedCategory = false
-        // Cancel can arrive with the amount or payee field still focused;
-        // a fresh form doesn't keep the old keyboard up.
+        // A reset can arrive with the amount or payee field still focused —
+        // Esc or ⌘Return from a hardware keyboard — and a fresh form doesn't
+        // keep the old keyboard up.
         dismissKeyboard()
     }
 

--- a/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
@@ -77,10 +77,7 @@ final class AddTransactionCancelUITests: XCTestCase {
 
         enterAmountAndCancel(in: app)
 
-        // The Start Page is this tab: cancel stays put and discards the entry
-        // without bringing a keyboard back up over the tab bar.
-        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
-                      "keyboard came back up after cancelling in place")
+        // The Start Page is this tab: cancel stays put and discards the entry.
         assertAmountCleared(in: app)
         XCTAssertTrue(app.tabBars.buttons["Accounts"].isHittable,
                       "tab bar not reachable after cancelling in place")

--- a/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionCancelUITests.swift
@@ -7,8 +7,10 @@ import XCTest
 /// to the Start Page tab instead.
 final class AddTransactionCancelUITests: XCTestCase {
 
-    /// Types an amount and taps Cancel with the keyboard still up — the
-    /// normal mid-entry state a cancel arrives from.
+    /// Types an amount, drops the keyboard the way the form offers (the Done
+    /// bar above the decimal pad), then taps the Cancel row at the foot of the
+    /// form — Cancel lives below the save button now, not in the navigation
+    /// bar, so it sits behind the keyboard mid-entry.
     @MainActor
     private func enterAmountAndCancel(in app: XCUIApplication) {
         let amountField = app.textFields.matching(
@@ -20,9 +22,19 @@ final class AddTransactionCancelUITests: XCTestCase {
                       "keyboard did not appear")
         amountField.typeText("500")
 
-        let cancel = app.navigationBars.buttons["Cancel"]
+        app.buttons["Done"].tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
+                      "keyboard did not dismiss after tapping Done")
+
+        let cancel = app.buttons["Cancel"]
         XCTAssertTrue(cancel.waitForExistence(timeout: 5),
                       "tab-hosted add flow has no Cancel button")
+        var scrollsLeft = 5
+        while !cancel.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
+        XCTAssertTrue(cancel.isHittable, "Cancel row not reachable at the foot of the form")
         cancel.tap()
     }
 
@@ -65,10 +77,10 @@ final class AddTransactionCancelUITests: XCTestCase {
 
         enterAmountAndCancel(in: app)
 
-        // The Start Page is this tab: cancel stays put, discards the entry,
-        // and dismisses the mid-entry keyboard (which covers the tab bar).
+        // The Start Page is this tab: cancel stays put and discards the entry
+        // without bringing a keyboard back up over the tab bar.
         XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 5),
-                      "keyboard stayed up after cancelling in place")
+                      "keyboard came back up after cancelling in place")
         assertAmountCleared(in: app)
         XCTAssertTrue(app.tabBars.buttons["Accounts"].isHittable,
                       "tab bar not reachable after cancelling in place")

--- a/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
+++ b/Actuali/ActualiUITests/AddTransactionKeyboardUITests.swift
@@ -80,9 +80,20 @@ final class AddTransactionKeyboardUITests: XCTestCase {
         let addTitle = app.navigationBars["Add Transaction"]
         XCTAssertTrue(addTitle.waitForExistence(timeout: 5), "add sheet did not present")
 
-        let cancel = app.navigationBars.buttons["Cancel"]
+        // The sheet autofocuses the amount field, and Cancel is a row at the
+        // foot of the form now — drop the keyboard first, then reach it.
+        if app.keyboards.firstMatch.waitForExistence(timeout: 5) {
+            app.buttons["Done"].tap()
+        }
+
+        let cancel = app.buttons["Cancel"]
         XCTAssertTrue(cancel.waitForExistence(timeout: 5),
                       "no Cancel button on the sheet-presented add flow")
+        var scrollsLeft = 5
+        while !cancel.isHittable && scrollsLeft > 0 {
+            app.swipeUp()
+            scrollsLeft -= 1
+        }
         cancel.tap()
 
         XCTAssertTrue(addTitle.waitForNonExistence(timeout: 5),


### PR DESCRIPTION
Three small changes to the Add/Edit Transaction form (actios-5br6).

**Cancel** was in the top-left navigation bar, as far as possible from the Add Transaction button it pairs with. It's now a full-width red row in its own section right under the save button — same width, same height, same card. The tab-hosted flow still discards the entry and routes to the Start Page; presented flows still dismiss.

**Notes** reserved a three-line box even when empty, pushing Cleared and the save button down the screen. It now starts at one line and grows with the text up to six (`lineLimit(1...6)`).

**Top inset:** the form's stock ~35pt top content inset is dead space on the header-less tab root, so that flow gets 8pt instead (`contentMargins(.top, canDismiss ? nil : 8, …)`). Presented flows have a title up there and keep the stock inset, unchanged. With this the whole form — Cancel included — fits without scrolling.

Trade-offs worth knowing, both from moving Cancel down:

- Mid-entry the row sits behind the keyboard, so backing out is Done (present in both keyboard toolbars) then Cancel, rather than one tap. The UI tests do exactly that now.
- `.keyboardShortcut(.cancelAction)` now lives on a lazy `Form` row, so Esc fires only while the row is realized — the same reachability the tap has. Hardware Esc can't be exercised in the simulator (`app.typeKey(.escape)` fails identically against `main`'s toolbar Cancel), so this is documented in a comment rather than tested.
- Cancel-with-a-live-keyboard is no longer a reachable tap path, so that assertion came out of `AddTransactionCancelUITests`. `resetForm()` still dismisses the keyboard for the Esc and ⌘Return paths.

Ran: unit tests (`-skip-testing:ActualiUITests`) green, plus `AddTransactionCancelUITests` and `AddTransactionKeyboardUITests/testSheetPresentedAddFlowShowsCancel` green on iPhone 17 Pro. Checked the layout by hand on the simulator.