### PR TITLE
Re-center the budget month stepper

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -315,15 +315,29 @@ struct BudgetView: View {
         // used to be mistaken for one (it steps the month, not the
         // navigation stack).
         ToolbarItem(placement: .principal) {
-            // The glyphs are ~14pt, so each one gets padded out to the 44pt
-            // minimum touch target and the stack drops its spacing — the
-            // padding is what separates them now.
+            // UIKit centers a title view only while it stays under ~140pt
+            // next to these two trailing buttons; one point over and it
+            // left-aligns the whole stepper against the leading edge instead.
+            // That cliff has been hit twice — GH #234, then again by #319
+            // padding both chevrons out to 44pt wide (44 + 44 + a 78pt
+            // "Aug 2026" = 166). So the width is the budget: the touch target
+            // grows downward to 44pt and stays 30pt wide, giving 138 total.
+            // `.frame(maxWidth: .infinity)` can't buy centering back — the
+            // title view is sized to fit its content, so the frame has no
+            // extra width to center in.
+            //
+            // ponytail: 138 of ~140 is all the headroom there is, and the slot
+            // shrinks as the trailing buttons scale, so raised text sizes still
+            // left-align (measured at XXXL). Anything that needs a bigger
+            // stepper — a third trailing button, unabbreviated months, real
+            // Dynamic Type support — has to leave the bar for a pinned header
+            // row above the summary card, where centering is real layout.
             HStack(spacing: 0) {
                 Button {
                     selectedMonth = Self.shiftMonth(selectedMonth, by: -1)
                 } label: {
                     Image(systemName: "chevron.left")
-                        .frame(width: 44, height: 44)
+                        .frame(width: 30, height: 44)
                         .contentShape(.rect)
                 }
                 .accessibilityLabel("Previous month")
@@ -334,15 +348,11 @@ struct BudgetView: View {
                     selectedMonth = Self.shiftMonth(selectedMonth, by: 1)
                 } label: {
                     Image(systemName: "chevron.right")
-                        .frame(width: 44, height: 44)
+                        .frame(width: 30, height: 44)
                         .contentShape(.rect)
                 }
                 .accessibilityLabel("Next month")
             }
-            // The wider hit targets make the group too big for the toolbar to
-            // center on its own, so it claims the whole title region and
-            // centers the stepper inside it.
-            .frame(maxWidth: .infinity)
         }
         // Creation, unlike everything in the options menu, changes the budget
         // rather than the view of it — so it gets its own button (GH #284).

--- a/Actuali/ActualiUITests/BudgetSummaryPinUITests.swift
+++ b/Actuali/ActualiUITests/BudgetSummaryPinUITests.swift
@@ -48,4 +48,28 @@ final class BudgetSummaryPinUITests: XCTestCase {
         XCTAssertTrue(nextMonth.isHittable,
                       "the inline bar keeps the stepper tappable while scrolled")
     }
+
+    /// UIKit silently gives up on centering a title view once it outgrows the
+    /// slot the trailing buttons leave, and jams it against the leading edge
+    /// instead — twice now (GH #234, #319). Only the rendered frames catch it,
+    /// and the stepper clears the slot by 2pt, so this is the guard for the
+    /// next thing that widens it.
+    @MainActor
+    func testMonthStepperIsCenteredInTheBar() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-loadDemoData"]
+        app.launch()
+
+        app.tabBars.buttons["Budget"].tap()
+
+        let navBar = app.navigationBars.firstMatch
+        let previousMonth = navBar.buttons["Previous month"]
+        XCTAssertTrue(previousMonth.waitForExistence(timeout: 10),
+                      "the month stepper lives in the bar")
+        let nextMonth = navBar.buttons["Next month"]
+
+        let stepperMidX = (previousMonth.frame.minX + nextMonth.frame.maxX) / 2
+        XCTAssertEqual(stepperMidX, navBar.frame.midX, accuracy: 4,
+                       "the month stepper must stay centered in the bar")
+    }
 }


### PR DESCRIPTION
The month stepper was sitting hard against the leading edge of the Budget nav bar again.

Cause: #319 padded both chevrons out to 44pt wide, which put the title view at 44 + 78 ("Aug 2026") + 44 = 166pt. UIKit only centers a title view while it stays under ~140pt next to the two trailing buttons; past that it silently left-aligns the whole thing. Same cliff as #234. The `.frame(maxWidth: .infinity)` that came with #319 was a no-op — the title view is sized to fit its content, so there's no spare width to center in.

Fix: chevron touch targets grow downward instead of sideways — 30x44 rather than 44x44 — for 138pt total, back under the slot. Dead `maxWidth` frame removed.

Also added `testMonthStepperIsCenteredInTheBar`, which asserts the rendered frames against the bar's midpoint. Nothing else catches this, and it's now regressed twice.

Known limitation, called out in a comment: 138 of ~140 is all the headroom there is, and the slot shrinks as the trailing buttons scale, so raised text sizes still left-align (measured at XXXL — already true before #319). Anything that needs a wider stepper has to leave the nav bar for a pinned header row above the summary card.

Ran on iPhone 17 Pro / iOS 26.5:
- `-only-testing:ActualiTests` — TEST SUCCEEDED
- `BudgetSummaryPinUITests` — the new centering test and `testMonthStepperStaysReachableAfterScrolling` pass. `testBudgetNavigationBarDoesNotResizeWithScrolling` fails identically on a clean tree (demo-data lookup), so it's pre-existing and untouched by this.