### PR TITLE
Currency Carryover When Switching Budgets

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -247,6 +247,10 @@ final class BudgetStore: ObservableObject {
         UserDefaults.standard.set(code, forKey: Self.currencyCodeCacheKey(for: budgetId))
     }
 
+    private func forgetCachedCurrencyCode(for budgetId: String) {
+        UserDefaults.standard.removeObject(forKey: Self.currencyCodeCacheKey(for: budgetId))
+    }
+
     /// User-initiated currency changes (the Settings picker) go through
     /// here, not a direct `currencyCode = ...` assignment: it also persists
     /// the choice into the budget's own `preferences` table via sync, so it
@@ -1185,6 +1189,7 @@ final class BudgetStore: ObservableObject {
                     try? EncryptionKeyManager.remove(fileId: fileId)
                 }
                 try? fileManager.deleteBudget(local.id)
+                forgetCachedCurrencyCode(for: local.id)
             }
         }
 
@@ -1359,12 +1364,6 @@ final class BudgetStore: ObservableObject {
     func loadLocalBudget(_ budgetId: String) async {
         isLoading = true
         error = nil
-        // A fresh budget download can predate the CRDT preference messages
-        // that its first sync will apply. Show this budget's last confirmed
-        // code during that short window. A budget without a cached or stored
-        // preference retains the current fallback currency.
-        let cachedCurrencyCode = cachedCurrencyCode(for: budgetId)
-        currencyCode = cachedCurrencyCode ?? currencyCode
 
         var db: BudgetDatabase?
         do {
@@ -1394,19 +1393,17 @@ final class BudgetStore: ObservableObject {
             // spinner and clears it when it finishes.
             guard database === openedDb else { return }
 
-            // The downloaded SQLite snapshot can predate the following CRDT
-            // sync. When a cached value already exists, keep showing it —
-            // the sync that always runs right after this load corrects it
-            // moments later via refreshDataOnly() (unconditional, so this
-            // can never get stuck on a wrong value either — GH #59/#297).
-            // With no cache yet (first time loading this budget), the fresh
-            // snapshot is still the best answer available, so show it now
-            // rather than leaving the previous budget's value on screen.
+            // The database stays authoritative whenever it has an answer, so a
+            // currency changed on another client always wins here. The cache
+            // only covers the gap: a freshly downloaded snapshot can predate
+            // the CRDT preference messages that carry the setting, and without
+            // it the previous budget's currency would stay on screen until the
+            // first sync lands (GH #297).
             if let fetchedCurrencyCode {
-                if cachedCurrencyCode == nil {
-                    currencyCode = fetchedCurrencyCode
-                }
+                currencyCode = fetchedCurrencyCode
                 cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
+            } else if let cached = cachedCurrencyCode(for: budgetId) {
+                currencyCode = cached
             }
             
             upcomingScheduledTransactionLength = fetchedUpcomingLength
@@ -1542,6 +1539,7 @@ final class BudgetStore: ObservableObject {
     private func refreshDataOnly() async {
         guard let database else { return }
         let budgetId = currentBudgetId
+        let currencyCodeBefore = currencyCode
         do {
             // Fetch into locals, then publish in one batch (no suspension
             // points between assignments) so overlapping refreshes can't
@@ -1556,20 +1554,14 @@ final class BudgetStore: ObservableObject {
             // Re-read here as well as on load: a sync can bring in a changed
             // upcoming window, and the status badges below are computed from it.
             let fetchedUpcomingLength = try await database.fetchUpcomingScheduledTransactionLength()
-            // Read this last so a Settings change cannot be overwritten by a
-            // stale currency value fetched before the other asynchronous reads.
+            // Re-read here too: a sync can bring in a currency set on another
+            // client, and nothing else republishes it (GH #297).
             let fetchedCurrencyCode = try await database.fetchCurrencyCode()
 
             // If the budget was switched while we were fetching, this
             // snapshot belongs to the old database — drop it.
             guard self.database === database, self.currentBudgetId == budgetId else { return }
 
-            if let fetchedCurrencyCode {
-                currencyCode = fetchedCurrencyCode
-                if let budgetId {
-                    cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
-                }
-            }
             accounts = fetchedAccounts
             transactions = fetchedTransactions
             uncategorizedCount = fetchedUncategorizedCount
@@ -1578,6 +1570,18 @@ final class BudgetStore: ObservableObject {
             currentBudgetMonth = fetchedBudgetMonth
             widgetBudgetMonth = fetchedBudgetMonth
             upcomingScheduledTransactionLength = fetchedUpcomingLength
+            // Last in the batch: assigning this publishes a widget snapshot,
+            // which must see the balances above rather than the previous
+            // refresh's. Skipped when the user picked a currency in Settings
+            // while the reads above were in flight — that choice is newer than
+            // anything this snapshot holds, and the write it kicked off will
+            // come back on the next refresh.
+            if let fetchedCurrencyCode, currencyCode == currencyCodeBefore {
+                currencyCode = fetchedCurrencyCode
+                if let budgetId {
+                    cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
+                }
+            }
             dataVersion += 1
 
             await loadSchedules()

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1370,9 +1370,8 @@ final class BudgetStore: ObservableObject {
             // spinner and clears it when it finishes.
             guard database === openedDb else { return }
 
-            if let code = fetchedCurrencyCode, !code.isEmpty {
-                currencyCode = code
-            }
+            currencyCode = fetchedCurrencyCode ?? ""
+
             
             upcomingScheduledTransactionLength = fetchedUpcomingLength
             
@@ -1510,6 +1509,7 @@ final class BudgetStore: ObservableObject {
             // Fetch into locals, then publish in one batch (no suspension
             // points between assignments) so overlapping refreshes can't
             // leave the UI with a mixed snapshot.
+            let fetchedCurrencyCode = try await database.fetchCurrencyCode()
             let fetchedAccounts = try await database.fetchAccounts()
             let fetchedTransactions = try await database.fetchTransactions()
             let fetchedUncategorizedCount = try await database.fetchUncategorizedCount()
@@ -1524,7 +1524,8 @@ final class BudgetStore: ObservableObject {
             // If the budget was switched while we were fetching, this
             // snapshot belongs to the old database — drop it.
             guard self.database === database else { return }
-
+            
+            currencyCode = fetchedCurrencyCode ?? ""
             accounts = fetchedAccounts
             transactions = fetchedTransactions
             uncategorizedCount = fetchedUncategorizedCount

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -866,11 +866,6 @@ final class BudgetStore: ObservableObject {
         loadTask = Task {}
     }
 
-    /// Test-only: model the initial sync window after a budget download.
-    func setInitialSyncingForTesting(_ value: Bool) {
-        isInitialSyncing = value
-    }
-
     /// Test-only: swap in a server client wired to a stub transport so the
     /// login and probe paths can be exercised without a reachable server.
     func setServerClientForTesting(_ client: ActualServerClient) {
@@ -1399,16 +1394,12 @@ final class BudgetStore: ObservableObject {
             // spinner and clears it when it finishes.
             guard database === openedDb else { return }
 
-            // The downloaded SQLite snapshot can predate the following CRDT
-            // sync. Keep any known budget currency while the two disagree;
-            // sync establishes the authoritative setting immediately after.
+            // Let the database stay authoritative; the post-sync refresh in
+            // refreshDataOnly() is what corrects a snapshot that trails the
+            // preference messages (GH #297).
             if let fetchedCurrencyCode {
-                if let cachedCurrencyCode, fetchedCurrencyCode != cachedCurrencyCode {
-                    // Keep the known cached currency until sync resolves the difference.
-                } else {
-                    currencyCode = fetchedCurrencyCode
-                    cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
-                }
+                currencyCode = fetchedCurrencyCode
+                cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
             }
             
             upcomingScheduledTransactionLength = fetchedUpcomingLength

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1394,11 +1394,18 @@ final class BudgetStore: ObservableObject {
             // spinner and clears it when it finishes.
             guard database === openedDb else { return }
 
-            // Let the database stay authoritative; the post-sync refresh in
-            // refreshDataOnly() is what corrects a snapshot that trails the
-            // preference messages (GH #297).
+            // The downloaded SQLite snapshot can predate the following CRDT
+            // sync. When a cached value already exists, keep showing it —
+            // the sync that always runs right after this load corrects it
+            // moments later via refreshDataOnly() (unconditional, so this
+            // can never get stuck on a wrong value either — GH #59/#297).
+            // With no cache yet (first time loading this budget), the fresh
+            // snapshot is still the best answer available, so show it now
+            // rather than leaving the previous budget's value on screen.
             if let fetchedCurrencyCode {
-                currencyCode = fetchedCurrencyCode
+                if cachedCurrencyCode == nil {
+                    currencyCode = fetchedCurrencyCode
+                }
                 cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
             }
             

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -233,6 +233,20 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    private static func currencyCodeCacheKey(for budgetId: String) -> String {
+        "currencyCode.\(budgetId)"
+    }
+
+    private func cachedCurrencyCode(for budgetId: String) -> String? {
+        UserDefaults.standard.string(forKey: Self.currencyCodeCacheKey(for: budgetId))
+    }
+
+    private func cacheCurrencyCode(_ code: String, for budgetId: String) {
+        // Keep an explicit empty value too: it is Actual's meaningful "None"
+        // preference, distinct from a budget we have never cached.
+        UserDefaults.standard.set(code, forKey: Self.currencyCodeCacheKey(for: budgetId))
+    }
+
     /// User-initiated currency changes (the Settings picker) go through
     /// here, not a direct `currencyCode = ...` assignment: it also persists
     /// the choice into the budget's own `preferences` table via sync, so it
@@ -242,6 +256,9 @@ final class BudgetStore: ObservableObject {
     /// exactly what keeps this from looping back on itself.
     func setCurrencyCode(_ code: String) async {
         currencyCode = code
+        if let currentBudgetId {
+            cacheCurrencyCode(code, for: currentBudgetId)
+        }
         guard let syncClient else { return }
         do {
             try await syncClient.updateCurrencyCode(code)
@@ -849,6 +866,11 @@ final class BudgetStore: ObservableObject {
         loadTask = Task {}
     }
 
+    /// Test-only: model the initial sync window after a budget download.
+    func setInitialSyncingForTesting(_ value: Bool) {
+        isInitialSyncing = value
+    }
+
     /// Test-only: swap in a server client wired to a stub transport so the
     /// login and probe paths can be exercised without a reachable server.
     func setServerClientForTesting(_ client: ActualServerClient) {
@@ -1342,6 +1364,12 @@ final class BudgetStore: ObservableObject {
     func loadLocalBudget(_ budgetId: String) async {
         isLoading = true
         error = nil
+        // A fresh budget download can predate the CRDT preference messages
+        // that its first sync will apply. Show this budget's last confirmed
+        // code during that short window. A budget without a cached or stored
+        // preference retains the current fallback currency.
+        let cachedCurrencyCode = cachedCurrencyCode(for: budgetId)
+        currencyCode = cachedCurrencyCode ?? currencyCode
 
         var db: BudgetDatabase?
         do {
@@ -1353,7 +1381,8 @@ final class BudgetStore: ObservableObject {
             // Fetch all data into locals first, then publish in one batch so
             // the UI never sees a torn snapshot if another load interleaves
             // at a suspension point.
-            // Currency code from preferences (use if non-empty, else keep UserDefaults value)
+            // Nil means the budget has no currency preference; an empty value
+            // is Actual's explicit "None" setting.
             let fetchedCurrencyCode = try await openedDb.fetchCurrencyCode()
             let fetchedUpcomingLength = try await openedDb.fetchUpcomingScheduledTransactionLength()
             let fetchedAccounts = try await openedDb.fetchAccounts()
@@ -1370,8 +1399,17 @@ final class BudgetStore: ObservableObject {
             // spinner and clears it when it finishes.
             guard database === openedDb else { return }
 
-            currencyCode = fetchedCurrencyCode ?? ""
-
+            // The downloaded SQLite snapshot can predate the following CRDT
+            // sync. Keep any known budget currency while the two disagree;
+            // sync establishes the authoritative setting immediately after.
+            if let fetchedCurrencyCode {
+                if let cachedCurrencyCode, fetchedCurrencyCode != cachedCurrencyCode {
+                    // Keep the known cached currency until sync resolves the difference.
+                } else {
+                    currencyCode = fetchedCurrencyCode
+                    cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
+                }
+            }
             
             upcomingScheduledTransactionLength = fetchedUpcomingLength
             
@@ -1505,11 +1543,11 @@ final class BudgetStore: ObservableObject {
     /// Use this after local changes to update the UI
     private func refreshDataOnly() async {
         guard let database else { return }
+        let budgetId = currentBudgetId
         do {
             // Fetch into locals, then publish in one batch (no suspension
             // points between assignments) so overlapping refreshes can't
             // leave the UI with a mixed snapshot.
-            let fetchedCurrencyCode = try await database.fetchCurrencyCode()
             let fetchedAccounts = try await database.fetchAccounts()
             let fetchedTransactions = try await database.fetchTransactions()
             let fetchedUncategorizedCount = try await database.fetchUncategorizedCount()
@@ -1520,12 +1558,20 @@ final class BudgetStore: ObservableObject {
             // Re-read here as well as on load: a sync can bring in a changed
             // upcoming window, and the status badges below are computed from it.
             let fetchedUpcomingLength = try await database.fetchUpcomingScheduledTransactionLength()
+            // Read this last so a Settings change cannot be overwritten by a
+            // stale currency value fetched before the other asynchronous reads.
+            let fetchedCurrencyCode = try await database.fetchCurrencyCode()
 
             // If the budget was switched while we were fetching, this
             // snapshot belongs to the old database — drop it.
-            guard self.database === database else { return }
-            
-            currencyCode = fetchedCurrencyCode ?? ""
+            guard self.database === database, self.currentBudgetId == budgetId else { return }
+
+            if let fetchedCurrencyCode {
+                currencyCode = fetchedCurrencyCode
+                if let budgetId {
+                    cacheCurrencyCode(fetchedCurrencyCode, for: budgetId)
+                }
+            }
             accounts = fetchedAccounts
             transactions = fetchedTransactions
             uncategorizedCount = fetchedUncategorizedCount

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCurrencyRefreshTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCurrencyRefreshTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Actuali
+
+/// Switching budgets must land on the new budget's currency, not carry the
+/// previous one over (GH #297). The database is authoritative whenever it has
+/// an answer; the per-budget cache only covers a freshly downloaded snapshot
+/// that predates the CRDT preference messages carrying the setting.
+@MainActor
+struct BudgetStoreCurrencyRefreshTests {
+
+    /// Store rooted in a unique temp directory. The currency cache lives in
+    /// UserDefaults keyed by budget id, and suites run in parallel, so both
+    /// the files and the ids have to be unique per test.
+    private func makeStore() throws -> (BudgetStore, BudgetFileManager, String, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("currency-tests-\(UUID().uuidString)", isDirectory: true)
+        let manager = BudgetFileManager(rootDirectoryForTesting: root)
+        let store = BudgetStore.previewInstance()
+        store.setFileManagerForTesting(manager)
+        return (store, manager, "budget-\(UUID().uuidString)", root)
+    }
+
+    /// An on-disk budget with the full schema loadLocalBudget reads. `groupId`
+    /// stays nil so the load leaves sync unconfigured and nothing reaches the
+    /// network — the currency paths under test are pure database reads.
+    private func seedBudget(
+        id: String, currency: String?, in manager: BudgetFileManager
+    ) throws {
+        let dir = manager.budgetDirectory(for: id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dbQueue = try DatabaseQueue(path: manager.databasePath(for: id).path)
+        try dbQueue.write { db in
+            try db.execute(sql: BudgetStoreInitialSyncTests.upstreamSchema)
+        }
+        try JSONEncoder().encode(BudgetMetadata(
+            id: id, budgetName: "Seed", cloudFileId: "cf-1", groupId: nil,
+            resetClock: nil, lastUploaded: nil, encryptKeyId: nil
+        )).write(to: manager.metadataPath(for: id))
+        if let currency {
+            try setCurrency(currency, id: id, in: manager)
+        }
+    }
+
+    /// Write the preference the way a sync would, straight into the table.
+    private func setCurrency(_ code: String?, id: String, in manager: BudgetFileManager) throws {
+        let dbQueue = try DatabaseQueue(path: manager.databasePath(for: id).path)
+        try dbQueue.write { db in
+            if let code {
+                try db.execute(
+                    sql: "INSERT OR REPLACE INTO preferences (id, value) VALUES ('defaultCurrencyCode', ?)",
+                    arguments: [code])
+            } else {
+                try db.execute(sql: "DELETE FROM preferences WHERE id = 'defaultCurrencyCode'")
+            }
+        }
+    }
+
+    // MARK: - Load
+
+    @Test func loadAppliesStoredCurrency() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: "CAD", in: manager)
+
+        store.currencyCode = "CHF"   // the budget we are switching away from
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode == "CAD")
+    }
+
+    /// No preference row at all: Actual only writes one once the user picks a
+    /// currency, so the current value has to survive rather than be blanked.
+    @Test func loadKeepsCurrentCurrencyWhenPreferenceIsAbsent() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: nil, in: manager)
+
+        store.currencyCode = "CHF"
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode == "CHF")
+    }
+
+    /// An empty value is Actual's explicit "None" setting, distinct from an
+    /// absent row — amounts render as plain numbers.
+    @Test func loadAppliesEmptyPreferenceAsNone() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: "", in: manager)
+
+        store.currencyCode = "CHF"
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode.isEmpty)
+        #expect(!store.formatCurrency(123_450).contains("CHF"))
+    }
+
+    /// The cache must never outrank a snapshot that has the answer, or a
+    /// currency changed on another client would stay hidden for the whole
+    /// session whenever the correcting sync fails.
+    @Test func storedCurrencyOutranksCachedCurrency() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: "USD", in: manager)
+
+        await store.loadLocalBudget(id)   // caches USD
+        #expect(store.currencyCode == "USD")
+
+        try setCurrency("GBP", id: id, in: manager)
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode == "GBP")
+    }
+
+    /// The one job the cache has: a re-downloaded snapshot whose preference
+    /// messages have not been applied yet must still show this budget's
+    /// currency, not the one belonging to the budget we came from.
+    @Test func cachedCurrencyCoversASnapshotMissingThePreference() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: "GBP", in: manager)
+
+        await store.loadLocalBudget(id)   // caches GBP
+        #expect(store.currencyCode == "GBP")
+
+        try setCurrency(nil, id: id, in: manager)
+        store.currencyCode = "CHF"        // the budget we are switching away from
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode == "GBP")
+    }
+
+    // MARK: - Refresh
+
+    /// GH #297 proper: the downloaded snapshot trails the preference messages,
+    /// so the currency only appears once sync applies them. refreshDataOnly()
+    /// runs after every sync and is what has to pick it up.
+    @Test func refreshAppliesCurrencyArrivingBySync() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: nil, in: manager)
+
+        store.currencyCode = "CHF"
+        store.currentBudgetId = id
+        await store.loadLocalBudget(id)
+        #expect(store.currencyCode == "CHF")   // nothing in the snapshot yet
+
+        try setCurrency("CAD", id: id, in: manager)   // as the first sync would
+        await store.resetSyncState()                  // no sync client: refresh only
+
+        #expect(store.currencyCode == "CAD")
+    }
+
+    /// A refresh must not blank the currency for a budget that has no
+    /// preference row — every local write goes through this path.
+    @Test func refreshKeepsCurrentCurrencyWhenPreferenceIsAbsent() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: nil, in: manager)
+
+        store.currencyCode = "CHF"
+        store.currentBudgetId = id
+        await store.loadLocalBudget(id)
+        await store.resetSyncState()
+
+        #expect(store.currencyCode == "CHF")
+    }
+
+    // MARK: - Cleanup
+
+    /// Disconnecting wipes the local budgets, so their cached currencies must
+    /// go too — a stale one would otherwise outlive the files and reappear if
+    /// the same budget were ever downloaded again.
+    @Test func logoutForgetsCachedCurrencies() async throws {
+        let (store, manager, id, root) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedBudget(id: id, currency: "GBP", in: manager)
+
+        await store.loadLocalBudget(id)   // caches GBP
+        #expect(store.currencyCode == "GBP")
+
+        store.logout()
+
+        // Same budget id downloaded again, this time from a snapshot whose
+        // preference messages have not landed: nothing may resurface.
+        try seedBudget(id: id, currency: nil, in: manager)
+        store.currencyCode = "CHF"
+        await store.loadLocalBudget(id)
+
+        #expect(store.currencyCode == "CHF")
+    }
+}


### PR DESCRIPTION
#297 

## Why

A budget’s downloaded snapshot can be older than its synced preference messages. After sync applied a newer `defaultCurrencyCode`, the app refreshed balances and other data but did not refresh the currency setting, so the UI could remain on “None” or a stale currency.

## What

- Refresh the budget currency code after sync, alongside the other refreshed budget data.
- Treat an empty code as Actual’s intentional “None” currency setting.

Tested on iphone 17 pro simulator