### PR TITLE
SimpleFIN Integration

### DIFF
--- a/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The provider an account's transactions are downloaded from. Actual stores
+/// this in `accounts.account_sync_source`; Actuali only speaks SimpleFIN, but
+/// the column is shared with every other client, so a value it doesn't
+/// recognise has to survive a round trip untouched.
+enum BankSyncSource: String, Sendable, Equatable {
+    case simpleFin = "simpleFin"
+}
+
+/// An account wired up to a bank feed: the budget's account plus the
+/// provider-side id its transactions come from.
+struct BankSyncAccount: Sendable, Equatable, Identifiable {
+    /// The budget's account id.
+    let id: String
+    let name: String
+    /// `accounts.account_id` — the id the provider knows the account by.
+    let externalAccountId: String
+    /// `accounts.account_sync_source`, verbatim. Not every value maps to a
+    /// provider Actuali can sync (see `source`).
+    let syncSource: String
+    let offBudget: Bool
+    let closed: Bool
+
+    var source: BankSyncSource? { BankSyncSource(rawValue: syncSource) }
+}
+
+/// Actual's `banks` row: the institution behind one or more linked accounts.
+/// Written so an account linked here looks the same to the web UI as one
+/// linked there — its unlink path reads `accounts.bank` and does nothing
+/// without it.
+struct Bank: Identifiable, Hashable, Sendable {
+    let id: String
+    /// The provider's own institution id — SimpleFIN's org domain, falling
+    /// back to its org id.
+    var bankId: String
+    var name: String
+    var tombstone: Bool = false
+}
+
+extension Bank: CRDTSyncable {
+    static var datasetName: String { "banks" }
+
+    var syncableFields: [String: Any?] {
+        [
+            "bank_id": bankId,
+            "name": name,
+            "tombstone": tombstone ? 1 : 0
+        ]
+    }
+}

--- a/Actuali/Actuali/Services/BankSync/BankSyncProvider.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncProvider.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// One account to download, and how far back to reach for it.
+struct BankSyncTarget: Sendable, Equatable {
+    /// The provider's account id (`accounts.account_id`).
+    let externalId: String
+    /// Earliest day (`YYYYMMDD`) worth downloading for this account.
+    let startDay: Int
+}
+
+/// What a provider came back with for one account.
+struct BankSyncDownload: Sendable, Equatable {
+    var candidates: [BankSyncCandidate] = []
+    /// The account's balance as of now, for working out an opening balance on
+    /// a first sync.
+    var currentBalanceCents: Int?
+    /// Something the person should know about this account, if anything.
+    var problem: String?
+    /// Actual's `bank_sync_status` value for this account after the download,
+    /// so the web UI reads the same state this device saw.
+    var status: String = "ok"
+}
+
+struct BankSyncDownloadSet: Sendable, Equatable {
+    var byAccount: [String: BankSyncDownload] = [:]
+    /// Problems that aren't tied to a single account.
+    var problems: [String] = []
+}
+
+/// Where a bank download comes from.
+///
+/// Two of these exist because the credential can live in either of two places
+/// and they can't be shared: Actual keeps the server's SimpleFIN access key in
+/// its own secrets store, deliberately out of the budget file, so no amount of
+/// syncing will hand it to this device. Preferring the server when it has one
+/// (see `BudgetStore.makeBankSyncProvider`) means a person who set SimpleFIN
+/// up on the web doesn't have to claim a second setup token here, and a person
+/// who links an account here doesn't leave the web with a link it can't
+/// service. The device's own key is the fallback for servers that have no
+/// SimpleFIN of their own.
+protocol BankSyncProvider: Sendable {
+    /// Every account the connection covers, for the linking screen.
+    func accounts() async throws -> [SimpleFINAccount]
+    func download(_ targets: [BankSyncTarget]) async throws -> BankSyncDownloadSet
+}
+
+// MARK: - The device's own connection
+
+/// Talks to the SimpleFIN bridge directly with a key this device claimed.
+struct SimpleFINDirectProvider: BankSyncProvider {
+    let client: SimpleFINClient
+    let accessKey: SimpleFINAccessKey
+
+    func accounts() async throws -> [SimpleFINAccount] {
+        try await client.fetchAccounts(accessKey: accessKey).accounts
+    }
+
+    func download(_ targets: [BankSyncTarget]) async throws -> BankSyncDownloadSet {
+        guard let earliest = targets.map(\.startDay).min() else { return BankSyncDownloadSet() }
+
+        // One request covers every account, so it reaches back as far as the
+        // hungriest of them; each account drops the surplus below.
+        let downloaded = try await client.fetchAccounts(
+            accessKey: accessKey,
+            accountIds: targets.map(\.externalId),
+            startDate: earliest
+        )
+
+        var set = BankSyncDownloadSet()
+        for target in targets {
+            guard let remote = downloaded.accounts.first(where: { $0.id == target.externalId })
+            else { continue }
+
+            var download = BankSyncDownload(
+                candidates: remote.transactions
+                    .compactMap(BankSyncCandidate.init(simpleFIN:))
+                    .filter { $0.date >= target.startDay },
+                currentBalanceCents: remote.balanceCents
+            )
+            // The bridge's errors aren't keyed by account, so pair them up the
+            // way upstream's server does — by the institution they name.
+            if let attention = downloaded.errors.first(where: {
+                $0.hasPrefix("Connection to \(remote.org.displayName) may need attention")
+            }) {
+                download.problem = attention
+                download.status = "attention-required"
+            }
+            set.byAccount[target.externalId] = download
+        }
+
+        // Anything left over is about the connection, not one account.
+        let named = Set(
+            downloaded.accounts
+                .filter { account in targets.contains { $0.externalId == account.id } }
+                .map { "Connection to \($0.org.displayName) may need attention" }
+        )
+        set.problems = downloaded.errors.filter { error in
+            !named.contains { error.hasPrefix($0) }
+        }
+        return set
+    }
+}
+
+// MARK: - The server's connection
+
+/// Routes the download through the Actual server's own SimpleFIN credentials,
+/// which it already exposes to any authenticated client at `/simplefin/*`.
+struct ActualServerBankSyncProvider: BankSyncProvider {
+    let client: ActualServerClient
+
+    func accounts() async throws -> [SimpleFINAccount] {
+        try await client.simpleFINAccounts()
+    }
+
+    func download(_ targets: [BankSyncTarget]) async throws -> BankSyncDownloadSet {
+        guard !targets.isEmpty else { return BankSyncDownloadSet() }
+
+        let downloaded = try await client.simpleFINTransactions(
+            accountIds: targets.map(\.externalId),
+            startDates: targets.map { BankSyncReconciler.isoString(from: $0.startDay) }
+        )
+
+        var set = BankSyncDownloadSet()
+        if let failure = downloaded.failure {
+            // The whole request was rejected, so no account got as far as
+            // having its own problem.
+            set.problems.append(
+                failure.reason ?? "Your server's SimpleFIN connection was rejected."
+            )
+            return set
+        }
+
+        for target in targets {
+            let account = downloaded.accounts[target.externalId]
+            let error = downloaded.errors[target.externalId]?.first
+            // Neither data nor an error means the server didn't mention this
+            // account at all; leave the key out so the caller says so.
+            guard account != nil || error != nil else { continue }
+
+            var download = BankSyncDownload()
+            if let error {
+                download.problem = error.reason ?? error.errorCode
+                download.status = error.bankSyncStatus
+            }
+            if let account {
+                download.candidates = (account.transactions?.all ?? [])
+                    .compactMap(BankSyncCandidate.init(serverBankSync:))
+                    .filter { $0.date >= target.startDay }
+                download.currentBalanceCents = account.startingBalance
+            }
+            set.byAccount[target.externalId] = download
+        }
+        return set
+    }
+}

--- a/Actuali/Actuali/Services/BankSync/BankSyncProvider.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncProvider.swift
@@ -117,7 +117,7 @@ struct ActualServerBankSyncProvider: BankSyncProvider {
 
         let downloaded = try await client.simpleFINTransactions(
             accountIds: targets.map(\.externalId),
-            startDates: targets.map { BankSyncReconciler.isoString(from: $0.startDay) }
+            startDates: targets.map { DayDate(yyyymmdd: $0.startDay)?.iso ?? "" }
         )
 
         var set = BankSyncDownloadSet()

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -95,14 +95,14 @@ enum BankSyncReconciler {
                 continue
             }
             let window = existing
-                .filter {
-                    $0.amount == candidate.amount
-                        && abs(dayNumber($0.date) - dayNumber(candidate.date)) <= fuzzyMatchDayRadius
+                .compactMap { row -> (row: BankSyncExistingTransaction, distance: Int)? in
+                    guard row.amount == candidate.amount,
+                          let distance = dayDistance(row.date, candidate.date),
+                          distance <= fuzzyMatchDayRadius else { return nil }
+                    return (row, distance)
                 }
-                .sorted {
-                    abs(dayNumber($0.date) - dayNumber(candidate.date))
-                        < abs(dayNumber($1.date) - dayNumber(candidate.date))
-                }
+                .sorted { $0.distance < $1.distance }
+                .map(\.row)
             pending.append((candidate, nil, window))
         }
 
@@ -172,52 +172,12 @@ enum BankSyncReconciler {
             || update.cleared != existing.cleared
     }
 
-    /// Days since an arbitrary epoch for a `YYYYMMDD` date, via the standard
-    /// Julian day number formula. Calendar-free so the match window is the
-    /// same width in every time zone.
-    static func dayNumber(_ yyyymmdd: Int) -> Int {
-        let year = yyyymmdd / 10000
-        let month = (yyyymmdd % 10000) / 100
-        let day = yyyymmdd % 100
-        let priorMonths = (14 - month) / 12
-        let years = year + 4800 - priorMonths
-        let months = month + 12 * priorMonths - 3
-        return day + (153 * months + 2) / 5 + 365 * years
-            + years / 4 - years / 100 + years / 400 - 32045
-    }
-
-    /// A `YYYYMMDD` date moved by whole days, month and year rollovers
-    /// included. The inverse of `dayNumber`, so the match window's edges are
-    /// computed the same way its width is.
-    static func day(_ yyyymmdd: Int, offsetBy days: Int) -> Int {
-        let shifted = dayNumber(yyyymmdd) + days + 32044
-        let centuries = (4 * shifted + 3) / 146097
-        let withinCentury = shifted - 146097 * centuries / 4
-        let years = (4 * withinCentury + 3) / 1461
-        let withinYear = withinCentury - 1461 * years / 4
-        let months = (5 * withinYear + 2) / 153
-        let day = withinYear - (153 * months + 2) / 5 + 1
-        let month = months + 3 - 12 * (months / 10)
-        let year = 100 * centuries + years - 4800 + months / 10
-        return year * 10000 + month * 100 + day
-    }
-    
-    /// `YYYYMMDD` for the `YYYY-MM-DD` strings the Actual server's bank-sync
-    /// routes speak, or nil if it isn't one.
-    static func day(fromISO iso: String) -> Int? {
-        let parts = iso.split(separator: "-")
-        guard parts.count == 3,
-              let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
-              (1...12).contains(month), (1...31).contains(day) else { return nil }
-        return year * 10000 + month * 100 + day
-    }
-
-    /// The inverse, for the `startDate` those routes take.
-    static func isoString(from yyyymmdd: Int) -> String {
-        String(
-            format: "%04d-%02d-%02d",
-            yyyymmdd / 10000, (yyyymmdd % 10000) / 100, yyyymmdd % 100
-        )
+    /// Whole days between two `YYYYMMDD` dates, or nil if either isn't a real
+    /// calendar date. `DayDate` is timezone-free, so the match window is the
+    /// same width wherever the phone is.
+    static func dayDistance(_ a: Int, _ b: Int) -> Int? {
+        guard let from = DayDate(yyyymmdd: a), let to = DayDate(yyyymmdd: b) else { return nil }
+        return abs(from.days(until: to))
     }
 }
 
@@ -252,7 +212,7 @@ extension BankSyncCandidate {
     init?(serverBankSync transaction: ServerBankSyncTransaction) {
         guard let importedId = transaction.transactionId,
               let iso = transaction.date,
-              let date = BankSyncReconciler.day(fromISO: iso),
+              let date = DayDate(iso: iso)?.yyyymmdd,
               let raw = transaction.transactionAmount?.amount,
               let amount = SimpleFINAmount.cents(from: raw) else { return nil }
         self.init(

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -201,6 +201,24 @@ enum BankSyncReconciler {
         let year = 100 * centuries + years - 4800 + months / 10
         return year * 10000 + month * 100 + day
     }
+    
+    /// `YYYYMMDD` for the `YYYY-MM-DD` strings the Actual server's bank-sync
+    /// routes speak, or nil if it isn't one.
+    static func day(fromISO iso: String) -> Int? {
+        let parts = iso.split(separator: "-")
+        guard parts.count == 3,
+              let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
+              (1...12).contains(month), (1...31).contains(day) else { return nil }
+        return year * 10000 + month * 100 + day
+    }
+
+    /// The inverse, for the `startDate` those routes take.
+    static func isoString(from yyyymmdd: Int) -> String {
+        String(
+            format: "%04d-%02d-%02d",
+            yyyymmdd / 10000, (yyyymmdd % 10000) / 100, yyyymmdd % 100
+        )
+    }
 }
 
 // MARK: - Normalization
@@ -219,25 +237,51 @@ extension BankSyncCandidate {
             importedId: transaction.id,
             date: SimpleFINAmount.day(fromTimestamp: transaction.effectiveTimestamp),
             amount: amount,
-            payeeName: Self.payeeName(for: transaction),
+            payeeName: Self.payeeName(from: [
+                transaction.payee, transaction.description, transaction.memo
+            ]),
             payeeId: nil,
-            notes: Self.notes(for: transaction),
+            notes: Self.notes(from: transaction.description),
             cleared: transaction.isBooked
         )
     }
 
-    /// The bridge's `payee` when it has one. Not every bridge fills it in, so
-    /// fall back to the description rather than importing a nameless payee.
-    private static func payeeName(for transaction: SimpleFINTransaction) -> String {
-        for candidate in [transaction.payee, transaction.description, transaction.memo] {
+    /// The same, from the shape the Actual server's `/simplefin/transactions`
+    /// route returns — already renamed and date-formatted by the time it
+    /// reaches us, so the raw bridge fields aren't available here.
+    init?(serverBankSync transaction: ServerBankSyncTransaction) {
+        guard let importedId = transaction.transactionId,
+              let iso = transaction.date,
+              let date = BankSyncReconciler.day(fromISO: iso),
+              let raw = transaction.transactionAmount?.amount,
+              let amount = SimpleFINAmount.cents(from: raw) else { return nil }
+        self.init(
+            importedId: importedId,
+            date: date,
+            amount: amount,
+            payeeName: Self.payeeName(from: [transaction.payeeName, transaction.notes]),
+            payeeId: nil,
+            notes: Self.notes(from: transaction.notes),
+            // The route only omits `booked` for shapes it never sends; treat a
+            // missing value as posted rather than importing everything
+            // uncleared.
+            cleared: transaction.booked ?? true
+        )
+    }
+
+    /// The first name with anything in it. Not every bridge fills in a payee,
+    /// and importing a nameless one would be worse than reusing the
+    /// description.
+    private static func payeeName(from candidates: [String?]) -> String {
+        for candidate in candidates {
             let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !trimmed.isEmpty { return trimmed }
         }
         return "Unknown"
     }
 
-    private static func notes(for transaction: SimpleFINTransaction) -> String? {
-        let trimmed = transaction.description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    private static func notes(from raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return nil }
         // Escape `#` the way upstream does, so a bank's own "#" in a
         // description doesn't silently become a tag (see TagFilter, where a

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+/// One downloaded transaction, normalized into the budget's own units and
+/// ready to be matched against what's already in the account.
+struct BankSyncCandidate: Sendable, Equatable {
+    /// The provider's transaction id — stored as `financial_id` and the
+    /// highest-fidelity way to recognise a transaction we already imported.
+    var importedId: String
+    var date: Int // YYYYMMDD
+    var amount: Int // cents, negative = outflow
+    var payeeName: String
+    /// The existing payee `payeeName` resolves to, or nil when the budget has
+    /// no payee by that name yet. Resolved before matching because the payee
+    /// pass compares ids, not names.
+    var payeeId: String?
+    var notes: String?
+    /// Booked at the bank. Pending transactions import uncleared and clear on
+    /// a later sync, once the bank posts them.
+    var cleared: Bool
+}
+
+/// An existing transaction in the fuzzy-match window, projected down to just
+/// the columns matching reads.
+struct BankSyncExistingTransaction: Sendable, Equatable {
+    var id: String
+    var date: Int // YYYYMMDD
+    var amount: Int // cents
+    var payeeId: String?
+    var importedId: String?
+    var importedPayee: String?
+    var notes: String?
+    var cleared: Bool
+    var reconciled: Bool
+}
+
+/// The columns a matched transaction takes from the downloaded one.
+struct BankSyncUpdate: Sendable, Equatable {
+    var existingId: String
+    var importedId: String
+    var payeeId: String?
+    var importedPayee: String?
+    var notes: String?
+    var cleared: Bool
+}
+
+struct BankSyncPlan: Sendable, Equatable {
+    var inserts: [BankSyncCandidate] = []
+    var updates: [BankSyncUpdate] = []
+    /// Downloaded transactions that matched something already correct — the
+    /// ordinary case for every sync after the first.
+    var unchanged: Int = 0
+
+    var isEmpty: Bool { inserts.isEmpty && updates.isEmpty }
+}
+
+/// Decides which downloaded transactions are new, which ones are transactions
+/// the budget already has, and what the latter should take from them.
+///
+/// Port of upstream loot-core `matchTransactions` / `reconcileTransactions`
+/// (`server/accounts/sync.ts`) for the bank-sync case, so a transaction
+/// entered by hand before it reached the bank feed is updated rather than
+/// duplicated. Three passes, highest fidelity first: the provider's own
+/// transaction id, then same-payee, then anything left in the window.
+///
+/// Pure and synchronous — the caller does the payee lookups and the writing.
+enum BankSyncReconciler {
+    /// How far either side of a downloaded transaction's date to look for the
+    /// transaction it might already be, matching upstream's window.
+    static let fuzzyMatchDayRadius = 7
+
+    static func plan(
+        candidates: [BankSyncCandidate],
+        existing: [BankSyncExistingTransaction]
+    ) -> BankSyncPlan {
+        var matchedIds = Set<String>()
+        var plan = BankSyncPlan()
+
+        // Pass 1: the provider's transaction id. Anything that misses gets a
+        // window of same-amount transactions to try the later passes against,
+        // nearest date first.
+        //
+        // Unlike a file import, the window deliberately keeps rows that
+        // already carry a *different* imported id (upstream's
+        // `strictIdChecking: false` for bank-sync accounts): providers hand
+        // out a new id for the same transaction often enough — a pending
+        // charge that posts, most commonly — that excluding them would
+        // duplicate it.
+        var pending: [(candidate: BankSyncCandidate, match: BankSyncExistingTransaction?, window: [BankSyncExistingTransaction])] = []
+        for candidate in candidates {
+            if let match = existing.first(where: {
+                $0.importedId == candidate.importedId && !matchedIds.contains($0.id)
+            }) {
+                matchedIds.insert(match.id)
+                pending.append((candidate, match, []))
+                continue
+            }
+            let window = existing
+                .filter {
+                    $0.amount == candidate.amount
+                        && abs(dayNumber($0.date) - dayNumber(candidate.date)) <= fuzzyMatchDayRadius
+                }
+                .sorted {
+                    abs(dayNumber($0.date) - dayNumber(candidate.date))
+                        < abs(dayNumber($1.date) - dayNumber(candidate.date))
+                }
+            pending.append((candidate, nil, window))
+        }
+
+        // Pass 2: same payee. Runs across every candidate before pass 3 so a
+        // confident match always wins the row a vaguer one would have taken.
+        for index in pending.indices {
+            guard pending[index].match == nil, let payeeId = pending[index].candidate.payeeId else { continue }
+            guard let match = pending[index].window.first(where: {
+                !matchedIds.contains($0.id) && $0.payeeId == payeeId
+            }) else { continue }
+            matchedIds.insert(match.id)
+            pending[index].match = match
+        }
+
+        // Pass 3: whatever is left in the window — same account, same amount,
+        // within a week.
+        for index in pending.indices {
+            guard pending[index].match == nil else { continue }
+            guard let match = pending[index].window.first(where: { !matchedIds.contains($0.id) }) else { continue }
+            matchedIds.insert(match.id)
+            pending[index].match = match
+        }
+
+        for entry in pending {
+            guard let match = entry.match else {
+                plan.inserts.append(entry.candidate)
+                continue
+            }
+            // Reconciled transactions are locked; upstream leaves them alone.
+            guard !match.reconciled else {
+                plan.unchanged += 1
+                continue
+            }
+            let update = self.update(for: entry.candidate, matching: match)
+            if changed(update, from: match) {
+                plan.updates.append(update)
+            } else {
+                plan.unchanged += 1
+            }
+        }
+
+        return plan
+    }
+
+    /// What a matched transaction ends up with. Anything the person already
+    /// filled in wins — the download only fills blanks — except the two fields
+    /// that are the bank's to state: its transaction id and whether it posted.
+    private static func update(
+        for candidate: BankSyncCandidate,
+        matching existing: BankSyncExistingTransaction
+    ) -> BankSyncUpdate {
+        BankSyncUpdate(
+            existingId: existing.id,
+            importedId: candidate.importedId,
+            payeeId: existing.payeeId ?? candidate.payeeId,
+            importedPayee: candidate.payeeName,
+            notes: existing.notes ?? candidate.notes,
+            cleared: existing.cleared || candidate.cleared
+        )
+    }
+
+    private static func changed(_ update: BankSyncUpdate, from existing: BankSyncExistingTransaction) -> Bool {
+        update.importedId != existing.importedId
+            || update.payeeId != existing.payeeId
+            || update.importedPayee != existing.importedPayee
+            || update.notes != existing.notes
+            || update.cleared != existing.cleared
+    }
+
+    /// Days since an arbitrary epoch for a `YYYYMMDD` date, via the standard
+    /// Julian day number formula. Calendar-free so the match window is the
+    /// same width in every time zone.
+    static func dayNumber(_ yyyymmdd: Int) -> Int {
+        let year = yyyymmdd / 10000
+        let month = (yyyymmdd % 10000) / 100
+        let day = yyyymmdd % 100
+        let priorMonths = (14 - month) / 12
+        let years = year + 4800 - priorMonths
+        let months = month + 12 * priorMonths - 3
+        return day + (153 * months + 2) / 5 + 365 * years
+            + years / 4 - years / 100 + years / 400 - 32045
+    }
+
+    /// A `YYYYMMDD` date moved by whole days, month and year rollovers
+    /// included. The inverse of `dayNumber`, so the match window's edges are
+    /// computed the same way its width is.
+    static func day(_ yyyymmdd: Int, offsetBy days: Int) -> Int {
+        let shifted = dayNumber(yyyymmdd) + days + 32044
+        let centuries = (4 * shifted + 3) / 146097
+        let withinCentury = shifted - 146097 * centuries / 4
+        let years = (4 * withinCentury + 3) / 1461
+        let withinYear = withinCentury - 1461 * years / 4
+        let months = (5 * withinYear + 2) / 153
+        let day = withinYear - (153 * months + 2) / 5 + 1
+        let month = months + 3 - 12 * (months / 10)
+        let year = 100 * centuries + years - 4800 + months / 10
+        return year * 10000 + month * 100 + day
+    }
+}
+
+// MARK: - Normalization
+
+extension BankSyncCandidate {
+    /// Turn a SimpleFIN transaction into a candidate, or nil when it carries
+    /// no readable amount (nothing sensible to import).
+    ///
+    /// Mirrors upstream's `normalizeBankSyncTransactions` for the fields
+    /// SimpleFIN provides: the bridge's `payee` is the payee, its
+    /// `description` the notes, and its `id` the dedup key.
+    /// `payeeId` is left nil — the caller resolves it.
+    init?(simpleFIN transaction: SimpleFINTransaction) {
+        guard let amount = transaction.amountCents else { return nil }
+        self.init(
+            importedId: transaction.id,
+            date: SimpleFINAmount.day(fromTimestamp: transaction.effectiveTimestamp),
+            amount: amount,
+            payeeName: Self.payeeName(for: transaction),
+            payeeId: nil,
+            notes: Self.notes(for: transaction),
+            cleared: transaction.isBooked
+        )
+    }
+
+    /// The bridge's `payee` when it has one. Not every bridge fills it in, so
+    /// fall back to the description rather than importing a nameless payee.
+    private static func payeeName(for transaction: SimpleFINTransaction) -> String {
+        for candidate in [transaction.payee, transaction.description, transaction.memo] {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return "Unknown"
+    }
+
+    private static func notes(for transaction: SimpleFINTransaction) -> String? {
+        let trimmed = transaction.description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        // Escape `#` the way upstream does, so a bank's own "#" in a
+        // description doesn't silently become a tag (see TagFilter, where a
+        // doubled `#` never matches).
+        return trimmed.replacingOccurrences(of: "#", with: "##")
+    }
+}

--- a/Actuali/Actuali/Services/BankSync/SimpleFINCredentials.swift
+++ b/Actuali/Actuali/Services/BankSync/SimpleFINCredentials.swift
@@ -1,0 +1,39 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "SimpleFIN")
+
+/// Where the claimed SimpleFIN access key lives.
+///
+/// The Keychain, not `@AppStorage`: the key is a bearer credential for the
+/// person's bank data, and `kSecAttrAccessibleAfterFirstUnlock` (Keychain's
+/// default here) is what lets a background refresh read it.
+///
+/// One key per device, not per budget file — a SimpleFIN setup token is
+/// claimed once and can't be claimed again, so tying it to a budget file
+/// would strand it when the file is re-downloaded.
+enum SimpleFINCredentials {
+    private static let accessKeyItem = "simplefin-access-key"
+
+    /// The stored access key, or nil when SimpleFIN isn't set up (or what's
+    /// stored is no longer parseable).
+    static var accessKey: SimpleFINAccessKey? {
+        guard let raw = Keychain.get(for: accessKeyItem) else { return nil }
+        do {
+            return try SimpleFINAccessKey.parse(raw)
+        } catch {
+            logger.error("Stored SimpleFIN access key is unreadable")
+            return nil
+        }
+    }
+
+    static var isConfigured: Bool { Keychain.get(for: accessKeyItem) != nil }
+
+    static func save(_ accessKey: SimpleFINAccessKey) throws {
+        try Keychain.set(accessKey.raw, for: accessKeyItem)
+    }
+
+    static func clear() throws {
+        try Keychain.remove(for: accessKeyItem)
+    }
+}

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -36,7 +36,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case ruleInvalidPattern(pattern: String)
     case ruleOwnedBySchedule
     case ruleNotSerializable
-    case bankSyncNotConfigured        // ← add
+    case bankSyncNotConfigured
     
     var errorDescription: String? {
         switch self {
@@ -98,8 +98,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "This rule belongs to a schedule. Delete the schedule instead."
         case .ruleNotSerializable:
             return "This rule contains a value that can't be saved. Check the amounts."
-        case .bankSyncNotConfigured:                                              // ← add
-            return "SimpleFIN isn't set up yet. Connect it in Settings first."     // ← add
+        case .bankSyncNotConfigured:
+            return "SimpleFIN isn't set up yet. Connect it in Settings first."
         }
     }
 }
@@ -1338,6 +1338,13 @@ final class BudgetStore: ObservableObject {
                 try? fileManager.deleteBudget(local.id)
                 forgetCachedCurrencyCode(for: local.id)
             }
+            
+            // The SimpleFIN access key goes too, for the same reason the
+            // encryption keys above do: it's a bearer credential for live bank
+            // data, and disconnecting should leave nothing behind that still
+            // reaches the previous person's accounts.
+            try? SimpleFINCredentials.clear()
+            isSimpleFINConfigured = false
         }
 
         isConnected = false
@@ -1756,7 +1763,7 @@ final class BudgetStore: ObservableObject {
             dataVersion += 1
 
             await loadSchedules()
-            await loadBankSyncAccounts()       // ← add
+            await loadBankSyncAccounts()
             publishWidgetSnapshot()
         } catch is CancellationError {
             // The caller's task was cancelled (e.g. a .refreshable task the
@@ -2404,9 +2411,8 @@ final class BudgetStore: ObservableObject {
 
         // An account that already has history only needs the window since its
         // earliest transaction; one that has none takes the full lookback.
-        let lookbackFloor = BankSyncReconciler.day(
-            Transaction.yyyymmdd(from: Date()), offsetBy: -Self.bankSyncMaxLookbackDays
-        )
+        let lookbackFloor = DayDate.today()
+            .adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
         var oldestDates: [String: Int] = [:]
         for target in targets {
             // Both "the read failed" and "the account has no transactions"
@@ -2502,21 +2508,23 @@ final class BudgetStore: ObservableObject {
         // ids, and a name the budget doesn't have yet can't match anything.
         // The payees the inserts need are created below, once it's settled
         // which downloads are actually new.
-        var payeeIdsByName: [String: String] = [:]
+        //
+        // One async read for the whole account rather than a synchronous
+        // `payee(named:)` per candidate — this runs on the main actor, and a
+        // 90-day first sync is hundreds of rows.
+        let payeeIdsByName = Dictionary(
+            (try? await database.fetchPayees())?.map { ($0.name, $0.id) } ?? [],
+            uniquingKeysWith: { first, _ in first }
+        )
         for index in candidates.indices {
-            let name = candidates[index].payeeName
-            if let cached = payeeIdsByName[name] {
-                candidates[index].payeeId = cached
-            } else if let payee = (try? database.payee(named: name)) ?? nil {
-                payeeIdsByName[name] = payee.id
-                candidates[index].payeeId = payee.id
-            }
+            candidates[index].payeeId = payeeIdsByName[candidates[index].payeeName]
         }
 
+        let radius = BankSyncReconciler.fuzzyMatchDayRadius
         let window = try await database.bankSyncWindow(
             accountId: target.id,
-            from: BankSyncReconciler.day(earliest, offsetBy: -BankSyncReconciler.fuzzyMatchDayRadius),
-            to: BankSyncReconciler.day(latest, offsetBy: BankSyncReconciler.fuzzyMatchDayRadius)
+            from: DayDate(yyyymmdd: earliest)?.adding(days: -radius).yyyymmdd ?? earliest,
+            to: DayDate(yyyymmdd: latest)?.adding(days: radius).yyyymmdd ?? latest
         )
 
         let plan = BankSyncReconciler.plan(candidates: candidates, existing: window)

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2416,7 +2416,7 @@ final class BudgetStore: ObservableObject {
         into target: BankSyncAccount,
         startDay: Int,
         isFirstSync: Bool,
-        prepared: PreparedRules
+        prepared: SyncClient.PreparedRules
     ) async throws -> (added: Int, updated: Int) {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2218,9 +2218,9 @@ final class BudgetStore: ObservableObject {
     
     // MARK: - Bank Sync (SimpleFIN)
 
-    /// Talks to the SimpleFIN bridge directly, with an access key this device
-    /// claimed for itself — see `SimpleFINClient` for why that rather than
-    /// going through the Actual server's own SimpleFIN support.
+    /// Talks to a SimpleFIN bridge directly, with a key claimed on this
+    /// device. Only used when the server has no SimpleFIN of its own — see
+    /// `makeBankSyncProvider`.
     private var simpleFINClient = SimpleFINClient()
 
     /// How far back a sync reaches when an account has nothing to anchor to.
@@ -2264,6 +2264,60 @@ final class BudgetStore: ObservableObject {
     /// is gone by the time it finishes.
     @Published var bankSyncSummary: String?
 
+    /// Whether the Actual server has a SimpleFIN connection of its own, as of
+    /// the last check. Refreshed by `refreshBankSyncSource()` and by every
+    /// sync.
+    @Published private(set) var serverProvidesBankSync = false
+
+    /// Whether a bank sync can run at all — through the server's connection or
+    /// one claimed on this device.
+    var canSyncBanks: Bool { serverProvidesBankSync || isSimpleFINConfigured }
+
+    /// Ask the server whether it does SimpleFIN, so the setup screen knows
+    /// which half of itself to show. Failures leave the flag alone: an
+    /// unreachable server isn't evidence either way.
+    func refreshBankSyncSource() async {
+        if let configured = try? await serverClient.simpleFINStatus() {
+            serverProvidesBankSync = configured == true
+        }
+    }
+
+    /// Where this sync's data comes from.
+    ///
+    /// The server's own connection wins whenever it has one. The two
+    /// credentials can't be shared — Actual keeps the server's access key in
+    /// its secrets store, deliberately out of the budget file — so preferring
+    /// the server is what keeps the web UI and this app in agreement: nobody
+    /// needs a second setup token, and a link made here is one the server can
+    /// actually service.
+    private func makeBankSyncProvider() async throws -> any BankSyncProvider {
+        let deviceKey = SimpleFINCredentials.accessKey
+        do {
+            // nil means the route isn't served here — an older server, or a
+            // proxy that strips it. Not a failure, just not an option.
+            if try await serverClient.simpleFINStatus() == true {
+                serverProvidesBankSync = true
+                return ActualServerBankSyncProvider(client: serverClient)
+            }
+            serverProvidesBankSync = false
+        } catch {
+            // The server couldn't be answered for. A key claimed on this
+            // device still reaches the bridge, so use it rather than failing.
+            guard let deviceKey else {
+                // With no key either: a server we genuinely couldn't reach is
+                // worth saying so, but anything else (no server configured, no
+                // session) just means bank sync isn't set up here.
+                if let serverError = error as? ActualServerError, serverError.isConnectionFailure {
+                    throw error
+                }
+                throw BudgetStoreError.bankSyncNotConfigured
+            }
+            return SimpleFINDirectProvider(client: simpleFINClient, accessKey: deviceKey)
+        }
+        guard let deviceKey else { throw BudgetStoreError.bankSyncNotConfigured }
+        return SimpleFINDirectProvider(client: simpleFINClient, accessKey: deviceKey)
+    }
+
     /// Run a sync and leave its outcome in `bankSyncSummary`. The button-shaped
     /// entry point — `syncBankAccounts` is the one that throws.
     func runBankSync(accountIds: [String] = []) async {
@@ -2274,9 +2328,9 @@ final class BudgetStore: ObservableObject {
         }
     }
 
-    /// Exchange a SimpleFIN setup token for the access key every later sync
-    /// uses. Setup tokens are single-use, so this only ever runs once per
-    /// token.
+    /// Exchange a SimpleFIN setup token for an access key this device keeps.
+    /// Only needed when the server has no SimpleFIN connection of its own.
+    /// Setup tokens are single-use, so this runs once per token.
     func connectSimpleFIN(setupToken: String) async throws {
         let accessKey = try await simpleFINClient.claimAccessKey(setupToken: setupToken)
         try SimpleFINCredentials.save(accessKey)
@@ -2291,14 +2345,9 @@ final class BudgetStore: ObservableObject {
         isSimpleFINConfigured = false
     }
 
-    /// Every account the access key covers, for the linking screen. Balances
-    /// only — asking the bridge for transactions here would be work nobody
-    /// looks at.
-    func fetchSimpleFINAccounts() async throws -> SimpleFINAccountSet {
-        guard let accessKey = SimpleFINCredentials.accessKey else {
-            throw BudgetStoreError.bankSyncNotConfigured
-        }
-        return try await simpleFINClient.fetchAccounts(accessKey: accessKey)
+    /// Every account the active connection covers, for the linking screen.
+    func fetchBankAccounts() async throws -> [SimpleFINAccount] {
+        try await makeBankSyncProvider().accounts()
     }
 
     func loadBankSyncAccounts() async {
@@ -2338,9 +2387,6 @@ final class BudgetStore: ObservableObject {
     @discardableResult
     func syncBankAccounts(accountIds: [String] = []) async throws -> BankSyncResult {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
-        guard let accessKey = SimpleFINCredentials.accessKey else {
-            throw BudgetStoreError.bankSyncNotConfigured
-        }
         // A second run on top of the first would re-download the same window
         // and race the first one's writes.
         guard !isBankSyncing else { return BankSyncResult() }
@@ -2354,6 +2400,8 @@ final class BudgetStore: ObservableObject {
         isBankSyncing = true
         defer { isBankSyncing = false }
 
+        let provider = try await makeBankSyncProvider()
+
         // An account that already has history only needs the window since its
         // earliest transaction; one that has none takes the full lookback.
         let lookbackFloor = BankSyncReconciler.day(
@@ -2365,45 +2413,61 @@ final class BudgetStore: ObservableObject {
             // mean the same thing here: take the full lookback.
             oldestDates[target.id] = (try? await database.oldestTransactionDate(accountId: target.id)) ?? nil
         }
-        // One request covers every account, so it has to reach back as far as
-        // the hungriest of them; each account drops the surplus itself.
-        let earliest = targets
-            .map { max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor) }
-            .min() ?? lookbackFloor
 
-        let downloaded = try await simpleFINClient.fetchAccounts(
-            accessKey: accessKey,
-            accountIds: targets.map(\.externalAccountId),
-            startDate: earliest
-        )
+        let downloaded = try await provider.download(targets.map {
+            BankSyncTarget(
+                externalId: $0.externalAccountId,
+                startDay: max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor)
+            )
+        })
 
         var result = BankSyncResult()
-        result.problems = downloaded.errors
+        result.problems = downloaded.problems
         // One rules/context fetch for the whole run, not one per row.
         let prepared = await syncClient.prepareRules()
+        let syncedAt = String(Int64(Date().timeIntervalSince1970 * 1000))
+        var statuses: [(accountId: String, lastSync: String?, status: String)] = []
 
         for target in targets {
-            guard let remote = downloaded.accounts.first(where: { $0.id == target.externalAccountId }) else {
-                result.problems.append(
-                    "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
-                )
+            guard let download = downloaded.byAccount[target.externalAccountId] else {
+                // A connection-level problem already explains why nothing came
+                // back; don't also tell them to relink an account that's fine.
+                if downloaded.problems.isEmpty {
+                    result.problems.append(
+                        "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
+                    )
+                    statuses.append((target.id, nil, "account-missing"))
+                } else {
+                    statuses.append((target.id, nil, "failed"))
+                }
                 continue
+            }
+            // A problem doesn't mean nothing came through — import whatever
+            // did, and say what went wrong alongside it.
+            if let problem = download.problem {
+                result.problems.append("\(target.name): \(problem)")
             }
             do {
                 let outcome = try await importBankSync(
-                    remote,
+                    download,
                     into: target,
-                    startDay: max(lookbackFloor, oldestDates[target.id] ?? lookbackFloor),
                     isFirstSync: oldestDates[target.id] == nil,
                     prepared: prepared
                 )
                 result.added += outcome.added
                 result.updated += outcome.updated
                 result.accountsSynced += 1
+                statuses.append((target.id, syncedAt, download.status))
             } catch {
                 result.problems.append("\(target.name): \(error.localizedDescription)")
+                statuses.append((target.id, nil, "failed"))
             }
         }
+
+        // The same two columns every other Actual client stamps, so the web
+        // UI's "last synced" and status badge reflect this run. Never worth
+        // failing the sync over — the transactions are already in.
+        try? await syncClient.recordBankSyncStatus(statuses)
 
         await refreshDataOnly()
         return result
@@ -2412,22 +2476,27 @@ final class BudgetStore: ObservableObject {
     /// Fold one account's download into the budget: match what we already
     /// have, insert what we don't.
     private func importBankSync(
-        _ remote: SimpleFINAccount,
+        _ download: BankSyncDownload,
         into target: BankSyncAccount,
-        startDay: Int,
         isFirstSync: Bool,
         prepared: SyncClient.PreparedRules
     ) async throws -> (added: Int, updated: Int) {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
 
-        var candidates = remote.transactions
-            .compactMap(BankSyncCandidate.init(simpleFIN:))
-            .filter { $0.date >= startDay }
+        // The provider already dropped anything older than this account's own
+        // start day — one request covers every account, so it reaches back as
+        // far as the hungriest of them.
+        var candidates = download.candidates
 
         if isFirstSync {
-            try await insertStartingBalance(for: target, remote: remote, candidates: candidates)
+            try await insertStartingBalance(
+                for: target,
+                currentBalanceCents: download.currentBalanceCents,
+                candidates: candidates
+            )
         }
-        guard !candidates.isEmpty else { return (0, 0) }
+        guard let earliest = candidates.map(\.date).min(),
+              let latest = candidates.map(\.date).max() else { return (0, 0) }
 
         // Resolve payees by name without creating any: the payee pass compares
         // ids, and a name the budget doesn't have yet can't match anything.
@@ -2444,15 +2513,10 @@ final class BudgetStore: ObservableObject {
             }
         }
 
-        let dates = candidates.map(\.date)
         let window = try await database.bankSyncWindow(
             accountId: target.id,
-            from: BankSyncReconciler.day(
-                dates.min() ?? startDay, offsetBy: -BankSyncReconciler.fuzzyMatchDayRadius
-            ),
-            to: BankSyncReconciler.day(
-                dates.max() ?? startDay, offsetBy: BankSyncReconciler.fuzzyMatchDayRadius
-            )
+            from: BankSyncReconciler.day(earliest, offsetBy: -BankSyncReconciler.fuzzyMatchDayRadius),
+            to: BankSyncReconciler.day(latest, offsetBy: BankSyncReconciler.fuzzyMatchDayRadius)
         )
 
         let plan = BankSyncReconciler.plan(candidates: candidates, existing: window)
@@ -2495,13 +2559,12 @@ final class BudgetStore: ObservableObject {
     /// (upstream `processBankSyncDownload`, initial sync).
     private func insertStartingBalance(
         for target: BankSyncAccount,
-        remote: SimpleFINAccount,
+        currentBalanceCents: Int?,
         candidates: [BankSyncCandidate]
     ) async throws {
-        guard let syncClient, let balance = remote.balanceCents else { return }
-        // SimpleFIN reports the balance as of now, so what the account opened
-        // with is what's left once everything about to be imported is taken
-        // back off it.
+        guard let syncClient, let balance = currentBalanceCents else { return }
+        // The balance is as of now, so what the account opened with is what's
+        // left once everything about to be imported is taken back off it.
         let opening = balance - candidates.reduce(0) { $0 + $1.amount }
         guard opening != 0 else { return }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -37,7 +37,7 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case ruleOwnedBySchedule
     case ruleNotSerializable
     case bankSyncNotConfigured
-    
+
     var errorDescription: String? {
         switch self {
         case .syncNotConfigured:
@@ -1014,7 +1014,7 @@ final class BudgetStore: ObservableObject {
     func setServerClientForTesting(_ client: ActualServerClient) {
         serverClient = client
     }
-    
+
     /// Test-only: swap in a SimpleFIN client wired to a stub transport so the
     /// bank sync path can be exercised without a reachable bridge.
     func setSimpleFINClientForTesting(_ client: SimpleFINClient) {
@@ -1338,7 +1338,7 @@ final class BudgetStore: ObservableObject {
                 try? fileManager.deleteBudget(local.id)
                 forgetCachedCurrencyCode(for: local.id)
             }
-            
+
             // The SimpleFIN access key goes too, for the same reason the
             // encryption keys above do: it's a bearer credential for live bank
             // data, and disconnecting should leave nothing behind that still
@@ -2222,7 +2222,7 @@ final class BudgetStore: ObservableObject {
     func walletFinancialIds(accountId: String) -> Set<String> {
         (try? database?.existingFinancialIds(accountId: accountId)) ?? []
     }
-    
+
     // MARK: - Bank Sync (SimpleFIN)
 
     /// Talks to a SimpleFIN bridge directly, with a key claimed on this
@@ -2328,6 +2328,10 @@ final class BudgetStore: ObservableObject {
     /// Run a sync and leave its outcome in `bankSyncSummary`. The button-shaped
     /// entry point — `syncBankAccounts` is the one that throws.
     func runBankSync(accountIds: [String] = []) async {
+        // A tap that lands while a sync is already running does nothing — the
+        // running sync posts its own summary, which would otherwise be
+        // clobbered by this call's empty one.
+        guard !isBankSyncing else { return }
         do {
             bankSyncSummary = try await syncBankAccounts(accountIds: accountIds).summary
         } catch {
@@ -2494,15 +2498,18 @@ final class BudgetStore: ObservableObject {
         // far as the hungriest of them.
         var candidates = download.candidates
 
+        // The opening balance counts as an import too (upstream folds its id
+        // into `added`), so a first sync never reports one fewer than it wrote.
+        var added = 0
         if isFirstSync {
-            try await insertStartingBalance(
+            added += try await insertStartingBalance(
                 for: target,
                 currentBalanceCents: download.currentBalanceCents,
                 candidates: candidates
-            )
+            ) ? 1 : 0
         }
         guard let earliest = candidates.map(\.date).min(),
-              let latest = candidates.map(\.date).max() else { return (0, 0) }
+              let latest = candidates.map(\.date).max() else { return (added, 0) }
 
         // Resolve payees by name without creating any: the payee pass compares
         // ids, and a name the budget doesn't have yet can't match anything.
@@ -2511,13 +2518,15 @@ final class BudgetStore: ObservableObject {
         //
         // One async read for the whole account rather than a synchronous
         // `payee(named:)` per candidate — this runs on the main actor, and a
-        // 90-day first sync is hundreds of rows.
+        // 90-day first sync is hundreds of rows. Keyed case-insensitively, the
+        // same way `findOrCreatePayee` and upstream's `getPayeeByName` match,
+        // so a bank that shouts "AMAZON" still resolves the budget's "Amazon".
         let payeeIdsByName = Dictionary(
-            (try? await database.fetchPayees())?.map { ($0.name, $0.id) } ?? [],
+            (try? await database.fetchPayees())?.map { ($0.name.lowercased(), $0.id) } ?? [],
             uniquingKeysWith: { first, _ in first }
         )
         for index in candidates.indices {
-            candidates[index].payeeId = payeeIdsByName[candidates[index].payeeName]
+            candidates[index].payeeId = payeeIdsByName[candidates[index].payeeName.lowercased()]
         }
 
         let radius = BankSyncReconciler.fuzzyMatchDayRadius
@@ -2558,23 +2567,25 @@ final class BudgetStore: ObservableObject {
             try await syncClient.createTransaction(transaction, prepared: prepared)
         }
 
-        return (plan.inserts.count, plan.updates.count)
+        return (added + plan.inserts.count, plan.updates.count)
     }
 
     /// Give a freshly linked account the opening balance its imported history
     /// starts from. Actual has no stored balance field, so without this the
     /// account would be short everything that happened before the sync window
     /// (upstream `processBankSyncDownload`, initial sync).
+    /// Returns whether a transaction was written (a zero opening writes none).
+    @discardableResult
     private func insertStartingBalance(
         for target: BankSyncAccount,
         currentBalanceCents: Int?,
         candidates: [BankSyncCandidate]
-    ) async throws {
-        guard let syncClient, let balance = currentBalanceCents else { return }
+    ) async throws -> Bool {
+        guard let syncClient, let balance = currentBalanceCents else { return false }
         // The balance is as of now, so what the account opened with is what's
         // left once everything about to be imported is taken back off it.
         let opening = balance - candidates.reduce(0) { $0 + $1.amount }
-        guard opening != 0 else { return }
+        guard opening != 0 else { return false }
 
         let payee = try await findOrCreatePayee(name: "Starting Balance")
         let category = target.offBudget ? nil : startingBalanceCategory()
@@ -2601,6 +2612,7 @@ final class BudgetStore: ObservableObject {
         )
         // Rules never see an opening balance, same as account creation's.
         try await syncClient.createTransaction(transaction, applyRules: false)
+        return true
     }
 
     /// Create a paired transfer between two accounts. Writes both legs with linked

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -36,7 +36,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case ruleInvalidPattern(pattern: String)
     case ruleOwnedBySchedule
     case ruleNotSerializable
-
+    case bankSyncNotConfigured        // ← add
+    
     var errorDescription: String? {
         switch self {
         case .syncNotConfigured:
@@ -97,6 +98,8 @@ enum BudgetStoreError: LocalizedError, Equatable {
             return "This rule belongs to a schedule. Delete the schedule instead."
         case .ruleNotSerializable:
             return "This rule contains a value that can't be saved. Check the amounts."
+        case .bankSyncNotConfigured:                                              // ← add
+            return "SimpleFIN isn't set up yet. Connect it in Settings first."     // ← add
         }
     }
 }
@@ -194,6 +197,14 @@ final class BudgetStore: ObservableObject {
     @Published var upcomingScheduledTransactionLength: String?
     @Published var scheduleStatuses: [String: ScheduleStatus] = [:]
     @Published var currentBudgetMonth: BudgetMonth?
+    /// Accounts wired up to a bank feed, refreshed alongside the rest of the
+    /// budget so the accounts tab knows which rows can be synced.
+    @Published private(set) var bankSyncAccounts: [BankSyncAccount] = []
+    /// Whether this device has claimed a SimpleFIN access key.
+    @Published private(set) var isSimpleFINConfigured = SimpleFINCredentials.isConfigured
+    /// True for the length of a bank sync, so the UI can show progress and
+    /// keep a second sync from starting on top of the first.
+    @Published private(set) var isBankSyncing = false
 
     /// The current calendar month's budget, tracked separately from
     /// `currentBudgetMonth` (which follows whatever month BudgetView is
@@ -1003,6 +1014,12 @@ final class BudgetStore: ObservableObject {
     func setServerClientForTesting(_ client: ActualServerClient) {
         serverClient = client
     }
+    
+    /// Test-only: swap in a SimpleFIN client wired to a stub transport so the
+    /// bank sync path can be exercised without a reachable bridge.
+    func setSimpleFINClientForTesting(_ client: SimpleFINClient) {
+        simpleFINClient = client
+    }
 
     /// Test-only: swap in a file manager rooted at a temp directory so
     /// logout()'s full wipe can be exercised without touching the shared
@@ -1739,6 +1756,7 @@ final class BudgetStore: ObservableObject {
             dataVersion += 1
 
             await loadSchedules()
+            await loadBankSyncAccounts()       // ← add
             publishWidgetSnapshot()
         } catch is CancellationError {
             // The caller's task was cancelled (e.g. a .refreshable task the
@@ -2196,6 +2214,322 @@ final class BudgetStore: ObservableObject {
     /// were imported before. Read-only convenience for `WalletImportView`.
     func walletFinancialIds(accountId: String) -> Set<String> {
         (try? database?.existingFinancialIds(accountId: accountId)) ?? []
+    }
+    
+    // MARK: - Bank Sync (SimpleFIN)
+
+    /// Talks to the SimpleFIN bridge directly, with an access key this device
+    /// claimed for itself — see `SimpleFINClient` for why that rather than
+    /// going through the Actual server's own SimpleFIN support.
+    private var simpleFINClient = SimpleFINClient()
+
+    /// How far back a sync reaches when an account has nothing to anchor to.
+    /// 89 days ago through today inclusive is 90 days, the window upstream
+    /// settled on because several bank integrations won't serve more.
+    private static let bankSyncMaxLookbackDays = 89
+
+    /// What one run of `syncBankAccounts` did.
+    struct BankSyncResult: Equatable {
+        var accountsSynced = 0
+        var added = 0
+        var updated = 0
+        /// Anything worth telling the person about: a bank connection that
+        /// needs re-authenticating, an account SimpleFIN no longer knows.
+        /// A run can succeed for some accounts and report problems for others.
+        var problems: [String] = []
+
+        /// What to show when the run finishes. Problems come last so the
+        /// counts above them still read as what did work.
+        var summary: String {
+            var lines: [String] = []
+            if added > 0 {
+                lines.append("Imported \(added) new transaction\(added == 1 ? "" : "s").")
+            }
+            if updated > 0 {
+                lines.append("Matched \(updated) transaction\(updated == 1 ? "" : "s") you already had.")
+            }
+            // Only claim there was nothing to do when nothing went wrong
+            // either — otherwise the problems below say what happened.
+            if lines.isEmpty, problems.isEmpty {
+                lines.append(accountsSynced == 0
+                    ? "No linked accounts to sync."
+                    : "Everything is already up to date.")
+            }
+            return (lines + problems).joined(separator: "\n\n")
+        }
+    }
+
+    /// The last bank sync's outcome, waiting to be shown. Held here rather
+    /// than in a view because the sync is kicked off from a toolbar menu that
+    /// is gone by the time it finishes.
+    @Published var bankSyncSummary: String?
+
+    /// Run a sync and leave its outcome in `bankSyncSummary`. The button-shaped
+    /// entry point — `syncBankAccounts` is the one that throws.
+    func runBankSync(accountIds: [String] = []) async {
+        do {
+            bankSyncSummary = try await syncBankAccounts(accountIds: accountIds).summary
+        } catch {
+            bankSyncSummary = error.localizedDescription
+        }
+    }
+
+    /// Exchange a SimpleFIN setup token for the access key every later sync
+    /// uses. Setup tokens are single-use, so this only ever runs once per
+    /// token.
+    func connectSimpleFIN(setupToken: String) async throws {
+        let accessKey = try await simpleFINClient.claimAccessKey(setupToken: setupToken)
+        try SimpleFINCredentials.save(accessKey)
+        isSimpleFINConfigured = true
+    }
+
+    /// Forget this device's access key. Accounts stay linked — the link lives
+    /// in the budget file, so the web UI (and this device, once a new token is
+    /// claimed) can still sync them.
+    func disconnectSimpleFIN() throws {
+        try SimpleFINCredentials.clear()
+        isSimpleFINConfigured = false
+    }
+
+    /// Every account the access key covers, for the linking screen. Balances
+    /// only — asking the bridge for transactions here would be work nobody
+    /// looks at.
+    func fetchSimpleFINAccounts() async throws -> SimpleFINAccountSet {
+        guard let accessKey = SimpleFINCredentials.accessKey else {
+            throw BudgetStoreError.bankSyncNotConfigured
+        }
+        return try await simpleFINClient.fetchAccounts(accessKey: accessKey)
+    }
+
+    func loadBankSyncAccounts() async {
+        guard let database else {
+            bankSyncAccounts = []
+            return
+        }
+        bankSyncAccounts = (try? await database.fetchBankSyncAccounts()) ?? []
+    }
+
+    /// The bank feed an account is wired up to, if any.
+    func bankSyncAccount(forAccountId accountId: String) -> BankSyncAccount? {
+        bankSyncAccounts.first { $0.id == accountId }
+    }
+
+    func linkBankAccount(accountId: String, to remote: SimpleFINAccount) async throws {
+        guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
+        try await syncClient.linkAccount(
+            accountId: accountId,
+            externalAccountId: remote.id,
+            source: .simpleFin,
+            institutionId: remote.org.bankId ?? remote.org.displayName,
+            institutionName: remote.org.displayName
+        )
+        await refreshDataOnly()
+    }
+
+    func unlinkBankAccount(accountId: String) async throws {
+        guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
+        try await syncClient.unlinkAccount(accountId: accountId)
+        await refreshDataOnly()
+    }
+
+    /// Download and import transactions for the linked accounts.
+    /// - Parameter accountIds: which accounts to sync; empty syncs every
+    ///   linked one, which is what the accounts tab's sync button does.
+    @discardableResult
+    func syncBankAccounts(accountIds: [String] = []) async throws -> BankSyncResult {
+        guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
+        guard let accessKey = SimpleFINCredentials.accessKey else {
+            throw BudgetStoreError.bankSyncNotConfigured
+        }
+        // A second run on top of the first would re-download the same window
+        // and race the first one's writes.
+        guard !isBankSyncing else { return BankSyncResult() }
+
+        let targets = bankSyncAccounts.filter {
+            $0.source == .simpleFin && !$0.closed
+                && (accountIds.isEmpty || accountIds.contains($0.id))
+        }
+        guard !targets.isEmpty else { return BankSyncResult() }
+
+        isBankSyncing = true
+        defer { isBankSyncing = false }
+
+        // An account that already has history only needs the window since its
+        // earliest transaction; one that has none takes the full lookback.
+        let lookbackFloor = BankSyncReconciler.day(
+            Transaction.yyyymmdd(from: Date()), offsetBy: -Self.bankSyncMaxLookbackDays
+        )
+        var oldestDates: [String: Int] = [:]
+        for target in targets {
+            // Both "the read failed" and "the account has no transactions"
+            // mean the same thing here: take the full lookback.
+            oldestDates[target.id] = (try? await database.oldestTransactionDate(accountId: target.id)) ?? nil
+        }
+        // One request covers every account, so it has to reach back as far as
+        // the hungriest of them; each account drops the surplus itself.
+        let earliest = targets
+            .map { max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor) }
+            .min() ?? lookbackFloor
+
+        let downloaded = try await simpleFINClient.fetchAccounts(
+            accessKey: accessKey,
+            accountIds: targets.map(\.externalAccountId),
+            startDate: earliest
+        )
+
+        var result = BankSyncResult()
+        result.problems = downloaded.errors
+        // One rules/context fetch for the whole run, not one per row.
+        let prepared = await syncClient.prepareRules()
+
+        for target in targets {
+            guard let remote = downloaded.accounts.first(where: { $0.id == target.externalAccountId }) else {
+                result.problems.append(
+                    "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
+                )
+                continue
+            }
+            do {
+                let outcome = try await importBankSync(
+                    remote,
+                    into: target,
+                    startDay: max(lookbackFloor, oldestDates[target.id] ?? lookbackFloor),
+                    isFirstSync: oldestDates[target.id] == nil,
+                    prepared: prepared
+                )
+                result.added += outcome.added
+                result.updated += outcome.updated
+                result.accountsSynced += 1
+            } catch {
+                result.problems.append("\(target.name): \(error.localizedDescription)")
+            }
+        }
+
+        await refreshDataOnly()
+        return result
+    }
+
+    /// Fold one account's download into the budget: match what we already
+    /// have, insert what we don't.
+    private func importBankSync(
+        _ remote: SimpleFINAccount,
+        into target: BankSyncAccount,
+        startDay: Int,
+        isFirstSync: Bool,
+        prepared: PreparedRules
+    ) async throws -> (added: Int, updated: Int) {
+        guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
+
+        var candidates = remote.transactions
+            .compactMap(BankSyncCandidate.init(simpleFIN:))
+            .filter { $0.date >= startDay }
+
+        if isFirstSync {
+            try await insertStartingBalance(for: target, remote: remote, candidates: candidates)
+        }
+        guard !candidates.isEmpty else { return (0, 0) }
+
+        // Resolve payees by name without creating any: the payee pass compares
+        // ids, and a name the budget doesn't have yet can't match anything.
+        // The payees the inserts need are created below, once it's settled
+        // which downloads are actually new.
+        var payeeIdsByName: [String: String] = [:]
+        for index in candidates.indices {
+            let name = candidates[index].payeeName
+            if let cached = payeeIdsByName[name] {
+                candidates[index].payeeId = cached
+            } else if let payee = (try? database.payee(named: name)) ?? nil {
+                payeeIdsByName[name] = payee.id
+                candidates[index].payeeId = payee.id
+            }
+        }
+
+        let dates = candidates.map(\.date)
+        let window = try await database.bankSyncWindow(
+            accountId: target.id,
+            from: BankSyncReconciler.day(
+                dates.min() ?? startDay, offsetBy: -BankSyncReconciler.fuzzyMatchDayRadius
+            ),
+            to: BankSyncReconciler.day(
+                dates.max() ?? startDay, offsetBy: BankSyncReconciler.fuzzyMatchDayRadius
+            )
+        )
+
+        let plan = BankSyncReconciler.plan(candidates: candidates, existing: window)
+
+        try await syncClient.applyBankSyncUpdates(plan.updates)
+
+        // Oldest first: sort_order is stamped at insert, so inserting in date
+        // order leaves the newest transaction at the top of the account.
+        for candidate in plan.inserts.sorted(by: { $0.date < $1.date }) {
+            let payeeId = try await resolvePayeeId(name: candidate.payeeName, editing: nil)
+            let transaction = Transaction(
+                id: UUID().uuidString,
+                accountId: target.id,
+                date: candidate.date,
+                amount: candidate.amount,
+                payeeId: payeeId,
+                payeeName: candidate.payeeName,
+                categoryId: nil,
+                categoryName: nil,
+                notes: candidate.notes,
+                cleared: candidate.cleared,
+                reconciled: false,
+                transferId: nil,
+                isParent: false,
+                parentId: nil,
+                tombstone: false,
+                sortOrder: nil,  // Set to Date.now() during insert
+                importedPayee: candidate.payeeName,
+                financialId: candidate.importedId
+            )
+            try await syncClient.createTransaction(transaction, prepared: prepared)
+        }
+
+        return (plan.inserts.count, plan.updates.count)
+    }
+
+    /// Give a freshly linked account the opening balance its imported history
+    /// starts from. Actual has no stored balance field, so without this the
+    /// account would be short everything that happened before the sync window
+    /// (upstream `processBankSyncDownload`, initial sync).
+    private func insertStartingBalance(
+        for target: BankSyncAccount,
+        remote: SimpleFINAccount,
+        candidates: [BankSyncCandidate]
+    ) async throws {
+        guard let syncClient, let balance = remote.balanceCents else { return }
+        // SimpleFIN reports the balance as of now, so what the account opened
+        // with is what's left once everything about to be imported is taken
+        // back off it.
+        let opening = balance - candidates.reduce(0) { $0 + $1.amount }
+        guard opening != 0 else { return }
+
+        let payee = try await findOrCreatePayee(name: "Starting Balance")
+        let category = target.offBudget ? nil : startingBalanceCategory()
+
+        let transaction = Transaction(
+            id: UUID().uuidString,
+            accountId: target.id,
+            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date()),
+            amount: opening,
+            payeeId: payee.id,
+            payeeName: payee.name,
+            categoryId: category?.id,
+            categoryName: category?.name,
+            notes: nil,
+            cleared: true,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil,
+            startingBalanceFlag: true
+        )
+        // Rules never see an opening balance, same as account creation's.
+        try await syncClient.createTransaction(transaction, applyRules: false)
     }
 
     /// Create a paired transfer between two accounts. Writes both legs with linked

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -229,7 +229,6 @@ final class BudgetDatabase: Sendable {
         (1780606215004, "accounts", "last_sync", [],
          "ALTER TABLE accounts ADD COLUMN last_sync TEXT")
     ]
-    ]
 
     // Tables added upstream after the original budget file was created. These run
     // unconditionally so CRDT messages targeting these tables have somewhere to land.
@@ -326,7 +325,6 @@ final class BudgetDatabase: Sendable {
         1780606215002, // second half of upstream index migration 1780606215001
         1780606215003, // locally minted accounts.account_sync_source backfill   // ← add
         1780606215004, // locally minted accounts.last_sync backfill             // ← add
-    ]
     ]
 
     /// Whether `runPendingMigrations()` would perform any write. Mirrors the

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -219,7 +219,7 @@ final class BudgetDatabase: Sendable {
         (1780606215001, "transactions", nil, ["acct", "tombstone"],
          "CREATE INDEX IF NOT EXISTS idx_transactions_acct_tombstone ON transactions(acct, tombstone)"),
         (1780606215002, "transactions", nil, ["schedule"],
-         "CREATE INDEX IF NOT EXISTS idx_transactions_schedule ON transactions(schedule)"),   // ← add comma
+         "CREATE INDEX IF NOT EXISTS idx_transactions_schedule ON transactions(schedule)"),
         // Locally minted ids for the bank-sync columns, which upstream added
         // long before any migration in this list: a snapshot old enough to
         // lack them would otherwise have nowhere for a link to land, and
@@ -305,6 +305,18 @@ final class BudgetDatabase: Sendable {
                 name TEXT NOT NULL,
                 tombstone INTEGER DEFAULT 0
             )
+        """),
+        // Defensive, like the two above: `banks` is upstream base schema, but
+        // the bank-sync link writes both the row and the accounts.bank pointer
+        // to it, and a runtime check on one without the other would only half
+        // protect the write.
+        (1770000000003, """
+            CREATE TABLE IF NOT EXISTS banks (
+                id TEXT PRIMARY KEY,
+                bank_id TEXT,
+                name TEXT,
+                tombstone INTEGER DEFAULT 0
+            )
         """)
     ]
     
@@ -323,8 +335,9 @@ final class BudgetDatabase: Sendable {
         1778510362741, // ALTER half of upstream 1778510362740 (cleanup_def)
         1780606214999, // locally minted transactions.schedule backfill
         1780606215002, // second half of upstream index migration 1780606215001
-        1780606215003, // locally minted accounts.account_sync_source backfill   // ← add
-        1780606215004, // locally minted accounts.last_sync backfill             // ← add
+        1780606215003, // locally minted accounts.account_sync_source backfill
+        1780606215004, // locally minted accounts.last_sync backfill
+        1770000000003, // defensive CREATE banks
     ]
 
     /// Whether `runPendingMigrations()` would perform any write. Mirrors the
@@ -2560,12 +2573,10 @@ final class BudgetDatabase: Sendable {
         messages: [CRDTMessage]
     ) throws -> [CRDTMessage] {
         try dbQueue.write { db in
-            if try db.tableExists("banks") {
-                try db.execute(sql: """
-                    INSERT OR REPLACE INTO banks (id, bank_id, name, tombstone)
-                    VALUES (?, ?, ?, ?)
-                    """, arguments: [bank.id, bank.bankId, bank.name, bank.tombstone ? 1 : 0])
-            }
+            try db.execute(sql: """
+                INSERT OR REPLACE INTO banks (id, bank_id, name, tombstone)
+                VALUES (?, ?, ?, ?)
+                """, arguments: [bank.id, bank.bankId, bank.name, bank.tombstone ? 1 : 0])
             try db.execute(sql: """
                 UPDATE accounts
                 SET account_id = ?, account_sync_source = ?, bank = ?
@@ -2626,7 +2637,6 @@ final class BudgetDatabase: Sendable {
     /// bank share one row.
     func bank(withBankId bankId: String) async throws -> Bank? {
         try await dbQueue.read { db in
-            guard try db.tableExists("banks") else { return nil }
             guard let row = try Row.fetchOne(db, sql: """
                 SELECT id, bank_id, name FROM banks
                 WHERE bank_id = ? AND (tombstone = 0 OR tombstone IS NULL)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -219,7 +219,16 @@ final class BudgetDatabase: Sendable {
         (1780606215001, "transactions", nil, ["acct", "tombstone"],
          "CREATE INDEX IF NOT EXISTS idx_transactions_acct_tombstone ON transactions(acct, tombstone)"),
         (1780606215002, "transactions", nil, ["schedule"],
-         "CREATE INDEX IF NOT EXISTS idx_transactions_schedule ON transactions(schedule)")
+         "CREATE INDEX IF NOT EXISTS idx_transactions_schedule ON transactions(schedule)"),   // ← add comma
+        // Locally minted ids for the bank-sync columns, which upstream added
+        // long before any migration in this list: a snapshot old enough to
+        // lack them would otherwise have nowhere for a link to land, and
+        // nowhere for the web UI's own link messages to apply.
+        (1780606215003, "accounts", "account_sync_source", [],
+         "ALTER TABLE accounts ADD COLUMN account_sync_source TEXT"),
+        (1780606215004, "accounts", "last_sync", [],
+         "ALTER TABLE accounts ADD COLUMN last_sync TEXT")
+    ]
     ]
 
     // Tables added upstream after the original budget file was created. These run
@@ -315,6 +324,9 @@ final class BudgetDatabase: Sendable {
         1778510362741, // ALTER half of upstream 1778510362740 (cleanup_def)
         1780606214999, // locally minted transactions.schedule backfill
         1780606215002, // second half of upstream index migration 1780606215001
+        1780606215003, // locally minted accounts.account_sync_source backfill   // ← add
+        1780606215004, // locally minted accounts.last_sync backfill             // ← add
+    ]
     ]
 
     /// Whether `runPendingMigrations()` would perform any write. Mirrors the
@@ -2430,6 +2442,152 @@ final class BudgetDatabase: Sendable {
                 WHERE acct = ? AND financial_id IS NOT NULL
                 """, arguments: [accountId])
             return Set(ids)
+        }
+    }
+    
+    // MARK: - Bank Sync
+
+    /// Every account wired up to a bank feed, in the order the accounts tab
+    /// lists them. Empty (rather than an error) on a budget file old enough
+    /// to predate the columns — nothing can be linked in that case anyway.
+    func fetchBankSyncAccounts() async throws -> [BankSyncAccount] {
+        try await dbQueue.read { db in
+            guard try db.columns(in: "accounts").contains(where: { $0.name == "account_sync_source" }) else {
+                return []
+            }
+            return try Row.fetchAll(db, sql: """
+                SELECT id, name, account_id, account_sync_source, offbudget, closed
+                FROM accounts
+                WHERE (tombstone = 0 OR tombstone IS NULL)
+                  AND account_id IS NOT NULL AND account_id <> ''
+                  AND account_sync_source IS NOT NULL AND account_sync_source <> ''
+                ORDER BY offbudget, sort_order
+                """).map { row in
+                BankSyncAccount(
+                    id: row["id"],
+                    name: row["name"] ?? "Unknown",
+                    externalAccountId: row["account_id"],
+                    syncSource: row["account_sync_source"],
+                    offBudget: row["offbudget"] == 1,
+                    closed: row["closed"] == 1
+                )
+            }
+        }
+    }
+
+    /// The transactions a download could be matching, projected down to the
+    /// columns `BankSyncReconciler` reads. Bounded by date because matching
+    /// only ever looks a week either side of a downloaded transaction.
+    ///
+    /// Split children are excluded: a download matches the parent (which
+    /// carries the full amount), never one of its portions. Tombstoned rows
+    /// are excluded too, so a transaction the person deleted isn't quietly
+    /// resurrected by the next sync — it re-imports as new instead, which is
+    /// the outcome they'd get on the web UI.
+    func bankSyncWindow(accountId: String, from: Int, to: Int) async throws -> [BankSyncExistingTransaction] {
+        try await dbQueue.read { db in
+            try Row.fetchAll(db, sql: """
+                SELECT id, date, amount, description, financial_id, imported_description,
+                       notes, cleared, reconciled
+                FROM transactions
+                WHERE acct = ?
+                  AND date IS NOT NULL AND date >= ? AND date <= ?
+                  AND (tombstone = 0 OR tombstone IS NULL)
+                  AND (isChild = 0 OR isChild IS NULL)
+                """, arguments: [accountId, from, to]).map { row in
+                BankSyncExistingTransaction(
+                    id: row["id"],
+                    date: row["date"] ?? 0,
+                    amount: row["amount"] ?? 0,
+                    payeeId: row["description"],
+                    importedId: row["financial_id"],
+                    importedPayee: row["imported_description"],
+                    notes: row["notes"],
+                    cleared: row["cleared"] == 1,
+                    reconciled: row["reconciled"] == 1
+                )
+            }
+        }
+    }
+
+    /// The date of an account's earliest transaction, or nil when it has none.
+    /// Decides how far back the first sync of an account reaches.
+    func oldestTransactionDate(accountId: String) async throws -> Int? {
+        try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT MIN(date) FROM transactions
+                WHERE acct = ? AND date IS NOT NULL AND (tombstone = 0 OR tombstone IS NULL)
+                """, arguments: [accountId])
+        }
+    }
+
+    /// Apply the reconciler's updates to transactions the download matched,
+    /// with their CRDT messages, in one SQLite transaction.
+    /// Returns the subset of messages that was actually new (see `insertMessages`).
+    func applyBankSyncUpdates(
+        _ updates: [BankSyncUpdate],
+        messages: [CRDTMessage]
+    ) throws -> [CRDTMessage] {
+        try dbQueue.write { db in
+            for update in updates {
+                try db.execute(sql: """
+                    UPDATE transactions
+                    SET financial_id = ?, description = ?, imported_description = ?,
+                        notes = ?, cleared = ?
+                    WHERE id = ?
+                    """, arguments: [
+                        update.importedId,
+                        update.payeeId,
+                        update.importedPayee,
+                        update.notes,
+                        update.cleared ? 1 : 0,
+                        update.existingId
+                    ])
+            }
+            return try Self.insertMessageRows(db, messages)
+        }
+    }
+
+    /// Point an account at a provider's account (or, with nil arguments, cut
+    /// it loose), writing the institution row it points at alongside it, with
+    /// all of their CRDT messages, in one SQLite transaction. The institution
+    /// row is rewritten whether or not it already existed — the caller reads
+    /// the existing one first, so a rewrite restates what's already there.
+    /// Returns the subset of messages that was actually new (see `insertMessages`).
+    func applyBankSyncLink(
+        accountId: String,
+        externalAccountId: String?,
+        syncSource: String?,
+        bank: Bank?,
+        messages: [CRDTMessage]
+    ) throws -> [CRDTMessage] {
+        try dbQueue.write { db in
+            if let bank, try db.tableExists("banks") {
+                try db.execute(sql: """
+                    INSERT OR REPLACE INTO banks (id, bank_id, name, tombstone)
+                    VALUES (?, ?, ?, ?)
+                    """, arguments: [bank.id, bank.bankId, bank.name, bank.tombstone ? 1 : 0])
+            }
+            try db.execute(sql: """
+                UPDATE accounts
+                SET account_id = ?, account_sync_source = ?, bank = ?
+                WHERE id = ?
+                """, arguments: [externalAccountId, syncSource, bank?.id, accountId])
+            return try Self.insertMessageRows(db, messages)
+        }
+    }
+
+    /// The institution row a provider's institution id already has, if any —
+    /// upstream's `findOrCreateBank` lookup half, so two accounts at the same
+    /// bank share one row.
+    func bank(withBankId bankId: String) async throws -> Bank? {
+        try await dbQueue.read { db in
+            guard try db.tableExists("banks") else { return nil }
+            guard let row = try Row.fetchOne(db, sql: """
+                SELECT id, bank_id, name FROM banks
+                WHERE bank_id = ? AND (tombstone = 0 OR tombstone IS NULL)
+                """, arguments: [bankId]) else { return nil }
+            return Bank(id: row["id"], bankId: bankId, name: row["name"] ?? "")
         }
     }
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2546,21 +2546,21 @@ final class BudgetDatabase: Sendable {
         }
     }
 
-    /// Point an account at a provider's account (or, with nil arguments, cut
-    /// it loose), writing the institution row it points at alongside it, with
-    /// all of their CRDT messages, in one SQLite transaction. The institution
-    /// row is rewritten whether or not it already existed — the caller reads
-    /// the existing one first, so a rewrite restates what's already there.
+    /// Point an account at a provider's account, writing the institution row
+    /// it points at alongside it, with all of their CRDT messages, in one
+    /// SQLite transaction. The institution row is rewritten whether or not it
+    /// already existed — the caller reads the existing one first, so a rewrite
+    /// restates what's already there.
     /// Returns the subset of messages that was actually new (see `insertMessages`).
     func applyBankSyncLink(
         accountId: String,
-        externalAccountId: String?,
-        syncSource: String?,
-        bank: Bank?,
+        externalAccountId: String,
+        syncSource: String,
+        bank: Bank,
         messages: [CRDTMessage]
     ) throws -> [CRDTMessage] {
         try dbQueue.write { db in
-            if let bank, try db.tableExists("banks") {
+            if try db.tableExists("banks") {
                 try db.execute(sql: """
                     INSERT OR REPLACE INTO banks (id, bank_id, name, tombstone)
                     VALUES (?, ?, ?, ?)
@@ -2570,7 +2570,53 @@ final class BudgetDatabase: Sendable {
                 UPDATE accounts
                 SET account_id = ?, account_sync_source = ?, bank = ?
                 WHERE id = ?
-                """, arguments: [externalAccountId, syncSource, bank?.id, accountId])
+                """, arguments: [externalAccountId, syncSource, bank.id, accountId])
+            return try Self.insertMessageRows(db, messages)
+        }
+    }
+
+    /// Cut an account loose from its bank feed. Clears every column upstream's
+    /// own unlink clears, not just the three that point at the provider: a
+    /// left-behind `bank_sync_status` would keep showing an error badge in the
+    /// web UI for an account that no longer syncs at all.
+    /// Returns the subset of messages that was actually new (see `insertMessages`).
+    func applyBankSyncUnlink(accountId: String, messages: [CRDTMessage]) throws -> [CRDTMessage] {
+        try dbQueue.write { db in
+            try db.execute(sql: """
+                UPDATE accounts
+                SET account_id = NULL, account_sync_source = NULL, bank = NULL,
+                    balance_current = NULL, balance_available = NULL, balance_limit = NULL,
+                    bank_sync_status = NULL
+                WHERE id = ?
+                """, arguments: [accountId])
+            return try Self.insertMessageRows(db, messages)
+        }
+    }
+
+    /// Stamp what a sync did on the account, the way every other Actual client
+    /// does, so the web UI's "last synced" and status badge reflect a sync
+    /// this device ran.
+    /// Returns the subset of messages that was actually new (see `insertMessages`).
+    func applyBankSyncStatus(
+        _ statuses: [(accountId: String, lastSync: String?, status: String)],
+        messages: [CRDTMessage]
+    ) throws -> [CRDTMessage] {
+        try dbQueue.write { db in
+            for entry in statuses {
+                // A failed sync leaves last_sync alone rather than nulling it:
+                // "we last had good data at X" stays true, and upstream does
+                // the same (it only writes bank_sync_status on failure).
+                guard let lastSync = entry.lastSync else {
+                    try db.execute(
+                        sql: "UPDATE accounts SET bank_sync_status = ? WHERE id = ?",
+                        arguments: [entry.status, entry.accountId]
+                    )
+                    continue
+                }
+                try db.execute(sql: """
+                    UPDATE accounts SET last_sync = ?, bank_sync_status = ? WHERE id = ?
+                    """, arguments: [lastSync, entry.status, entry.accountId])
+            }
             return try Self.insertMessageRows(db, messages)
         }
     }

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2455,7 +2455,7 @@ final class BudgetDatabase: Sendable {
             return Set(ids)
         }
     }
-    
+
     // MARK: - Bank Sync
 
     /// Every account wired up to a bank feed, in the order the accounts tab

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -181,6 +181,108 @@ struct KeyInfoResponse: Codable, Sendable {
     }
 }
 
+// MARK: - Bank sync (server-hosted SimpleFIN)
+
+/// An error the `/simplefin/*` routes report. They answer HTTP 200 and put
+/// the failure in `data`, so a status-code check alone never sees these.
+struct ServerBankSyncError: Decodable, Sendable, Equatable {
+    let errorType: String?
+    let errorCode: String?
+    let reason: String?
+
+    /// Actual's `bank_sync_status` vocabulary for this failure — the same
+    /// mapping upstream's `getBankSyncStatusFromError` applies, so an account
+    /// this device failed to sync reads the same in the web UI.
+    var bankSyncStatus: String {
+        switch errorCode {
+        case "ITEM_LOGIN_REQUIRED", "INVALID_ACCESS_TOKEN": return "reauth-required"
+        case "ACCOUNT_NEEDS_ATTENTION": return "attention-required"
+        case "RATE_LIMIT_EXCEEDED": return "rate-limit-exceeded"
+        case "TIMED_OUT": return "timed-out"
+        case "ACCOUNT_MISSING": return "account-missing"
+        default: return "failed"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case errorType = "error_type"
+        case errorCode = "error_code"
+        case reason
+    }
+}
+
+/// One account's slice of a `/simplefin/transactions` response.
+struct ServerBankSyncAccountDownload: Decodable, Sendable {
+    /// The account's balance *as of now*, in cents, despite the name — see
+    /// upstream `processBankSyncDownload`, which calls the same field
+    /// "actually the current balance".
+    let startingBalance: Int?
+    let transactions: Transactions?
+
+    struct Transactions: Decodable, Sendable {
+        let all: [ServerBankSyncTransaction]?
+    }
+}
+
+/// The server's already-normalized transaction shape — not raw SimpleFIN.
+/// The bridge's own fields have been renamed and its dates turned into
+/// `YYYY-MM-DD` strings by the time they reach us.
+struct ServerBankSyncTransaction: Decodable, Sendable {
+    let transactionId: String?
+    let date: String?
+    let payeeName: String?
+    let notes: String?
+    let booked: Bool?
+    let transactionAmount: Amount?
+
+    struct Amount: Decodable, Sendable {
+        let amount: String?
+    }
+}
+
+/// A whole `/simplefin/transactions` response body. The payload is keyed by
+/// account id, with `errors` alongside, so it needs dynamic-key decoding.
+struct ServerBankSyncDownloads: Decodable, Sendable {
+    var accounts: [String: ServerBankSyncAccountDownload] = [:]
+    var errors: [String: [ServerBankSyncError]] = [:]
+    /// Set when the request failed as a whole (a rejected access key, say),
+    /// in which case `data` *is* the error object rather than containing one.
+    var failure: ServerBankSyncError?
+
+    init(from decoder: any Decoder) throws {
+        // A whole-request failure decodes cleanly here too — every field is
+        // optional — so it only counts as one when it names a code.
+        let possibleFailure = try? ServerBankSyncError(from: decoder)
+        failure = possibleFailure?.errorCode == nil ? nil : possibleFailure
+
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        for key in container.allKeys {
+            switch key.stringValue {
+            case "errors":
+                errors = (try? container.decode([String: [ServerBankSyncError]].self, forKey: key)) ?? [:]
+            case "error_type", "error_code", "reason", "status":
+                continue
+            default:
+                // An account the bridge didn't return comes back as null, and
+                // decoding it simply doesn't contribute an entry.
+                if let download = try? container.decode(
+                    ServerBankSyncAccountDownload.self, forKey: key
+                ) {
+                    accounts[key.stringValue] = download
+                }
+            }
+        }
+    }
+
+    private struct DynamicKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+}
+
+
 /// Version gate for features that depend on the server's Actual release.
 enum ServerVersion {
     /// payee_locations shipped in Actual 26.4.0. Writing those CRDT messages
@@ -739,6 +841,132 @@ actor ActualServerClient {
         }
         return ServerKeyInfo(id: key.id, salt: key.salt, test: key.test)
     }
+    
+    // MARK: - Bank sync (server-hosted SimpleFIN)
+
+    /// Whether the server has its own SimpleFIN credentials, or nil when it
+    /// has no `/simplefin` routes at all (an Actual release that predates
+    /// them, or a reverse proxy that strips them). Callers treat nil as "this
+    /// server can't do bank sync" and fall back to the device's own key —
+    /// which is why a route that isn't there and a server that can't be
+    /// reached must not look the same: the latter throws.
+    func simpleFINStatus() async throws -> Bool? {
+        let response: SimpleFINStatusResponse? = try await postBankSync(
+            path: "/simplefin/status", body: EmptyBody()
+        )
+        return response?.data?.configured
+    }
+
+    /// Every account the server's SimpleFIN connection covers, in the raw
+    /// bridge shape (the route passes it through untouched).
+    func simpleFINAccounts() async throws -> [SimpleFINAccount] {
+        guard let response: SimpleFINServerAccountsResponse = try await postBankSync(
+            path: "/simplefin/accounts", body: EmptyBody()
+        ) else {
+            throw ActualServerError.invalidResponse
+        }
+        if let failure = response.data?.failure {
+            throw ActualServerError.httpError(
+                statusCode: 200, message: failure.reason ?? failure.errorCode
+            )
+        }
+        return response.data?.accounts ?? []
+    }
+
+    /// Transactions for the named accounts, each from its own start date.
+    /// - Parameters:
+    ///   - accountIds: the provider's account ids (`accounts.account_id`).
+    ///   - startDates: `YYYY-MM-DD`, one per account id and the same length —
+    ///     the route rejects a mismatch.
+    func simpleFINTransactions(
+        accountIds: [String],
+        startDates: [String]
+    ) async throws -> ServerBankSyncDownloads {
+        guard accountIds.count == startDates.count else {
+            throw ActualServerError.invalidResponse
+        }
+        // Always the array form, even for one account: it keeps the response
+        // shape the same, and the single-account form buries an error where
+        // the account's data would be.
+        let body = SimpleFINTransactionsRequest(accountId: accountIds, startDate: startDates)
+        guard let response: SimpleFINTransactionsResponse = try await postBankSync(
+            path: "/simplefin/transactions", body: body
+        ) else {
+            throw ActualServerError.invalidResponse
+        }
+        guard let data = response.data else { throw ActualServerError.invalidResponse }
+        return data
+    }
+
+    private struct EmptyBody: Encodable {}
+
+    private struct SimpleFINTransactionsRequest: Encodable {
+        let accountId: [String]
+        let startDate: [String]
+    }
+
+    private struct SimpleFINStatusResponse: Decodable {
+        let data: StatusData?
+        struct StatusData: Decodable { let configured: Bool? }
+    }
+
+    private struct SimpleFINServerAccountsResponse: Decodable {
+        let data: AccountsData?
+
+        struct AccountsData: Decodable {
+            let accounts: [SimpleFINAccount]?
+            let failure: ServerBankSyncError?
+
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                accounts = try? container.decodeIfPresent([SimpleFINAccount].self, forKey: .accounts)
+                let possibleFailure = try? ServerBankSyncError(from: decoder)
+                failure = possibleFailure?.errorCode == nil ? nil : possibleFailure
+            }
+
+            private enum CodingKeys: String, CodingKey { case accounts }
+        }
+    }
+
+    private struct SimpleFINTransactionsResponse: Decodable {
+        let data: ServerBankSyncDownloads?
+    }
+
+    /// Shared plumbing for the `/simplefin` routes. Returns nil when the route
+    /// isn't there; throws for everything else.
+    private func postBankSync<Body: Encodable, Response: Decodable>(
+        path: String,
+        body: Body
+    ) async throws -> Response? {
+        guard let serverURL else { throw ActualServerError.invalidURL }
+        guard let token else { throw ActualServerError.unauthorized }
+
+        var request = makeRequest(serverURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await send(request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ActualServerError.invalidResponse
+        }
+        if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
+        // The route genuinely isn't served here — not a failure, just an older
+        // server. 501 covers proxies that answer unimplemented paths that way.
+        if [404, 405, 501].contains(httpResponse.statusCode) { return nil }
+        guard httpResponse.statusCode == 200 else {
+            throw ActualServerError.httpError(
+                statusCode: httpResponse.statusCode, message: String(data: data, encoding: .utf8)
+            )
+        }
+        do {
+            return try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            throw ActualServerError.decodingError(error)
+        }
+    }
+
 
     // MARK: - Sync
 

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -841,7 +841,7 @@ actor ActualServerClient {
         }
         return ServerKeyInfo(id: key.id, salt: key.salt, test: key.test)
     }
-    
+
     // MARK: - Bank sync (server-hosted SimpleFIN)
 
     /// Whether the server has its own SimpleFIN credentials, or nil when it

--- a/Actuali/Actuali/Services/Network/SimpleFINClient.swift
+++ b/Actuali/Actuali/Services/Network/SimpleFINClient.swift
@@ -1,0 +1,452 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.mfazz.Actuali", category: "SimpleFIN")
+
+// MARK: - Errors
+
+enum SimpleFINError: LocalizedError, Equatable {
+    /// The pasted setup token isn't base64, or doesn't decode to an https URL.
+    case invalidSetupToken
+    /// The stored access key isn't in `scheme://user:pass@host/path` form.
+    case invalidAccessKey
+    /// The bridge refused the claim — setup tokens are single-use, so this
+    /// usually means the token was already claimed (by another app or an
+    /// earlier attempt).
+    case claimRejected
+    /// Basic auth was rejected: the access key is no longer valid.
+    case forbidden
+    case httpError(statusCode: Int)
+    case invalidResponse
+    case networkError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidSetupToken:
+            return "That doesn't look like a SimpleFIN setup token. Copy the whole token from SimpleFIN and paste it again."
+        case .invalidAccessKey:
+            return "The stored SimpleFIN access key is unreadable. Disconnect SimpleFIN and set it up again."
+        case .claimRejected:
+            return "SimpleFIN rejected this setup token. Tokens can only be claimed once — generate a new one at SimpleFIN and paste that."
+        case .forbidden:
+            return "SimpleFIN rejected the saved access key. Disconnect SimpleFIN and set it up again with a new setup token."
+        case .httpError(let statusCode):
+            return "SimpleFIN returned an unexpected response (HTTP \(statusCode))."
+        case .invalidResponse:
+            return "SimpleFIN returned a response Actuali couldn't read."
+        case .networkError(let message):
+            return "Couldn't reach SimpleFIN: \(message)"
+        }
+    }
+}
+
+// MARK: - Access key
+
+/// The long-lived credential a claimed setup token yields, in SimpleFIN's
+/// `https://user:password@bridge.example.com/simplefin` form.
+///
+/// Parsed by hand rather than through `URLComponents`: the bridge's generated
+/// passwords are arbitrary strings, and `URLComponents` refuses (or silently
+/// mangles) several characters that appear in them.
+struct SimpleFINAccessKey: Sendable, Equatable {
+    /// The key exactly as SimpleFIN issued it. Kept so it can be stored and
+    /// read back byte for byte rather than reassembled from its parts.
+    let raw: String
+    let baseURL: URL
+    let username: String
+    let password: String
+
+    /// The `Authorization` header value every request carries.
+    var basicAuthHeader: String? {
+        guard let data = "\(username):\(password)".data(using: .utf8) else { return nil }
+        return "Basic \(data.base64EncodedString())"
+    }
+
+    static func parse(_ raw: String) throws -> SimpleFINAccessKey {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let schemeRange = trimmed.range(of: "://") else {
+            throw SimpleFINError.invalidAccessKey
+        }
+        let scheme = String(trimmed[trimmed.startIndex..<schemeRange.lowerBound])
+        let rest = String(trimmed[schemeRange.upperBound...])
+
+        // Split on the *last* "@": the password may legitimately contain one,
+        // the host may not.
+        guard let atIndex = rest.lastIndex(of: "@") else {
+            throw SimpleFINError.invalidAccessKey
+        }
+        let auth = String(rest[rest.startIndex..<atIndex])
+        let host = String(rest[rest.index(after: atIndex)...])
+
+        // Split on the *first* ":" for the same reason, in reverse.
+        guard let colonIndex = auth.firstIndex(of: ":") else {
+            throw SimpleFINError.invalidAccessKey
+        }
+        let username = String(auth[auth.startIndex..<colonIndex])
+        let password = String(auth[auth.index(after: colonIndex)...])
+
+        // iOS blocks cleartext HTTP outright (App Transport Security), and the
+        // key travels in an Authorization header, so refuse anything but https
+        // here rather than failing later with a confusing transport error.
+        guard scheme.lowercased() == "https", !host.isEmpty,
+              !username.isEmpty, !password.isEmpty,
+              let baseURL = URL(string: "https://\(host)") else {
+            throw SimpleFINError.invalidAccessKey
+        }
+
+        return SimpleFINAccessKey(
+            raw: trimmed, baseURL: baseURL, username: username, password: password
+        )
+    }
+
+    /// The claim URL a setup token encodes. Setup tokens are the base64 of a
+    /// plain URL — nothing more.
+    static func claimURL(fromSetupToken token: String) throws -> URL {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = Data(base64Encoded: trimmed, options: [.ignoreUnknownCharacters]),
+              let decoded = String(data: data, encoding: .utf8)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              let url = URL(string: decoded),
+              url.scheme?.lowercased() == "https",
+              url.host != nil else {
+            throw SimpleFINError.invalidSetupToken
+        }
+        return url
+    }
+}
+
+// MARK: - Protocol types
+
+/// A `GET /accounts` response. `errors` carries bridge-level problems (a
+/// connection that needs re-authenticating, say) alongside whatever account
+/// data did come back, so it is never a reason to discard the accounts.
+struct SimpleFINAccountSet: Decodable, Sendable, Equatable {
+    var errors: [String]
+    var accounts: [SimpleFINAccount]
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Bridges have been seen sending structured errors here rather than
+        // the protocol's array of strings; an unreadable `errors` must not
+        // cost us the account data alongside it.
+        if let decoded = try? container.decodeIfPresent([String].self, forKey: .errors) {
+            errors = decoded ?? []
+        } else {
+            errors = []
+        }
+        accounts = try container.decodeIfPresent([SimpleFINAccount].self, forKey: .accounts) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case errors, accounts
+    }
+}
+
+struct SimpleFINOrg: Decodable, Sendable, Equatable {
+    let domain: String?
+    let name: String?
+    let id: String?
+
+    /// The stable identifier Actual keys its `banks` rows on
+    /// (`orgDomain ?? orgId` upstream), so an account linked here and an
+    /// account linked in the web UI land on the same bank row.
+    var bankId: String? { domain ?? id }
+
+    /// What to show a person picking accounts. Falls back through the org's
+    /// other identifiers rather than showing nothing.
+    var displayName: String { name ?? domain ?? id ?? "Unknown institution" }
+
+    private enum CodingKeys: String, CodingKey {
+        case domain, name, id
+    }
+}
+
+struct SimpleFINAccount: Decodable, Sendable, Equatable, Identifiable {
+    let id: String
+    let name: String
+    let org: SimpleFINOrg
+    /// Decimal string, e.g. "-1234.56". Use `balanceCents`.
+    let balance: String
+    let availableBalance: String?
+    /// Seconds since the epoch.
+    let balanceDate: Int?
+    let transactions: [SimpleFINTransaction]
+
+    var balanceCents: Int? { SimpleFINAmount.cents(from: balance) }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Account"
+        org = try container.decode(SimpleFINOrg.self, forKey: .org)
+        balance = try container.decodeIfPresent(String.self, forKey: .balance) ?? "0"
+        availableBalance = try container.decodeIfPresent(String.self, forKey: .availableBalance)
+        balanceDate = try container.decodeIfPresent(Int.self, forKey: .balanceDate)
+        // Absent entirely on a `balances-only` fetch.
+        transactions = try container.decodeIfPresent([SimpleFINTransaction].self, forKey: .transactions) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, org, balance, transactions
+        case availableBalance = "available-balance"
+        case balanceDate = "balance-date"
+    }
+}
+
+struct SimpleFINTransaction: Decodable, Sendable, Equatable, Identifiable {
+    let id: String
+    /// Seconds since the epoch; 0 while the transaction is still pending.
+    let posted: Int
+    /// Seconds since the epoch, when the bank reports it.
+    let transactedAt: Int?
+    /// Decimal string, e.g. "-33.45". Use `amountCents`.
+    let amount: String
+    let description: String?
+    let payee: String?
+    let memo: String?
+    let pending: Bool?
+
+    var amountCents: Int? { SimpleFINAmount.cents(from: amount) }
+
+    /// Whether the bank considers the transaction final. Mirrors upstream's
+    /// `trans.pending ?? trans.posted === 0` — `pending` is optional in the
+    /// protocol, and a zero `posted` is how bridges that omit it say the same
+    /// thing. Booked transactions import as cleared.
+    var isBooked: Bool { !(pending ?? (posted == 0)) }
+
+    /// The timestamp the transaction's date comes from: what the bank posted
+    /// it on once it is final, when it happened while it is still pending.
+    var effectiveTimestamp: Int { isBooked ? posted : (transactedAt ?? posted) }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        posted = try container.decodeIfPresent(Int.self, forKey: .posted) ?? 0
+        transactedAt = try container.decodeIfPresent(Int.self, forKey: .transactedAt)
+        amount = try container.decodeIfPresent(String.self, forKey: .amount) ?? "0"
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        payee = try container.decodeIfPresent(String.self, forKey: .payee)
+        memo = try container.decodeIfPresent(String.self, forKey: .memo)
+        pending = try container.decodeIfPresent(Bool.self, forKey: .pending)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, posted, amount, description, payee, memo, pending
+        case transactedAt = "transacted_at"
+    }
+}
+
+// MARK: - Amounts and dates
+
+/// SimpleFIN sends money as decimal strings ("-33.45") and times as UNIX
+/// seconds, neither of which any existing helper here reads.
+enum SimpleFINAmount {
+    /// Integer cents for a SimpleFIN decimal string, or nil if it isn't one.
+    ///
+    /// Parsed through `Decimal` rather than `Double` so amounts round-trip
+    /// exactly, and with an explicit shape check first because
+    /// `Decimal(string:)` happily reads a leading number out of any junk.
+    static func cents(from raw: String) -> Int? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isDecimalString(trimmed) else { return nil }
+        // Decimal(string:) doesn't read an explicit "+", which the shape check
+        // above allows because the protocol does.
+        let unsigned = trimmed.hasPrefix("+") ? String(trimmed.dropFirst()) : trimmed
+        guard let value = Decimal(string: unsigned, locale: posixLocale) else { return nil }
+
+        var scaled = value * 100
+        var rounded = Decimal()
+        // .plain rounds halves away from zero, matching Transaction.cents.
+        NSDecimalRound(&rounded, &scaled, 0, .plain)
+
+        guard rounded >= Decimal(Int.min), rounded <= Decimal(Int.max) else { return nil }
+        return NSDecimalNumber(decimal: rounded).intValue
+    }
+
+    /// `YYYYMMDD` for a UNIX timestamp, in UTC.
+    ///
+    /// UTC, not the device's zone: upstream's server takes the date off an ISO
+    /// string (`toISOString().split('T')[0]`), so a transaction imported here
+    /// and the same one imported by the web UI land on the same day instead of
+    /// drifting apart by one for anyone east or west of Greenwich.
+    static func day(fromTimestamp timestamp: Int) -> Int {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let parts = utcCalendar.dateComponents([.year, .month, .day], from: date)
+        return (parts.year ?? 0) * 10000 + (parts.month ?? 0) * 100 + (parts.day ?? 0)
+    }
+
+    /// The UNIX timestamp for midnight UTC on a `YYYYMMDD` day — what the
+    /// `start-date` query parameter takes.
+    static func timestamp(fromDay day: Int) -> Int {
+        var components = DateComponents()
+        components.year = day / 10000
+        components.month = (day % 10000) / 100
+        components.day = day % 100
+        guard let date = utcCalendar.date(from: components) else { return 0 }
+        return Int(date.timeIntervalSince1970)
+    }
+
+    private static let posixLocale = Locale(identifier: "en_US_POSIX")
+
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar
+    }()
+
+    private static func isDecimalString(_ value: String) -> Bool {
+        var digitsSeen = false
+        var dotSeen = false
+        for (offset, character) in value.enumerated() {
+            switch character {
+            case "+", "-":
+                guard offset == 0 else { return false }
+            case ".":
+                guard !dotSeen else { return false }
+                dotSeen = true
+            case "0"..."9":
+                digitsSeen = true
+            default:
+                return false
+            }
+        }
+        return digitsSeen
+    }
+}
+
+// MARK: - Client
+
+/// Talks the SimpleFIN protocol (https://www.simplefin.org/protocol.html)
+/// straight from the device: claim a setup token once, then `GET /accounts`
+/// with the resulting access key on every sync.
+///
+/// Actual's own SimpleFIN support runs through its sync server, which holds
+/// the access key and proxies the bridge. Actuali claims its own key instead,
+/// so bank sync works against any server (including ones the user doesn't
+/// administer) — the two coexist because both write the bridge's transaction
+/// id into `financial_id`, so whichever imports a transaction first, the other
+/// recognises it as already imported.
+actor SimpleFINClient {
+    private let session: URLSession
+
+    /// - Parameter session: overridable so tests can drive the client through a
+    ///   stub transport; production callers take the default.
+    init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+            return
+        }
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 60
+        // A first sync can pull 90 days across every linked account.
+        config.timeoutIntervalForResource = 300
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Exchange a setup token for the long-lived access key. Setup tokens are
+    /// single-use: a second claim of the same token fails.
+    func claimAccessKey(setupToken: String) async throws -> SimpleFINAccessKey {
+        let claimURL = try SimpleFINAccessKey.claimURL(fromSetupToken: setupToken)
+
+        var request = URLRequest(url: claimURL)
+        request.httpMethod = "POST"
+
+        let (data, response) = try await send(request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SimpleFINError.invalidResponse
+        }
+        guard httpResponse.statusCode == 200 else {
+            logger.error("SimpleFIN claim failed (HTTP \(httpResponse.statusCode, privacy: .public))")
+            throw httpResponse.statusCode == 403 ? SimpleFINError.claimRejected
+                                                 : SimpleFINError.httpError(statusCode: httpResponse.statusCode)
+        }
+        guard let body = String(data: data, encoding: .utf8) else {
+            throw SimpleFINError.invalidResponse
+        }
+        // The bridge answers 200 with a "Forbidden…" body for an already-claimed
+        // token, so the status code alone doesn't settle it.
+        guard !body.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("Forbidden") else {
+            throw SimpleFINError.claimRejected
+        }
+        do {
+            return try SimpleFINAccessKey.parse(body)
+        } catch {
+            // A bridge that answers 200 with something that isn't an access key
+            // is telling us the token was no good, not that our parser is.
+            throw SimpleFINError.claimRejected
+        }
+    }
+
+    /// Balances (and optionally transactions) for the accounts the access key
+    /// covers.
+    /// - Parameters:
+    ///   - accountIds: restricts the fetch to these bridge account ids; empty
+    ///     fetches everything, which is what the account picker wants.
+    ///   - startDate: earliest day (`YYYYMMDD`) to pull transactions from.
+    ///     `nil` asks for balances only, skipping the bridge's transaction work.
+    func fetchAccounts(
+        accessKey: SimpleFINAccessKey,
+        accountIds: [String] = [],
+        startDate: Int? = nil
+    ) async throws -> SimpleFINAccountSet {
+        guard var components = URLComponents(
+            url: accessKey.baseURL.appendingPathComponent("accounts"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw SimpleFINError.invalidAccessKey
+        }
+
+        var queryItems: [URLQueryItem] = []
+        if let startDate {
+            queryItems.append(URLQueryItem(
+                name: "start-date",
+                value: String(SimpleFINAmount.timestamp(fromDay: startDate))
+            ))
+            // Pending transactions are how a purchase shows up before it
+            // posts; they import uncleared and clear on a later sync.
+            queryItems.append(URLQueryItem(name: "pending", value: "1"))
+        } else {
+            queryItems.append(URLQueryItem(name: "balances-only", value: "1"))
+        }
+        queryItems += accountIds.map { URLQueryItem(name: "account", value: $0) }
+        components.queryItems = queryItems
+
+        guard let url = components.url, let authorization = accessKey.basicAuthHeader else {
+            throw SimpleFINError.invalidAccessKey
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await send(request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SimpleFINError.invalidResponse
+        }
+        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            throw SimpleFINError.forbidden
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw SimpleFINError.httpError(statusCode: httpResponse.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(SimpleFINAccountSet.self, from: data)
+        } catch {
+            logger.error("Couldn't decode the SimpleFIN account set: \(error.localizedDescription, privacy: .public)")
+            throw SimpleFINError.invalidResponse
+        }
+    }
+
+    private func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            // Cancellation is ordinary control flow (a screen the user left).
+            throw urlError
+        } catch {
+            throw SimpleFINError.networkError(error.localizedDescription)
+        }
+    }
+}

--- a/Actuali/Actuali/Services/Network/SimpleFINClient.swift
+++ b/Actuali/Actuali/Services/Network/SimpleFINClient.swift
@@ -130,7 +130,7 @@ struct SimpleFINAccountSet: Decodable, Sendable, Equatable {
         // the protocol's array of strings; an unreadable `errors` must not
         // cost us the account data alongside it.
         if let decoded = try? container.decodeIfPresent([String].self, forKey: .errors) {
-            errors = decoded ?? []
+            errors = decoded
         } else {
             errors = []
         }

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -500,6 +500,125 @@ actor SyncClient {
         await automaticSync()
     }
     
+    // MARK: - Bank Sync
+
+    /// Point an account at a provider's account, so later syncs know where to
+    /// download its transactions from (optimistic local-first).
+    ///
+    /// Writes the same three columns the web UI's own link writes —
+    /// `account_id`, `account_sync_source`, `bank` — plus the institution row
+    /// `bank` points at, reusing an existing row for the institution when
+    /// there is one (upstream `findOrCreateBank`). Both clients therefore see
+    /// the same link, and either can sync or unlink the account.
+    func linkAccount(
+        accountId: String,
+        externalAccountId: String,
+        source: BankSyncSource,
+        institutionId: String,
+        institutionName: String
+    ) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        logger.debug("linkAccount() - id: \(accountId, privacy: .private)")
+
+        let existingBank = try await database.bank(withBankId: institutionId)
+        let bank = existingBank ?? Bank(
+            id: UUID().uuidString, bankId: institutionId, name: institutionName
+        )
+
+        var messages = try await messageGenerator.messages(
+            dataset: "accounts",
+            row: accountId,
+            fields: [
+                ("account_id", externalAccountId),
+                ("account_sync_source", source.rawValue),
+                ("bank", bank.id)
+            ]
+        )
+        if existingBank == nil {
+            messages += try await messageGenerator.messagesForInsert(bank)
+        }
+
+        for msg in try database.applyBankSyncLink(
+            accountId: accountId,
+            externalAccountId: externalAccountId,
+            syncSource: source.rawValue,
+            bank: bank,
+            messages: messages
+        ) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        await automaticSync()
+    }
+
+    /// Cut an account loose from its bank feed. The transactions it already
+    /// imported stay — only the link goes, matching the web UI's unlink.
+    func unlinkAccount(accountId: String) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        logger.debug("unlinkAccount() - id: \(accountId, privacy: .private)")
+
+        let messages = try await messageGenerator.messages(
+            dataset: "accounts",
+            row: accountId,
+            fields: [
+                ("account_id", nil),
+                ("account_sync_source", nil),
+                ("bank", nil)
+            ]
+        )
+
+        for msg in try database.applyBankSyncLink(
+            accountId: accountId,
+            externalAccountId: nil,
+            syncSource: nil,
+            bank: nil,
+            messages: messages
+        ) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        await automaticSync()
+    }
+
+    /// Fold a bank download into the transactions it matched (optimistic
+    /// local-first). One merkle/clock save and one sync for the whole batch,
+    /// like `updateTransactions`.
+    func applyBankSyncUpdates(_ updates: [BankSyncUpdate]) async throws {
+        guard let database else { throw SyncError.notConfigured }
+        guard !updates.isEmpty else { return }
+
+        logger.debug("applyBankSyncUpdates() - \(updates.count, privacy: .public) rows")
+
+        var messages: [CRDTMessage] = []
+        for update in updates {
+            messages += try await messageGenerator.messages(
+                dataset: "transactions",
+                row: update.existingId,
+                fields: [
+                    ("financial_id", update.importedId),
+                    ("description", update.payeeId),
+                    ("imported_description", update.importedPayee),
+                    ("notes", update.notes),
+                    ("cleared", update.cleared ? 1 : 0)
+                ]
+            )
+        }
+
+        for msg in try database.applyBankSyncUpdates(updates, messages: messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        scheduleAutomaticSync()
+    }
+    
     /// Create a category group (optimistic local-first). Placement, the
     /// duplicate-name check and the row itself are the database's job — this
     /// turns what it wrote into CRDT messages.

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -555,7 +555,8 @@ actor SyncClient {
     }
 
     /// Cut an account loose from its bank feed. The transactions it already
-    /// imported stay — only the link goes, matching the web UI's unlink.
+    /// imported stay — only the link goes, matching the web UI's unlink, which
+    /// clears the cached balances and the status badge along with the pointer.
     func unlinkAccount(accountId: String) async throws {
         guard let database else { throw SyncError.notConfigured }
 
@@ -567,23 +568,54 @@ actor SyncClient {
             fields: [
                 ("account_id", nil),
                 ("account_sync_source", nil),
-                ("bank", nil)
+                ("bank", nil),
+                ("balance_current", nil),
+                ("balance_available", nil),
+                ("balance_limit", nil),
+                ("bank_sync_status", nil)
             ]
         )
 
-        for msg in try database.applyBankSyncLink(
-            accountId: accountId,
-            externalAccountId: nil,
-            syncSource: nil,
-            bank: nil,
-            messages: messages
-        ) {
+        for msg in try database.applyBankSyncUnlink(accountId: accountId, messages: messages) {
             merkle = merkle.inserting(msg.timestamp)
         }
         merkle = merkle.pruned()
         try saveClock()
 
         await automaticSync()
+    }
+
+    /// Record what a bank sync did on each account it touched — `last_sync`
+    /// and `bank_sync_status`, the two columns every Actual client stamps, so
+    /// a sync run here reads the same in the web UI.
+    func recordBankSyncStatus(
+        _ statuses: [(accountId: String, lastSync: String?, status: String)]
+    ) async throws {
+        guard let database else { throw SyncError.notConfigured }
+        guard !statuses.isEmpty else { return }
+
+        var messages: [CRDTMessage] = []
+        for entry in statuses {
+            var fields: [(column: String, value: (any Sendable)?)] = [
+                ("bank_sync_status", entry.status)
+            ]
+            // Only stamp last_sync when there was a sync to stamp — see
+            // BudgetDatabase.applyBankSyncStatus.
+            if let lastSync = entry.lastSync {
+                fields.append(("last_sync", lastSync))
+            }
+            messages += try await messageGenerator.messages(
+                dataset: "accounts", row: entry.accountId, fields: fields
+            )
+        }
+
+        for msg in try database.applyBankSyncStatus(statuses, messages: messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        scheduleAutomaticSync()
     }
 
     /// Fold a bank download into the transactions it matched (optimistic

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -650,7 +650,7 @@ actor SyncClient {
 
         scheduleAutomaticSync()
     }
-    
+
     /// Create a category group (optimistic local-first). Placement, the
     /// duplicate-name check and the row itself are the database's job — this
     /// turns what it wrote into CRDT messages.

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -336,6 +336,16 @@ struct AccountDetailView: View {
                     }
                 }
             }
+            if budgetStore.bankSyncAccount(forAccountId: account.id) != nil {
+                ToolbarItem(placement: .secondaryAction) {
+                    Button {
+                        Task { await budgetStore.runBankSync(accountIds: [account.id]) }
+                    } label: {
+                        Label("Sync from Bank", systemImage: "building.columns")
+                    }
+                    .disabled(budgetStore.isBankSyncing)
+                }
+            }
             ToolbarItem(placement: .secondaryAction) {
                 TransactionGroupingToggle()
             }

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -413,7 +413,7 @@ struct AccountsListView: View {
             set: { if !$0 { budgetStore.bankSyncSummary = nil } }
         )
     }
-    
+
     private func loadMonthSummary() async {
         let month = BudgetView.currentMonthString()
         guard let totals = await budgetStore.fetchAccountsMonthSummary(month: month) else { return }

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -320,6 +320,14 @@ struct AccountsListView: View {
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
+                        if !budgetStore.bankSyncAccounts.isEmpty {          // ← add block
+                            Button {
+                                Task { await budgetStore.runBankSync() }
+                            } label: {
+                                Label("Sync Bank Accounts", systemImage: "building.columns")
+                            }
+                            .disabled(budgetStore.isBankSyncing)
+                        }
                         Toggle(isOn: $budgetStore.hideClosedAccounts) {
                             Label("Hide Closed Accounts", systemImage: "archivebox")
                         }
@@ -356,6 +364,14 @@ struct AccountsListView: View {
                 AddAccountView()
                     .environmentObject(budgetStore)
             }
+            // Attached here, not on the menu item that starts the sync: the
+            // menu is long gone by the time the download finishes, and this
+            // stack's pushed account views sit above this alert anyway.
+            .alert("Bank Sync", isPresented: bankSyncAlertBinding) {
+                Button("OK", role: .cancel) { budgetStore.bankSyncSummary = nil }
+            } message: {
+                Text(budgetStore.bankSyncSummary ?? "")
+            }
             .sheet(isPresented: $showingPendingImports) {
                 PendingImportsView()
                     .environmentObject(budgetStore)
@@ -389,6 +405,13 @@ struct AccountsListView: View {
                     ProgressView()
                 }
             }
+    }
+    
+    private var bankSyncAlertBinding: Binding<Bool> {
+        Binding(
+            get: { budgetStore.bankSyncSummary != nil },
+            set: { if !$0 { budgetStore.bankSyncSummary = nil } }
+        )
     }
     
     private func loadMonthSummary() async {

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -320,7 +320,7 @@ struct AccountsListView: View {
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
-                        if !budgetStore.bankSyncAccounts.isEmpty {          // ← add block
+                        if !budgetStore.bankSyncAccounts.isEmpty {
                             Button {
                                 Task { await budgetStore.runBankSync() }
                             } label: {

--- a/Actuali/Actuali/Views/Accounts/AddAccountView.swift
+++ b/Actuali/Actuali/Views/Accounts/AddAccountView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Entry point for the Accounts tab's + button. A simple menu of account
-/// creation methods, matching the PWA's own "Add account" popup — currently
-/// just the local (manual) account, since bank-linked import (Plaid/
-/// SimpleFin) isn't implemented here.
+/// creation methods, matching the PWA's own "Add account" popup: a local
+/// (manual) account, or one fed by a bank through SimpleFIN. GoCardless and
+/// the other providers the PWA offers aren't implemented here.
 struct AddAccountView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -14,6 +14,11 @@ struct AddAccountView: View {
                     CreateLocalAccountView(onCreated: { dismiss() })
                 } label: {
                     Text("Create a local account")
+                }
+                NavigationLink {
+                    BankSyncSetupView()
+                } label: {
+                    Text("Link a bank account")
                 }
             }
             .navigationTitle("Add Account")

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 private let simpleFINBridgeURL = URL(string: "https://bridge.simplefin.org/")!
 
-/// Set up SimpleFIN on this device and wire its accounts to budget accounts.
+/// Set up SimpleFIN and wire its accounts to budget accounts.
 ///
-/// Two states: before a setup token is claimed it's a paste field, after it's
-/// the list of accounts the bridge serves, each either linked to a budget
-/// account or waiting to be.
+/// Two states. With a connection available — the server's own, or one claimed
+/// on this device — it lists the accounts the bridge serves, each either
+/// linked to a budget account or waiting to be. With neither, it's a paste
+/// field for a setup token. Which connection is in play is worth saying out
+/// loud: only the server's is shared with the web app.
 struct BankSyncSetupView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
@@ -14,16 +16,13 @@ struct BankSyncSetupView: View {
     @State private var isConnecting = false
     @State private var isLoadingAccounts = false
     @State private var remoteAccounts: [SimpleFINAccount] = []
-    /// Problems the bridge reported alongside the accounts — a connection that
-    /// needs re-authenticating, most often.
-    @State private var bridgeErrors: [String] = []
     @State private var errorMessage: String?
     @State private var linkTarget: SimpleFINAccount?
     @State private var showingDisconnectConfirmation = false
 
     var body: some View {
         List {
-            if budgetStore.isSimpleFINConfigured {
+            if budgetStore.canSyncBanks {
                 connectedSections
             } else {
                 setupSection
@@ -32,7 +31,10 @@ struct BankSyncSetupView: View {
         .navigationTitle("Bank Sync")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            if budgetStore.isSimpleFINConfigured, remoteAccounts.isEmpty {
+            // Which half of this screen applies depends on whether the server
+            // does SimpleFIN itself, so ask before deciding.
+            await budgetStore.refreshBankSyncSource()
+            if budgetStore.canSyncBanks, remoteAccounts.isEmpty {
                 await loadRemoteAccounts()
             }
         }
@@ -85,7 +87,7 @@ struct BankSyncSetupView: View {
         } header: {
             Text("SimpleFIN")
         } footer: {
-            Text("SimpleFIN gives apps read-only access to your bank. Create a token at bridge.simplefin.org and paste it here — it can only be claimed once, so use a fresh one if another app already has it.")
+            Text("SimpleFIN gives apps read-only access to your bank. Create a token at bridge.simplefin.org and paste it here — it can only be claimed once, so use a fresh one if another app already has it.\n\nIf you set SimpleFIN up on your Actual server instead, this app uses that connection automatically and you won't need a token here at all.")
         }
 
         Section {
@@ -99,14 +101,19 @@ struct BankSyncSetupView: View {
 
     @ViewBuilder
     private var connectedSections: some View {
-        if !bridgeErrors.isEmpty {
-            Section {
-                ForEach(bridgeErrors, id: \.self) { message in
-                    Label(message, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.orange)
-                }
-            } header: {
-                Text("Needs attention")
+        Section {
+            Label(
+                budgetStore.serverProvidesBankSync
+                    ? "Using your server's SimpleFIN connection"
+                    : "Using this device's SimpleFIN connection",
+                systemImage: budgetStore.serverProvidesBankSync ? "server.rack" : "iphone"
+            )
+            .foregroundStyle(.secondary)
+        } footer: {
+            if budgetStore.serverProvidesBankSync {
+                Text("Your Actual server holds the SimpleFIN credentials, so this app and the web app share one connection — accounts you link in either place work in both.")
+            } else {
+                Text("Your server has no SimpleFIN connection of its own, so this device uses the token you gave it. Accounts you link here still appear in the web app, but it needs its own SimpleFIN setup to sync them.")
             }
         }
 
@@ -144,10 +151,12 @@ struct BankSyncSetupView: View {
             }
             .disabled(isLoadingAccounts)
 
-            Button(role: .destructive) {
-                showingDisconnectConfirmation = true
-            } label: {
-                Label("Disconnect SimpleFIN", systemImage: "minus.circle")
+            if budgetStore.isSimpleFINConfigured {
+                Button(role: .destructive) {
+                    showingDisconnectConfirmation = true
+                } label: {
+                    Label("Disconnect this device", systemImage: "minus.circle")
+                }
             }
         }
     }
@@ -210,9 +219,7 @@ struct BankSyncSetupView: View {
         isLoadingAccounts = true
         defer { isLoadingAccounts = false }
         do {
-            let set = try await budgetStore.fetchSimpleFINAccounts()
-            remoteAccounts = set.accounts
-            bridgeErrors = set.errors
+            remoteAccounts = try await budgetStore.fetchBankAccounts()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -222,7 +229,6 @@ struct BankSyncSetupView: View {
         do {
             try budgetStore.disconnectSimpleFIN()
             remoteAccounts = []
-            bridgeErrors = []
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -1,0 +1,356 @@
+import SwiftUI
+
+private let simpleFINBridgeURL = URL(string: "https://bridge.simplefin.org/")!
+
+/// Set up SimpleFIN on this device and wire its accounts to budget accounts.
+///
+/// Two states: before a setup token is claimed it's a paste field, after it's
+/// the list of accounts the bridge serves, each either linked to a budget
+/// account or waiting to be.
+struct BankSyncSetupView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+
+    @State private var setupToken = ""
+    @State private var isConnecting = false
+    @State private var isLoadingAccounts = false
+    @State private var remoteAccounts: [SimpleFINAccount] = []
+    /// Problems the bridge reported alongside the accounts — a connection that
+    /// needs re-authenticating, most often.
+    @State private var bridgeErrors: [String] = []
+    @State private var errorMessage: String?
+    @State private var linkTarget: SimpleFINAccount?
+    @State private var showingDisconnectConfirmation = false
+
+    var body: some View {
+        List {
+            if budgetStore.isSimpleFINConfigured {
+                connectedSections
+            } else {
+                setupSection
+            }
+        }
+        .navigationTitle("Bank Sync")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if budgetStore.isSimpleFINConfigured, remoteAccounts.isEmpty {
+                await loadRemoteAccounts()
+            }
+        }
+        .sheet(item: $linkTarget) { remote in
+            BankAccountLinkView(remote: remote)
+                .environmentObject(budgetStore)
+        }
+        .alert("Bank Sync", isPresented: errorAlertBinding) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .confirmationDialog(
+            "Disconnect SimpleFIN?",
+            isPresented: $showingDisconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Disconnect", role: .destructive) { disconnect() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Your accounts stay linked and keep the transactions they've already imported. To sync from this device again you'll need a new setup token.")
+        }
+    }
+
+    // MARK: - Not connected yet
+
+    @ViewBuilder
+    private var setupSection: some View {
+        Section {
+            TextField("Setup token", text: $setupToken, axis: .vertical)
+                .lineLimit(3...6)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .font(.system(.footnote, design: .monospaced))
+                .disabled(isConnecting)
+
+            Button {
+                connect()
+            } label: {
+                if isConnecting {
+                    HStack {
+                        ProgressView()
+                        Text("Connecting…")
+                    }
+                } else {
+                    Text("Connect")
+                }
+            }
+            .disabled(isConnecting || setupToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        } header: {
+            Text("SimpleFIN")
+        } footer: {
+            Text("SimpleFIN gives apps read-only access to your bank. Create a token at bridge.simplefin.org and paste it here — it can only be claimed once, so use a fresh one if another app already has it.")
+        }
+
+        Section {
+            Link(destination: simpleFINBridgeURL) {
+                Label("Open SimpleFIN Bridge", systemImage: "safari")
+            }
+        }
+    }
+
+    // MARK: - Connected
+
+    @ViewBuilder
+    private var connectedSections: some View {
+        if !bridgeErrors.isEmpty {
+            Section {
+                ForEach(bridgeErrors, id: \.self) { message in
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                }
+            } header: {
+                Text("Needs attention")
+            }
+        }
+
+        Section {
+            if isLoadingAccounts {
+                HStack {
+                    ProgressView()
+                    Text("Loading accounts…")
+                        .foregroundStyle(.secondary)
+                }
+            } else if remoteAccounts.isEmpty {
+                Text("No accounts yet. Add a bank at SimpleFIN, then pull to refresh.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(remoteAccounts) { remote in
+                    Button {
+                        linkTarget = remote
+                    } label: {
+                        remoteAccountRow(remote)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        } header: {
+            Text("Bank Accounts")
+        } footer: {
+            Text("Tap an account to link it to a budget account. Linked accounts import new transactions every time you sync.")
+        }
+
+        Section {
+            Button {
+                Task { await loadRemoteAccounts() }
+            } label: {
+                Label("Refresh account list", systemImage: "arrow.clockwise")
+            }
+            .disabled(isLoadingAccounts)
+
+            Button(role: .destructive) {
+                showingDisconnectConfirmation = true
+            } label: {
+                Label("Disconnect SimpleFIN", systemImage: "minus.circle")
+            }
+        }
+    }
+
+    private func remoteAccountRow(_ remote: SimpleFINAccount) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(remote.name)
+                Text(remote.org.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let linked = linkedAccountName(for: remote) {
+                    Label(linked, systemImage: "link")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            }
+            Spacer()
+            if let cents = remote.balanceCents {
+                Text(budgetStore.displayBalance(cents))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    /// The budget account a bridge account is already wired to, if any.
+    private func linkedAccountName(for remote: SimpleFINAccount) -> String? {
+        guard let link = budgetStore.bankSyncAccounts.first(where: {
+            $0.externalAccountId == remote.id && $0.source == .simpleFin
+        }) else { return nil }
+        return link.name
+    }
+
+    // MARK: - Actions
+
+    private var errorAlertBinding: Binding<Bool> {
+        Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+    }
+
+    private func connect() {
+        let token = setupToken
+        isConnecting = true
+        Task {
+            defer { isConnecting = false }
+            do {
+                try await budgetStore.connectSimpleFIN(setupToken: token)
+                setupToken = ""
+                await loadRemoteAccounts()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func loadRemoteAccounts() async {
+        isLoadingAccounts = true
+        defer { isLoadingAccounts = false }
+        do {
+            let set = try await budgetStore.fetchSimpleFINAccounts()
+            remoteAccounts = set.accounts
+            bridgeErrors = set.errors
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func disconnect() {
+        do {
+            try budgetStore.disconnectSimpleFIN()
+            remoteAccounts = []
+            bridgeErrors = []
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+/// Pick what a bridge account feeds: an account the budget already has, or a
+/// new one created for it.
+struct BankAccountLinkView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    let remote: SimpleFINAccount
+
+    @State private var newAccountOffBudget = false
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let linked = currentLink {
+                    Section {
+                        Button(role: .destructive) {
+                            perform { try await budgetStore.unlinkBankAccount(accountId: linked.id) }
+                        } label: {
+                            Label("Unlink from \(linked.name)", systemImage: "link.badge.plus")
+                        }
+                    } footer: {
+                        Text("Transactions already imported stay in the account.")
+                    }
+                }
+
+                Section {
+                    Toggle("Off budget", isOn: $newAccountOffBudget)
+                    Button {
+                        createAndLink()
+                    } label: {
+                        Label("Create “\(remote.name)”", systemImage: "plus.circle")
+                    }
+                } header: {
+                    Text("New account")
+                } footer: {
+                    Text("Creates a budget account for \(remote.name) at \(remote.org.displayName) and links it. Its opening balance is worked out on the first sync.")
+                }
+
+                Section("Link to an existing account") {
+                    if linkableAccounts.isEmpty {
+                        Text("Every open account is already linked.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(linkableAccounts) { account in
+                            Button {
+                                perform {
+                                    try await budgetStore.linkBankAccount(
+                                        accountId: account.id, to: remote
+                                    )
+                                }
+                            } label: {
+                                HStack {
+                                    Text(account.name)
+                                    Spacer()
+                                    Text(budgetStore.displayBalance(account.balance))
+                                        .foregroundStyle(.secondary)
+                                        .monospacedDigit()
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .disabled(isWorking)
+            .navigationTitle(remote.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .alert("Bank Sync", isPresented: errorAlertBinding) {
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private var currentLink: BankSyncAccount? {
+        budgetStore.bankSyncAccounts.first {
+            $0.externalAccountId == remote.id && $0.source == .simpleFin
+        }
+    }
+
+    /// Open accounts with no bank feed of their own. An account already linked
+    /// to a different bridge account isn't offered — one feed per account.
+    private var linkableAccounts: [Account] {
+        let linkedIds = Set(budgetStore.bankSyncAccounts.map(\.id))
+        return budgetStore.accounts.filter { !$0.closed && !linkedIds.contains($0.id) }
+    }
+
+    private var errorAlertBinding: Binding<Bool> {
+        Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+    }
+
+    private func createAndLink() {
+        perform {
+            let account = try await budgetStore.createAccount(
+                name: remote.name,
+                offBudget: newAccountOffBudget,
+                // No opening balance here: the first sync works it out from
+                // the bridge's current balance and the history it downloads.
+                startingBalanceCents: 0
+            )
+            try await budgetStore.linkBankAccount(accountId: account.id, to: remote)
+        }
+    }
+
+    private func perform(_ work: @escaping @MainActor () async throws -> Void) {
+        isWorking = true
+        Task {
+            defer { isWorking = false }
+            do {
+                try await work()
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -164,6 +164,12 @@ struct TransactionAutomationSettingsView: View {
 
             Section {
                 NavigationLink {
+                    BankSyncSetupView()
+                } label: {
+                    Label("Bank Sync (SimpleFIN)", systemImage: "building.columns")
+                }
+
+                NavigationLink {
                     WalletAutomationView()
                 } label: {
                     Label("Log Wallet Payments Automatically", systemImage: "wallet.pass")
@@ -177,12 +183,12 @@ struct TransactionAutomationSettingsView: View {
                     }
                 }
             } header: {
-                Text("Wallet Automation")
+                Text("Automations")
             } footer: {
                 if WalletImportView.isSupported {
-                    Text("Set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions directly.")
+                    Text("Connect SimpleFIN to import transactions straight from your bank, set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions directly.")
                 } else {
-                    Text("Set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet.")
+                    Text("Connect SimpleFIN to import transactions straight from your bank, or set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet.")
                 }
             }
         }

--- a/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct BankSyncReconcilerTests {
+
+    private func candidate(
+        importedId: String = "sf-1",
+        date: Int = 20240310,
+        amount: Int = -1250,
+        payeeName: String = "Blue Bottle",
+        payeeId: String? = nil,
+        notes: String? = nil,
+        cleared: Bool = true
+    ) -> BankSyncCandidate {
+        BankSyncCandidate(
+            importedId: importedId, date: date, amount: amount,
+            payeeName: payeeName, payeeId: payeeId, notes: notes, cleared: cleared
+        )
+    }
+
+    private func existing(
+        id: String = "tx-1",
+        date: Int = 20240310,
+        amount: Int = -1250,
+        payeeId: String? = nil,
+        importedId: String? = nil,
+        importedPayee: String? = nil,
+        notes: String? = nil,
+        cleared: Bool = false,
+        reconciled: Bool = false
+    ) -> BankSyncExistingTransaction {
+        BankSyncExistingTransaction(
+            id: id, date: date, amount: amount, payeeId: payeeId, importedId: importedId,
+            importedPayee: importedPayee, notes: notes, cleared: cleared, reconciled: reconciled
+        )
+    }
+
+    // MARK: - Nothing to match against
+
+    @Test func downloadsWithNothingToMatchAreInserts() {
+        let plan = BankSyncReconciler.plan(candidates: [candidate()], existing: [])
+
+        #expect(plan.inserts.count == 1)
+        #expect(plan.updates.isEmpty)
+        #expect(plan.unchanged == 0)
+    }
+
+    // MARK: - Pass 1: the provider's transaction id
+
+    @Test func aTransactionWeAlreadyImportedIsLeftAlone() {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-1")],
+            existing: [existing(importedId: "sf-1", importedPayee: "Blue Bottle", cleared: true)]
+        )
+
+        #expect(plan.isEmpty)
+        #expect(plan.unchanged == 1)
+    }
+
+    /// The common re-sync: a pending charge posts, so the same transaction
+    /// comes back booked and the row it already made should clear.
+    @Test func aPendingTransactionThatPostsClearsTheRowItMade() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-1", cleared: true)],
+            existing: [existing(importedId: "sf-1", importedPayee: "Blue Bottle", cleared: false)]
+        )
+
+        #expect(plan.inserts.isEmpty)
+        let update = try #require(plan.updates.first)
+        #expect(update.existingId == "tx-1")
+        #expect(update.cleared)
+    }
+
+    /// The id match beats the fuzzy window even when the window has a nearer
+    /// row: it's the only match the provider actually vouched for.
+    @Test func theIdMatchWinsOverACloserDate() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-1", date: 20240310)],
+            existing: [
+                existing(id: "tx-near", date: 20240310),
+                existing(id: "tx-far", date: 20240313, importedId: "sf-1")
+            ]
+        )
+
+        #expect(plan.updates.map(\.existingId) == ["tx-far"])
+    }
+
+    // MARK: - Pass 2 and 3: the fuzzy window
+
+    /// The case this whole pass exists for: someone entered a purchase by hand
+    /// before the bank posted it.
+    @Test func aHandEnteredTransactionIsAdoptedRatherThanDuplicated() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-1", date: 20240310, notes: "Coffee")],
+            existing: [existing(id: "tx-manual", date: 20240308, payeeId: "payee-1")]
+        )
+
+        #expect(plan.inserts.isEmpty)
+        let update = try #require(plan.updates.first)
+        #expect(update.existingId == "tx-manual")
+        #expect(update.importedId == "sf-1")
+        #expect(update.importedPayee == "Blue Bottle")
+        // What the person already filled in stays theirs.
+        #expect(update.payeeId == "payee-1")
+        #expect(update.notes == "Coffee")
+    }
+
+    @Test func matchingLooksSevenDaysEitherSideAndNoFurther() {
+        let inWindow = BankSyncReconciler.plan(
+            candidates: [candidate(date: 20240310)],
+            existing: [existing(date: 20240303)]
+        )
+        let outOfWindow = BankSyncReconciler.plan(
+            candidates: [candidate(date: 20240310)],
+            existing: [existing(date: 20240302)]
+        )
+
+        #expect(inWindow.updates.count == 1)
+        #expect(outOfWindow.inserts.count == 1)
+        #expect(outOfWindow.updates.isEmpty)
+    }
+
+    @Test func differentAmountsNeverMatch() {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(amount: -1250)],
+            existing: [existing(amount: -1251)]
+        )
+
+        #expect(plan.inserts.count == 1)
+    }
+
+    /// Pass 2 runs across every download before pass 3, so a same-payee match
+    /// can't be stolen by an earlier download that only matched on amount.
+    @Test func aSamePayeeMatchOutranksAnEarlierVaguerOne() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [
+                candidate(importedId: "sf-1", date: 20240310, payeeName: "Other", payeeId: "payee-2"),
+                candidate(importedId: "sf-2", date: 20240310, payeeName: "Blue Bottle", payeeId: "payee-1")
+            ],
+            existing: [existing(id: "tx-1", date: 20240310, payeeId: "payee-1")]
+        )
+
+        #expect(plan.updates.count == 1)
+        let update = try #require(plan.updates.first)
+        #expect(update.importedId == "sf-2")
+        #expect(update.existingId == "tx-1")
+        // The one that lost the row is new after all.
+        #expect(plan.inserts.map(\.importedId) == ["sf-1"])
+    }
+
+    @Test func oneLocalRowIsClaimedByAtMostOneDownload() {
+        let plan = BankSyncReconciler.plan(
+            candidates: [
+                candidate(importedId: "sf-1", date: 20240310),
+                candidate(importedId: "sf-2", date: 20240310)
+            ],
+            existing: [existing(id: "tx-1", date: 20240310)]
+        )
+
+        #expect(plan.updates.count == 1)
+        #expect(plan.inserts.count == 1)
+    }
+
+    @Test func theNearestDateInTheWindowIsMatchedFirst() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(date: 20240310)],
+            existing: [
+                existing(id: "tx-far", date: 20240305),
+                existing(id: "tx-near", date: 20240311)
+            ]
+        )
+
+        #expect(try #require(plan.updates.first).existingId == "tx-near")
+    }
+
+    /// Providers reissue ids for the same transaction (a pending charge that
+    /// posts, most often), so bank-sync matching deliberately doesn't skip
+    /// rows that already carry a different one.
+    @Test func aRowWithADifferentProviderIdCanStillMatch() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-new", date: 20240310)],
+            existing: [existing(id: "tx-1", date: 20240310, importedId: "sf-old")]
+        )
+
+        #expect(plan.inserts.isEmpty)
+        #expect(try #require(plan.updates.first).importedId == "sf-new")
+    }
+
+    // MARK: - Locked rows
+
+    @Test func reconciledTransactionsAreNeverTouched() {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(importedId: "sf-1")],
+            existing: [existing(reconciled: true)]
+        )
+
+        #expect(plan.isEmpty)
+        #expect(plan.unchanged == 1)
+    }
+
+    // MARK: - Day arithmetic
+
+    @Test(arguments: [
+        (20240301, -1, 20240229),  // leap day
+        (20230301, -1, 20230228),
+        (20240101, -1, 20231231),
+        (20241231, 1, 20250101),
+        (20240310, 7, 20240317),
+        (20240310, -89, 20231212)
+    ])
+    func daysShiftAcrossMonthAndYearBoundaries(_ from: Int, _ offset: Int, _ expected: Int) {
+        #expect(BankSyncReconciler.day(from, offsetBy: offset) == expected)
+    }
+
+    @Test func dayNumbersMeasureTheGapBetweenDates() {
+        #expect(
+            BankSyncReconciler.dayNumber(20240301) - BankSyncReconciler.dayNumber(20240229) == 1
+        )
+        #expect(
+            BankSyncReconciler.dayNumber(20250101) - BankSyncReconciler.dayNumber(20240101) == 366
+        )
+    }
+}
+
+struct BankSyncCandidateNormalizationTests {
+
+    private func transaction(_ json: String) throws -> SimpleFINTransaction {
+        try JSONDecoder().decode(SimpleFINTransaction.self, from: Data(json.utf8))
+    }
+
+    @Test func takesThePayeeFromPayeeAndTheNotesFromDescription() throws {
+        let candidate = try #require(BankSyncCandidate(simpleFIN: transaction("""
+        {"id": "sf-1", "posted": 1709253000, "amount": "-33.45",
+         "payee": "Uncle Frank", "description": "Uncle Frank's Bait Shop"}
+        """)))
+
+        #expect(candidate.importedId == "sf-1")
+        #expect(candidate.date == 20240301)
+        #expect(candidate.amount == -3345)
+        #expect(candidate.payeeName == "Uncle Frank")
+        #expect(candidate.notes == "Uncle Frank's Bait Shop")
+        #expect(candidate.cleared)
+        #expect(candidate.payeeId == nil)
+    }
+
+    /// Not every bridge fills in `payee`, and importing a nameless payee would
+    /// be worse than reusing the description.
+    @Test func fallsBackToTheDescriptionWhenThereIsNoPayee() throws {
+        let candidate = try #require(BankSyncCandidate(simpleFIN: transaction("""
+        {"id": "sf-1", "posted": 1709253000, "amount": "-1.00", "description": "ACME CORP  #4821"}
+        """)))
+
+        #expect(candidate.payeeName == "ACME CORP  #4821")
+    }
+
+    /// A "#" in a bank's own description would otherwise read as a tag.
+    @Test func escapesHashesInTheNotes() throws {
+        let candidate = try #require(BankSyncCandidate(simpleFIN: transaction("""
+        {"id": "sf-1", "posted": 1709253000, "amount": "-1.00", "description": "ACME #4821"}
+        """)))
+
+        #expect(candidate.notes == "ACME ##4821")
+        #expect(!TagFilter.notesContainTag(candidate.notes ?? "", tag: "#4821", caseSensitive: true))
+    }
+
+    @Test func pendingTransactionsImportUnclearedAndDatedWhenTheyHappened() throws {
+        let candidate = try #require(BankSyncCandidate(simpleFIN: transaction("""
+        {"id": "sf-1", "posted": 0, "pending": true, "transacted_at": 1709253000,
+         "amount": "-1.00", "description": "Coffee"}
+        """)))
+
+        #expect(!candidate.cleared)
+        #expect(candidate.date == 20240301)
+    }
+
+    @Test func transactionsWithAnUnreadableAmountAreSkipped() throws {
+        #expect(BankSyncCandidate(simpleFIN: transaction("""
+        {"id": "sf-1", "posted": 1709253000, "amount": "not-a-number", "description": "Coffee"}
+        """)) == nil)
+    }
+}

--- a/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
@@ -202,24 +202,14 @@ struct BankSyncReconcilerTests {
     // MARK: - Day arithmetic
 
     @Test(arguments: [
-        (20240301, -1, 20240229),  // leap day
-        (20230301, -1, 20230228),
-        (20240101, -1, 20231231),
-        (20241231, 1, 20250101),
-        (20240310, 7, 20240317),
-        (20240310, -89, 20231212)
+        (20240301, 20240229, 1),
+        (20250101, 20240101, 366),
+        (20240310, 20231212, 89)
     ])
-    func daysShiftAcrossMonthAndYearBoundaries(_ from: Int, _ offset: Int, _ expected: Int) {
-        #expect(BankSyncReconciler.day(from, offsetBy: offset) == expected)
-    }
-
-    @Test func dayNumbersMeasureTheGapBetweenDates() {
-        #expect(
-            BankSyncReconciler.dayNumber(20240301) - BankSyncReconciler.dayNumber(20240229) == 1
-        )
-        #expect(
-            BankSyncReconciler.dayNumber(20250101) - BankSyncReconciler.dayNumber(20240101) == 366
-        )
+    func dayDistanceMeasuresAcrossMonthAndYearBoundaries(
+        _ from: Int, _ to: Int, _ expected: Int
+    ) {
+        #expect(BankSyncReconciler.dayDistance(from, to) == expected)
     }
 }
 

--- a/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
@@ -275,7 +275,7 @@ struct BankSyncCandidateNormalizationTests {
     }
 
     @Test func transactionsWithAnUnreadableAmountAreSkipped() throws {
-        #expect(BankSyncCandidate(simpleFIN: transaction("""
+        #expect(try BankSyncCandidate(simpleFIN: transaction("""
         {"id": "sf-1", "posted": 1709253000, "amount": "not-a-number", "description": "Coffee"}
         """)) == nil)
     }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -32,6 +32,40 @@ private final class BridgeTransport: URLProtocol {
     override func stopLoading() {}
 }
 
+/// Answers the `/simplefin/*` routes by path.
+private final class ServerTransport: URLProtocol {
+    nonisolated(unsafe) static var bodies: [String: String] = [:]
+    nonisolated(unsafe) static var requestedPaths: [String] = []
+
+    static func makeSession(_ bodies: [String: String]) -> URLSession {
+        Self.bodies = bodies
+        Self.requestedPaths = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ServerTransport.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        Self.requestedPaths.append(path)
+        let body = Self.bodies[path]
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: body == nil ? 404 : 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data((body ?? "").utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 @MainActor
 @Suite(.serialized)
 struct BudgetStoreBankSyncTests {
@@ -82,9 +116,12 @@ struct BudgetStoreBankSyncTests {
                     sort_order REAL,
                     account_id TEXT,
                     account_sync_source TEXT,
-                    bank TEXT
+                    bank TEXT,
+                    balance_current INTEGER,
+                    balance_available INTEGER,
+                    balance_limit INTEGER
                 )
-                """)
+            """)
             try db.execute(sql: """
                 CREATE TABLE transactions (
                     id TEXT PRIMARY KEY,
@@ -330,8 +367,17 @@ struct BudgetStoreBankSyncTests {
 
         let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
 
-        #expect(result.problems == ["Connection to My Bank may need attention"])
+        // The bridge's errors aren't keyed by account, so they're paired up by
+        // the institution they name — which is what lets the account carry the
+        // status the web UI reads.
+        #expect(result.problems == ["Checking: Connection to My Bank may need attention"])
         #expect(result.summary.contains("Connection to My Bank may need attention"))
+
+        let queue = try DatabaseQueue(path: url.path)
+        let account = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        })
+        #expect(account["bank_sync_status"] == "attention-required")
     }
 
     // MARK: - Linking
@@ -376,8 +422,195 @@ struct BudgetStoreBankSyncTests {
         })
         let externalId: String? = account["account_id"]
         let source: String? = account["account_sync_source"]
+        let bank: String? = account["bank"]
+        let status: String? = account["bank_sync_status"]
+        let cachedBalance: Int? = account["balance_current"]
         #expect(externalId == nil)
         #expect(source == nil)
+        #expect(bank == nil)
+        // A left-behind status would keep showing an error badge in the web UI
+        // for an account that no longer syncs at all.
+        #expect(status == nil)
+        #expect(cachedBalance == nil)
         #expect(try rows(path: url).count == 1)
+    }
+    
+    @Test func aSyncStampsLastSyncAndStatusForTheWebUI() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+            """))
+
+        _ = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        let queue = try DatabaseQueue(path: url.path)
+        let account = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        })
+        #expect(account["bank_sync_status"] == "ok")
+        let lastSync: String? = account["last_sync"]
+        // Milliseconds since the epoch as a string, the way every other client
+        // writes it.
+        #expect((Int64(lastSync ?? "") ?? 0) > 1_700_000_000_000)
+    }
+
+    /// A `YYYY-MM-DD` string the sync window will accept, however long this
+    /// test lives.
+    private static func isoDaysAgo(_ days: Int) -> String {
+        BankSyncReconciler.isoString(
+            from: BankSyncReconciler.day(Transaction.yyyymmdd(from: Date()), offsetBy: -days)
+        )
+    }
+
+    private func makeServerStore(
+        database: BudgetDatabase,
+        bodies: [String: String]
+    ) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+
+        let serverClient = ActualServerClient(session: ServerTransport.makeSession(bodies))
+        try await serverClient.configure(serverURL: "https://budget.example.com")
+        await serverClient.setToken("session-token")
+        store.setServerClientForTesting(serverClient)
+
+        // Deliberately not given a SimpleFIN client or a stored access key:
+        // anything that reaches the bridge directly would fail the test.
+        await store.loadBankSyncAccounts()
+        return store
+    }
+
+    // MARK: - Through the server
+
+    /// The point of the whole arrangement: a server that already has SimpleFIN
+    /// needs no second setup token here.
+    @Test func syncsThroughTheServerWithNoDeviceKey() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [
+            "/simplefin/status": #"{"status":"ok","data":{"configured":true}}"#,
+            "/simplefin/transactions": """
+            {"status":"ok","data":{"\(Self.externalAccountId)":{
+              "startingBalance": 10000,
+              "transactions": {"all": [
+                {"transactionId": "sf-1", "date": "\(Self.isoDaysAgo(5))",
+                 "payeeName": "Blue Bottle", "notes": "BLUE BOTTLE COFFEE", "booked": true,
+                 "transactionAmount": {"amount": "-33.45", "currency": "USD"}}
+              ]}}}}
+            """
+        ])
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.added == 1)
+        #expect(result.accountsSynced == 1)
+        #expect(result.problems.isEmpty)
+        #expect(store.serverProvidesBankSync)
+        #expect(ServerTransport.requestedPaths.contains("/simplefin/transactions"))
+
+        let queue = try DatabaseQueue(path: url.path)
+        let imported = try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions WHERE financial_id = 'sf-1'")
+        }
+        #expect(imported.count == 1)
+        #expect(imported[0]["amount"] == -3345)
+        #expect(imported[0]["cleared"] == 1)
+    }
+
+    /// A server without its own connection, and no key here either, is the one
+    /// case where there's genuinely nothing to sync with.
+    @Test func refusesWhenNeitherTheServerNorTheDeviceHasAConnection() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [
+            "/simplefin/status": #"{"status":"ok","data":{"configured":false}}"#
+        ])
+        try? SimpleFINCredentials.clear()
+
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
+        }
+        #expect(!store.serverProvidesBankSync)
+    }
+
+    /// An Actual release that predates the routes 404s them, which must read as
+    /// "this server can't do bank sync" rather than as a failure.
+    @Test func treatsAMissingRouteAsNoServerConnection() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [:])
+        try? SimpleFINCredentials.clear()
+
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
+        }
+    }
+
+    @Test func reportsAnAccountTheServerCouldntFetch() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [
+            "/simplefin/status": #"{"status":"ok","data":{"configured":true}}"#,
+            "/simplefin/transactions": """
+            {"status":"ok","data":{"errors":{"\(Self.externalAccountId)":[
+              {"error_type":"ACCOUNT_NEEDS_ATTENTION","error_code":"ACCOUNT_NEEDS_ATTENTION",
+               "reason":"The account needs your attention at SimpleFIN."}
+            ]}}}
+            """
+        ])
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.problems.count == 1)
+        #expect(result.problems[0].contains("needs your attention"))
+
+        // The status the web UI reads comes across too.
+        let queue = try DatabaseQueue(path: url.path)
+        let account = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        })
+        #expect(account["bank_sync_status"] == "attention-required")
+    }
+
+    @Test func aRejectedServerKeyIsReportedNotSwallowed() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [
+            "/simplefin/status": #"{"status":"ok","data":{"configured":true}}"#,
+            "/simplefin/transactions": """
+            {"status":"ok","data":{"error_type":"INVALID_ACCESS_TOKEN",
+             "error_code":"INVALID_ACCESS_TOKEN","status":"rejected",
+             "reason":"Invalid SimpleFIN access token."}}
+            """
+        ])
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.accountsSynced == 0)
+        #expect(result.problems.contains { $0.contains("Invalid SimpleFIN access token.") })
+    }
+
+    @Test func linkingScreenListsTheServersAccounts() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeServerStore(database: database, bodies: [
+            "/simplefin/status": #"{"status":"ok","data":{"configured":true}}"#,
+            "/simplefin/accounts": """
+            {"status":"ok","data":{"accounts":[
+              {"org":{"domain":"mybank.com","name":"My Bank"},"id":"sf-acct-1",
+               "name":"Checking","balance":"100.00"}
+            ]}}
+            """
+        ])
+
+        let accounts = try await store.fetchBankAccounts()
+
+        #expect(accounts.count == 1)
+        #expect(accounts[0].id == "sf-acct-1")
+        #expect(accounts[0].org.bankId == "mybank.com")
+        #expect(accounts[0].balanceCents == 10000)
     }
 }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -200,6 +200,15 @@ struct BudgetStoreBankSyncTests {
         }
     }
 
+    /// Fetches a single row synchronously so the non-Sendable `Row` never
+    /// crosses an async boundary (see AGENTS.md on GRDB `Row` isolation).
+    private func row(path: URL, sql: String, arguments: StatementArguments = StatementArguments()) throws -> Row? {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchOne(db, sql: sql, arguments: arguments)
+        }
+    }
+
     private func withStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
         try SimpleFINCredentials.save(
             SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
@@ -373,10 +382,9 @@ struct BudgetStoreBankSyncTests {
         #expect(result.problems == ["Checking: Connection to My Bank may need attention"])
         #expect(result.summary.contains("Connection to My Bank may need attention"))
 
-        let queue = try DatabaseQueue(path: url.path)
-        let account = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
-        })
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
         #expect(account["bank_sync_status"] == "attention-required")
     }
 
@@ -393,18 +401,17 @@ struct BudgetStoreBankSyncTests {
 
         try await store.linkBankAccount(accountId: Self.accountId, to: remote)
 
-        let queue = try DatabaseQueue(path: url.path)
-        let account = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
-        })
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
         #expect(account["account_id"] == "sf-acct-9")
         #expect(account["account_sync_source"] == "simpleFin")
         let bankRowId: String? = account["bank"]
         #expect(bankRowId != nil)
 
-        let bank = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM banks WHERE id = ?", arguments: [bankRowId])
-        })
+        let bank = try #require(
+            try row(path: url, sql: "SELECT * FROM banks WHERE id = ?", arguments: [bankRowId])
+        )
         #expect(bank["bank_id"] == "mybank.com")
         #expect(bank["name"] == "My Bank")
     }
@@ -416,10 +423,9 @@ struct BudgetStoreBankSyncTests {
 
         try await store.unlinkBankAccount(accountId: Self.accountId)
 
-        let queue = try DatabaseQueue(path: url.path)
-        let account = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
-        })
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
         let externalId: String? = account["account_id"]
         let source: String? = account["account_sync_source"]
         let bank: String? = account["bank"]
@@ -444,10 +450,9 @@ struct BudgetStoreBankSyncTests {
 
         _ = try await withStoredAccessKey { try await store.syncBankAccounts() }
 
-        let queue = try DatabaseQueue(path: url.path)
-        let account = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
-        })
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
         #expect(account["bank_sync_status"] == "ok")
         let lastSync: String? = account["last_sync"]
         // Milliseconds since the epoch as a string, the way every other client
@@ -511,10 +516,7 @@ struct BudgetStoreBankSyncTests {
         #expect(store.serverProvidesBankSync)
         #expect(ServerTransport.requestedPaths.contains("/simplefin/transactions"))
 
-        let queue = try DatabaseQueue(path: url.path)
-        let imported = try queue.read { db in
-            try Row.fetchAll(db, sql: "SELECT * FROM transactions WHERE financial_id = 'sf-1'")
-        }
+        let imported = try rows(path: url, where: "financial_id = 'sf-1'")
         #expect(imported.count == 1)
         #expect(imported[0]["amount"] == -3345)
         #expect(imported[0]["cleared"] == 1)
@@ -568,10 +570,9 @@ struct BudgetStoreBankSyncTests {
         #expect(result.problems[0].contains("needs your attention"))
 
         // The status the web UI reads comes across too.
-        let queue = try DatabaseQueue(path: url.path)
-        let account = try #require(try queue.read { db in
-            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
-        })
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
         #expect(account["bank_sync_status"] == "attention-required")
     }
 

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -210,10 +210,29 @@ struct BudgetStoreBankSyncTests {
     }
 
     private func withStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
+        // Put back whatever the app container's Keychain held before, so a key
+        // someone genuinely configured in this simulator survives a test run.
+        let previous = SimpleFINCredentials.accessKey
         try SimpleFINCredentials.save(
             SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
         )
-        defer { try? SimpleFINCredentials.clear() }
+        defer {
+            if let previous {
+                try? SimpleFINCredentials.save(previous)
+            } else {
+                try? SimpleFINCredentials.clear()
+            }
+        }
+        return try await body()
+    }
+
+    /// The inverse: run with no key stored, putting back whatever was there.
+    private func withoutStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
+        let previous = SimpleFINCredentials.accessKey
+        try? SimpleFINCredentials.clear()
+        defer {
+            if let previous { try? SimpleFINCredentials.save(previous) }
+        }
         return try await body()
     }
 
@@ -249,7 +268,9 @@ struct BudgetStoreBankSyncTests {
             try await store.syncBankAccounts()
         }
 
-        #expect(result.added == 2)
+        // Two downloads plus the opening balance, which counts as an import
+        // too (upstream folds its id into `added`).
+        #expect(result.added == 3)
         #expect(result.updated == 0)
         #expect(result.accountsSynced == 1)
         #expect(result.problems.isEmpty)
@@ -288,7 +309,7 @@ struct BudgetStoreBankSyncTests {
         let first = try await withStoredAccessKey { try await store.syncBankAccounts() }
         let second = try await withStoredAccessKey { try await store.syncBankAccounts() }
 
-        #expect(first.added == 1)
+        #expect(first.added == 2)  // the download and the opening balance
         #expect(second.added == 0)
         #expect(second.updated == 0)
         #expect(try rows(path: url, where: "financial_id = 'sf-1'").count == 1)
@@ -318,6 +339,39 @@ struct BudgetStoreBankSyncTests {
         #expect(try rows(path: url, where: "starting_balance_flag = 1").isEmpty)
     }
 
+    /// Payee names resolve case-insensitively, the same way payees resolve
+    /// everywhere else — a bank that shouts "BLUE BOTTLE" still claims the row
+    /// filed under "Blue Bottle", even when a vaguer row sits closer in time.
+    @Test func payeeMatchingIgnoresCase() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let queue = try DatabaseQueue(path: url.path)
+        let accountId = Self.accountId
+        let payeeDay = Self.expectedDay(7)
+        let decoyDay = Self.expectedDay(5)
+        try await queue.write { db in
+            try db.execute(sql: "INSERT INTO payees (id, name) VALUES ('payee-blue', 'Blue Bottle')")
+            // The decoy sits on the candidate's own date; only the payee pass
+            // reaches past it to the row two days away.
+            try db.execute(sql: """
+                INSERT INTO transactions (id, acct, date, amount, description, cleared, sort_order)
+                VALUES ('tx-payee', ?, ?, -3345, 'payee-blue', 0, 1),
+                       ('tx-decoy', ?, ?, -3345, NULL, 0, 2)
+                """, arguments: [accountId, payeeDay, accountId, decoyDay])
+        }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "BLUE BOTTLE"}
+            """))
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.added == 0)
+        #expect(result.updated == 1)
+        let matched = try rows(path: url, where: "financial_id = 'sf-1'")
+        #expect(matched.count == 1)
+        #expect(matched[0]["id"] == "tx-payee")
+    }
+
     @Test func importedTransactionsGenerateCRDTMessages() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
@@ -341,10 +395,11 @@ struct BudgetStoreBankSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
-        try? SimpleFINCredentials.clear()
 
-        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-            _ = try await store.syncBankAccounts()
+        try await withoutStoredAccessKey {
+            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+                _ = try await store.syncBankAccounts()
+            }
         }
     }
 
@@ -440,7 +495,7 @@ struct BudgetStoreBankSyncTests {
         #expect(cachedBalance == nil)
         #expect(try rows(path: url).count == 1)
     }
-    
+
     @Test func aSyncStampsLastSyncAndStatusForTheWebUI() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
@@ -508,7 +563,7 @@ struct BudgetStoreBankSyncTests {
 
         let result = try await store.syncBankAccounts()
 
-        #expect(result.added == 1)
+        #expect(result.added == 2)  // the download and the opening balance
         #expect(result.accountsSynced == 1)
         #expect(result.problems.isEmpty)
         #expect(store.serverProvidesBankSync)
@@ -528,10 +583,11 @@ struct BudgetStoreBankSyncTests {
         let store = try await makeServerStore(database: database, bodies: [
             "/simplefin/status": #"{"status":"ok","data":{"configured":false}}"#
         ])
-        try? SimpleFINCredentials.clear()
 
-        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-            _ = try await store.syncBankAccounts()
+        try await withoutStoredAccessKey {
+            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+                _ = try await store.syncBankAccounts()
+            }
         }
         #expect(!store.serverProvidesBankSync)
     }
@@ -542,10 +598,11 @@ struct BudgetStoreBankSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeServerStore(database: database, bodies: [:])
-        try? SimpleFINCredentials.clear()
 
-        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-            _ = try await store.syncBankAccounts()
+        try await withoutStoredAccessKey {
+            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+                _ = try await store.syncBankAccounts()
+            }
         }
     }
 

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -463,9 +463,7 @@ struct BudgetStoreBankSyncTests {
     /// A `YYYY-MM-DD` string the sync window will accept, however long this
     /// test lives.
     private static func isoDaysAgo(_ days: Int) -> String {
-        BankSyncReconciler.isoString(
-            from: BankSyncReconciler.day(Transaction.yyyymmdd(from: Date()), offsetBy: -days)
-        )
+        DayDate.today().adding(days: -days).iso
     }
 
     private func makeServerStore(

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -1,0 +1,383 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// Serves one canned SimpleFIN account set to every request.
+private final class BridgeTransport: URLProtocol {
+    nonisolated(unsafe) static var body = ""
+    nonisolated(unsafe) static var requestedURLs: [URL] = []
+
+    static func makeSession(body: String) -> URLSession {
+        Self.body = body
+        Self.requestedURLs = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BridgeTransport.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestedURLs.append(request.url!)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+@Suite(.serialized)
+struct BudgetStoreBankSyncTests {
+
+    private static let accountId = "acct-1"
+    private static let externalAccountId = "sf-acct-1"
+
+    /// Timestamps relative to now, so the download always lands inside the
+    /// 90-day sync window however long this test lives.
+    private static func daysAgo(_ days: Int) -> Int {
+        Int(Date().timeIntervalSince1970) - days * 86_400
+    }
+
+    private static func expectedDay(_ days: Int) -> Int {
+        SimpleFINAmount.day(fromTimestamp: daysAgo(days))
+    }
+
+    private func accountSet(
+        balance: String = "100.00",
+        transactions: String
+    ) -> String {
+        """
+        {"errors": [], "accounts": [{
+          "org": {"domain": "mybank.com", "name": "My Bank"},
+          "id": "\(Self.externalAccountId)",
+          "name": "Checking",
+          "currency": "USD",
+          "balance": "\(balance)",
+          "balance-date": \(Self.daysAgo(0)),
+          "transactions": [\(transactions)]
+        }]}
+        """
+    }
+
+    private func makeDatabase(seedTransactions: Bool = false) throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    account_id TEXT,
+                    account_sync_source TEXT,
+                    bank TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    schedule TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY, name TEXT, transfer_acct TEXT, tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: "CREATE TABLE payee_mapping (id TEXT PRIMARY KEY, targetId TEXT)")
+            try db.execute(sql: """
+                CREATE TABLE banks (
+                    id TEXT PRIMARY KEY, bank_id TEXT, name TEXT, tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order,
+                                      account_id, account_sync_source)
+                VALUES (?, 'Checking', 'checking', 0, 0, 0, 1, ?, 'simpleFin')
+                """, arguments: [Self.accountId, Self.externalAccountId])
+            if seedTransactions {
+                try db.execute(sql: """
+                    INSERT INTO transactions (id, acct, date, amount, cleared, tombstone, sort_order)
+                    VALUES ('tx-manual', ?, ?, -3345, 0, 0, 1)
+                    """, arguments: [Self.accountId, Self.expectedDay(6)])
+            }
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase, responseBody: String) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        store.setSimpleFINClientForTesting(
+            SimpleFINClient(session: BridgeTransport.makeSession(body: responseBody))
+        )
+        await store.loadBankSyncAccounts()
+        return store
+    }
+
+    private func rows(path: URL, where clause: String = "1=1") throws -> [Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions WHERE \(clause) ORDER BY date, amount")
+        }
+    }
+
+    private func withStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
+        try SimpleFINCredentials.save(
+            SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
+        )
+        defer { try? SimpleFINCredentials.clear() }
+        return try await body()
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Tests
+
+    @Test func linkedAccountsAreDiscoveredFromTheBudgetFile() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
+
+        #expect(store.bankSyncAccounts.count == 1)
+        let linked = try #require(store.bankSyncAccounts.first)
+        #expect(linked.id == Self.accountId)
+        #expect(linked.externalAccountId == Self.externalAccountId)
+        #expect(linked.source == .simpleFin)
+    }
+
+    @Test func firstSyncImportsTransactionsAndAnOpeningBalance() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45",
+             "payee": "Blue Bottle", "description": "BLUE BOTTLE COFFEE"},
+            {"id": "sf-2", "posted": 0, "pending": true, "transacted_at": \(Self.daysAgo(1)),
+             "amount": "-12.00", "description": "Corner Store"}
+            """))
+
+        let result = try await withStoredAccessKey {
+            try await store.syncBankAccounts()
+        }
+
+        #expect(result.added == 2)
+        #expect(result.updated == 0)
+        #expect(result.accountsSynced == 1)
+        #expect(result.problems.isEmpty)
+
+        let imported = try rows(path: url, where: "financial_id IS NOT NULL")
+        #expect(imported.count == 2)
+        #expect(imported[0]["financial_id"] == "sf-1")
+        #expect(imported[1]["financial_id"] == "sf-2")
+        #expect(imported[0]["amount"] == -3345)
+        #expect(imported[0]["date"] == Self.expectedDay(5))
+        #expect(imported[0]["cleared"] == 1)
+        #expect(imported[0]["imported_description"] == "Blue Bottle")
+        #expect(imported[0]["notes"] == "BLUE BOTTLE COFFEE")
+        // Pending transactions import uncleared, dated when they happened.
+        #expect(imported[1]["cleared"] == 0)
+        #expect(imported[1]["date"] == Self.expectedDay(1))
+        // With no payee of its own, the description names the payee.
+        #expect(imported[1]["imported_description"] == "Corner Store")
+
+        // The balance SimpleFIN reports is current, so what the account opened
+        // with is that balance less everything just imported: 10000 - -4545.
+        let opening = try rows(path: url, where: "starting_balance_flag = 1")
+        #expect(opening.count == 1)
+        #expect(opening[0]["amount"] == 14545)
+        #expect(opening[0]["date"] == Self.expectedDay(5))
+    }
+
+    @Test func syncingAgainImportsNothingTwice() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let body = accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+            """)
+        let store = try await makeStore(database: database, responseBody: body)
+
+        let first = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let second = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(first.added == 1)
+        #expect(second.added == 0)
+        #expect(second.updated == 0)
+        #expect(try rows(path: url, where: "financial_id = 'sf-1'").count == 1)
+    }
+
+    /// A transaction entered by hand before the bank posted it should be
+    /// adopted, not duplicated.
+    @Test func aMatchingLocalTransactionIsAdoptedRatherThanDuplicated() async throws {
+        let (database, url) = try makeDatabase(seedTransactions: true)
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+            """))
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.added == 0)
+        #expect(result.updated == 1)
+
+        let all = try rows(path: url, where: "acct = '\(Self.accountId)' AND starting_balance_flag = 0")
+        #expect(all.count == 1)
+        #expect(all[0]["id"] == "tx-manual")
+        #expect(all[0]["financial_id"] == "sf-1")
+        #expect(all[0]["cleared"] == 1)
+
+        // An account that already had history takes no opening balance.
+        #expect(try rows(path: url, where: "starting_balance_flag = 1").isEmpty)
+    }
+
+    @Test func importedTransactionsGenerateCRDTMessages() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+            """))
+
+        _ = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        let queue = try DatabaseQueue(path: url.path)
+        let financialIdMessages = try await queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM messages_crdt
+                WHERE dataset = 'transactions' AND column = 'financial_id'
+                """) ?? 0
+        }
+        #expect(financialIdMessages == 1)
+    }
+
+    @Test func syncingWithoutAnAccessKeyIsRefused() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
+        try? SimpleFINCredentials.clear()
+
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
+        }
+    }
+
+    @Test func anAccountTheBridgeDoesntReturnIsReportedNotSilentlySkipped() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(
+            database: database, responseBody: #"{"errors": [], "accounts": []}"#
+        )
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.accountsSynced == 0)
+        #expect(result.problems.count == 1)
+        #expect(result.problems[0].contains("Checking"))
+    }
+
+    @Test func bridgeErrorsAreCarriedIntoTheResult() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let body = """
+        {"errors": ["Connection to My Bank may need attention"], "accounts": [{
+          "org": {"domain": "mybank.com", "name": "My Bank"},
+          "id": "\(Self.externalAccountId)", "name": "Checking",
+          "balance": "0.00", "transactions": []
+        }]}
+        """
+        let store = try await makeStore(database: database, responseBody: body)
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.problems == ["Connection to My Bank may need attention"])
+        #expect(result.summary.contains("Connection to My Bank may need attention"))
+    }
+
+    // MARK: - Linking
+
+    @Test func linkingWritesTheColumnsTheWebUIReads() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
+        let remote = try JSONDecoder().decode(SimpleFINAccount.self, from: Data("""
+            {"org": {"domain": "mybank.com", "name": "My Bank"}, "id": "sf-acct-9",
+             "name": "Savings", "balance": "0.00"}
+            """.utf8))
+
+        try await store.linkBankAccount(accountId: Self.accountId, to: remote)
+
+        let queue = try DatabaseQueue(path: url.path)
+        let account = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        })
+        #expect(account["account_id"] == "sf-acct-9")
+        #expect(account["account_sync_source"] == "simpleFin")
+        let bankRowId: String? = account["bank"]
+        #expect(bankRowId != nil)
+
+        let bank = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM banks WHERE id = ?", arguments: [bankRowId])
+        })
+        #expect(bank["bank_id"] == "mybank.com")
+        #expect(bank["name"] == "My Bank")
+    }
+
+    @Test func unlinkingClearsTheColumnsAndLeavesTransactionsBehind() async throws {
+        let (database, url) = try makeDatabase(seedTransactions: true)
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
+
+        try await store.unlinkBankAccount(accountId: Self.accountId)
+
+        let queue = try DatabaseQueue(path: url.path)
+        let account = try #require(try queue.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        })
+        let externalId: String? = account["account_id"]
+        let source: String? = account["account_sync_source"]
+        #expect(externalId == nil)
+        #expect(source == nil)
+        #expect(try rows(path: url).count == 1)
+    }
+}

--- a/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
@@ -125,7 +125,7 @@ struct ServerBankSyncNormalizationTests {
         #"{"transactionId": "t1", "date": "2024-03-01"}"#                          // no amount
     ])
     func skipsTransactionsMissingWhatAnImportNeeds(_ json: String) throws {
-        #expect(BankSyncCandidate(serverBankSync: transaction(json)) == nil)
+        #expect(try BankSyncCandidate(serverBankSync: transaction(json)) == nil)
     }
 
     @Test func isoDatesRoundTrip() {

--- a/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct ServerBankSyncDecodingTests {
+
+    private func decode(_ json: String) throws -> ServerBankSyncDownloads {
+        try JSONDecoder().decode(ServerBankSyncDownloads.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesTheAccountKeyedPayload() throws {
+        let downloads = try decode("""
+        {"sf-1": {"startingBalance": 10023,
+                  "transactions": {"all": [
+                    {"transactionId": "t1", "date": "2024-03-01", "payeeName": "Blue Bottle",
+                     "notes": "BLUE BOTTLE", "booked": true,
+                     "transactionAmount": {"amount": "-33.45", "currency": "USD"}}
+                  ]}},
+         "sf-2": {"startingBalance": 500, "transactions": {"all": []}}}
+        """)
+
+        #expect(downloads.failure == nil)
+        #expect(downloads.errors.isEmpty)
+        #expect(downloads.accounts.count == 2)
+        #expect(downloads.accounts["sf-1"]?.startingBalance == 10023)
+        #expect(downloads.accounts["sf-1"]?.transactions?.all?.count == 1)
+        #expect(downloads.accounts["sf-2"]?.transactions?.all?.isEmpty == true)
+    }
+
+    /// `errors` sits alongside the account keys, so dynamic-key decoding has to
+    /// know not to read it as an account.
+    @Test func separatesPerAccountErrorsFromAccountData() throws {
+        let downloads = try decode("""
+        {"sf-1": {"startingBalance": 100, "transactions": {"all": []}},
+         "errors": {"sf-2": [{"error_type": "ACCOUNT_MISSING", "error_code": "ACCOUNT_MISSING",
+                              "reason": "The account was not found."}]}}
+        """)
+
+        #expect(downloads.accounts.keys.sorted() == ["sf-1"])
+        #expect(downloads.errors["sf-2"]?.first?.errorCode == "ACCOUNT_MISSING")
+        #expect(downloads.errors["sf-2"]?.first?.bankSyncStatus == "account-missing")
+    }
+
+    /// A rejected access key replaces the whole payload with the error object
+    /// rather than putting one inside it.
+    @Test func recognisesAWholeRequestFailure() throws {
+        let downloads = try decode("""
+        {"error_type": "INVALID_ACCESS_TOKEN", "error_code": "INVALID_ACCESS_TOKEN",
+         "status": "rejected", "reason": "Invalid SimpleFIN access token."}
+        """)
+
+        #expect(downloads.failure?.errorCode == "INVALID_ACCESS_TOKEN")
+        #expect(downloads.failure?.bankSyncStatus == "reauth-required")
+        #expect(downloads.accounts.isEmpty)
+    }
+
+    /// An account the bridge didn't return comes back as null.
+    @Test func toleratesANullAccountEntry() throws {
+        let downloads = try decode(#"{"sf-1": null}"#)
+
+        #expect(downloads.accounts.isEmpty)
+        #expect(downloads.failure == nil)
+    }
+
+    @Test(arguments: [
+        ("ITEM_LOGIN_REQUIRED", "reauth-required"),
+        ("ACCOUNT_NEEDS_ATTENTION", "attention-required"),
+        ("RATE_LIMIT_EXCEEDED", "rate-limit-exceeded"),
+        ("TIMED_OUT", "timed-out"),
+        ("SOMETHING_ELSE", "failed")
+    ])
+    func mapsErrorCodesOntoActualsStatusVocabulary(_ code: String, _ expected: String) throws {
+        let downloads = try decode("""
+        {"errors": {"sf-1": [{"error_code": "\(code)"}]}}
+        """)
+
+        #expect(downloads.errors["sf-1"]?.first?.bankSyncStatus == expected)
+    }
+}
+
+struct ServerBankSyncNormalizationTests {
+
+    private func transaction(_ json: String) throws -> ServerBankSyncTransaction {
+        try JSONDecoder().decode(ServerBankSyncTransaction.self, from: Data(json.utf8))
+    }
+
+    @Test func readsTheServersAlreadyNormalizedShape() throws {
+        let candidate = try #require(BankSyncCandidate(serverBankSync: transaction("""
+        {"transactionId": "t1", "date": "2024-03-01", "payeeName": "Blue Bottle",
+         "notes": "BLUE BOTTLE #12", "booked": true,
+         "transactionAmount": {"amount": "-33.45", "currency": "USD"}}
+        """)))
+
+        #expect(candidate.importedId == "t1")
+        #expect(candidate.date == 20240301)
+        #expect(candidate.amount == -3345)
+        #expect(candidate.payeeName == "Blue Bottle")
+        // Hashes are escaped here too, the same as on the direct path.
+        #expect(candidate.notes == "BLUE BOTTLE ##12")
+        #expect(candidate.cleared)
+    }
+
+    @Test func pendingTransactionsStayUncleared() throws {
+        let candidate = try #require(BankSyncCandidate(serverBankSync: transaction("""
+        {"transactionId": "t1", "date": "2024-03-01", "payeeName": "Corner Store",
+         "booked": false, "transactionAmount": {"amount": "-12.00"}}
+        """)))
+
+        #expect(!candidate.cleared)
+    }
+
+    @Test func fallsBackToTheNotesWhenThereIsNoPayeeName() throws {
+        let candidate = try #require(BankSyncCandidate(serverBankSync: transaction("""
+        {"transactionId": "t1", "date": "2024-03-01", "notes": "ACME CORP",
+         "booked": true, "transactionAmount": {"amount": "-1.00"}}
+        """)))
+
+        #expect(candidate.payeeName == "ACME CORP")
+    }
+
+    @Test(arguments: [
+        #"{"date": "2024-03-01", "transactionAmount": {"amount": "-1.00"}}"#,      // no id
+        #"{"transactionId": "t1", "transactionAmount": {"amount": "-1.00"}}"#,     // no date
+        #"{"transactionId": "t1", "date": "not-a-date", "transactionAmount": {"amount": "-1.00"}}"#,
+        #"{"transactionId": "t1", "date": "2024-03-01"}"#                          // no amount
+    ])
+    func skipsTransactionsMissingWhatAnImportNeeds(_ json: String) throws {
+        #expect(BankSyncCandidate(serverBankSync: transaction(json)) == nil)
+    }
+
+    @Test func isoDatesRoundTrip() {
+        #expect(BankSyncReconciler.day(fromISO: "2024-03-01") == 20240301)
+        #expect(BankSyncReconciler.isoString(from: 20240301) == "2024-03-01")
+        #expect(BankSyncReconciler.day(fromISO: "2024-3-1") == 20240301)
+        #expect(BankSyncReconciler.day(fromISO: "2024-03") == nil)
+        #expect(BankSyncReconciler.day(fromISO: "2024-13-01") == nil)
+    }
+}

--- a/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/ServerBankSyncTests.swift
@@ -128,11 +128,4 @@ struct ServerBankSyncNormalizationTests {
         #expect(try BankSyncCandidate(serverBankSync: transaction(json)) == nil)
     }
 
-    @Test func isoDatesRoundTrip() {
-        #expect(BankSyncReconciler.day(fromISO: "2024-03-01") == 20240301)
-        #expect(BankSyncReconciler.isoString(from: 20240301) == "2024-03-01")
-        #expect(BankSyncReconciler.day(fromISO: "2024-3-1") == 20240301)
-        #expect(BankSyncReconciler.day(fromISO: "2024-03") == nil)
-        #expect(BankSyncReconciler.day(fromISO: "2024-13-01") == nil)
-    }
 }

--- a/Actuali/ActualiTests/Services/Database/UpstreamSchemaMigrationTests.swift
+++ b/Actuali/ActualiTests/Services/Database/UpstreamSchemaMigrationTests.swift
@@ -4,7 +4,8 @@ import GRDB
 @testable import Actuali
 
 /// Covers the 26.6.0/26.7.0 upstream migrations mirrored in BudgetDatabase:
-/// tags.hidden, accounts.bank_sync_status, categories.cleanup_def,
+/// tags.hidden, accounts.bank_sync_status, the bank-sync link columns,
+/// categories.cleanup_def,
 /// custom_reports.show_trend_lines, cleanup_groups, transaction indexes —
 /// plus the already-migrated-file guard and CRDT replay into new columns.
 @MainActor
@@ -44,6 +45,8 @@ struct UpstreamSchemaMigrationTests {
 
         #expect(try columnNames(path, table: "tags").contains("hidden"))
         #expect(try columnNames(path, table: "accounts").contains("bank_sync_status"))
+        #expect(try columnNames(path, table: "accounts").contains("account_sync_source"))   // ← add
+        #expect(try columnNames(path, table: "accounts").contains("last_sync"))             // ← add
         #expect(try columnNames(path, table: "categories").contains("cleanup_def"))
         #expect(try columnNames(path, table: "custom_reports").contains("show_trend_lines"))
         #expect(try columnNames(path, table: "schedules").contains("custom_upcoming_length"))

--- a/Actuali/ActualiTests/Services/Database/UpstreamSchemaMigrationTests.swift
+++ b/Actuali/ActualiTests/Services/Database/UpstreamSchemaMigrationTests.swift
@@ -45,8 +45,8 @@ struct UpstreamSchemaMigrationTests {
 
         #expect(try columnNames(path, table: "tags").contains("hidden"))
         #expect(try columnNames(path, table: "accounts").contains("bank_sync_status"))
-        #expect(try columnNames(path, table: "accounts").contains("account_sync_source"))   // ← add
-        #expect(try columnNames(path, table: "accounts").contains("last_sync"))             // ← add
+        #expect(try columnNames(path, table: "accounts").contains("account_sync_source"))
+        #expect(try columnNames(path, table: "accounts").contains("last_sync"))
         #expect(try columnNames(path, table: "categories").contains("cleanup_def"))
         #expect(try columnNames(path, table: "custom_reports").contains("show_trend_lines"))
         #expect(try columnNames(path, table: "schedules").contains("custom_upcoming_length"))

--- a/Actuali/ActualiTests/Services/Network/SimpleFINClientTests.swift
+++ b/Actuali/ActualiTests/Services/Network/SimpleFINClientTests.swift
@@ -1,0 +1,357 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+struct SimpleFINAccessKeyTests {
+
+    @Test func parsesTheProtocolsAccessKeyForm() throws {
+        let key = try SimpleFINAccessKey.parse("https://user123:pass456@bridge.simplefin.org/simplefin")
+
+        #expect(key.username == "user123")
+        #expect(key.password == "pass456")
+        #expect(key.baseURL.absoluteString == "https://bridge.simplefin.org/simplefin")
+    }
+
+    /// Bridge-generated passwords are arbitrary strings, so the split has to
+    /// happen at the last "@" and the first ":", not the other way round.
+    @Test func splitsAroundCredentialsContainingSeparators() throws {
+        let key = try SimpleFINAccessKey.parse("https://user:p@ss:word@bridge.example.com/simplefin")
+
+        #expect(key.username == "user")
+        #expect(key.password == "p@ss:word")
+        #expect(key.baseURL.absoluteString == "https://bridge.example.com/simplefin")
+    }
+
+    @Test func surroundingWhitespaceIsIgnored() throws {
+        let key = try SimpleFINAccessKey.parse("  https://u:p@bridge.example.com/simplefin\n")
+
+        #expect(key.username == "u")
+        #expect(key.raw == "https://u:p@bridge.example.com/simplefin")
+    }
+
+    @Test(arguments: [
+        "",
+        "not-a-url",
+        "https://bridge.example.com/simplefin",       // no credentials
+        "https://user@bridge.example.com/simplefin",  // no password
+        "https://:pass@bridge.example.com/simplefin", // no username
+        // Cleartext is refused outright: the key travels in an Authorization
+        // header and iOS would block the request anyway.
+        "http://user:pass@bridge.example.com/simplefin"
+    ])
+    func rejectsKeysThatArentUsable(_ raw: String) {
+        #expect(throws: SimpleFINError.invalidAccessKey) {
+            _ = try SimpleFINAccessKey.parse(raw)
+        }
+    }
+
+    @Test func basicAuthHeaderIsTheBase64OfUserAndPassword() throws {
+        let key = try SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
+
+        #expect(key.basicAuthHeader == "Basic \(Data("demo:demo".utf8).base64EncodedString())")
+    }
+
+    @Test func setupTokenDecodesToItsClaimURL() throws {
+        let claim = "https://bridge.simplefin.org/simplefin/claim/abc123"
+        let token = Data(claim.utf8).base64EncodedString()
+
+        #expect(try SimpleFINAccessKey.claimURL(fromSetupToken: token).absoluteString == claim)
+    }
+
+    /// Tokens are pasted, so they arrive wrapped and padded in all sorts of ways.
+    @Test func setupTokenSurvivesWrappingWhitespace() throws {
+        let claim = "https://bridge.simplefin.org/simplefin/claim/abc123"
+        let token = Data(claim.utf8).base64EncodedString()
+        let wrapped = "\(token.prefix(8))\n\(token.dropFirst(8))  "
+
+        #expect(try SimpleFINAccessKey.claimURL(fromSetupToken: wrapped).absoluteString == claim)
+    }
+
+    @Test(arguments: [
+        "",
+        "definitely not base64 ****",
+        // Valid base64, but not a URL we'd ever POST to.
+        "aGVsbG8gd29ybGQ=",                                     // "hello world"
+        "aHR0cDovL2JyaWRnZS5leGFtcGxlLmNvbS9jbGFpbQ=="          // http:// claim URL
+    ])
+    func rejectsSetupTokensThatArentClaimURLs(_ token: String) {
+        #expect(throws: SimpleFINError.invalidSetupToken) {
+            _ = try SimpleFINAccessKey.claimURL(fromSetupToken: token)
+        }
+    }
+}
+
+struct SimpleFINAmountTests {
+
+    @Test(arguments: [
+        ("0", 0),
+        ("12", 1200),
+        ("-33.45", -3345),
+        ("+33.45", 3345),
+        ("1234.00", 123_400),
+        // One decimal place is legal in the protocol and means tenths, not
+        // hundredths — the trap a naive "drop the dot" parser falls into.
+        ("12.3", 1230),
+        ("-0.05", -5),
+        // More than two places rounds, halves away from zero.
+        ("1.005", 101),
+        ("-1.005", -101),
+        ("1.004", 100)
+    ])
+    func readsDecimalStringsAsCents(_ raw: String, _ expected: Int) {
+        #expect(SimpleFINAmount.cents(from: raw) == expected)
+    }
+
+    @Test(arguments: ["", "abc", "12abc", "1.2.3", "1-2", "--1", "1 000.00", ".", "+"])
+    func rejectsAnythingThatIsntADecimalString(_ raw: String) {
+        #expect(SimpleFINAmount.cents(from: raw) == nil)
+    }
+
+    /// UTC, not the device's zone, so a transaction imported here lands on the
+    /// same day as the same one imported by the web UI.
+    @Test func datesAreTakenInUTC() {
+        // 2024-03-01T00:30:00Z — the previous day anywhere west of Greenwich.
+        #expect(SimpleFINAmount.day(fromTimestamp: 1_709_253_000) == 20240301)
+        // 2019-06-03T16:40:53Z, the protocol documentation's own example time.
+        #expect(SimpleFINAmount.day(fromTimestamp: 1_559_580_053) == 20190603)
+    }
+
+    @Test func startDatesConvertBackToMidnightUTC() {
+        let timestamp = SimpleFINAmount.timestamp(fromDay: 20240301)
+
+        #expect(timestamp == 1_709_251_200)
+        #expect(SimpleFINAmount.day(fromTimestamp: timestamp) == 20240301)
+    }
+}
+
+struct SimpleFINDecodingTests {
+
+    /// The shape from the protocol documentation's example response.
+    private let sample = """
+    {
+      "errors": ["Connection to Acme Bank may need attention"],
+      "accounts": [
+        {
+          "org": {"domain": "mybank.com", "sfin-url": "https://sfin.mybank.com", "name": "My Bank"},
+          "id": "2930002",
+          "name": "Savings",
+          "currency": "USD",
+          "balance": "100.23",
+          "available-balance": "75.23",
+          "balance-date": 978366153,
+          "transactions": [
+            {
+              "id": "12394832938",
+              "posted": 978366153,
+              "amount": "-33.45",
+              "description": "Uncle Frank's Bait Shop",
+              "payee": "Uncle Frank",
+              "memo": "Worms",
+              "transacted_at": 978360000
+            },
+            {
+              "id": "12394832939",
+              "posted": 0,
+              "amount": "-12.00",
+              "description": "Coffee",
+              "pending": true,
+              "transacted_at": 978370000
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    private func decodeSample() throws -> SimpleFINAccountSet {
+        try JSONDecoder().decode(SimpleFINAccountSet.self, from: Data(sample.utf8))
+    }
+
+    @Test func decodesAccountsAndTheirBalances() throws {
+        let set = try decodeSample()
+
+        #expect(set.errors == ["Connection to Acme Bank may need attention"])
+        #expect(set.accounts.count == 1)
+        let account = try #require(set.accounts.first)
+        #expect(account.id == "2930002")
+        #expect(account.name == "Savings")
+        #expect(account.org.name == "My Bank")
+        #expect(account.org.bankId == "mybank.com")
+        #expect(account.balanceCents == 10023)
+        #expect(account.availableBalance == "75.23")
+        #expect(account.balanceDate == 978_366_153)
+    }
+
+    @Test func booksTransactionsByPostedAndPending() throws {
+        let account = try #require(try decodeSample().accounts.first)
+        let posted = try #require(account.transactions.first)
+        let pending = try #require(account.transactions.last)
+
+        #expect(posted.isBooked)
+        #expect(posted.effectiveTimestamp == 978_366_153)
+        #expect(posted.amountCents == -3345)
+        #expect(posted.payee == "Uncle Frank")
+
+        // Pending transactions have no posted date, so their date comes from
+        // when they happened.
+        #expect(!pending.isBooked)
+        #expect(pending.effectiveTimestamp == 978_370_000)
+    }
+
+    /// A `balances-only` fetch omits `transactions` entirely.
+    @Test func decodesAnAccountWithNoTransactionsKey() throws {
+        let json = """
+        {"accounts": [{"org": {"name": "My Bank"}, "id": "1", "name": "Checking", "balance": "5.00"}]}
+        """
+        let set = try JSONDecoder().decode(SimpleFINAccountSet.self, from: Data(json.utf8))
+
+        #expect(set.errors.isEmpty)
+        #expect(set.accounts.first?.transactions.isEmpty == true)
+        #expect(set.accounts.first?.balanceCents == 500)
+    }
+
+    /// A bridge that sends something other than the protocol's array of
+    /// strings must not cost us the accounts alongside it.
+    @Test func survivesAnUnreadableErrorsField() throws {
+        let json = """
+        {"errors": [{"code": "NEEDS_ATTENTION"}],
+         "accounts": [{"org": {"name": "My Bank"}, "id": "1", "name": "Checking", "balance": "5.00"}]}
+        """
+        let set = try JSONDecoder().decode(SimpleFINAccountSet.self, from: Data(json.utf8))
+
+        #expect(set.errors.isEmpty)
+        #expect(set.accounts.count == 1)
+    }
+}
+
+// MARK: - Transport
+
+private final class SimpleFINTransport: URLProtocol {
+    nonisolated(unsafe) static var requestedURLs: [URL] = []
+    nonisolated(unsafe) static var requestedHeaders: [[String: String]] = []
+    nonisolated(unsafe) static var status = 200
+    nonisolated(unsafe) static var body = ""
+
+    static func reset(status: Int = 200, body: String = "") {
+        requestedURLs = []
+        requestedHeaders = []
+        Self.status = status
+        Self.body = body
+    }
+
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SimpleFINTransport.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestedURLs.append(request.url!)
+        Self.requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: Self.status, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite(.serialized)
+struct SimpleFINClientTests {
+    private let accessKey = try! SimpleFINAccessKey.parse(
+        "https://demo:demo@bridge.example.com/simplefin"
+    )
+
+    private func makeClient() -> SimpleFINClient {
+        SimpleFINClient(session: SimpleFINTransport.makeSession())
+    }
+
+    @Test func claimingPostsToTheTokensURLAndReturnsTheKey() async throws {
+        let claim = "https://bridge.example.com/simplefin/claim/abc"
+        SimpleFINTransport.reset(body: "https://user:pass@bridge.example.com/simplefin")
+
+        let key = try await makeClient().claimAccessKey(
+            setupToken: Data(claim.utf8).base64EncodedString()
+        )
+
+        #expect(SimpleFINTransport.requestedURLs.map(\.absoluteString) == [claim])
+        #expect(key.username == "user")
+        #expect(key.password == "pass")
+    }
+
+    /// The bridge answers a re-used token with 200 and a "Forbidden" body, so
+    /// the status code alone doesn't settle it.
+    @Test func claimingRejectsAnAlreadyClaimedToken() async {
+        SimpleFINTransport.reset(body: "Forbidden: token already claimed")
+        let token = Data("https://bridge.example.com/claim/abc".utf8).base64EncodedString()
+
+        await #expect(throws: SimpleFINError.claimRejected) {
+            _ = try await makeClient().claimAccessKey(setupToken: token)
+        }
+    }
+
+    @Test func claimingRejectsAForbiddenResponse() async {
+        SimpleFINTransport.reset(status: 403, body: "")
+        let token = Data("https://bridge.example.com/claim/abc".utf8).base64EncodedString()
+
+        await #expect(throws: SimpleFINError.claimRejected) {
+            _ = try await makeClient().claimAccessKey(setupToken: token)
+        }
+    }
+
+    @Test func transactionFetchAsksForPendingAndTheNamedAccounts() async throws {
+        SimpleFINTransport.reset(body: #"{"errors":[],"accounts":[]}"#)
+
+        _ = try await makeClient().fetchAccounts(
+            accessKey: accessKey, accountIds: ["a1", "a2"], startDate: 20240301
+        )
+
+        let url = try #require(SimpleFINTransport.requestedURLs.first)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+        #expect(components.path == "/simplefin/accounts")
+        #expect(items.contains(URLQueryItem(name: "start-date", value: "1709251200")))
+        #expect(items.contains(URLQueryItem(name: "pending", value: "1")))
+        #expect(items.filter { $0.name == "account" }.map(\.value) == ["a1", "a2"])
+        #expect(!items.contains { $0.name == "balances-only" })
+        #expect(
+            SimpleFINTransport.requestedHeaders.first?["Authorization"] == accessKey.basicAuthHeader
+        )
+    }
+
+    /// The account picker only needs balances, and asking for transactions
+    /// makes the bridge do work nobody looks at.
+    @Test func balanceOnlyFetchSkipsTransactions() async throws {
+        SimpleFINTransport.reset(body: #"{"errors":[],"accounts":[]}"#)
+
+        _ = try await makeClient().fetchAccounts(accessKey: accessKey)
+
+        let url = try #require(SimpleFINTransport.requestedURLs.first)
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        #expect(items == [URLQueryItem(name: "balances-only", value: "1")])
+    }
+
+    @Test(arguments: [401, 403])
+    func rejectedCredentialsSurfaceAsForbidden(_ status: Int) async {
+        SimpleFINTransport.reset(status: status, body: "")
+
+        await #expect(throws: SimpleFINError.forbidden) {
+            _ = try await makeClient().fetchAccounts(accessKey: accessKey)
+        }
+    }
+
+    @Test func unreadableBodySurfacesAsAnInvalidResponse() async {
+        SimpleFINTransport.reset(body: "<html>not json</html>")
+
+        await #expect(throws: SimpleFINError.invalidResponse) {
+            _ = try await makeClient().fetchAccounts(accessKey: accessKey)
+        }
+    }
+}


### PR DESCRIPTION
## Why

Closes #60: the ask was a bank sync button, so this adds the SimpleFIN integration behind it. Actual already has its own SimpleFIN support, so the main design constraint was making the two agree rather than compete.

## What

- Link accounts to a bank feed and pull transactions, from the accounts tab or from a single account.
- **Uses your server's SimpleFIN connection when it has one**, falling back to a token claimed on the device otherwise. The credential can't be shared (Actual keeps the server's access key in its secrets store, out of the budget file), so preferring the server is what keeps a link made in either place working in both. A `/simplefin` route that 404s means "this server can't do bank sync" and is told apart from a server that can't be reached.
- Links write the same columns the web UI writes — `account_id`, `account_sync_source`, `bank`, plus the `banks` row — and syncs stamp `last_sync` / `bank_sync_status`, so state made here reads correctly there and vice versa.
- Imports match before inserting (provider transaction id → same payee → same amount within 7 days), so a purchase entered by hand before it posted is adopted rather than duplicated. Port of loot-core's `matchTransactions`/`reconcileTransactions` in `server/accounts/sync.ts`; the route shapes follow `sync-server/src/app-simplefin/app-simplefin.js`.
- A newly linked account gets its opening balance worked out from the current balance less the history just imported, matching upstream's initial sync.

## How it was tested

- Unit tests added for the protocol parsing (access keys, setup tokens, decimal amounts, UTC dates), the reconciler's three matching passes and its day arithmetic, both response shapes, and the import end to end against a temp budget file through a stubbed transport — server path and device path.
- Ran the unit suite with Device Hub using iPhone 17 Pro running iOS 27.
- Manually: linked an account with SimpleFIN configured on the server, synced, confirmed the same link and last-synced time in the web UI; re-synced and confirmed nothing duplicated; unlinked and confirmed the columns cleared on both sides.

## Screenshots

<img width="301" alt="Screenshot 2026-08-22 at 1 33 57 PM" src="https://github.com/user-attachments/assets/c75fcf8b-8b34-41aa-ae0b-2158740a9b4b" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-22-2026 at 1 30 59 PM" src="https://github.com/user-attachments/assets/9e5c250a-10bb-4a2d-94f2-e54418f659b3" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-22-2026 at 1 31 05 PM" src="https://github.com/user-attachments/assets/b8b12c12-68dd-4479-97ea-b99185364c2c" />
<img width="301" alt="Screenshot 2026-08-22 at 1 41 25 PM" src="https://github.com/user-attachments/assets/e14ab776-6f16-4220-b3db-1a8f597a0192" />


**The verbiage was created with assistance from AI to provide important detail and clearly define scope**