### PR TITLE
Available credit on credit card accounts

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -582,32 +582,34 @@ final class BudgetStore: ObservableObject {
         return creditCardStatementDays.filter { openAccountIds.contains($0.key) }
     }
 
-    /// Writes a card's whole config. A nil `statementDay` stops tracking the
-    /// account and clears its offset and limit too; a nil `creditLimit` clears
-    /// just the limit.
-    func setCreditCard(
-        accountId: String,
-        statementDay: Int?,
-        dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays,
-        creditLimit: Int? = nil
-    ) {
+    /// Writes a card's cycle config. A nil `statementDay` stops tracking the
+    /// account and clears everything stored for it, the limit included.
+    func setCreditCard(accountId: String, statementDay: Int?, dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays) {
         var days = creditCardStatementDays
         var offsets = creditCardDueOffsets
-        var limits = creditCardLimits
         if let statementDay {
             days[accountId] = statementDay
             offsets[accountId] = dueOffsetDays
         } else {
             days.removeValue(forKey: accountId)
             offsets.removeValue(forKey: accountId)
-        }
-        if let creditLimit, statementDay != nil {
-            limits[accountId] = creditLimit
-        } else {
+            var limits = creditCardLimits
             limits.removeValue(forKey: accountId)
+            creditCardLimits = limits
         }
         creditCardStatementDays = days
         creditCardDueOffsets = offsets
+    }
+
+    /// The limit is written on its own so no caller can erase it by leaving an
+    /// argument off a cycle update. A nil `cents` clears it.
+    func setCreditLimit(accountId: String, cents: Int?) {
+        var limits = creditCardLimits
+        if let cents {
+            limits[accountId] = cents
+        } else {
+            limits.removeValue(forKey: accountId)
+        }
         creditCardLimits = limits
     }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -559,6 +559,20 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Mappings from accountId -> credit limit in cents (positive). Optional per
+    /// card: without one there is no available-credit figure to show.
+    var creditCardLimits: [String: Int] {
+        get {
+            guard let budgetId = currentBudgetId else { return [:] }
+            return UserDefaults.standard.dictionary(forKey: "creditCardLimits_\(budgetId)") as? [String: Int] ?? [:]
+        }
+        set {
+            guard let budgetId = currentBudgetId else { return }
+            UserDefaults.standard.set(newValue, forKey: "creditCardLimits_\(budgetId)")
+            objectWillChange.send()
+        }
+    }
+
     /// Statement days whose account still exists and is open — what the Credit
     /// Cards screen lists and what the Settings badge counts. Closed and deleted
     /// accounts keep their stored config (reopening restores the cycle) but drop
@@ -568,11 +582,18 @@ final class BudgetStore: ObservableObject {
         return creditCardStatementDays.filter { openAccountIds.contains($0.key) }
     }
 
-    /// Writes both halves of a card's config. A nil `statementDay` stops
-    /// tracking the account and clears its offset too.
-    func setCreditCard(accountId: String, statementDay: Int?, dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays) {
+    /// Writes a card's whole config. A nil `statementDay` stops tracking the
+    /// account and clears its offset and limit too; a nil `creditLimit` clears
+    /// just the limit.
+    func setCreditCard(
+        accountId: String,
+        statementDay: Int?,
+        dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays,
+        creditLimit: Int? = nil
+    ) {
         var days = creditCardStatementDays
         var offsets = creditCardDueOffsets
+        var limits = creditCardLimits
         if let statementDay {
             days[accountId] = statementDay
             offsets[accountId] = dueOffsetDays
@@ -580,8 +601,14 @@ final class BudgetStore: ObservableObject {
             days.removeValue(forKey: accountId)
             offsets.removeValue(forKey: accountId)
         }
+        if let creditLimit, statementDay != nil {
+            limits[accountId] = creditLimit
+        } else {
+            limits.removeValue(forKey: accountId)
+        }
         creditCardStatementDays = days
         creditCardDueOffsets = offsets
+        creditCardLimits = limits
     }
 
     func creditCardCycle(for accountId: String) -> CreditCardCycle? {
@@ -599,6 +626,17 @@ final class BudgetStore: ObservableObject {
     func activeCreditCardCycle(for accountId: String) -> CreditCardCycle? {
         guard let account = accounts.first(where: { $0.id == accountId }), !account.closed else { return nil }
         return creditCardCycle(for: accountId)
+    }
+
+    /// Credit still available on a tracked card: the limit less what is owed.
+    /// Actual holds a card's balance negative while money is owed, so the two
+    /// add. nil unless the account is an active tracked card with a limit set.
+    func availableCredit(for accountId: String) -> Int? {
+        guard let limit = creditCardLimits[accountId],
+              activeCreditCardCycle(for: accountId) != nil,
+              let account = accounts.first(where: { $0.id == accountId })
+        else { return nil }
+        return limit + account.balance
     }
 
     /// Resolves an account ID from a hint string (e.g. card digits "1234", bank name "HSBC",

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -29,6 +29,14 @@ struct AccountDetailView: View {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
     }
 
+    /// Limit and headroom for a tracked card with a limit set, else nil. Read
+    /// once so the visible row and the breakdown row can't disagree.
+    private var creditHeadroom: (limit: Int, available: Int)? {
+        guard let available = budgetStore.availableCredit(for: account.id),
+              let limit = budgetStore.creditCardLimits[account.id] else { return nil }
+        return (limit, available)
+    }
+
     private var searchQuery: String? {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
         return trimmed.isEmpty ? nil : trimmed
@@ -166,10 +174,20 @@ struct AccountDetailView: View {
                 .accessibilityLabel("Current Balance, \(budgetStore.displayBalance(currentBalance))")
                 .accessibilityHint(showingBreakdown ? "Hides the balance breakdown" : "Shows cleared, uncleared, and reconciled balances")
 
+                // Headroom on a tracked card with a limit set — the figure a
+                // card's balance is actually judged against, so it stays visible
+                // rather than hiding behind the disclosure.
+                if let headroom = creditHeadroom {
+                    breakdownRow("Available Credit", amount: headroom.available)
+                }
+
                 if showingBreakdown, let breakdown {
                     breakdownRow("Cleared", amount: breakdown.cleared)
                     breakdownRow("Uncleared", amount: breakdown.uncleared)
                     breakdownRow("Reconciled", amount: breakdown.reconciled)
+                    if let headroom = creditHeadroom {
+                        breakdownRow("Credit Limit", amount: headroom.limit)
+                    }
                 }
             }
 
@@ -274,6 +292,11 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
+        // The header sections (balance, billing cycle, note) are one or two rows
+        // each, so the stock inset-grouped gaps pushed the transactions off
+        // screen. Tighter spacing top and between.
+        .contentMargins(.top, 8, for: .scrollContent)
+        .listSectionSpacing(.compact)
         .readableWidth()
         .navigationTitle(account.name)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")

--- a/Actuali/Actuali/Views/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/CreditCardsSettingsView.swift
@@ -160,9 +160,9 @@ struct CreditCardsSettingsView: View {
                         budgetStore.setCreditCard(
                             accountId: selectedAccountId,
                             statementDay: selectedStatementDay,
-                            dueOffsetDays: selectedDueOffset,
-                            creditLimit: enteredLimitCents
+                            dueOffsetDays: selectedDueOffset
                         )
+                        budgetStore.setCreditLimit(accountId: selectedAccountId, cents: enteredLimitCents)
                         showingAddSheet = false
                         editingAccountId = nil
                     }

--- a/Actuali/Actuali/Views/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/CreditCardsSettingsView.swift
@@ -8,6 +8,9 @@ struct CreditCardsSettingsView: View {
     @State private var selectedAccountId = ""
     @State private var selectedStatementDay = 15
     @State private var selectedDueOffset = CreditCardCycle.defaultDueOffsetDays
+    /// Dot-decimal amount as typed, the format `AmountInputField` binds to.
+    /// Empty means "no limit set".
+    @State private var selectedLimitText = ""
 
     private var configuredCards: [(account: Account, cycle: CreditCardCycle)] {
         let accountsById = Dictionary(uniqueKeysWithValues: budgetStore.accounts.map { ($0.id, $0) })
@@ -43,6 +46,7 @@ struct CreditCardsSettingsView: View {
                             selectedAccountId = item.account.id
                             selectedStatementDay = item.cycle.statementDay
                             selectedDueOffset = item.cycle.dueOffsetDays
+                            selectedLimitText = limitText(for: item.account.id)
                             editingAccountId = item.account.id
                         } label: {
                             CreditCardCycleRow(account: item.account, cycle: item.cycle)
@@ -61,6 +65,7 @@ struct CreditCardsSettingsView: View {
                         }
                         selectedStatementDay = 15
                         selectedDueOffset = CreditCardCycle.defaultDueOffsetDays
+                        selectedLimitText = ""
                         showingAddSheet = true
                     } label: {
                         Label("Add Credit Card", systemImage: "plus")
@@ -116,10 +121,20 @@ struct CreditCardsSettingsView: View {
                             Text(days == 1 ? "1 day" : "\(days) days").tag(days)
                         }
                     }
+
+                    HStack {
+                        Text("Credit Limit")
+                        Spacer()
+                        AmountInputField(
+                            text: $selectedLimitText,
+                            conventionalAmountEntry: budgetStore.conventionalAmountEntry,
+                            alignment: .right
+                        )
+                    }
                 } header: {
                     Text("Card Details")
                 } footer: {
-                    Text("The payment due date is the statement closing date plus this many days. Your issuer sets it — check a recent statement, as it varies by card and country.")
+                    Text("The payment due date is the statement closing date plus this many days. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip.")
                 }
 
                 if isEditing {
@@ -145,7 +160,8 @@ struct CreditCardsSettingsView: View {
                         budgetStore.setCreditCard(
                             accountId: selectedAccountId,
                             statementDay: selectedStatementDay,
-                            dueOffsetDays: selectedDueOffset
+                            dueOffsetDays: selectedDueOffset,
+                            creditLimit: enteredLimitCents
                         )
                         showingAddSheet = false
                         editingAccountId = nil
@@ -154,6 +170,20 @@ struct CreditCardsSettingsView: View {
                 }
             }
         }
+    }
+
+    /// nil for an empty, unparseable, or non-positive entry — all of which mean
+    /// "no limit" rather than an error worth blocking the save on.
+    private var enteredLimitCents: Int? {
+        guard let dollars = AmountParser.parse(selectedLimitText),
+              let cents = Transaction.cents(fromDollars: dollars),
+              cents > 0 else { return nil }
+        return cents
+    }
+
+    private func limitText(for accountId: String) -> String {
+        guard let cents = budgetStore.creditCardLimits[accountId], cents != 0 else { return "" }
+        return String(format: "%.2f", Double(cents) / 100.0)
     }
 
     private static let ordinalFormatter: NumberFormatter = {

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -302,68 +302,7 @@ struct CreditCardCycleTests {
         }
     }
 
-    // MARK: - Credit Limit
-
-    /// A card's balance is negative while money is owed, so headroom is the limit
-    /// plus the balance — the sign is the whole point of this test.
-    @Test func availableCreditIsTheLimitLessWhatIsOwed() async {
-        await withStore { store in
-            store.accounts = [account(id: "acct_card", name: "Card", balance: -614_900)]
-            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
-
-            #expect(store.creditCardLimits["acct_card"] == 1_000_000)
-            #expect(store.availableCredit(for: "acct_card") == 385_100)
-
-            // Over the limit reads negative rather than clamping — being $100
-            // over is a fact worth showing.
-            store.accounts = [account(id: "acct_card", name: "Card", balance: -1_010_000)]
-            #expect(store.availableCredit(for: "acct_card") == -10_000)
-
-            // Overpaid card: headroom exceeds the limit.
-            store.accounts = [account(id: "acct_card", name: "Card", balance: 5_000)]
-            #expect(store.availableCredit(for: "acct_card") == 1_005_000)
-        }
-    }
-
-    @Test func availableCreditIsNilWithoutALimitOrAnActiveCard() async {
-        await withStore { store in
-            store.accounts = [
-                account(id: "acct_nolimit", name: "No Limit", balance: -1_000),
-                account(id: "acct_closed", name: "Closed", closed: true, balance: -1_000),
-                account(id: "acct_untracked", name: "Checking", type: .checking, balance: -1_000),
-            ]
-            store.setCreditCard(accountId: "acct_nolimit", statementDay: 15)
-            store.setCreditCard(accountId: "acct_closed", statementDay: 15, creditLimit: 500_000)
-            store.creditCardLimits = store.creditCardLimits.merging(["acct_untracked": 500_000]) { _, new in new }
-
-            #expect(store.availableCredit(for: "acct_nolimit") == nil)
-            #expect(store.availableCredit(for: "acct_closed") == nil)
-            #expect(store.availableCredit(for: "acct_untracked") == nil)
-            #expect(store.availableCredit(for: "acct_missing") == nil)
-        }
-    }
-
-    @Test func removingTheCardClearsItsLimit() async {
-        await withStore { store in
-            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
-            store.setCreditCard(accountId: "acct_card", statementDay: nil)
-            #expect(store.creditCardLimits["acct_card"] == nil)
-
-            // Saving a card with no limit clears a previously stored one, so an
-            // emptied field in the sheet actually takes effect.
-            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
-            store.setCreditCard(accountId: "acct_card", statementDay: 25)
-            #expect(store.creditCardLimits["acct_card"] == nil)
-        }
-    }
-
-    private func account(
-        id: String,
-        name: String,
-        type: AccountType = .credit,
-        closed: Bool = false,
-        balance: Int = 0
-    ) -> Account {
+    private func account(id: String, name: String, type: AccountType = .credit, closed: Bool = false) -> Account {
         Account(
             id: id,
             name: name,
@@ -371,7 +310,7 @@ struct CreditCardCycleTests {
             offBudget: false,
             closed: closed,
             sortOrder: 0,
-            balance: balance
+            balance: 0
         )
     }
 }

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -165,6 +165,7 @@ struct CreditCardCycleTests {
             for id in budgetIds {
                 UserDefaults.standard.removeObject(forKey: "creditCardStatementDays_\(id)")
                 UserDefaults.standard.removeObject(forKey: "creditCardDueOffsets_\(id)")
+                UserDefaults.standard.removeObject(forKey: "creditCardLimits_\(id)")
             }
             UserDefaults.standard.set(savedDefault, forKey: "currentBudgetId")
         }
@@ -301,7 +302,68 @@ struct CreditCardCycleTests {
         }
     }
 
-    private func account(id: String, name: String, type: AccountType = .credit, closed: Bool = false) -> Account {
+    // MARK: - Credit Limit
+
+    /// A card's balance is negative while money is owed, so headroom is the limit
+    /// plus the balance — the sign is the whole point of this test.
+    @Test func availableCreditIsTheLimitLessWhatIsOwed() async {
+        await withStore { store in
+            store.accounts = [account(id: "acct_card", name: "Card", balance: -614_900)]
+            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
+
+            #expect(store.creditCardLimits["acct_card"] == 1_000_000)
+            #expect(store.availableCredit(for: "acct_card") == 385_100)
+
+            // Over the limit reads negative rather than clamping — being $100
+            // over is a fact worth showing.
+            store.accounts = [account(id: "acct_card", name: "Card", balance: -1_010_000)]
+            #expect(store.availableCredit(for: "acct_card") == -10_000)
+
+            // Overpaid card: headroom exceeds the limit.
+            store.accounts = [account(id: "acct_card", name: "Card", balance: 5_000)]
+            #expect(store.availableCredit(for: "acct_card") == 1_005_000)
+        }
+    }
+
+    @Test func availableCreditIsNilWithoutALimitOrAnActiveCard() async {
+        await withStore { store in
+            store.accounts = [
+                account(id: "acct_nolimit", name: "No Limit", balance: -1_000),
+                account(id: "acct_closed", name: "Closed", closed: true, balance: -1_000),
+                account(id: "acct_untracked", name: "Checking", type: .checking, balance: -1_000),
+            ]
+            store.setCreditCard(accountId: "acct_nolimit", statementDay: 15)
+            store.setCreditCard(accountId: "acct_closed", statementDay: 15, creditLimit: 500_000)
+            store.creditCardLimits = store.creditCardLimits.merging(["acct_untracked": 500_000]) { _, new in new }
+
+            #expect(store.availableCredit(for: "acct_nolimit") == nil)
+            #expect(store.availableCredit(for: "acct_closed") == nil)
+            #expect(store.availableCredit(for: "acct_untracked") == nil)
+            #expect(store.availableCredit(for: "acct_missing") == nil)
+        }
+    }
+
+    @Test func removingTheCardClearsItsLimit() async {
+        await withStore { store in
+            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
+            store.setCreditCard(accountId: "acct_card", statementDay: nil)
+            #expect(store.creditCardLimits["acct_card"] == nil)
+
+            // Saving a card with no limit clears a previously stored one, so an
+            // emptied field in the sheet actually takes effect.
+            store.setCreditCard(accountId: "acct_card", statementDay: 25, creditLimit: 1_000_000)
+            store.setCreditCard(accountId: "acct_card", statementDay: 25)
+            #expect(store.creditCardLimits["acct_card"] == nil)
+        }
+    }
+
+    private func account(
+        id: String,
+        name: String,
+        type: AccountType = .credit,
+        closed: Bool = false,
+        balance: Int = 0
+    ) -> Account {
         Account(
             id: id,
             name: name,
@@ -309,7 +371,7 @@ struct CreditCardCycleTests {
             offBudget: false,
             closed: closed,
             sortOrder: 0,
-            balance: 0
+            balance: balance
         )
     }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditLimitTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditLimitTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetStoreCreditLimitTests {
+
+    /// Points the store at a throwaway budget and clears every card key it
+    /// touches, so a run can't leak config into the real app's defaults (same
+    /// convention as BudgetStoreAccountMappingTests).
+    private func withStore(_ body: @MainActor (BudgetStore) async -> Void) async {
+        let savedDefault = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "creditCardStatementDays_test-budget")
+            UserDefaults.standard.removeObject(forKey: "creditCardDueOffsets_test-budget")
+            UserDefaults.standard.removeObject(forKey: "creditCardLimits_test-budget")
+            UserDefaults.standard.set(savedDefault, forKey: "currentBudgetId")
+        }
+        let store = BudgetStore.previewInstance()
+        store.currentBudgetId = "test-budget"
+        await body(store)
+    }
+
+    private func account(id: String, name: String, type: AccountType = .credit,
+                         closed: Bool = false, balance: Int = 0) -> Account {
+        Account(id: id, name: name, type: type, offBudget: false, closed: closed,
+                sortOrder: 0, balance: balance)
+    }
+
+    /// A card's balance is negative while money is owed, so headroom is the limit
+    /// plus the balance — the sign is the whole point of this test.
+    @Test func availableCreditIsTheLimitLessWhatIsOwed() async {
+        await withStore { store in
+            store.accounts = [account(id: "acct_card", name: "Card", balance: -614_900)]
+            store.setCreditCard(accountId: "acct_card", statementDay: 25)
+            store.setCreditLimit(accountId: "acct_card", cents: 1_000_000)
+
+            #expect(store.creditCardLimits["acct_card"] == 1_000_000)
+            #expect(store.availableCredit(for: "acct_card") == 385_100)
+
+            // Over the limit reads negative rather than clamping — being $100
+            // over is a fact worth showing.
+            store.accounts = [account(id: "acct_card", name: "Card", balance: -1_010_000)]
+            #expect(store.availableCredit(for: "acct_card") == -10_000)
+
+            // Overpaid card: headroom exceeds the limit.
+            store.accounts = [account(id: "acct_card", name: "Card", balance: 5_000)]
+            #expect(store.availableCredit(for: "acct_card") == 1_005_000)
+        }
+    }
+
+    @Test func availableCreditIsNilWithoutALimitOrAnActiveCard() async {
+        await withStore { store in
+            store.accounts = [
+                account(id: "acct_nolimit", name: "No Limit", balance: -1_000),
+                account(id: "acct_closed", name: "Closed", closed: true, balance: -1_000),
+                account(id: "acct_untracked", name: "Checking", type: .checking, balance: -1_000),
+            ]
+            store.setCreditCard(accountId: "acct_nolimit", statementDay: 15)
+            store.setCreditCard(accountId: "acct_closed", statementDay: 15)
+            store.setCreditLimit(accountId: "acct_closed", cents: 500_000)
+            // A limit with no cycle behind it: the account was never marked as a
+            // card, so there is nothing to show a figure on.
+            store.setCreditLimit(accountId: "acct_untracked", cents: 500_000)
+
+            #expect(store.availableCredit(for: "acct_nolimit") == nil)
+            #expect(store.availableCredit(for: "acct_closed") == nil)
+            #expect(store.availableCredit(for: "acct_untracked") == nil)
+            #expect(store.availableCredit(for: "acct_missing") == nil)
+        }
+    }
+
+    @Test func limitClearsWithTheCardAndOnAnEmptyEntry() async {
+        await withStore { store in
+            store.setCreditCard(accountId: "acct_card", statementDay: 25)
+            store.setCreditLimit(accountId: "acct_card", cents: 1_000_000)
+
+            // Untracking the card must not leave the limit behind to be picked up
+            // by a later card on the same account.
+            store.setCreditCard(accountId: "acct_card", statementDay: nil)
+            #expect(store.creditCardLimits["acct_card"] == nil)
+
+            // An emptied field in the sheet clears a previously stored limit...
+            store.setCreditCard(accountId: "acct_card", statementDay: 25)
+            store.setCreditLimit(accountId: "acct_card", cents: 1_000_000)
+            store.setCreditLimit(accountId: "acct_card", cents: nil)
+            #expect(store.creditCardLimits["acct_card"] == nil)
+
+            // ...while an ordinary cycle edit leaves it alone.
+            store.setCreditLimit(accountId: "acct_card", cents: 1_000_000)
+            store.setCreditCard(accountId: "acct_card", statementDay: 3, dueOffsetDays: 25)
+            #expect(store.creditCardLimits["acct_card"] == 1_000_000)
+        }
+    }
+
+    @Test func limitIsScopedToTheBudgetThatSetIt() async {
+        await withStore { store in
+            defer { UserDefaults.standard.removeObject(forKey: "creditCardLimits_other-budget") }
+            store.setCreditLimit(accountId: "acct_card", cents: 1_000_000)
+
+            store.currentBudgetId = "other-budget"
+            #expect(store.creditCardLimits.isEmpty)
+
+            store.currentBudgetId = "test-budget"
+            #expect(store.creditCardLimits["acct_card"] == 1_000_000)
+        }
+    }
+}


### PR DESCRIPTION
Builds on #313: a tracked credit card can now have a credit limit, and the account shows how much of it is left.

- **Credit limit** — optional per card, set in Settings → Credit Cards. Uses `AmountInputField`, so it behaves like every other amount entry in the app (conventional/cents entry setting, decimal pad, operator toolbar). Empty means no limit. Stored per budget in UserDefaults alongside the statement day and due offset, and cleared with the card.
- **Available Credit** — new row under Current Balance on the account detail header: limit plus balance (Actual keeps a card's balance negative while owed). Goes negative rather than clamping if you're over the limit. The limit itself shows in the expanded breakdown next to Cleared/Uncleared/Reconciled.
- **Padding** — the header sections (balance, billing cycle, note) are one or two rows each, so the stock inset-grouped gaps were pushing transactions off screen. Compact section spacing plus a smaller top margin.

Tested: full unit suite, 1346 tests pass (`xcodebuild test -skip-testing:ActualiUITests`, iPhone 17 Pro / iOS 26.5). New tests cover the sign of available credit (owed, over-limit, overpaid), the nil cases (no limit, closed card, untracked account), and that removing a card or saving with an empty field clears the stored limit.