### PR TITLE
Match Source of Fund group styling

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1182,7 +1182,7 @@ struct BudgetGroupHeader: View {
                     )
                 } else if let receivedTotal {
                     if labelsReceivedTotal {
-                        Text("Received \(budgetStore.displayBalance(receivedTotal))")
+                        Text("Received \(receivedText(receivedTotal))")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -1216,6 +1216,14 @@ struct BudgetGroupHeader: View {
             spent \(budgetStore.displayBalance(totals.spent)), \
             balance \(budgetStore.displayBalance(totals.balance))
             """
+    }
+
+    /// Detailed tables omit currency symbols from every numeric column; the
+    /// clean layout keeps the app-wide currency formatting used by its rows.
+    private func receivedText(_ amount: Int) -> String {
+        reservesTwoLines
+            ? budgetStore.displayBudgetCell(amount)
+            : budgetStore.displayBalance(amount)
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -56,7 +56,18 @@ private extension BudgetStore {
 }
 
 struct BudgetView: View {
-    private static let incomeGroupCollapseID = "__income_group__"
+    static let incomeGroupCollapseID = "__income_group__"
+
+    /// IDs controlled by Expand/Collapse All for the budget currently shown.
+    /// Kept pure so the income-group participation has non-UI test coverage.
+    nonisolated static func displayedGroupIDs(
+        groupIDs: [String],
+        hasIncome: Bool
+    ) -> Set<String> {
+        var ids = Set(groupIDs)
+        if hasIncome { ids.insert(incomeGroupCollapseID) }
+        return ids
+    }
 
     @EnvironmentObject var budgetStore: BudgetStore
     @State private var selectedMonth = currentMonthString()
@@ -85,19 +96,19 @@ struct BudgetView: View {
     // Expand/collapse all touch only the displayed budget's groups; ids
     // remembered for other budget files stay put (GH #130).
     private func collapseAllGroups() {
-        var displayedGroupIDs = Set(groupedCategories.map(\.id))
-        if budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false {
-            displayedGroupIDs.insert(Self.incomeGroupCollapseID)
-        }
+        let displayedGroupIDs = Self.displayedGroupIDs(
+            groupIDs: groupedCategories.map(\.id),
+            hasIncome: budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false
+        )
         let groups = collapsedGroups.union(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
     private func expandAllGroups() {
-        var displayedGroupIDs = Set(groupedCategories.map(\.id))
-        if budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false {
-            displayedGroupIDs.insert(Self.incomeGroupCollapseID)
-        }
+        let displayedGroupIDs = Self.displayedGroupIDs(
+            groupIDs: groupedCategories.map(\.id),
+            hasIncome: budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false
+        )
         let groups = collapsedGroups.subtracting(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
@@ -243,7 +254,7 @@ struct BudgetView: View {
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
-        let name = "Source of Fund"
+        let name = budget.incomeCategories.first?.groupName ?? "Income"
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
@@ -261,7 +272,6 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     receivedTotal: budget.totalIncome,
-                    labelsReceivedTotal: true,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
                     }
@@ -274,10 +284,10 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     receivedTotal: budget.totalIncome,
-                    labelsReceivedTotal: true,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
                     },
+                    usesTableNumberFormat: true,
                     reservesTwoLines: true
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
@@ -1137,10 +1147,10 @@ struct BudgetGroupHeader: View {
     /// money received. It occupies the trailing column where expense groups
     /// show their balance.
     var receivedTotal: Int? = nil
-    /// Clean group headers retain the income-specific "Received" context;
-    /// detailed headers use the compact amount pill shared by the table.
-    var labelsReceivedTotal = false
     let onToggleCollapse: () -> Void
+    /// Detailed tables omit currency symbols from their numeric columns;
+    /// clean headers retain the app-wide currency presentation.
+    var usesTableNumberFormat = false
     /// The detailed style reserves two lines so group rows stay equal-height
     /// whether names wrap or not (GH #252); the clean style's plain section
     /// titles keep their natural height.
@@ -1181,18 +1191,11 @@ struct BudgetGroupHeader: View {
                         color: totals.balance < 0 ? .red : (totals.balance == 0 ? .secondary : .green)
                     )
                 } else if let receivedTotal {
-                    if labelsReceivedTotal {
-                        Text("Received \(receivedText(receivedTotal))")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                    } else {
-                        BudgetAmountPill(
-                            text: budgetStore.displayBudgetCell(receivedTotal),
-                            color: receivedTotal > 0 ? .green : .secondary
-                        )
-                    }
+                    Text("Received \(receivedText(receivedTotal))")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                 }
             }
             .contentShape(Rectangle())
@@ -1218,10 +1221,8 @@ struct BudgetGroupHeader: View {
             """
     }
 
-    /// Detailed tables omit currency symbols from every numeric column; the
-    /// clean layout keeps the app-wide currency formatting used by its rows.
     private func receivedText(_ amount: Int) -> String {
-        reservesTwoLines
+        usesTableNumberFormat
             ? budgetStore.displayBudgetCell(amount)
             : budgetStore.displayBalance(amount)
     }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -56,6 +56,8 @@ private extension BudgetStore {
 }
 
 struct BudgetView: View {
+    private static let incomeGroupCollapseID = "__income_group__"
+
     @EnvironmentObject var budgetStore: BudgetStore
     @State private var selectedMonth = currentMonthString()
     @State private var editingCategory: CategoryBudget?
@@ -83,12 +85,20 @@ struct BudgetView: View {
     // Expand/collapse all touch only the displayed budget's groups; ids
     // remembered for other budget files stay put (GH #130).
     private func collapseAllGroups() {
-        let groups = collapsedGroups.union(groupedCategories.map(\.id))
+        var displayedGroupIDs = Set(groupedCategories.map(\.id))
+        if budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false {
+            displayedGroupIDs.insert(Self.incomeGroupCollapseID)
+        }
+        let groups = collapsedGroups.union(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
     private func expandAllGroups() {
-        let groups = collapsedGroups.subtracting(groupedCategories.map(\.id))
+        var displayedGroupIDs = Set(groupedCategories.map(\.id))
+        if budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false {
+            displayedGroupIDs.insert(Self.incomeGroupCollapseID)
+        }
+        let groups = collapsedGroups.subtracting(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
@@ -232,21 +242,55 @@ struct BudgetView: View {
     /// `List` so the body stays within the compiler's type-check budget.
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
-        Section {
-            ForEach(budget.incomeCategories) { income in
-                IncomeCategoryRow(
-                    income: income,
-                    // Only tracking budgets budget income;
-                    // envelope budgets just receive it.
-                    showsBudgeted: budget.toBudget == nil,
-                    onShowTransactions: showTransactions
+        let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
+        let name = budget.incomeCategories.first?.groupName ?? "Income"
+        if budgetStore.budgetDisplayStyle == .clean {
+            Section {
+                if !isCollapsed {
+                    ForEach(budget.incomeCategories) { income in
+                        IncomeCategoryRow(
+                            income: income,
+                            showsBudgeted: budget.toBudget == nil,
+                            isDetailed: false,
+                            onShowTransactions: showTransactions
+                        )
+                    }
+                }
+            } header: {
+                BudgetGroupHeader(
+                    name: name,
+                    isCollapsed: isCollapsed,
+                    receivedTotal: budget.totalIncome,
+                    labelsReceivedTotal: true,
+                    onToggleCollapse: {
+                        toggleCollapsed(Self.incomeGroupCollapseID)
+                    }
                 )
+                .textCase(nil)
             }
-        } header: {
-            HStack {
-                Text(budget.incomeCategories.first?.groupName ?? "Income")
-                Spacer()
-                Text("Received \(budgetStore.displayBalance(budget.totalIncome))")
+        } else {
+            Section {
+                BudgetGroupHeader(
+                    name: name,
+                    isCollapsed: isCollapsed,
+                    receivedTotal: budget.totalIncome,
+                    onToggleCollapse: {
+                        toggleCollapsed(Self.incomeGroupCollapseID)
+                    },
+                    reservesTwoLines: true
+                )
+                .listRowBackground(Color(.tertiarySystemFill))
+                .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
+                if !isCollapsed {
+                    ForEach(budget.incomeCategories) { income in
+                        IncomeCategoryRow(
+                            income: income,
+                            showsBudgeted: budget.toBudget == nil,
+                            isDetailed: true,
+                            onShowTransactions: showTransactions
+                        )
+                    }
+                }
             }
         }
     }
@@ -1088,6 +1132,13 @@ struct BudgetGroupHeader: View {
     /// The detailed style totals its columns here; the clean style's header
     /// is a plain section title above the card, so it leaves this nil.
     var totals: CategoryGroupTotals?
+    /// Income groups use the same header shell but have one meaningful total:
+    /// money received. It occupies the trailing column where expense groups
+    /// show their balance.
+    var receivedTotal: Int? = nil
+    /// Clean group headers retain the income-specific "Received" context;
+    /// detailed headers use the compact amount pill shared by the table.
+    var labelsReceivedTotal = false
     let onToggleCollapse: () -> Void
     /// The detailed style reserves two lines so group rows stay equal-height
     /// whether names wrap or not (GH #252); the clean style's plain section
@@ -1128,6 +1179,19 @@ struct BudgetGroupHeader: View {
                         // group that lands on zero doesn't read as healthy.
                         color: totals.balance < 0 ? .red : (totals.balance == 0 ? .secondary : .green)
                     )
+                } else if let receivedTotal {
+                    if labelsReceivedTotal {
+                        Text("Received \(budgetStore.displayBalance(receivedTotal))")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    } else {
+                        BudgetAmountPill(
+                            text: budgetStore.displayBudgetCell(receivedTotal),
+                            color: receivedTotal > 0 ? .green : .secondary
+                        )
+                    }
                 }
             }
             .contentShape(Rectangle())
@@ -1142,6 +1206,9 @@ struct BudgetGroupHeader: View {
     /// formatting, not the table's symbol-less cells, reads better aloud.
     private var accessibilityLabel: String {
         let state = isCollapsed ? "collapsed" : "expanded"
+        if let receivedTotal {
+            return "\(name), \(state), received \(budgetStore.displayBalance(receivedTotal))"
+        }
         guard let totals else { return "\(name), \(state)" }
         return """
             \(name), \(state), \
@@ -1157,26 +1224,36 @@ struct IncomeCategoryRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let income: IncomeCategory
     var showsBudgeted = false
+    var isDetailed = false
     var onShowTransactions: (IncomeCategory, String?) -> Void = { _, _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack {
+            HStack(spacing: isDetailed ? BudgetColumn.spacing : 8) {
                 Button {
                     onShowTransactions(income, nil)
                 } label: {
-                    TwoLineName(text: income.categoryName, font: .body)
+                    TwoLineName(
+                        text: income.categoryName,
+                        font: isDetailed ? .subheadline : .body,
+                        minimumScaleFactor: 0.85
+                    )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("All transactions for \(income.categoryName)")
 
                 Spacer()
 
-                Button {
-                    onShowTransactions(income, income.month)
-                } label: {
-                    Text(budgetStore.displayBalance(income.received))
-                        .foregroundColor(income.received > 0 ? .green : .secondary)
+                Button { onShowTransactions(income, income.month) } label: {
+                    if isDetailed {
+                        BudgetAmountPill(
+                            text: budgetStore.displayBudgetCell(income.received),
+                            color: income.received > 0 ? .green : .secondary
+                        )
+                    } else {
+                        Text(budgetStore.displayBalance(income.received))
+                            .foregroundColor(income.received > 0 ? .green : .secondary)
+                    }
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Transactions for \(income.categoryName) in \(MonthPicker.title(for: income.month))")
@@ -1187,7 +1264,12 @@ struct IncomeCategoryRow: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+        .listRowInsets(EdgeInsets(
+            top: 4,
+            leading: isDetailed ? 12 : 16,
+            bottom: 4,
+            trailing: 16
+        ))
     }
 }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -243,7 +243,7 @@ struct BudgetView: View {
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
-        let name = budget.incomeCategories.first?.groupName ?? "Income"
+        let name = "Source of Fund"
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
@@ -274,6 +274,7 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     receivedTotal: budget.totalIncome,
+                    labelsReceivedTotal: true,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
                     },

--- a/Actuali/ActualiTests/Views/BudgetViewTests.swift
+++ b/Actuali/ActualiTests/Views/BudgetViewTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import Actuali
+
+struct BudgetViewTests {
+
+    @Test func displayedGroupsIncludeIncomeWhenPresent() {
+        let ids = BudgetView.displayedGroupIDs(
+            groupIDs: ["essentials", "lifestyle"],
+            hasIncome: true
+        )
+
+        #expect(ids == ["essentials", "lifestyle", BudgetView.incomeGroupCollapseID])
+    }
+
+    @Test func displayedGroupsExcludeIncomeWhenAbsent() {
+        let ids = BudgetView.displayedGroupIDs(
+            groupIDs: ["essentials", "lifestyle"],
+            hasIncome: false
+        )
+
+        #expect(ids == ["essentials", "lifestyle"])
+    }
+}

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -93,19 +93,29 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         ]
         app.launch()
 
+        let groceries = app.buttons["Details for Groceries"].firstMatch
+        XCTAssertTrue(groceries.waitForExistence(timeout: 10),
+                      "demo data should load before scrolling to the income group")
+
+        let incomeGroupName = "Income"
+        let anyHeader = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "\(incomeGroupName), ")
+        ).firstMatch
         let expandedHeader = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH 'Source of Fund, expanded'")
+            NSPredicate(format: "label BEGINSWITH %@", "\(incomeGroupName), expanded")
         ).firstMatch
         let collapsedHeader = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH 'Source of Fund, collapsed'")
+            NSPredicate(format: "label BEGINSWITH %@", "\(incomeGroupName), collapsed")
         ).firstMatch
         let salary = app.buttons["All transactions for Salary"]
 
         var scrollsLeft = 20
-        while !expandedHeader.isHittable && !collapsedHeader.isHittable && scrollsLeft > 0 {
+        while !anyHeader.waitForExistence(timeout: 2) && scrollsLeft > 0 {
             app.swipeUp(velocity: .slow)
             scrollsLeft -= 1
         }
+        XCTAssertTrue(anyHeader.waitForExistence(timeout: 10),
+                      "the income group header should be reachable")
         if collapsedHeader.isHittable {
             collapsedHeader.tap()
         }

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -74,4 +74,47 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "expand all should restore the category rows")
     }
+
+    @MainActor
+    func testIncomeGroupMatchesCollapseBehaviorInCleanStyle() throws {
+        try assertIncomeGroupCollapses(displayStyle: "clean")
+    }
+
+    @MainActor
+    func testIncomeGroupMatchesCollapseBehaviorInDetailedStyle() throws {
+        try assertIncomeGroupCollapses(displayStyle: "detailed")
+    }
+
+    @MainActor
+    private func assertIncomeGroupCollapses(displayStyle: String) throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", displayStyle, "-initialTab", "1",
+        ]
+        app.launch()
+
+        let expandedHeader = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Income, expanded'")
+        ).firstMatch
+        let collapsedHeader = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Income, collapsed'")
+        ).firstMatch
+        let salary = app.buttons["All transactions for Salary"]
+
+        var scrollsLeft = 20
+        while !expandedHeader.isHittable && !collapsedHeader.isHittable && scrollsLeft > 0 {
+            app.swipeUp(velocity: .slow)
+            scrollsLeft -= 1
+        }
+        if collapsedHeader.isHittable {
+            collapsedHeader.tap()
+        }
+
+        XCTAssertTrue(expandedHeader.waitForExistence(timeout: 10))
+        XCTAssertTrue(salary.waitForExistence(timeout: 10))
+        expandedHeader.tap()
+
+        XCTAssertTrue(collapsedHeader.waitForExistence(timeout: 10))
+        XCTAssertFalse(salary.exists, "collapsing Income should hide its categories")
+    }
 }

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -94,10 +94,10 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         app.launch()
 
         let expandedHeader = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH 'Income, expanded'")
+            NSPredicate(format: "label BEGINSWITH 'Source of Fund, expanded'")
         ).firstMatch
         let collapsedHeader = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH 'Income, collapsed'")
+            NSPredicate(format: "label BEGINSWITH 'Source of Fund, collapsed'")
         ).firstMatch
         let salary = app.buttons["All transactions for Salary"]
 


### PR DESCRIPTION
## Why

Closes #322. In v1.0.9, Actual's income/source-of-funds group uses different typography and a non-collapsible header, so it does not visually align with expense category groups in either Budget layout.

## What

- Keep the income group visually separated below expense categories while displaying its name from Actual's backend data.
- Show the group's Received total in both layouts.
- Reuse the expense-group disclosure header and spacing in Clean view.
- Use the same tinted in-card group header and subheadline category font as expense groups in Detailed view.
- Format the Detailed Received total without a currency symbol, matching the other table amounts.
- Persist the income-group collapse state and include it in Expand/Collapse All Groups.
- Remove redundant header configuration and make table-number formatting explicit.
- Add focused unit and UI coverage for the collapse behavior.

## How it was tested

- Xcode 27 beta on the iPhone Air simulator.
- `BudgetViewTests`: 2 passed.
- `BudgetGroupCollapseUITests`: Clean and Detailed tests passed (2 passed).
- `git diff --check` passes.

## Screenshots

The v1.0.9 before-state screenshots supplied with #322 show the mismatched income/source-of-funds section in both Detailed and Clean views. The updated section follows the existing expense-group design in each layout while remaining visually separated below the expense categories.
