### PR TITLE
Restore the uncategorized link's full-width look

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -447,9 +447,18 @@ struct BudgetView: View {
                     }
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.orange)
+                    // Reads as a full-width row like the List section it used
+                    // to live in (GH #29 / #305), not a stray line of text.
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color(.secondarySystemGroupedBackground))
+                    )
                 }
                 .accessibilityIdentifier("budgetUncategorized")
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 4)
                 .padding(.bottom, 8)
             }
 


### PR DESCRIPTION
The uncategorized link on the Budget tab used to be a full-width row inside the Budget Check-In List section. #305 replaced that section with the filter strip and moved the link out of the List, which left it looking like a stray line of text above the chips.

Gives it the card background and full width back, matching the summary card above it. Orange text/icon and chevron unchanged.

Ran: `xcodebuild build` on iPhone 17 Pro (iOS 26.5) — succeeded. Visual-only change; the existing `budgetUncategorized` UI test still covers the tap route.