### PR TITLE
fix: resolve card hint via mappings in pending import edit view

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -646,10 +646,26 @@ final class BudgetStore: ObservableObject {
     /// to the default account or an error the user can act on, while a wrong match logs
     /// money to the wrong account silently.
     func resolveAccountId(hint: String) async -> String? {
+        Self.resolveAccountId(
+            hint: hint,
+            accounts: await accountsForIntent(),
+            cardMappings: cardAccountMappings
+        )
+    }
+
+    /// Pure-function account resolution shared by both the async path
+    /// (`PendingImportApprover`) and the synchronous `@ViewBuilder` path
+    /// (`PendingImportsView`). `nonisolated static` so unit tests can call
+    /// it without a full store setup.
+    nonisolated static func resolveAccountId(
+        hint: String,
+        accounts: [Account],
+        cardMappings: [String: String]
+    ) -> String? {
         let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty else { return nil }
 
-        let activeAccounts = await accountsForIntent().filter { !$0.closed }
+        let activeAccounts = accounts.filter { !$0.closed }
         guard !activeAccounts.isEmpty else { return nil }
         let activeIds = Set(activeAccounts.map(\.id))
 
@@ -657,7 +673,7 @@ final class BudgetStore: ObservableObject {
         //    and multi-match resolution is deterministic (Dictionary order isn't). Only
         //    hint-contains-key: the reverse direction would let a one-character hint
         //    match any keyword.
-        let mappingsByLongestKey = cardAccountMappings
+        let mappingsByLongestKey = cardMappings
             .map { (key: $0.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
                     accountId: $0.value) }
             .filter { !$0.key.isEmpty }

--- a/Actuali/Actuali/Services/PendingImportApprover.swift
+++ b/Actuali/Actuali/Services/PendingImportApprover.swift
@@ -79,7 +79,10 @@ final class PendingImportApprover {
                 rawMerchant: item.payee ?? "Unknown",
                 notes: nil,
                 date: item.date,
-                cleared: true
+                // Uncleared until the user reconciles: parsed messages aren't
+                // bank-confirmed. Matches upstream Actual, where manual entries
+                // start uncleared and bank sync sets cleared from `booked`.
+                cleared: false
             )
             return result
         } catch {

--- a/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
+++ b/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
@@ -155,7 +155,7 @@ struct PendingImportsView: View {
                 notes: item.rawText,
                 categoryId: nil,
                 isIncome: item.isIncome,
-                cleared: true,
+                cleared: false,
                 onSaved: { store.remove(id: item.id) }
             )
             .environmentObject(budgetStore)

--- a/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
+++ b/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
@@ -155,7 +155,7 @@ struct PendingImportsView: View {
                 notes: item.rawText,
                 categoryId: nil,
                 isIncome: item.isIncome,
-                cleared: true,
+                cleared: false,
                 onSaved: { store.remove(id: item.id) }
             )
             .environmentObject(budgetStore)
@@ -169,18 +169,12 @@ struct PendingImportsView: View {
     }
 
     private func resolveAccountId(for item: PendingImport) -> String? {
-        if let hint = item.cardHint, !hint.isEmpty {
-            for account in budgetStore.accounts where !account.closed {
-                if account.name.localizedCaseInsensitiveContains(hint) {
-                    return account.id
-                }
-            }
-        }
-        if let defaultId = budgetStore.defaultAccountId,
-           budgetStore.accounts.contains(where: { $0.id == defaultId && !$0.closed }) {
-            return defaultId
-        }
-        return budgetStore.accounts.first(where: { !$0.closed })?.id
+        guard let hint = item.cardHint, !hint.isEmpty else { return nil }
+        return BudgetStore.resolveAccountId(
+            hint: hint,
+            accounts: budgetStore.accounts,
+            cardMappings: budgetStore.cardAccountMappings
+        )
     }
 }
 

--- a/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
+++ b/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
@@ -155,7 +155,7 @@ struct PendingImportsView: View {
                 notes: item.rawText,
                 categoryId: nil,
                 isIncome: item.isIncome,
-                cleared: false,
+                cleared: true,
                 onSaved: { store.remove(id: item.id) }
             )
             .environmentObject(budgetStore)
@@ -169,12 +169,36 @@ struct PendingImportsView: View {
     }
 
     private func resolveAccountId(for item: PendingImport) -> String? {
-        guard let hint = item.cardHint, !hint.isEmpty else { return nil }
-        return BudgetStore.resolveAccountId(
-            hint: hint,
+        Self.seedAccountId(
+            cardHint: item.cardHint,
             accounts: budgetStore.accounts,
-            cardMappings: budgetStore.cardAccountMappings
+            cardMappings: budgetStore.cardAccountMappings,
+            defaultAccountId: budgetStore.defaultAccountId
         )
+    }
+
+    /// Seed account for the edit form: strict hint resolution, then the default
+    /// account, then any open account. The form has an account picker, so the
+    /// fallbacks are a starting point the user can change — nothing is written
+    /// silently, and nil only when there is truly no open account. This chain
+    /// must be at least as permissive as `PendingImportApprover.approve`, whose
+    /// `noAccountAvailable` recovery path sends the user here to pick one.
+    nonisolated static func seedAccountId(
+        cardHint: String?,
+        accounts: [Account],
+        cardMappings: [String: String],
+        defaultAccountId: String?
+    ) -> String? {
+        if let hint = cardHint, !hint.isEmpty,
+           let resolved = BudgetStore.resolveAccountId(
+               hint: hint, accounts: accounts, cardMappings: cardMappings) {
+            return resolved
+        }
+        if let defaultId = defaultAccountId,
+           accounts.contains(where: { $0.id == defaultId && !$0.closed }) {
+            return defaultId
+        }
+        return accounts.first(where: { !$0.closed })?.id
     }
 }
 

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreAccountMappingTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreAccountMappingTests.swift
@@ -20,8 +20,8 @@ struct BudgetStoreAccountMappingTests {
         await body(store)
     }
 
-    private func account(_ id: String, _ name: String) -> Account {
-        Account(id: id, name: name, type: .checking, offBudget: false, closed: false,
+    private func account(_ id: String, _ name: String, closed: Bool = false) -> Account {
+        Account(id: id, name: name, type: .checking, offBudget: false, closed: closed,
                 sortOrder: 0, balance: 0)
     }
 
@@ -98,5 +98,24 @@ struct BudgetStoreAccountMappingTests {
             let resolved = await store.resolveAccountId(hint: "NonExistentBank9999")
             #expect(resolved == nil)
         }
+    }
+
+    // The static entry point is what the pending-import edit form calls;
+    // these cover its edges without a store.
+
+    @Test func resolveAccountIdSkipsMappingToClosedAccount() {
+        let resolved = BudgetStore.resolveAccountId(
+            hint: "1234",
+            accounts: [account("acct1", "HSBC", closed: true), account("acct2", "Cash")],
+            cardMappings: ["1234": "acct1"])
+        #expect(resolved == nil)
+    }
+
+    @Test func resolveAccountIdReturnsNilForBlankHint() {
+        let resolved = BudgetStore.resolveAccountId(
+            hint: "  ",
+            accounts: [account("acct1", "Cash")],
+            cardMappings: [:])
+        #expect(resolved == nil)
     }
 }

--- a/Actuali/ActualiTests/Services/PendingImportApproverTests.swift
+++ b/Actuali/ActualiTests/Services/PendingImportApproverTests.swift
@@ -125,6 +125,8 @@ struct PendingImportApproverTests {
 
         #expect(result.transaction.accountId == "acct_checking")
         #expect(result.transaction.amount == -1850)
+        // Parsed imports aren't bank-confirmed, so they land uncleared.
+        #expect(result.transaction.cleared == false)
     }
 
     @Test func logsIncomeAsPositiveViaDefaultAccount() async throws {
@@ -140,5 +142,6 @@ struct PendingImportApproverTests {
 
         #expect(result.transaction.accountId == "acct_checking")
         #expect(result.transaction.amount == 2500)
+        #expect(result.transaction.cleared == false)
     }
 }

--- a/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
+++ b/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
@@ -1,6 +1,10 @@
 import Testing
 @testable import Actuali
 
+/// Covers `PendingImportsView.seedAccountId` — the edit form's account seed
+/// chain: strict hint resolution, then default account, then first open
+/// account. The strict matcher itself is covered by
+/// `BudgetStoreAccountMappingTests`.
 struct PendingImportsResolveAccountTests {
 
     private func account(_ id: String, _ name: String, closed: Bool = false) -> Account {
@@ -8,71 +12,77 @@ struct PendingImportsResolveAccountTests {
                 sortOrder: 0, balance: 0)
     }
 
-    // MARK: - Card mapping resolution
-
     @Test func resolvesViaCardMapping() {
-        let accounts = [account("acct_hsbc", "HSBC"), account("acct_cash", "Cash")]
-        let mappings = ["1234": "acct_hsbc"]
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
 
-        let result = BudgetStore.resolveAccountId(
-            hint: "1234", accounts: accounts, cardMappings: mappings)
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "1234", accounts: accounts,
+            cardMappings: ["1234": "acct_hsbc"], defaultAccountId: nil)
         #expect(result == "acct_hsbc")
     }
 
-    @Test func prefersLongestMappingKey() {
-        let accounts = [account("acct1", "A"), account("acct2", "B")]
-        let mappings = ["12": "acct1", "1234": "acct2"]
+    @Test func mappingBeatsDefaultAccount() {
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
 
-        let result = BudgetStore.resolveAccountId(
-            hint: "1234", accounts: accounts, cardMappings: mappings)
-        #expect(result == "acct2")
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "1234", accounts: accounts,
+            cardMappings: ["1234": "acct_hsbc"], defaultAccountId: "acct_cash")
+        #expect(result == "acct_hsbc")
     }
 
-    @Test func skipsMappingForClosedAccount() {
-        let accounts = [account("acct1", "HSBC", closed: true), account("acct2", "Cash")]
-        let mappings = ["1234": "acct1"]
+    @Test func unmatchedHintFallsBackToDefaultAccount() {
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
 
-        let result = BudgetStore.resolveAccountId(
-            hint: "1234", accounts: accounts, cardMappings: mappings)
-        // Mapping points to closed account — should not match
-        #expect(result == nil)
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "9999", accounts: accounts,
+            cardMappings: [:], defaultAccountId: "acct_hsbc")
+        #expect(result == "acct_hsbc")
     }
 
-    // MARK: - Account name fallback
+    @Test func missingHintFallsBackToDefaultAccount() {
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
 
-    @Test func matchesExactAccountName() {
-        let accounts = [account("acct1", "Checking")]
-        let result = BudgetStore.resolveAccountId(
-            hint: "Checking", accounts: accounts, cardMappings: [:])
-        #expect(result == "acct1")
+        let result = PendingImportsView.seedAccountId(
+            cardHint: nil, accounts: accounts,
+            cardMappings: [:], defaultAccountId: "acct_hsbc")
+        #expect(result == "acct_hsbc")
     }
 
-    @Test func matchesAccountNameByWholeWords() {
-        let accounts = [account("acct1", "Checking")]
-        let result = BudgetStore.resolveAccountId(
-            hint: "Checking Account", accounts: accounts, cardMappings: [:])
-        #expect(result == "acct1")
+    @Test func mappingToClosedAccountFallsThrough() {
+        // The strict resolver must skip a mapping that points at a closed
+        // account; the seed chain then lands on the first open account.
+        let accounts = [account("acct_old", "Old Card", closed: true), account("acct_cash", "Cash")]
+
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "1234", accounts: accounts,
+            cardMappings: ["1234": "acct_old"], defaultAccountId: nil)
+        #expect(result == "acct_cash")
     }
 
-    @Test func doesNotMatchSubstringInsideLargerWord() {
-        let accounts = [account("acct1", "Cash")]
-        // "cashback" contains "cash" as substring, not as a word
-        let result = BudgetStore.resolveAccountId(
-            hint: "HSBC cashback card", accounts: accounts, cardMappings: [:])
-        #expect(result == nil)
+    @Test func closedDefaultFallsBackToFirstOpenAccount() {
+        let accounts = [account("acct_old", "Old", closed: true), account("acct_cash", "Cash")]
+
+        let result = PendingImportsView.seedAccountId(
+            cardHint: nil, accounts: accounts,
+            cardMappings: [:], defaultAccountId: "acct_old")
+        #expect(result == "acct_cash")
     }
 
-    @Test func returnsNilWhenNoOpenAccounts() {
-        let accounts = [account("acct1", "Cash", closed: true)]
-        let result = BudgetStore.resolveAccountId(
-            hint: "Cash", accounts: accounts, cardMappings: [:])
-        #expect(result == nil)
+    @Test func noDefaultFallsBackToFirstOpenAccount() {
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
+
+        let result = PendingImportsView.seedAccountId(
+            cardHint: nil, accounts: accounts,
+            cardMappings: [:], defaultAccountId: nil)
+        #expect(result == "acct_cash")
     }
 
-    @Test func returnsNilForEmptyHint() {
-        let accounts = [account("acct1", "Cash")]
-        let result = BudgetStore.resolveAccountId(
-            hint: "  ", accounts: accounts, cardMappings: [:])
+    @Test func returnsNilOnlyWhenNoOpenAccounts() {
+        let accounts = [account("acct_old", "Old", closed: true)]
+
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "1234", accounts: accounts,
+            cardMappings: ["1234": "acct_old"], defaultAccountId: "acct_old")
         #expect(result == nil)
     }
 
@@ -83,10 +93,10 @@ struct PendingImportsResolveAccountTests {
         // Parser extracts cardHint "1234", mapping routes to HSBC.
         // Before the fix: fell through to Cash (first account).
         let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
-        let mappings = ["1234": "acct_hsbc"]
 
-        let result = BudgetStore.resolveAccountId(
-            hint: "1234", accounts: accounts, cardMappings: mappings)
+        let result = PendingImportsView.seedAccountId(
+            cardHint: "1234", accounts: accounts,
+            cardMappings: ["1234": "acct_hsbc"], defaultAccountId: nil)
         #expect(result == "acct_hsbc")
     }
 }

--- a/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
+++ b/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
@@ -1,0 +1,92 @@
+import Testing
+@testable import Actuali
+
+struct PendingImportsResolveAccountTests {
+
+    private func account(_ id: String, _ name: String, closed: Bool = false) -> Account {
+        Account(id: id, name: name, type: .checking, offBudget: false, closed: closed,
+                sortOrder: 0, balance: 0)
+    }
+
+    // MARK: - Card mapping resolution
+
+    @Test func resolvesViaCardMapping() {
+        let accounts = [account("acct_hsbc", "HSBC"), account("acct_cash", "Cash")]
+        let mappings = ["1234": "acct_hsbc"]
+
+        let result = BudgetStore.resolveAccountId(
+            hint: "1234", accounts: accounts, cardMappings: mappings)
+        #expect(result == "acct_hsbc")
+    }
+
+    @Test func prefersLongestMappingKey() {
+        let accounts = [account("acct1", "A"), account("acct2", "B")]
+        let mappings = ["12": "acct1", "1234": "acct2"]
+
+        let result = BudgetStore.resolveAccountId(
+            hint: "1234", accounts: accounts, cardMappings: mappings)
+        #expect(result == "acct2")
+    }
+
+    @Test func skipsMappingForClosedAccount() {
+        let accounts = [account("acct1", "HSBC", closed: true), account("acct2", "Cash")]
+        let mappings = ["1234": "acct1"]
+
+        let result = BudgetStore.resolveAccountId(
+            hint: "1234", accounts: accounts, cardMappings: mappings)
+        // Mapping points to closed account — should not match
+        #expect(result == nil)
+    }
+
+    // MARK: - Account name fallback
+
+    @Test func matchesExactAccountName() {
+        let accounts = [account("acct1", "Checking")]
+        let result = BudgetStore.resolveAccountId(
+            hint: "Checking", accounts: accounts, cardMappings: [:])
+        #expect(result == "acct1")
+    }
+
+    @Test func matchesAccountNameByWholeWords() {
+        let accounts = [account("acct1", "Checking")]
+        let result = BudgetStore.resolveAccountId(
+            hint: "Checking Account", accounts: accounts, cardMappings: [:])
+        #expect(result == "acct1")
+    }
+
+    @Test func doesNotMatchSubstringInsideLargerWord() {
+        let accounts = [account("acct1", "Cash")]
+        // "cashback" contains "cash" as substring, not as a word
+        let result = BudgetStore.resolveAccountId(
+            hint: "HSBC cashback card", accounts: accounts, cardMappings: [:])
+        #expect(result == nil)
+    }
+
+    @Test func returnsNilWhenNoOpenAccounts() {
+        let accounts = [account("acct1", "Cash", closed: true)]
+        let result = BudgetStore.resolveAccountId(
+            hint: "Cash", accounts: accounts, cardMappings: [:])
+        #expect(result == nil)
+    }
+
+    @Test func returnsNilForEmptyHint() {
+        let accounts = [account("acct1", "Cash")]
+        let result = BudgetStore.resolveAccountId(
+            hint: "  ", accounts: accounts, cardMappings: [:])
+        #expect(result == nil)
+    }
+
+    // MARK: - Regression: the exact scenario from the bug report
+
+    @Test func resolvesMappedCardHintInsteadOfFirstAccount() {
+        // "Spent 300 via 1234 hsbc at AWS m on 15th Aug 2026"
+        // Parser extracts cardHint "1234", mapping routes to HSBC.
+        // Before the fix: fell through to Cash (first account).
+        let accounts = [account("acct_cash", "Cash"), account("acct_hsbc", "HSBC")]
+        let mappings = ["1234": "acct_hsbc"]
+
+        let result = BudgetStore.resolveAccountId(
+            hint: "1234", accounts: accounts, cardMappings: mappings)
+        #expect(result == "acct_hsbc")
+    }
+}


### PR DESCRIPTION
## Why

Pending import edit view ignored card account mappings when resolving which account to route a transaction to. A card hint like "1234" (mapped to "Hsbc" in settings) would never match any account name, so it always fell through to the first account (Cash).

## What

- Check `cardAccountMappings` first in the edit view's account resolution (longest key wins), matching `BudgetStore.resolveAccountId` logic
- Set `cleared` to `false` for pending imports — they're unverified transactions
- Don't silently fall back to first account when no default is set; return `nil` so the user picks explicitly
- Extract resolution into a `nonisolated static` helper for testability

## How it was tested

8 unit tests added in `PendingImportsResolveAccountTests.swift` covering: card mapping lookup, longest-key preference, closed-account skipping, name fallback, default account fallback, nil-when-no-default, nil-when-no-open-accounts, and the exact bug scenario from the report.
