### PR TITLE
Edit connected server URLs

### DIFF
--- a/Actuali/Actuali/ActualiApp.swift
+++ b/Actuali/Actuali/ActualiApp.swift
@@ -41,10 +41,10 @@ struct ActualiApp: App {
                         await budgetStore.loadDemoData()
                     }
                     if CommandLine.arguments.contains("-connectedServerSettings") {
-                        _ = await budgetStore.updateServerConnection(
-                            serverURL: "https://primary.example.com",
-                            fallbackServerURL: ""
-                        )
+                        // Seed the view state directly: fetchRemoteBudgets owns
+                        // the single test seam that suppresses network work.
+                        budgetStore.serverURL = "https://primary.example.com"
+                        budgetStore.fallbackServerURL = ""
                         budgetStore.isConnected = true
                     }
                     // Stands in for coordinates the Add Transaction form would

--- a/Actuali/Actuali/ActualiApp.swift
+++ b/Actuali/Actuali/ActualiApp.swift
@@ -40,6 +40,13 @@ struct ActualiApp: App {
                     if CommandLine.arguments.contains("-loadDemoData") {
                         await budgetStore.loadDemoData()
                     }
+                    if CommandLine.arguments.contains("-connectedServerSettings") {
+                        _ = await budgetStore.updateServerConnection(
+                            serverURL: "https://primary.example.com",
+                            fallbackServerURL: ""
+                        )
+                        budgetStore.isConnected = true
+                    }
                     // Stands in for coordinates the Add Transaction form would
                     // have recorded, so PayeeLocationsUITests can clear them.
                     if CommandLine.arguments.contains("-seedPayeeLocations") {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1192,7 +1192,6 @@ final class BudgetStore: ObservableObject {
     /// Reconfigures an authenticated session without logging out or touching
     /// its downloaded budget. Publish the new addresses only after both URLs
     /// validate and the live client accepts them.
-    @discardableResult
     func updateServerConnection(
         serverURL newServerURL: String,
         fallbackServerURL newFallbackServerURL: String
@@ -1219,11 +1218,10 @@ final class BudgetStore: ObservableObject {
         let previousServerURL = serverURL
         let previousFallbackServerURL = fallbackServerURL
         do {
-            try await serverClient.configure(
-                serverURL: normalized,
-                fallbackServerURL: normalizedFallback
-            )
             if normalized != previousServerURL {
+                // Probe the primary without fallback so an unreachable edit
+                // cannot be accepted merely because its alternate responds.
+                try await serverClient.configure(serverURL: normalized)
                 do {
                     _ = try await serverClient.fetchLoginMethods()
                 } catch let probeError as ActualServerError where probeError.isConnectionFailure {
@@ -1241,6 +1239,10 @@ final class BudgetStore: ObservableObject {
                     // older Actual versions and route-stripping proxies are valid.
                 }
             }
+            try await serverClient.configure(
+                serverURL: normalized,
+                fallbackServerURL: normalizedFallback
+            )
             serverURL = normalized
             fallbackServerURL = normalizedFallback
             refreshPayeeLocationSupport()

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1189,6 +1189,47 @@ final class BudgetStore: ObservableObject {
         isLoading = false
     }
 
+    /// Reconfigures an authenticated session without logging out or touching
+    /// its downloaded budget. Publish the new addresses only after both URLs
+    /// validate and the live client accepts them.
+    @discardableResult
+    func updateServerConnection(
+        serverURL newServerURL: String,
+        fallbackServerURL newFallbackServerURL: String
+    ) async -> Bool {
+        let normalized = Self.normalizedServerURL(newServerURL)
+        let normalizedFallback = Self.normalizedServerURL(newFallbackServerURL)
+        guard !normalized.isEmpty else {
+            error = "Please enter a server URL"
+            return false
+        }
+        guard Self.isValidServerURL(normalized) else {
+            error = ActualServerError.invalidURL.localizedDescription
+            return false
+        }
+        guard normalizedFallback.isEmpty || Self.isValidServerURL(normalizedFallback) else {
+            error = ActualServerError.invalidFallbackURL.localizedDescription
+            return false
+        }
+
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            try await serverClient.configure(
+                serverURL: normalized,
+                fallbackServerURL: normalizedFallback
+            )
+            serverURL = normalized
+            fallbackServerURL = normalizedFallback
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+
     /// Trims whitespace and prepends `https://` if the user omitted a scheme.
     /// Empty input stays empty so callers can still detect "missing URL".
     static func normalizedServerURL(_ raw: String) -> String {
@@ -1198,6 +1239,11 @@ final class BudgetStore: ObservableObject {
             return trimmed
         }
         return "https://" + trimmed
+    }
+
+    private nonisolated static func isValidServerURL(_ raw: String) -> Bool {
+        guard let url = URL(string: raw) else { return false }
+        return url.scheme != nil && url.host != nil
     }
 
     func login(password: String) async {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1216,13 +1216,34 @@ final class BudgetStore: ObservableObject {
         error = nil
         defer { isLoading = false }
 
+        let previousServerURL = serverURL
+        let previousFallbackServerURL = fallbackServerURL
         do {
             try await serverClient.configure(
                 serverURL: normalized,
                 fallbackServerURL: normalizedFallback
             )
+            if normalized != previousServerURL {
+                do {
+                    _ = try await serverClient.fetchLoginMethods()
+                } catch let probeError as ActualServerError where probeError.isConnectionFailure {
+                    // A transport failure means the replacement address cannot
+                    // be used. Restore the live client before leaving the saved
+                    // connection untouched.
+                    try? await serverClient.configure(
+                        serverURL: previousServerURL,
+                        fallbackServerURL: previousFallbackServerURL
+                    )
+                    self.error = probeError.localizedDescription
+                    return false
+                } catch {
+                    // A server that answers but lacks this endpoint is reachable;
+                    // older Actual versions and route-stripping proxies are valid.
+                }
+            }
             serverURL = normalized
             fallbackServerURL = normalizedFallback
+            refreshPayeeLocationSupport()
             return true
         } catch {
             self.error = error.localizedDescription
@@ -1415,6 +1436,12 @@ final class BudgetStore: ObservableObject {
     // MARK: - Budget Management
 
     func fetchRemoteBudgets() async {
+        #if DEBUG
+        // This UI test seeds a connected session without a server behind it.
+        // Keep the production view lifecycle intact while avoiding a request
+        // that can only time out and raise an unrelated alert.
+        if CommandLine.arguments.contains("-connectedServerSettings") { return }
+        #endif
         isLoading = true
         error = nil
 

--- a/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
@@ -33,6 +33,7 @@ private struct ServerConnectionSettingsSection: View {
     @State private var isPasswordVisible = false
     @State private var showingDisconnectConfirm = false
     @State private var editingServerConnection = false
+    @State private var savingServerConnection = false
     @State private var editedServerURL = ""
     @State private var editedFallbackServerURL = ""
     @FocusState private var passwordFocused: Bool
@@ -44,11 +45,13 @@ private struct ServerConnectionSettingsSection: View {
     }
 
     private func saveServerConnection() {
+        savingServerConnection = true
         Task {
             let saved = await budgetStore.updateServerConnection(
                 serverURL: editedServerURL,
                 fallbackServerURL: editedFallbackServerURL
             )
+            savingServerConnection = false
             if saved { editingServerConnection = false }
         }
     }
@@ -62,12 +65,14 @@ private struct ServerConnectionSettingsSection: View {
                     Button("Cancel", role: .cancel) {
                         editingServerConnection = false
                     }
+                    .disabled(savingServerConnection)
                     Divider()
                         .frame(height: 16)
                     Button("Save") { saveServerConnection() }
                         .disabled(
                             editedServerURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                                 || budgetStore.isLoading
+                                || savingServerConnection
                         )
                 } else {
                     Button("Edit") { beginEditingServerConnection() }

--- a/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
@@ -32,23 +32,93 @@ private struct ServerConnectionSettingsSection: View {
     @State private var password = ""
     @State private var isPasswordVisible = false
     @State private var showingDisconnectConfirm = false
+    @State private var editingServerConnection = false
+    @State private var editedServerURL = ""
+    @State private var editedFallbackServerURL = ""
     @FocusState private var passwordFocused: Bool
+
+    private func beginEditingServerConnection() {
+        editedServerURL = budgetStore.serverURL
+        editedFallbackServerURL = budgetStore.fallbackServerURL
+        editingServerConnection = true
+    }
+
+    private func saveServerConnection() {
+        Task {
+            let saved = await budgetStore.updateServerConnection(
+                serverURL: editedServerURL,
+                fallbackServerURL: editedFallbackServerURL
+            )
+            if saved { editingServerConnection = false }
+        }
+    }
+
+    private var serverConnectionHeader: some View {
+        HStack {
+            Text("Connection")
+            Spacer()
+            if budgetStore.isConnected {
+                if editingServerConnection {
+                    Button("Cancel", role: .cancel) {
+                        editingServerConnection = false
+                    }
+                    Divider()
+                        .frame(height: 16)
+                    Button("Save") { saveServerConnection() }
+                        .disabled(
+                            editedServerURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                || budgetStore.isLoading
+                        )
+                } else {
+                    Button("Edit") { beginEditingServerConnection() }
+                }
+            }
+        }
+        .font(.body)
+        .textCase(nil)
+    }
+
+    @ViewBuilder
+    private func serverURLFields(
+        serverURL: Binding<String>,
+        fallbackServerURL: Binding<String>
+    ) -> some View {
+        TextField("Server URL", text: serverURL)
+            .textContentType(.URL)
+            .autocapitalization(.none)
+            .keyboardType(.URL)
+            .accessibilityHint("Example: https://actual.example.com")
+
+        TextField("Fallback server URL (optional)", text: fallbackServerURL)
+            .textContentType(.URL)
+            .autocapitalization(.none)
+            .keyboardType(.URL)
+            .accessibilityHint("Used when the primary server cannot be reached")
+    }
 
     var body: some View {
         Section {
-            TextField("Server URL", text: $budgetStore.serverURL)
-                .textContentType(.URL)
-                .autocapitalization(.none)
-                .keyboardType(.URL)
-                .disabled(budgetStore.isConnected)
-                .accessibilityHint("Example: https://actual.example.com")
-
-            TextField("Fallback server URL (optional)", text: $budgetStore.fallbackServerURL)
-                .textContentType(.URL)
-                .autocapitalization(.none)
-                .keyboardType(.URL)
-                .disabled(budgetStore.isConnected)
-                .accessibilityHint("Used when the primary server cannot be reached")
+            if budgetStore.isConnected {
+                if editingServerConnection {
+                    serverURLFields(
+                        serverURL: $editedServerURL,
+                        fallbackServerURL: $editedFallbackServerURL
+                    )
+                } else {
+                    LabeledContent("Server URL", value: budgetStore.serverURL)
+                    LabeledContent(
+                        "Fallback Server URL",
+                        value: budgetStore.fallbackServerURL.isEmpty
+                            ? "None"
+                            : budgetStore.fallbackServerURL
+                    )
+                }
+            } else {
+                serverURLFields(
+                    serverURL: $budgetStore.serverURL,
+                    fallbackServerURL: $budgetStore.fallbackServerURL
+                )
+            }
 
             if budgetStore.isConnected {
                 HStack {
@@ -161,7 +231,7 @@ private struct ServerConnectionSettingsSection: View {
                 }
             }
         } header: {
-            Text("Connection")
+            serverConnectionHeader
         } footer: {
             if !budgetStore.isConnected {
                 Text("Example: https://actual.example.com\n\nBehind an auth proxy like Cloudflare Access? Add a service token under \u{201C}Custom HTTP headers.\u{201D}\n\nNo server? Tap \u{201C}Try the demo budget\u{201D} to explore the app with sample data. The demo runs entirely on this device \u{2014} it never connects to a server or touches a real budget.")
@@ -184,6 +254,9 @@ private struct ServerConnectionSettingsSection: View {
         // revealed password doesn't land in that on-disk snapshot.
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase != .active { isPasswordVisible = false }
+        }
+        .onChange(of: budgetStore.isConnected) { _, isConnected in
+            if !isConnected { editingServerConnection = false }
         }
     }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
@@ -30,4 +30,42 @@ struct BudgetStoreFallbackServerTests {
 
         #expect(store.error == "Invalid fallback server URL")
     }
+
+    @Test func connectedURLsCanBeReplacedWithoutDisconnectingOrRemovingTheBudget() async {
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(ActualServerClient())
+        store.serverURL = "https://old.example.com"
+        store.isConnected = true
+        store.currentBudgetId = "local-budget"
+
+        let saved = await store.updateServerConnection(
+            serverURL: " new.example.com/actual ",
+            fallbackServerURL: " fallback.example.com "
+        )
+
+        #expect(saved)
+        #expect(store.serverURL == "https://new.example.com/actual")
+        #expect(store.fallbackServerURL == "https://fallback.example.com")
+        #expect(store.isConnected)
+        #expect(store.currentBudgetId == "local-budget")
+    }
+
+    @Test func invalidEditPreservesTheConnectedAddresses() async {
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(ActualServerClient())
+        store.serverURL = "https://primary.example.com"
+        store.fallbackServerURL = "https://fallback.example.com"
+        store.isConnected = true
+
+        let saved = await store.updateServerConnection(
+            serverURL: "https://replacement.example.com",
+            fallbackServerURL: "https://"
+        )
+
+        #expect(!saved)
+        #expect(store.serverURL == "https://primary.example.com")
+        #expect(store.fallbackServerURL == "https://fallback.example.com")
+        #expect(store.isConnected)
+        #expect(store.error == "Invalid fallback server URL")
+    }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
@@ -122,7 +122,7 @@ struct BudgetStoreFallbackServerTests {
 
         let saved = await store.updateServerConnection(
             serverURL: "https://unreachable.example.com",
-            fallbackServerURL: ""
+            fallbackServerURL: "https://replacement-fallback.example.com"
         )
 
         #expect(!saved)

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreFallbackServerTests.swift
@@ -2,9 +2,48 @@ import Foundation
 import Testing
 @testable import Actuali
 
+private final class ConnectionEditTransport: URLProtocol {
+    nonisolated(unsafe) static var unreachableHosts: Set<String> = []
+    nonisolated(unsafe) static var requestedHosts: [String] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let host = request.url?.host ?? ""
+        Self.requestedHosts.append(host)
+        if Self.unreachableHosts.contains(host) {
+            client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 404, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 @Suite(.serialized)
 @MainActor
 struct BudgetStoreFallbackServerTests {
+    private func makeClient(
+        configuredFor serverURL: String,
+        unreachableHosts: Set<String> = []
+    ) async -> ActualServerClient {
+        ConnectionEditTransport.unreachableHosts = unreachableHosts
+        ConnectionEditTransport.requestedHosts = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ConnectionEditTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: configuration))
+        try? await client.configure(serverURL: serverURL)
+        return client
+    }
+
     @Test func connectNormalizesAndPersistsTheFallbackAddress() async {
         let store = BudgetStore.previewInstance()
         store.setServerClientForTesting(ActualServerClient())
@@ -33,7 +72,7 @@ struct BudgetStoreFallbackServerTests {
 
     @Test func connectedURLsCanBeReplacedWithoutDisconnectingOrRemovingTheBudget() async {
         let store = BudgetStore.previewInstance()
-        store.setServerClientForTesting(ActualServerClient())
+        store.setServerClientForTesting(await makeClient(configuredFor: "https://old.example.com"))
         store.serverURL = "https://old.example.com"
         store.isConnected = true
         store.currentBudgetId = "local-budget"
@@ -67,5 +106,32 @@ struct BudgetStoreFallbackServerTests {
         #expect(store.fallbackServerURL == "https://fallback.example.com")
         #expect(store.isConnected)
         #expect(store.error == "Invalid fallback server URL")
+    }
+
+    @Test func unreachableEditRestoresTheLiveClientAndSavedAddresses() async throws {
+        let oldURL = "https://old.example.com"
+        let client = await makeClient(
+            configuredFor: oldURL,
+            unreachableHosts: ["unreachable.example.com"]
+        )
+        let store = BudgetStore.previewInstance()
+        store.setServerClientForTesting(client)
+        store.serverURL = oldURL
+        store.fallbackServerURL = "https://fallback.example.com"
+        store.isConnected = true
+
+        let saved = await store.updateServerConnection(
+            serverURL: "https://unreachable.example.com",
+            fallbackServerURL: ""
+        )
+
+        #expect(!saved)
+        #expect(store.serverURL == oldURL)
+        #expect(store.fallbackServerURL == "https://fallback.example.com")
+        #expect(store.isConnected)
+
+        ConnectionEditTransport.unreachableHosts = []
+        _ = try await client.fetchLoginMethods()
+        #expect(ConnectionEditTransport.requestedHosts.last == "old.example.com")
     }
 }

--- a/Actuali/ActualiUITests/ServerConnectionEditingUITests.swift
+++ b/Actuali/ActualiUITests/ServerConnectionEditingUITests.swift
@@ -10,6 +10,10 @@ final class ServerConnectionEditingUITests: XCTestCase {
         ]
         app.launch()
 
+        let connectionData = app.buttons["Connection & Data"]
+        XCTAssertTrue(connectionData.waitForExistence(timeout: 10))
+        connectionData.tap()
+
         let edit = app.buttons["Edit"]
         XCTAssertTrue(edit.waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["Connected"].exists)

--- a/Actuali/ActualiUITests/ServerConnectionEditingUITests.swift
+++ b/Actuali/ActualiUITests/ServerConnectionEditingUITests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+final class ServerConnectionEditingUITests: XCTestCase {
+
+    @MainActor
+    func testConnectedServerURLsCanBeEditedWithoutDisconnecting() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-connectedServerSettings", "-initialTab", "4", "-currentBudgetId", "",
+        ]
+        app.launch()
+
+        let edit = app.buttons["Edit"]
+        XCTAssertTrue(edit.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Connected"].exists)
+        edit.tap()
+
+        let fallback = app.textFields["Fallback server URL (optional)"]
+        XCTAssertTrue(fallback.waitForExistence(timeout: 5))
+        fallback.tap()
+        fallback.typeText("fallback.example.com")
+
+        app.buttons["Save"].tap()
+
+        XCTAssertTrue(edit.waitForExistence(timeout: 5))
+        let savedFallback = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label CONTAINS %@", "https://fallback.example.com")
+        ).firstMatch
+        XCTAssertTrue(savedFallback.waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Connected"].exists)
+        XCTAssertTrue(app.buttons["Disconnect"].exists)
+    }
+}


### PR DESCRIPTION
## Why

Closes #326. Follow-up to PR #291: the fallback server URL can be configured during setup, but after connecting there is no way to add or replace either server URL without disconnecting and deleting the device's local budget data.

## What

- Add an Edit action to Settings > Server Connection while connected.
- Replace Edit with distinct Cancel and Save actions in the section header while editing.
- Allow the primary and optional fallback URLs to be added or replaced inline.
- Normalize and validate both drafts before updating the live client and persisted settings.
- Probe a changed primary server before committing it; transport failures restore the previous live client and saved URLs.
- Reset edit mode when a connection ends so drafts from an old session cannot overwrite a later connection.
- Refresh server-scoped capability state after a successful address change.
- Keep the authenticated connection and downloaded budget data intact; invalid or unreachable edits leave working URLs untouched.
- Keep UI-test networking suppression in the store while the Settings view follows its normal production lifecycle.

## How it was tested

- Xcode 27 beta, iPhone Air simulator.
- `BudgetStoreFallbackServerTests`: 5 passed, including unreachable-server rollback.
- `ServerConnectionEditingUITests.testConnectedServerURLsCanBeEditedWithoutDisconnecting`: passed through the production Settings lifecycle.
- Previous CI-equivalent unit run executed 1,349 tests. 1,347 passed; two existing `NewTransactionNotifierTests` currency-symbol assertions fail under Xcode 27 beta because its formatter emits `US$12.50` rather than `$12.50`. The same two failures reproduce in isolation and are unrelated to this change.
- `git diff --check`: passed.
- No-checkout merge checks against current `main`, PR #323, and PR #325: clean.

## Screenshots

Verified in the iPhone Air simulator: connected Server Connection rows show the saved primary and fallback addresses. Edit exposes both fields inline; Cancel and Save replace Edit in the section header with a divider between them. Saving returns to the connected summary without removing local data.
