### PR TITLE
Default dashboard for the Reports tab

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -463,6 +463,24 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Dashboard page the Reports tab opens on (GH #223). nil means the first
+    /// live page, matching the web app's ReportsDashboardRouter.
+    var defaultDashboardPageId: String? {
+        get {
+            guard let budgetId = currentBudgetId else { return nil }
+            return UserDefaults.standard.string(forKey: "defaultDashboardPageId_\(budgetId)")
+        }
+        set {
+            guard let budgetId = currentBudgetId else { return }
+            if let value = newValue {
+                UserDefaults.standard.set(value, forKey: "defaultDashboardPageId_\(budgetId)")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "defaultDashboardPageId_\(budgetId)")
+            }
+            objectWillChange.send()
+        }
+    }
+
     /// Mappings from card last-4 / bank keywords (e.g. "1234", "HSBC") -> accountId.
     /// Persisted per budget in UserDefaults.
     var cardAccountMappings: [String: String] {

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -61,6 +61,16 @@ struct ReportsTabView: View {
             // the budget finishes opening (launching straight onto this tab
             // races loadLocalBudget) and when the budget is switched.
             .task(id: budgetStore.databaseForLogger.map(ObjectIdentifier.init)) { await reload() }
+            // This is a resident tab: nothing rebuilds it on the way back from
+            // Settings, and `reload` has already written the resolved page into
+            // `selectedPageId` — which outranks the new default. So changing the
+            // setting has to switch the dashboard itself, or it appears to do
+            // nothing until the next launch. Clearing it (nil) re-resolves to
+            // the first page.
+            .onChange(of: budgetStore.defaultDashboardPageId) { _, newValue in
+                selectedPageId = newValue
+                Task { await reload() }
+            }
             .refreshable {
                 await budgetStore.sync()
                 await reload()

--- a/Actuali/Actuali/Views/Reports/ReportsTabView.swift
+++ b/Actuali/Actuali/Views/Reports/ReportsTabView.swift
@@ -115,13 +115,20 @@ struct ReportsTabView: View {
         page.name.isEmpty ? "Untitled" : page.name
     }
 
-    /// Which page to show: a still-live explicit selection wins, otherwise
-    /// the first live page (the web's ReportsDashboardRouter redirects to
-    /// dashboardPages[0]), otherwise nil so the pre-pages pageless fallback
-    /// applies.
-    static func resolvePageId(selected: String?, pages: [DashboardPage]) -> String? {
+    /// Which page to show: a still-live explicit selection wins, then the
+    /// dashboard configured in Settings (GH #223), otherwise the first live
+    /// page (the web's ReportsDashboardRouter redirects to dashboardPages[0]),
+    /// otherwise nil so the pre-pages pageless fallback applies.
+    static func resolvePageId(
+        selected: String?,
+        configuredDefault: String? = nil,
+        pages: [DashboardPage]
+    ) -> String? {
         if let selected, pages.contains(where: { $0.id == selected }) {
             return selected
+        }
+        if let configuredDefault, pages.contains(where: { $0.id == configuredDefault }) {
+            return configuredDefault
         }
         return pages.first?.id
     }
@@ -133,7 +140,11 @@ struct ReportsTabView: View {
         }
         do {
             let fetchedPages = try await database.fetchDashboardPages()
-            let pageId = Self.resolvePageId(selected: selectedPageId, pages: fetchedPages)
+            let pageId = Self.resolvePageId(
+                selected: selectedPageId,
+                configuredDefault: budgetStore.defaultDashboardPageId,
+                pages: fetchedPages
+            )
             let fetched = try await database.fetchWidgets(pageId: pageId)
             self.pages = fetchedPages
             self.selectedPageId = pageId

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -127,12 +127,17 @@ struct SettingsView: View {
             dashboardPages = []
             return
         }
-        dashboardPages = (try? await database.fetchDashboardPages()) ?? []
+        // Bail on a failed or cancelled read rather than treating "no pages"
+        // as fact: a budget switch cancels this task mid-read and resumes
+        // after currentBudgetId has already flipped, so clearing the default
+        // here would wipe the *incoming* budget's preference.
+        guard let pages = try? await database.fetchDashboardPages() else { return }
+        dashboardPages = pages
         // A default naming a page that's since been deleted has no tag to
         // match in the picker, and the Reports tab already falls back to the
         // first page — so drop it rather than show a phantom selection.
         if let id = budgetStore.defaultDashboardPageId,
-           !dashboardPages.contains(where: { $0.id == id }) {
+           !pages.contains(where: { $0.id == id }) {
             budgetStore.defaultDashboardPageId = nil
         }
     }
@@ -711,6 +716,13 @@ struct SettingsView: View {
             // tab, so a plain .task only ever runs once.
             .task(id: budgetStore.databaseForLogger.map(ObjectIdentifier.init)) {
                 await reloadDashboardPages()
+            }
+            // Sync mutates dashboard_pages in the already-open database, whose
+            // identity doesn't change — so the task above can't see it. Matters
+            // most on a fresh budget, where the database opens before the first
+            // sync lands any pages at all.
+            .onChange(of: budgetStore.lastSyncTime) {
+                Task { await reloadDashboardPages() }
             }
             // The background refresh task fires while the app is suspended —
             // same process, so the @State snapshot taken at launch never

--- a/Actuali/Actuali/Views/SettingsView.swift
+++ b/Actuali/Actuali/Views/SettingsView.swift
@@ -82,6 +82,7 @@ struct SettingsView: View {
     @State private var lastBackgroundRefresh = BackgroundRefreshStatus().lastRun
     @State private var refreshRequestError = BackgroundRefreshStatus().lastScheduleError
     @State private var confirmBackupOverBaseline = false
+    @State private var dashboardPages: [DashboardPage] = []
 
     /// Persists the opt-in and requests permission on enable. Background
     /// refresh runs regardless of this toggle (it keeps data fresh for
@@ -119,6 +120,21 @@ struct SettingsView: View {
         let status = BackgroundRefreshStatus()
         lastBackgroundRefresh = status.lastRun
         refreshRequestError = status.lastScheduleError
+    }
+
+    private func reloadDashboardPages() async {
+        guard let database = budgetStore.databaseForLogger else {
+            dashboardPages = []
+            return
+        }
+        dashboardPages = (try? await database.fetchDashboardPages()) ?? []
+        // A default naming a page that's since been deleted has no tag to
+        // match in the picker, and the Reports tab already falls back to the
+        // first page — so drop it rather than show a phantom selection.
+        if let id = budgetStore.defaultDashboardPageId,
+           !dashboardPages.contains(where: { $0.id == id }) {
+            budgetStore.defaultDashboardPageId = nil
+        }
     }
 
     private static var appVersion: String {
@@ -393,6 +409,17 @@ struct SettingsView: View {
                     Picker("Start Page", selection: $budgetStore.startTab) {
                         ForEach(StartTab.allCases) { tab in
                             Text(tab.label).tag(tab)
+                        }
+                    }
+
+                    // Nothing to choose between with one page, and the picker
+                    // would only ever offer the page already on screen.
+                    if dashboardPages.count > 1 {
+                        Picker("Default Dashboard", selection: $budgetStore.defaultDashboardPageId) {
+                            Text("First Dashboard").tag(nil as String?)
+                            ForEach(dashboardPages) { page in
+                                Text(page.name.isEmpty ? "Untitled" : page.name).tag(page.id as String?)
+                            }
                         }
                     }
 
@@ -678,6 +705,12 @@ struct SettingsView: View {
             .task {
                 reloadBackgroundRefreshStatus()
                 await refreshNotificationPermissionState()
+            }
+            // Keyed to the open database so the pages re-load when the budget
+            // finishes opening and when it's switched — Settings is a resident
+            // tab, so a plain .task only ever runs once.
+            .task(id: budgetStore.databaseForLogger.map(ObjectIdentifier.init)) {
+                await reloadDashboardPages()
             }
             // The background refresh task fires while the app is suspended —
             // same process, so the @State snapshot taken at launch never

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseDashboardTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseDashboardTests.swift
@@ -169,9 +169,9 @@ struct BudgetDatabaseDashboardTests {
 }
 
 // Resolution of which dashboard page the Reports tab shows: a still-live
-// explicit selection wins, otherwise the first live page (matching the web's
-// ReportsDashboardRouter redirect to dashboardPages[0]), otherwise nil so the
-// pre-pages pageless fallback applies.
+// explicit selection wins, then the dashboard configured in Settings, then the
+// first live page (matching the web's ReportsDashboardRouter redirect to
+// dashboardPages[0]), otherwise nil so the pre-pages pageless fallback applies.
 struct ReportsPageSelectionTests {
 
     private let pages = [
@@ -193,5 +193,39 @@ struct ReportsPageSelectionTests {
 
     @Test func isNilWhenNoLivePages() {
         #expect(ReportsTabView.resolvePageId(selected: "anything", pages: []) == nil)
+    }
+
+    @Test func opensConfiguredDefaultWhenNothingSelected() {
+        #expect(ReportsTabView.resolvePageId(
+            selected: nil,
+            configuredDefault: "page-second",
+            pages: pages
+        ) == "page-second")
+    }
+
+    // A live in-session selection is a deliberate switch, so it outranks the
+    // setting until the tab is rebuilt.
+    @Test func selectionOutranksConfiguredDefault() {
+        #expect(ReportsTabView.resolvePageId(
+            selected: "page-main",
+            configuredDefault: "page-second",
+            pages: pages
+        ) == "page-main")
+    }
+
+    @Test func ignoresConfiguredDefaultForDeletedPage() {
+        #expect(ReportsTabView.resolvePageId(
+            selected: nil,
+            configuredDefault: "page-deleted",
+            pages: pages
+        ) == "page-main")
+    }
+
+    @Test func ignoresConfiguredDefaultWhenNoLivePages() {
+        #expect(ReportsTabView.resolvePageId(
+            selected: nil,
+            configuredDefault: "page-main",
+            pages: []
+        ) == nil)
     }
 }


### PR DESCRIPTION
The Reports tab always opened on the first dashboard page. With ~8 dashboards that means scrolling the picker every time, so this adds a setting for which one it opens on.

**What changed**

- `BudgetStore.defaultDashboardPageId` — per-budget `UserDefaults` preference, same pattern as `defaultAccountId`.
- `ReportsTabView.resolvePageId` now resolves: still-live in-session selection → configured default (if the page is still live) → first live page → nil (the pre-dashboard-pages pageless fallback). A deliberate switch on the tab still wins until the tab is rebuilt.
- Settings → Preferences gains a "Default Dashboard" picker with a "First Dashboard" option, populated from `fetchDashboardPages()`. Hidden when the budget has one page or fewer, since there would be nothing to choose. A stored default whose page has since been deleted is cleared on load rather than rendering a phantom selection.

**Verified**

Full unit suite on iPhone 17 Pro / iOS 26.5:

```
✔ Test run with 1297 tests in 161 suites passed after 5.934 seconds.
** TEST SUCCEEDED **
```

Four new cases in `ReportsPageSelectionTests` cover the default being honoured, being outranked by an explicit selection, being ignored when its page is gone, and being ignored when there are no live pages. `xcodebuild build` is clean (the one `BudgetStore.swift:2221` warning is pre-existing and unrelated).

**Out of scope**

- Auto-remembering the last-viewed dashboard as the default.
- A "set as default" affordance on the Reports tab picker itself.

Fixes #223