### PR TITLE
Keep Budget and Accounts menu options on one line

### DIFF
--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -321,7 +321,7 @@ struct AccountsListView: View {
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
                         Toggle(isOn: $budgetStore.hideClosedAccounts) {
-                            Label("Hide Closed Accounts", systemImage: "archivebox")
+                            Label("Hide Closed", systemImage: "archivebox")
                         }
                     } label: {
                         Image(systemName: "ellipsis.circle")

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -323,6 +323,7 @@ struct AccountsListView: View {
                         Toggle(isOn: $budgetStore.hideClosedAccounts) {
                             Label("Hide Closed", systemImage: "archivebox")
                         }
+                        .accessibilityLabel("Hide Closed Accounts")
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -56,10 +56,10 @@ struct BudgetOptionsMenu: View {
             if let expandAllGroups, let collapseAllGroups {
                 Section {
                     Button(action: expandAllGroups) {
-                        Label("Expand All Groups", systemImage: "chevron.down")
+                        Label("Expand Groups", systemImage: "chevron.down")
                     }
                     Button(action: collapseAllGroups) {
-                        Label("Collapse All Groups", systemImage: "chevron.right")
+                        Label("Collapse Groups", systemImage: "chevron.right")
                     }
                 }
             }
@@ -78,7 +78,7 @@ struct BudgetOptionsMenu: View {
                     Label("Status Filters", systemImage: "line.3.horizontal.decrease.circle")
                 }
                 Toggle(isOn: $budgetStore.hideZeroBudgetCategories) {
-                    Label("Hide Spent Categories", systemImage: "line.3.horizontal.decrease")
+                    Label("Hide Spent", systemImage: "line.3.horizontal.decrease")
                 }
             }
         } label: {

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -80,6 +80,7 @@ struct BudgetOptionsMenu: View {
                 Toggle(isOn: $budgetStore.hideZeroBudgetCategories) {
                     Label("Hide Spent", systemImage: "line.3.horizontal.decrease")
                 }
+                .accessibilityLabel("Hide Spent Categories")
             }
         } label: {
             Image(systemName: "ellipsis.circle")

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -58,9 +58,11 @@ struct BudgetOptionsMenu: View {
                     Button(action: expandAllGroups) {
                         Label("Expand Groups", systemImage: "chevron.down")
                     }
+                    .accessibilityLabel("Expand All Groups")
                     Button(action: collapseAllGroups) {
                         Label("Collapse Groups", systemImage: "chevron.right")
                     }
+                    .accessibilityLabel("Collapse All Groups")
                 }
             }
 

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -371,8 +371,9 @@ struct BudgetView: View {
                     Button {
                         newBudgetItem = .group
                     } label: {
-                        Label("New Category Group", systemImage: "folder")
+                        Label("New Group", systemImage: "folder")
                     }
+                    .accessibilityLabel("New Category Group")
                 } label: {
                     Image(systemName: "plus")
                 }

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -48,7 +48,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
                       "the budget toolbar should offer the options menu")
         menuButton.tap()
 
-        let collapseAll = app.buttons["Collapse Groups"]
+        let collapseAll = app.buttons["Collapse All Groups"]
         XCTAssertTrue(collapseAll.waitForExistence(timeout: 10))
         collapseAll.tap()
 
@@ -61,7 +61,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
 
         menuButton.tap()
 
-        let expandAll = app.buttons["Expand Groups"]
+        let expandAll = app.buttons["Expand All Groups"]
         XCTAssertTrue(expandAll.waitForExistence(timeout: 10))
         expandAll.tap()
 

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -48,7 +48,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
                       "the budget toolbar should offer the options menu")
         menuButton.tap()
 
-        let collapseAll = app.buttons["Collapse All Groups"]
+        let collapseAll = app.buttons["Collapse Groups"]
         XCTAssertTrue(collapseAll.waitForExistence(timeout: 10))
         collapseAll.tap()
 
@@ -61,7 +61,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
 
         menuButton.tap()
 
-        let expandAll = app.buttons["Expand All Groups"]
+        let expandAll = app.buttons["Expand Groups"]
         XCTAssertTrue(expandAll.waitForExistence(timeout: 10))
         expandAll.tap()
 

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -27,44 +27,11 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
         optionsMenu.tap()
 
-        for option in ["Clean", "Detailed", "Expand All Groups",
-                       "Collapse All Groups", "Status Filters",
-                       "Hide Spent Categories"] {
+        for option in ["Clean", "Detailed", "Expand Groups",
+                       "Collapse Groups", "Status Filters", "Hide Spent"] {
             XCTAssertTrue(app.buttons[option].waitForExistence(timeout: 5),
                           "the options menu should offer '\(option)'")
         }
-    }
-
-    @MainActor
-    func testLongMenuOptionsStayOnOneLine() throws {
-        let app = XCUIApplication()
-        launchBudgetTab(app)
-
-        let optionsMenu = app.buttons["Budget options"]
-        XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
-        optionsMenu.tap()
-
-        let clean = app.buttons["Clean"]
-        let collapse = app.buttons["Collapse Groups"]
-        let hideSpent = app.buttons["Hide Spent"]
-        XCTAssertTrue(clean.waitForExistence(timeout: 5))
-        XCTAssertTrue(collapse.waitForExistence(timeout: 5))
-        XCTAssertTrue(hideSpent.waitForExistence(timeout: 5))
-        XCTAssertEqual(collapse.frame.height, clean.frame.height, accuracy: 2)
-        XCTAssertEqual(hideSpent.frame.height, clean.frame.height, accuracy: 2)
-        let singleLineHeight = clean.frame.height
-
-        // Verify the Accounts menu uses the same compact single-line layout.
-        app.terminate()
-        app.launchArguments = ["-loadDemoData"]
-        app.launch()
-        app.tabBars.buttons["Accounts"].tap()
-        let accountsMenu = app.buttons["Accounts options"]
-        XCTAssertTrue(accountsMenu.waitForExistence(timeout: 10))
-        accountsMenu.tap()
-        let hideClosed = app.buttons["Hide Closed"]
-        XCTAssertTrue(hideClosed.waitForExistence(timeout: 5))
-        XCTAssertLessThanOrEqual(hideClosed.frame.height, singleLineHeight + 2)
     }
 
     /// The strip costs a row of vertical space on a phone, so it's optional.
@@ -116,7 +83,7 @@ final class BudgetOptionsMenuUITests: XCTestCase {
                       "demo data should show the Essentials categories")
 
         optionsMenu.tap()
-        let hideSpent = app.buttons["Hide Spent Categories"]
+        let hideSpent = app.buttons["Hide Spent"]
         XCTAssertTrue(hideSpent.waitForExistence(timeout: 5))
         XCTAssertFalse(hideSpent.isSelected, "the filter starts off")
         hideSpent.tap()

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -27,24 +27,11 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
         optionsMenu.tap()
 
-        for option in ["Clean", "Detailed", "Expand Groups",
-                       "Collapse Groups", "Status Filters", "Hide Spent"] {
+        for option in ["Clean", "Detailed", "Expand All Groups",
+                       "Collapse All Groups", "Status Filters", "Hide Spent Categories"] {
             XCTAssertTrue(app.buttons[option].waitForExistence(timeout: 5),
                           "the options menu should offer '\(option)'")
         }
-    }
-
-    @MainActor
-    func testAddMenuUsesConciseLabels() throws {
-        let app = XCUIApplication()
-        launchBudgetTab(app)
-
-        let addMenu = app.navigationBars["Budget"].buttons["Add"]
-        XCTAssertTrue(addMenu.waitForExistence(timeout: 10))
-        addMenu.tap()
-
-        XCTAssertTrue(app.buttons["New Category"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["New Category Group"].waitForExistence(timeout: 5))
     }
 
     /// The strip costs a row of vertical space on a phone, so it's optional.
@@ -96,7 +83,7 @@ final class BudgetOptionsMenuUITests: XCTestCase {
                       "demo data should show the Essentials categories")
 
         optionsMenu.tap()
-        let hideSpent = app.buttons["Hide Spent"]
+        let hideSpent = app.buttons["Hide Spent Categories"]
         XCTAssertTrue(hideSpent.waitForExistence(timeout: 5))
         XCTAssertFalse(hideSpent.isSelected, "the filter starts off")
         hideSpent.tap()

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -34,6 +34,19 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testAddMenuUsesConciseLabels() throws {
+        let app = XCUIApplication()
+        launchBudgetTab(app)
+
+        let addMenu = app.navigationBars["Budget"].buttons["Add"]
+        XCTAssertTrue(addMenu.waitForExistence(timeout: 10))
+        addMenu.tap()
+
+        XCTAssertTrue(app.buttons["New Category"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["New Category Group"].waitForExistence(timeout: 5))
+    }
+
     /// The strip costs a row of vertical space on a phone, so it's optional.
     /// Starting state isn't asserted: the setting persists live in the
     /// simulator and a default-true preference can't be seeded from a launch

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -35,6 +35,38 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testLongMenuOptionsStayOnOneLine() throws {
+        let app = XCUIApplication()
+        launchBudgetTab(app)
+
+        let optionsMenu = app.buttons["Budget options"]
+        XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
+        optionsMenu.tap()
+
+        let clean = app.buttons["Clean"]
+        let collapse = app.buttons["Collapse Groups"]
+        let hideSpent = app.buttons["Hide Spent"]
+        XCTAssertTrue(clean.waitForExistence(timeout: 5))
+        XCTAssertTrue(collapse.waitForExistence(timeout: 5))
+        XCTAssertTrue(hideSpent.waitForExistence(timeout: 5))
+        XCTAssertEqual(collapse.frame.height, clean.frame.height, accuracy: 2)
+        XCTAssertEqual(hideSpent.frame.height, clean.frame.height, accuracy: 2)
+        let singleLineHeight = clean.frame.height
+
+        // Verify the Accounts menu uses the same compact single-line layout.
+        app.terminate()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+        app.tabBars.buttons["Accounts"].tap()
+        let accountsMenu = app.buttons["Accounts options"]
+        XCTAssertTrue(accountsMenu.waitForExistence(timeout: 10))
+        accountsMenu.tap()
+        let hideClosed = app.buttons["Hide Closed"]
+        XCTAssertTrue(hideClosed.waitForExistence(timeout: 5))
+        XCTAssertLessThanOrEqual(hideClosed.frame.height, singleLineHeight + 2)
+    }
+
     /// The strip costs a row of vertical space on a phone, so it's optional.
     /// Starting state isn't asserted: the setting persists live in the
     /// simulator and a default-true preference can't be seeded from a launch


### PR DESCRIPTION
## Why

Closes #330. On iPhone Air, several Budget and Accounts options wrapped onto two lines, making the native menus unnecessarily tall and harder to scan.

## What

- Uses concise single-line labels for the Budget group controls and spent-category toggle.
- Uses a concise single-line label for the Accounts closed-account toggle.
- Uses “New Group” for the Budget add-menu item so it also stays on one line.
- Keeps complete VoiceOver labels for “Hide Spent Categories” and “Hide Closed Accounts.”
- Keeps “New Category Group” as the full VoiceOver label for the shortened add-menu item.
- Updates the existing Budget options and group-collapse UI tests to use the concise labels.
- Removes the device-width-dependent row-height test added in the first revision.

## How it was tested

- Xcode beta build on the iPhone Air simulator (iOS 27.0): succeeded.
- `BudgetOptionsMenuUITests.testMenuOffersEveryBudgetViewOption`: passed with all revised labels.
- `BudgetOptionsMenuUITests.testAddMenuUsesConciseLabels`: passed on the iPhone Air simulator.
- The group-collapse test found and activated both revised group controls. Its unrelated demo-category assertions still failed against the current accessibility hierarchy (`Transactions for Groceries in August 2026` instead of the test's older `All transactions for Groceries` expectation).
- The hide-spent interaction test encountered an Xcode 27 beta toolbar automation-type mismatch during one launch; this occurred before querying the revised toggle label.
