### PR TITLE
Stop Log Transaction popping a dialog outside Siri

### DIFF
--- a/Actuali/Actuali/AppIntents/ActualiShortcutsProvider.swift
+++ b/Actuali/Actuali/AppIntents/ActualiShortcutsProvider.swift
@@ -5,7 +5,9 @@ struct ActualiShortcutsProvider: AppShortcutsProvider {
 
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
-            intent: LogTransactionIntent(),
+            // Voice invocation is the one surface where the spoken confirmation is
+            // wanted; see LogTransactionIntent.showConfirmation.
+            intent: LogTransactionIntent(showConfirmation: true),
             phrases: [
                 "Log transaction in \(.applicationName)",
                 "Log transaction to \(\.$account) in \(.applicationName)",

--- a/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
+++ b/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
@@ -36,6 +36,20 @@ struct LogTransactionIntent: AppIntent {
     @Parameter(title: "Cleared", default: true)
     var cleared: Bool
 
+    // Siri speaks a returned dialog, but Shortcuts and Wallet automations render
+    // it as a card the user must dismiss with "Done" — which #143 turned into the
+    // normal outcome of a tap-to-pay automation. Nothing in AppIntents exposes the
+    // invocation surface, so the Siri App Shortcut opts in explicitly and every
+    // other caller stays silent; the success notification is the feedback there.
+    @Parameter(title: "Show Confirmation", default: false)
+    var showConfirmation: Bool
+
+    init() {}
+
+    init(showConfirmation: Bool) {
+        self.showConfirmation = showConfirmation
+    }
+
     static var parameterSummary: some ParameterSummary {
         Summary("Log \(\.$amount) at \(\.$payee) in \(\.$account)") {
             \.$cardHint
@@ -43,7 +57,18 @@ struct LogTransactionIntent: AppIntent {
             \.$date
             \.$isIncome
             \.$cleared
+            \.$showConfirmation
         }
+    }
+
+    nonisolated static func result(
+        dialogText: String,
+        showConfirmation: Bool
+    ) -> IntentResultContainer<Never, Never, Never, IntentDialog> {
+        var result = IntentResultContainer<Never, Never, Never, IntentDialog>
+            .result(dialog: IntentDialog(stringLiteral: dialogText))
+        if !showConfirmation { result.dialog = nil }
+        return result
     }
 
     @MainActor
@@ -141,7 +166,7 @@ struct LogTransactionIntent: AppIntent {
             let dialogText = displayPayee.isEmpty
                 ? "\(verb) \(amountString)"
                 : "\(verb) \(amountString) at \(displayPayee)"
-            return .result(dialog: IntentDialog(stringLiteral: dialogText))
+            return Self.result(dialogText: dialogText, showConfirmation: showConfirmation)
         } catch {
             let mapped: LogTransactionError = (error as? LogTransactionError)
                 ?? .writeFailed(underlying: error.localizedDescription)

--- a/Actuali/ActualiTests/AppIntents/LogTransactionIntentTests.swift
+++ b/Actuali/ActualiTests/AppIntents/LogTransactionIntentTests.swift
@@ -1,0 +1,21 @@
+import AppIntents
+import Testing
+@testable import Actuali
+
+struct LogTransactionIntentTests {
+
+    @Test func silentByDefaultSoAutomationsDoNotShowADialog() {
+        let result = LogTransactionIntent.result(dialogText: "Logged $4.50 at Blue Bottle", showConfirmation: false)
+        #expect(result.dialog == nil)
+    }
+
+    @Test func speaksWhenTheCallerAsksFor() {
+        let result = LogTransactionIntent.result(dialogText: "Logged $4.50 at Blue Bottle", showConfirmation: true)
+        #expect(result.dialog != nil)
+    }
+
+    @Test func siriShortcutOptsIntoTheSpokenConfirmation() {
+        #expect(LogTransactionIntent(showConfirmation: true).showConfirmation)
+        #expect(LogTransactionIntent().showConfirmation == false)
+    }
+}

--- a/website/src/pages/guides/shortcuts.astro
+++ b/website/src/pages/guides/shortcuts.astro
@@ -41,7 +41,8 @@ import Layout from "../../layouts/Layout.astro";
         <li>
           <strong>Log Transaction</strong> — add a transaction with amount, payee, account, date, and notes. Used by the
           <a href="/guides/wallet-automation" class="underline hover:text-neutral-900">Apple Wallet automation</a> to log
-          tap-to-pay purchases automatically.
+          tap-to-pay purchases automatically. It reports the result with a notification rather than an on-screen card;
+          turn on <strong>Show Confirmation</strong> in the action if you want a dialog you dismiss yourself.
         </li>
         <li>
           <strong>Add Transaction with Review</strong> — open the app on the add-transaction screen with any fields you


### PR DESCRIPTION
Tapping to pay started requiring a "Done" tap after the last update. #143 changed `LogTransactionIntent.perform()` to return `ProvidesDialog`, and Shortcuts/Wallet automations present a returned dialog as a modal card — so every tap-to-pay ended in a card you had to dismiss. Before that it returned a bare `.result()` and the automation finished silently.

Nothing in AppIntents (iOS 26) exposes the invocation surface — `IntentSystemContext.currentMode` only reports foreground/background — so the choice has to be explicit:

- new `Show Confirmation` parameter, **off** by default; when off, the result container's `dialog` is cleared, so there's nothing for Shortcuts to present
- the Siri App Shortcut passes `showConfirmation: true`, keeping the spoken confirmation on the voice path
- existing automations take the new default (a newly added parameter isn't stored in an already-configured action), so tap-to-pay goes back to notification-only with no user edit

The success notification from `TransactionLogNotifier` was always there, and it survives the app being backgrounded — the dialog was duplicate feedback in the automation case.

`ParseAndQueueTransactionIntent` still returns a dialog: its share-sheet path has no notification, so silencing it would leave no feedback at all.

## Testing

Full unit suite (`-skip-testing:ActualiUITests`) on iPhone 17 Pro / iOS 26.5: passing. New `LogTransactionIntentTests` covers silent-by-default, dialog-when-opted-in, and the provider's init.

Two bits need a device check, since unit tests only reach `result.dialog == nil`: that a nil dialog really suppresses the card (tap to pay), and that Siri honours the preset parameter (say "Log transaction in Actuali" and listen for the confirmation).