### PR TITLE
Fix Budget month data after foreground sync

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1479,6 +1479,7 @@ final class BudgetStore: ObservableObject {
     func loadLocalBudget(_ budgetId: String) async {
         isLoading = true
         error = nil
+        let requestedMonthBeforeLoad = requestedBudgetMonth
 
         var db: BudgetDatabase?
         do {
@@ -1528,8 +1529,13 @@ final class BudgetStore: ObservableObject {
             uncategorizedCount = fetchedUncategorizedCount
             categoryGroups = fetchedGroups
             payees = fetchedPayees
-            requestedBudgetMonth = currentMonth
-            currentBudgetMonth = fetchedBudgetMonth
+            // A month selected while the database reads were in flight is
+            // newer than this initial current-month snapshot. Leave that
+            // request and its fetch result intact instead of replacing it.
+            if requestedBudgetMonth == requestedMonthBeforeLoad {
+                requestedBudgetMonth = currentMonth
+                currentBudgetMonth = fetchedBudgetMonth
+            }
             widgetBudgetMonth = fetchedBudgetMonth
             dataVersion += 1
             publishWidgetSnapshot()
@@ -1670,10 +1676,7 @@ final class BudgetStore: ObservableObject {
             // Foreground sync must not silently replace a historical month
             // with the current calendar month while the toolbar still shows
             // the user's selection (GH #328).
-            let displayedMonth = requestedBudgetMonth ?? currentBudgetMonth?.month ?? currentMonth
-            if requestedBudgetMonth == nil {
-                requestedBudgetMonth = displayedMonth
-            }
+            let displayedMonth = requestedBudgetMonth ?? currentMonth
             let fetchedBudgetMonth = try await database.fetchBudgetMonth(month: displayedMonth)
             let fetchedWidgetBudgetMonth: BudgetMonth
             if displayedMonth == currentMonth {
@@ -1690,16 +1693,19 @@ final class BudgetStore: ObservableObject {
 
             // If the budget was switched while we were fetching, this
             // snapshot belongs to the old database — drop it.
-            guard self.database === database,
-                  self.currentBudgetId == budgetId,
-                  requestedBudgetMonth == displayedMonth else { return }
+            guard self.database === database, self.currentBudgetId == budgetId else { return }
 
             accounts = fetchedAccounts
             transactions = fetchedTransactions
             uncategorizedCount = fetchedUncategorizedCount
             categoryGroups = fetchedGroups
             payees = fetchedPayees
-            currentBudgetMonth = fetchedBudgetMonth
+            // A month selected while these reads were in flight owns the
+            // Budget tab now. Its fetch publishes separately, while the rest
+            // of this valid refresh snapshot must still reach the app.
+            if requestedBudgetMonth == displayedMonth {
+                currentBudgetMonth = fetchedBudgetMonth
+            }
             widgetBudgetMonth = fetchedWidgetBudgetMonth
             upcomingScheduledTransactionLength = fetchedUpcomingLength
             // Last in the batch: assigning this publishes a widget snapshot,

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1320,6 +1320,7 @@ final class BudgetStore: ObservableObject {
         // the old budget lingers in the UI post-disconnect. The dataVersion
         // bump makes views that cache their own fetches drop them.
         currentBudgetId = nil
+        requestedBudgetMonth = nil
         currentBudgetMonth = nil
         widgetBudgetMonth = nil
         accounts = []
@@ -1527,6 +1528,7 @@ final class BudgetStore: ObservableObject {
             uncategorizedCount = fetchedUncategorizedCount
             categoryGroups = fetchedGroups
             payees = fetchedPayees
+            requestedBudgetMonth = currentMonth
             currentBudgetMonth = fetchedBudgetMonth
             widgetBudgetMonth = fetchedBudgetMonth
             dataVersion += 1
@@ -1664,7 +1666,21 @@ final class BudgetStore: ObservableObject {
             let fetchedGroups = try await database.fetchCategoryGroups()
             let fetchedPayees = try await database.fetchPayees()
             let currentMonth = currentMonthString()
-            let fetchedBudgetMonth = try await database.fetchBudgetMonth(month: currentMonth)
+            // `currentBudgetMonth` follows the month BudgetView is browsing.
+            // Foreground sync must not silently replace a historical month
+            // with the current calendar month while the toolbar still shows
+            // the user's selection (GH #328).
+            let displayedMonth = requestedBudgetMonth ?? currentBudgetMonth?.month ?? currentMonth
+            if requestedBudgetMonth == nil {
+                requestedBudgetMonth = displayedMonth
+            }
+            let fetchedBudgetMonth = try await database.fetchBudgetMonth(month: displayedMonth)
+            let fetchedWidgetBudgetMonth: BudgetMonth
+            if displayedMonth == currentMonth {
+                fetchedWidgetBudgetMonth = fetchedBudgetMonth
+            } else {
+                fetchedWidgetBudgetMonth = try await database.fetchBudgetMonth(month: currentMonth)
+            }
             // Re-read here as well as on load: a sync can bring in a changed
             // upcoming window, and the status badges below are computed from it.
             let fetchedUpcomingLength = try await database.fetchUpcomingScheduledTransactionLength()
@@ -1674,7 +1690,9 @@ final class BudgetStore: ObservableObject {
 
             // If the budget was switched while we were fetching, this
             // snapshot belongs to the old database — drop it.
-            guard self.database === database, self.currentBudgetId == budgetId else { return }
+            guard self.database === database,
+                  self.currentBudgetId == budgetId,
+                  requestedBudgetMonth == displayedMonth else { return }
 
             accounts = fetchedAccounts
             transactions = fetchedTransactions
@@ -1682,7 +1700,7 @@ final class BudgetStore: ObservableObject {
             categoryGroups = fetchedGroups
             payees = fetchedPayees
             currentBudgetMonth = fetchedBudgetMonth
-            widgetBudgetMonth = fetchedBudgetMonth
+            widgetBudgetMonth = fetchedWidgetBudgetMonth
             upcomingScheduledTransactionLength = fetchedUpcomingLength
             // Last in the batch: assigning this publishes a widget snapshot,
             // which must see the balances above rather than the previous

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -142,7 +142,7 @@ struct BudgetView: View {
             .sheet(item: $transferContext) { context in
                 BudgetTransferSheet(context: context)
             }
-            .sheet(item: $newBudgetItem, onDismiss: reloadAfterCreating) { item in
+            .sheet(item: $newBudgetItem) { item in
                 switch item {
                 case .category:
                     NewCategorySheet(groupId: firstSelectableGroupId ?? "")
@@ -445,9 +445,6 @@ struct BudgetView: View {
             // fired a sync.
             .refreshable {
                 await budgetStore.sync()
-                // sync() refreshes the current calendar month; re-fetch in
-                // case the user is viewing another.
-                await budgetStore.fetchBudgetMonth(selectedMonth)
             }
             .contentMargins(.horizontal, 4, for: .scrollContent)
             // The rest of the gap under the pinned summary — this part
@@ -517,15 +514,6 @@ struct BudgetView: View {
         let visible = budgetStore.categoryGroups.filter { !$0.hidden }
         return visible.min { $0.sortOrder < $1.sortOrder }?.id
     }
-
-    /// `createCategory`/`createCategoryGroup` refresh the current calendar
-    /// month; if the table is showing a different one, fetch that too so the
-    /// new row appears without a pull-to-refresh.
-    private func reloadAfterCreating() {
-        guard selectedMonth != Self.currentMonthString() else { return }
-        Task { await budgetStore.fetchBudgetMonth(selectedMonth) }
-    }
-
 
     /// Push the category's transactions: month narrows to one "yyyy-MM",
     /// nil means all time (GH #56).

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDataVersionTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDataVersionTests.swift
@@ -178,5 +178,8 @@ struct BudgetStoreDataVersionTests {
 
         #expect(store.error == nil)
         #expect(store.currentBudgetMonth?.month == "2026-06")
+        // Widgets always show the current calendar month, even while the app
+        // is browsing a historical budget.
+        #expect(store.widgetBudgetMonth?.month == BudgetView.currentMonthString())
     }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDataVersionTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDataVersionTests.swift
@@ -162,4 +162,21 @@ struct BudgetStoreDataVersionTests {
         #expect(store.error == nil)
         #expect(store.dataVersion > before)
     }
+
+    @Test func syncPreservesBrowsedBudgetMonth() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        await store.fetchBudgetMonth("2026-06")
+        #expect(store.currentBudgetMonth?.month == "2026-06")
+
+        // Foreground sync and pull-to-refresh share this refresh pipeline.
+        // It must refresh the selected historical month, not publish today's
+        // calendar month underneath an unchanged month toolbar.
+        await store.sync()
+
+        #expect(store.error == nil)
+        #expect(store.currentBudgetMonth?.month == "2026-06")
+    }
 }


### PR DESCRIPTION
## Why

Closes #328.

Foreground sync always republished the current calendar month's budget data, even when the Budget tab was browsing a historical month. The toolbar retained its local historical selection, leaving the date and figures out of sync.

## What

- Preserve the most recently requested Budget month across foreground and pull-to-refresh data refreshes.
- Keep the widget snapshot on the current calendar month through its separate `widgetBudgetMonth` state.
- If the user selects another month during a refresh, suppress only the stale month result while still publishing refreshed accounts, transactions, payees, schedules, currency, and widget data.
- Preserve a month selected while the initial local-budget load is still reading the database.
- Remove redundant Budget-view month refetches now that the store refreshes the displayed month directly.
- Reset the requested month when disconnecting or loading another budget.
- Add regression coverage for both the browsed historical month and the widget's current calendar month.

## How it was tested

- Xcode beta build on the iPhone Air simulator (iOS 27.0): succeeded.
- `BudgetStoreDataVersionTests`: 3/3 passed, including `syncPreservesBrowsedBudgetMonth` and its widget-month assertion.
- A subsequent complete `ActualiTests` run reached an Xcode-beta result-bundle finalization hang and was stopped; no test failure was emitted before the tooling hang.
