### PR TITLE
Fix low-contrast purple accent in dark mode

### DIFF
--- a/Actuali/Actuali/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Actuali/Actuali/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.753",
+          "green" : "0.450",
+          "blue" : "1.000",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Actuali/ActualiTests/Views/AccentColorContrastTests.swift
+++ b/Actuali/ActualiTests/Views/AccentColorContrastTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import UIKit
+
+@testable import Actuali
+
+/// The accent color is the app's global tint, so it lands on top of every
+/// standard background. WCAG AA requires 4.5:1 for body-sized text.
+private let minimumContrastRatio = 4.5
+
+/// Backgrounds the app actually draws accent-tinted text on: grouped list rows,
+/// report cards, and plain screens.
+private let contentBackgrounds: [(name: String, color: UIColor)] = [
+    ("systemBackground", .systemBackground),
+    ("secondarySystemBackground", .secondarySystemBackground),
+    ("systemGroupedBackground", .systemGroupedBackground),
+    ("secondarySystemGroupedBackground", .secondarySystemGroupedBackground),
+    ("tertiarySystemBackground", .tertiarySystemBackground),
+]
+
+private func relativeLuminance(of color: UIColor) -> Double {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+    func linearized(_ component: CGFloat) -> Double {
+        let value = Double(component)
+        return value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+    }
+
+    return 0.2126 * linearized(red) + 0.7152 * linearized(green) + 0.0722 * linearized(blue)
+}
+
+private func contrastRatio(_ first: UIColor, _ second: UIColor) -> Double {
+    let lighter = max(relativeLuminance(of: first), relativeLuminance(of: second))
+    let darker = min(relativeLuminance(of: first), relativeLuminance(of: second))
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+@Suite("Accent color contrast")
+struct AccentColorContrastTests {
+    private func assertAccentIsReadable(in style: UIUserInterfaceStyle) throws {
+        let traits = UITraitCollection(userInterfaceStyle: style)
+        let accent = try #require(UIColor(named: "AccentColor")).resolvedColor(with: traits)
+
+        for background in contentBackgrounds {
+            let ratio = contrastRatio(accent, background.color.resolvedColor(with: traits))
+            #expect(
+                ratio >= minimumContrastRatio,
+                "Accent on \(background.name) is \(ratio) — needs \(minimumContrastRatio)"
+            )
+        }
+    }
+
+    @Test("Accent text is readable on dark mode backgrounds")
+    func darkModeContrast() throws {
+        try assertAccentIsReadable(in: .dark)
+    }
+
+    @Test("Accent text is readable on light mode backgrounds")
+    func lightModeContrast() throws {
+        try assertAccentIsReadable(in: .light)
+    }
+}


### PR DESCRIPTION
The accent purple was hard to read in dark mode.

`AccentColor.colorset` only had one universal color (`#871AE0`) — no dark appearance variant — and it's the app's global tint, so every purple label, value and link resolved to that same color in both modes. Measured against the dark backgrounds the app actually draws on:

| Background (dark) | Contrast |
|-|-|
| systemBackground / systemGroupedBackground (#000) | 3.24:1 |
| secondarySystemBackground / rows (#1C1C1E) | 2.63:1 |
| tertiarySystemBackground (#2C2C2E) | 2.15:1 |

WCAG AA wants 4.5:1 for body text. Light mode was already fine (~6.5:1 on white), which matches the report that it's dark-mode only.

Added a dark appearance variant at roughly the same hue (~273°) with lifted lightness, `#C073FF`. That gets 7.1:1 on black, 5.8:1 on `#1C1C1E`, 4.7:1 on `#2C2C2E`. Light mode is untouched.

One asset file, so it fixes every site at once rather than patching individual views.

## Verification

New `AccentColorContrastTests` computes the WCAG relative-luminance contrast ratio between the resolved accent color and the five standard content backgrounds, in both interface styles.

Before the fix (reproduces the bug):

```
✔ Test "Accent text is readable on light mode backgrounds" passed after 0.001 seconds.
✘ Test "Accent text is readable on dark mode backgrounds" recorded an issue: Expectation failed: (ratio → 3.242575185903412) >= (minimumContrastRatio → 4.5)
✘ Test "Accent text is readable on dark mode backgrounds" recorded an issue: Expectation failed: (ratio → 2.6272170566425883) >= (minimumContrastRatio → 4.5)
✘ Test "Accent text is readable on dark mode backgrounds" recorded an issue: Expectation failed: (ratio → 2.151934476971935) >= (minimumContrastRatio → 4.5)
✘ Test run with 2 tests in 1 suite failed after 0.011 seconds with 5 issues.
```

After:

```
✔ Test "Accent text is readable on light mode backgrounds" passed after 0.001 seconds.
✔ Test "Accent text is readable on dark mode backgrounds" passed after 0.001 seconds.
```

Full unit suite on iPhone 17 Pro / iOS 26.2:

```
xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' -skip-testing:ActualiUITests

✔ Test run with 1293 tests in 161 suites passed after 5.835 seconds.
** TEST SUCCEEDED **
```

## Out of scope

- The chart palettes in the reports widgets (`SankeyWidgetView`, `MonteCarloWidgetView`) use SwiftUI system colors, which already adapt to dark mode — left alone.
- No broader dark-mode contrast audit of secondary/tertiary label usage; this is scoped to the reported purple tint.

Fixes #304
