### PR TITLE
Add a Hide Decimal Places preference

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -440,7 +440,8 @@ final class BudgetStore: ObservableObject {
 
     /// Formats a standard currency amount unless the privacy mask is enabled.
     func displayBalance(_ cents: Int) -> String {
-        hideBalances ? Self.hiddenBalanceText : formatCurrency(cents)
+        guard !hideBalances else { return Self.hiddenBalanceText }
+        return hideDecimalPlaces ? formatCurrencyWholeUnits(cents) : formatCurrency(cents)
     }
 
     /// Equivalent to `displayBalance(_:)` for reports that intentionally omit
@@ -455,9 +456,13 @@ final class BudgetStore: ObservableObject {
     /// deposits can't masquerade as spending (GH #102).
     func displaySpentCaption(_ spentCents: Int) -> String {
         guard !hideBalances else { return Self.hiddenBalanceText }
+        let magnitude = spentCents > 0 ? spentCents : -spentCents
+        let text = hideDecimalPlaces
+            ? formatCurrencyWholeUnits(magnitude)
+            : formatCurrency(magnitude)
         return spentCents > 0
-            ? "+\(formatCurrency(spentCents))"
-            : formatCurrency(-spentCents)
+            ? "+\(text)"
+            : text
     }
 
     /// Whether transaction saves record the payee's location (GH #24).
@@ -4179,13 +4184,11 @@ final class BudgetStore: ObservableObject {
     // MARK: - Currency Formatting
 
     /// Format an amount in cents to a currency string using the budget's currency.
-    /// Respects the device's display-only decimal-place preference.
     /// - Parameter cents: Amount in cents (e.g., 1050 = $10.50)
     /// - Returns: Formatted currency string (e.g., "$10.50")
     func formatCurrency(_ cents: Int) -> String {
         CurrencyAmountFormat.string(cents: cents, currencyCode: currencyCode,
-                                    narrowSymbol: useNarrowCurrencySymbol,
-                                    wholeUnits: hideDecimalPlaces)
+                                    narrowSymbol: useNarrowCurrencySymbol)
     }
 
     /// Like `formatCurrency`, but rounded to whole units (e.g., "$1,051").

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -382,6 +382,15 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether displayed currency amounts omit their fractional digits.
+    /// The underlying cent values remain unchanged; this is presentation only.
+    @Published var hideDecimalPlaces: Bool = false {
+        didSet {
+            UserDefaults.standard.set(hideDecimalPlaces, forKey: "hideDecimalPlaces")
+            publishWidgetSnapshot()
+        }
+    }
+
     /// Whether Budget hides categories with no budget left this month.
     /// Persisted to UserDefaults, defaults to off.
     @Published var hideZeroBudgetCategories: Bool = false {
@@ -1061,6 +1070,8 @@ final class BudgetStore: ObservableObject {
             .object(forKey: "conventionalAmountEntry") as? Bool ?? false)
         _hideBalances = Published(initialValue: UserDefaults.standard
             .object(forKey: "hideBalances") as? Bool ?? false)
+        _hideDecimalPlaces = Published(initialValue: UserDefaults.standard
+            .object(forKey: "hideDecimalPlaces") as? Bool ?? false)
         _recordPayeeLocations = Published(initialValue: UserDefaults.standard
             .object(forKey: "recordPayeeLocations") as? Bool ?? true)
         // bool(forKey:) defaults to false — the correct opt-in default.
@@ -4167,12 +4178,14 @@ final class BudgetStore: ObservableObject {
 
     // MARK: - Currency Formatting
 
-    /// Format an amount in cents to a currency string using the budget's currency
+    /// Format an amount in cents to a currency string using the budget's currency.
+    /// Respects the device's display-only decimal-place preference.
     /// - Parameter cents: Amount in cents (e.g., 1050 = $10.50)
     /// - Returns: Formatted currency string (e.g., "$10.50")
     func formatCurrency(_ cents: Int) -> String {
         CurrencyAmountFormat.string(cents: cents, currencyCode: currencyCode,
-                                    narrowSymbol: useNarrowCurrencySymbol)
+                                    narrowSymbol: useNarrowCurrencySymbol,
+                                    wholeUnits: hideDecimalPlaces)
     }
 
     /// Like `formatCurrency`, but rounded to whole units (e.g., "$1,051").

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -41,8 +41,9 @@ enum BudgetColumn {
     /// Cell text for the budget table: a plain grouped number without the
     /// currency symbol, like the PWA's budget table — "USD 1,850.00" in
     /// every cell would drown the category names on a phone.
-    static func text(_ cents: Int) -> String {
-        (Double(cents) / 100.0).formatted(.number.precision(.fractionLength(2)))
+    static func text(_ cents: Int, wholeUnits: Bool = false) -> String {
+        (Double(cents) / 100.0).formatted(
+            .number.precision(.fractionLength(wholeUnits ? 0 : 2)))
     }
 }
 
@@ -51,7 +52,7 @@ private extension BudgetStore {
     /// Lives here rather than on the store proper so the table's
     /// symbol-less number format stays private to this file.
     func displayBudgetCell(_ cents: Int) -> String {
-        hideBalances ? Self.hiddenBalanceText : BudgetColumn.text(cents)
+        hideBalances ? Self.hiddenBalanceText : BudgetColumn.text(cents, wholeUnits: hideDecimalPlaces)
     }
 }
 

--- a/Actuali/Actuali/Views/Schedules/DiscoverSchedulesView.swift
+++ b/Actuali/Actuali/Views/Schedules/DiscoverSchedulesView.swift
@@ -27,7 +27,7 @@ struct DiscoverSchedulesView: View {
                             Text(payeeName(proposal.payeeId))
                                 .font(.body.weight(.medium))
                             Spacer()
-                            Text(budgetStore.formatCurrency(proposal.amount))
+                            Text(budgetStore.displayBalance(proposal.amount))
                                 .monospacedDigit()
                         }
                         Text(ScheduleDescription.recurring(proposal.config))

--- a/Actuali/Actuali/Views/Schedules/ScheduleEditView.swift
+++ b/Actuali/Actuali/Views/Schedules/ScheduleEditView.swift
@@ -162,7 +162,7 @@ struct ScheduleEditView: View {
                                         .foregroundStyle(.secondary)
                                 }
                                 Spacer()
-                                Text(budgetStore.formatCurrency(transaction.amount))
+                                Text(budgetStore.displayBalance(transaction.amount))
                                     .monospacedDigit()
                             }
                             .swipeActions {

--- a/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
+++ b/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
@@ -297,11 +297,11 @@ struct ScheduleRow: View {
         switch (schedule.amountOp, schedule.amount) {
         case (.isBetween, .range(let low, let high)):
             let ordered = low <= high ? (low, high) : (high, low)
-            return "\(budgetStore.formatCurrency(ordered.0)) – \(budgetStore.formatCurrency(ordered.1))"
+            return "\(budgetStore.displayBalance(ordered.0)) – \(budgetStore.displayBalance(ordered.1))"
         case (.isApprox, _):
-            return "~" + budgetStore.formatCurrency(schedule.postAmount)
+            return "~" + budgetStore.displayBalance(schedule.postAmount)
         default:
-            return budgetStore.formatCurrency(schedule.postAmount)
+            return budgetStore.displayBalance(schedule.postAmount)
         }
     }
 }

--- a/Actuali/Actuali/Views/Settings/PrivacySettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/PrivacySettingsView.swift
@@ -7,10 +7,11 @@ struct PrivacySettingsView: View {
         Form {
             Section {
                 Toggle("Hide Balances", isOn: $budgetStore.hideBalances)
+                Toggle("Hide Decimal Places", isOn: $budgetStore.hideDecimalPlaces)
             } header: {
                 Text("Balance Visibility")
             } footer: {
-                Text("Hide Balances masks amounts across the app while leaving amount entry and reconciliation visible.")
+                Text("Hide Balances masks amounts across the app while leaving amount entry and reconciliation visible. Hide Decimal Places rounds displayed amounts to whole units without changing their values.")
             }
         }
         .readableWidth()

--- a/Actuali/Actuali/Views/Settings/WalletImportView.swift
+++ b/Actuali/Actuali/Views/Settings/WalletImportView.swift
@@ -122,7 +122,7 @@ struct WalletImportView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    Text(budgetStore.formatCurrency(candidate.amountCents))
+                    Text(budgetStore.displayBalance(candidate.amountCents))
                         .foregroundStyle(candidate.amountCents < 0 ? .primary : Color.green)
                 }
             }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreBalanceVisibilityTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreBalanceVisibilityTests.swift
@@ -39,4 +39,28 @@ struct BudgetStoreBalanceVisibilityTests {
         store.hideBalances = false
         #expect(UserDefaults.standard.object(forKey: "hideBalances") as? Bool == false)
     }
+
+    @Test func decimalPlacePreferenceFormatsDisplayOnlyAsWholeUnits() {
+        let store = BudgetStore.previewInstance()
+        store.currencyCode = "USD"
+        store.useNarrowCurrencySymbol = true
+        store.hideDecimalPlaces = true
+
+        #expect(store.displayBalance(123_456) == store.formatCurrencyWholeUnits(123_456))
+        #expect(store.formatCurrency(123_456) == store.formatCurrencyWholeUnits(123_456))
+
+        store.hideDecimalPlaces = false
+        let standard = CurrencyAmountFormat.string(
+            cents: 123_456, currencyCode: store.currencyCode,
+            narrowSymbol: store.useNarrowCurrencySymbol)
+        #expect(store.displayBalance(123_456) == standard)
+    }
+
+    @Test func decimalPlacePreferencePersistsToUserDefaults() {
+        let store = BudgetStore.previewInstance()
+        store.hideDecimalPlaces = true
+        #expect(UserDefaults.standard.object(forKey: "hideDecimalPlaces") as? Bool == true)
+        store.hideDecimalPlaces = false
+        #expect(UserDefaults.standard.object(forKey: "hideDecimalPlaces") as? Bool == false)
+    }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreBalanceVisibilityTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreBalanceVisibilityTests.swift
@@ -47,7 +47,10 @@ struct BudgetStoreBalanceVisibilityTests {
         store.hideDecimalPlaces = true
 
         #expect(store.displayBalance(123_456) == store.formatCurrencyWholeUnits(123_456))
-        #expect(store.formatCurrency(123_456) == store.formatCurrencyWholeUnits(123_456))
+        // Exact-value workflows such as reconciliation and split remainders
+        // deliberately bypass the display preference.
+        #expect(store.formatCurrency(123_456) != store.formatCurrencyWholeUnits(123_456))
+        #expect(store.displaySpentCaption(-123_456) == store.formatCurrencyWholeUnits(123_456))
 
         store.hideDecimalPlaces = false
         let standard = CurrencyAmountFormat.string(

--- a/Actuali/ActualiTests/Services/CurrencyAmountFormatTests.swift
+++ b/Actuali/ActualiTests/Services/CurrencyAmountFormatTests.swift
@@ -48,9 +48,12 @@ struct CurrencyAmountFormatTests {
     }
 
     @Test func budgetTableWholeUnitsUseTheSameRounding() {
-        #expect(BudgetColumn.text(105_150, wholeUnits: true) == "1,052")
-        #expect(BudgetColumn.text(-105_150, wholeUnits: true) == "-1,052")
-        #expect(BudgetColumn.text(105_150) == "1,051.50")
+        for cents in [105_150, -105_150] {
+            #expect(BudgetColumn.text(cents, wholeUnits: true) ==
+                    CurrencyAmountFormat.string(
+                        cents: cents, currencyCode: "", narrowSymbol: false,
+                        wholeUnits: true))
+        }
     }
 
     /// Empty code means no currency (Actual's defaultCurrencyCode convention);

--- a/Actuali/ActualiTests/Services/CurrencyAmountFormatTests.swift
+++ b/Actuali/ActualiTests/Services/CurrencyAmountFormatTests.swift
@@ -40,6 +40,19 @@ struct CurrencyAmountFormatTests {
         #expect(formatted == "$1,052")
     }
 
+    @Test func wholeUnitsRoundPlainNumbersWithoutCurrency() {
+        let formatted = CurrencyAmountFormat.string(
+            cents: 105_150, currencyCode: "", narrowSymbol: false, wholeUnits: true,
+            locale: enUS)
+        #expect(formatted == "1,052")
+    }
+
+    @Test func budgetTableWholeUnitsUseTheSameRounding() {
+        #expect(BudgetColumn.text(105_150, wholeUnits: true) == "1,052")
+        #expect(BudgetColumn.text(-105_150, wholeUnits: true) == "-1,052")
+        #expect(BudgetColumn.text(105_150) == "1,051.50")
+    }
+
     /// Empty code means no currency (Actual's defaultCurrencyCode convention);
     /// narrowSymbol has nothing to narrow and must not disturb plain numbers.
     @Test func emptyCodeRendersPlainNumber() {

--- a/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
+++ b/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
@@ -4,6 +4,14 @@ import XCTest
 /// labels throughout the live app without changing the underlying cent values.
 final class HideDecimalPlacesUITests: XCTestCase {
 
+    /// SwiftUI toggle rows may expose a nested switch whose control must be
+    /// tapped directly on some iOS versions.
+    @MainActor
+    private func tapSwitch(_ toggle: XCUIElement) {
+        let control = toggle.switches.firstMatch
+        (control.exists ? control : toggle).tap()
+    }
+
     @MainActor
     func testPreferenceRemovesFractionalDigitsFromBudgetAmounts() throws {
         let app = XCUIApplication()
@@ -22,13 +30,33 @@ final class HideDecimalPlacesUITests: XCTestCase {
         }
         XCTAssertTrue(toggle.waitForExistence(timeout: 5),
                       "Hide Decimal Places toggle not found in Preferences")
-        if toggle.value as? String == "1" { toggle.tap() }
-        toggle.tap()
-        XCTAssertEqual(toggle.value as? String, "1")
+        let decimalPlacesWasHidden = toggle.value as? String == "1"
 
         let hideBalances = app.switches["Hide Balances"]
         XCTAssertTrue(hideBalances.exists)
-        if hideBalances.value as? String == "1" { hideBalances.tap() }
+        let balancesWereHidden = hideBalances.value as? String == "1"
+
+        defer {
+            app.tabBars.buttons["Settings"].tap()
+            var swipesLeft = 8
+            while !toggle.exists && swipesLeft > 0 {
+                app.swipeUp()
+                swipesLeft -= 1
+            }
+            if (toggle.value as? String == "1") != decimalPlacesWasHidden {
+                tapSwitch(toggle)
+            }
+            if (hideBalances.value as? String == "1") != balancesWereHidden {
+                tapSwitch(hideBalances)
+            }
+        }
+
+        if !decimalPlacesWasHidden { tapSwitch(toggle) }
+        let enabled = NSPredicate(format: "value == '1'")
+        expectation(for: enabled, evaluatedWith: toggle)
+        waitForExpectations(timeout: 3)
+
+        if balancesWereHidden { tapSwitch(hideBalances) }
 
         app.tabBars.buttons["Budget"].tap()
         XCTAssertTrue(app.buttons["Details for Groceries"].waitForExistence(timeout: 10))

--- a/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
+++ b/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
@@ -15,21 +15,16 @@ final class HideDecimalPlacesUITests: XCTestCase {
     @MainActor
     func testPreferenceRemovesFractionalDigitsFromBudgetAmounts() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-loadDemoData"]
+        app.launchArguments = ["-loadDemoData", "-initialTab", "4"]
         app.launch()
 
-        let settingsTab = app.tabBars.buttons["Settings"]
-        XCTAssertTrue(settingsTab.waitForExistence(timeout: 15))
-        settingsTab.tap()
+        let privacy = app.buttons["Privacy"]
+        XCTAssertTrue(privacy.waitForExistence(timeout: 15))
+        privacy.tap()
 
         let toggle = app.switches["Hide Decimal Places"]
-        var swipesLeft = 8
-        while !toggle.exists && swipesLeft > 0 {
-            app.swipeUp()
-            swipesLeft -= 1
-        }
         XCTAssertTrue(toggle.waitForExistence(timeout: 5),
-                      "Hide Decimal Places toggle not found in Preferences")
+                      "Hide Decimal Places toggle not found in Privacy")
         let decimalPlacesWasHidden = toggle.value as? String == "1"
 
         let hideBalances = app.switches["Hide Balances"]
@@ -38,11 +33,7 @@ final class HideDecimalPlacesUITests: XCTestCase {
 
         defer {
             app.tabBars.buttons["Settings"].tap()
-            var swipesLeft = 8
-            while !toggle.exists && swipesLeft > 0 {
-                app.swipeUp()
-                swipesLeft -= 1
-            }
+            XCTAssertTrue(toggle.waitForExistence(timeout: 5))
             if (toggle.value as? String == "1") != decimalPlacesWasHidden {
                 tapSwitch(toggle)
             }

--- a/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
+++ b/Actuali/ActualiUITests/HideDecimalPlacesUITests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+/// The preference is exposed directly below Hide Balances and updates money
+/// labels throughout the live app without changing the underlying cent values.
+final class HideDecimalPlacesUITests: XCTestCase {
+
+    @MainActor
+    func testPreferenceRemovesFractionalDigitsFromBudgetAmounts() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        let settingsTab = app.tabBars.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 15))
+        settingsTab.tap()
+
+        let toggle = app.switches["Hide Decimal Places"]
+        var swipesLeft = 8
+        while !toggle.exists && swipesLeft > 0 {
+            app.swipeUp()
+            swipesLeft -= 1
+        }
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5),
+                      "Hide Decimal Places toggle not found in Preferences")
+        if toggle.value as? String == "1" { toggle.tap() }
+        toggle.tap()
+        XCTAssertEqual(toggle.value as? String, "1")
+
+        let hideBalances = app.switches["Hide Balances"]
+        XCTAssertTrue(hideBalances.exists)
+        if hideBalances.value as? String == "1" { hideBalances.tap() }
+
+        app.tabBars.buttons["Budget"].tap()
+        XCTAssertTrue(app.buttons["Details for Groceries"].waitForExistence(timeout: 10))
+
+        let decimalAmount = app.staticTexts.matching(
+            NSPredicate(format: "label MATCHES '.*[0-9][.][0-9]{2}.*'"))
+        XCTAssertEqual(decimalAmount.count, 0,
+                       "Budget still exposed a two-digit fractional amount")
+    }
+}


### PR DESCRIPTION
## Why

Closes #324. People who prefer cleaner whole-unit figures currently have to read fractional digits throughout the app even when that precision is not useful to them.

## What

- Adds a **Hide Decimal Places** toggle directly below **Hide Balances** in Settings > Preferences.
- Rounds ordinary displayed monetary amounts to whole units across the app, including symbol-free Budget table cells and widget snapshots.
- Preserves cents in exact-value workflows such as reconciliation and split-transaction remainders so non-zero residuals cannot appear as zero.
- Keeps stored cent values, calculations, and amount-entry fields unchanged.

## How it was tested

- Xcode Beta build for the iPhone Air simulator: passed.
- `CurrencyAmountFormatTests` and `BudgetStoreBalanceVisibilityTests`: 14 tests passed.
- `HideDecimalPlacesUITests` on the iPhone Air simulator: passed; it enables the preference through Settings, opens Budget, verifies fractional amount labels are absent, and restores persistent settings afterward.
- `git diff --check`: passed.

## Screenshots

Verified on the iPhone Air simulator: the new toggle appears immediately below **Hide Balances** in Preferences, and enabling it removes fractional digits from ordinary displayed amounts.
