### PR TITLE
Increase Budget Overspending Screen Height

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
@@ -195,7 +195,7 @@ struct BudgetTransferSheet: View {
                 }
             }
         }
-        .presentationDetents([.fraction(0.70)])
+        .presentationDetents([.fraction(0.70), .large])
         .interactiveDismissDisabled(isSaving)
     }
 

--- a/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetTransferSheet.swift
@@ -195,7 +195,7 @@ struct BudgetTransferSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.fraction(0.70)])
         .interactiveDismissDisabled(isSaving)
     }
 


### PR DESCRIPTION
Why

When you click on a budget's negative balance, you need to scroll down to view the amount field.

What

Changes the height of the Budget Transfer sheet from .presentationDetents([.medium]) to .presentationDetents([.fraction(0.70)]), ensuring the amount field is visible on the screen.

How it was tested

Tested on an iPhone 17 Pro simulator.