### PR TITLE
Always Post Scheduled Transactions

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -513,14 +513,10 @@ final class BudgetStore: ObservableObject {
         }
     }
 
-    /// Whether due scheduled transactions are posted automatically after a
-    /// successful sync on launch/foreground. Opt-in (defaults off) because
-    /// every post writes to the user's real Actual server.
-    @Published var postScheduledTransactions: Bool = false {
-        didSet {
-            UserDefaults.standard.set(postScheduledTransactions, forKey: "postScheduledTransactions")
-        }
-    }
+   /// Due scheduled transactions are always posted automatically after a successful sync on launch/foreground. 
+    ///This was previously a user-facing, opt-in toggle (defaulting off); it's now always on and
+    /// no longer configurable or persisted.
+ let postScheduledTransactions: Bool = true
 
     /// Transient toast text ("Posted N scheduled transaction(s)"), cleared
     /// automatically a few seconds after being set. Nil = no toast.

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1131,8 +1131,7 @@ final class BudgetStore: ObservableObject {
             .bool(forKey: "hideClearedTransactions"))
         _hideClosedAccounts = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideClosedAccounts"))
-        _postScheduledTransactions = Published(initialValue: UserDefaults.standard
-            .bool(forKey: "postScheduledTransactions"))
+
 
         let token = loadAndMigrateAuthToken()
 
@@ -4233,9 +4232,8 @@ final class BudgetStore: ObservableObject {
     }
 
     @discardableResult
-    private func postDueSchedulesIfNeeded() async -> Int {
-        guard postScheduledTransactions,
-              let client = syncClient,
+    private func postDueSchedulesIfNeeded() async -> Int {     
+           guard let client = syncClient,
               let database,
               let budgetId = currentBudgetId else { return 0 }
         // Lazy-create; no suspension between this check and the cache write,

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -513,11 +513,6 @@ final class BudgetStore: ObservableObject {
         }
     }
 
-   /// Due scheduled transactions are always posted automatically after a successful sync on launch/foreground. 
-    ///This was previously a user-facing, opt-in toggle (defaulting off); it's now always on and
-    /// no longer configurable or persisted.
- let postScheduledTransactions: Bool = true
-
     /// Transient toast text ("Posted N scheduled transaction(s)"), cleared
     /// automatically a few seconds after being set. Nil = no toast.
     @Published var schedulePostNotice: String?
@@ -1131,7 +1126,6 @@ final class BudgetStore: ObservableObject {
             .bool(forKey: "hideClearedTransactions"))
         _hideClosedAccounts = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideClosedAccounts"))
-
 
         let token = loadAndMigrateAuthToken()
 
@@ -4232,8 +4226,8 @@ final class BudgetStore: ObservableObject {
     }
 
     @discardableResult
-    private func postDueSchedulesIfNeeded() async -> Int {     
-           guard let client = syncClient,
+    private func postDueSchedulesIfNeeded() async -> Int {
+        guard let client = syncClient,
               let database,
               let budgetId = currentBudgetId else { return 0 }
         // Lazy-create; no suspension between this check and the cache write,

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -134,7 +134,6 @@ struct TransactionAutomationSettingsView: View {
                 } label: {
                     Label("Scheduled Transactions", systemImage: "calendar.badge.clock")
                 }
-
             } header: {
                 Text("Scheduled Transactions")
             } footer: {

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -135,11 +135,10 @@ struct TransactionAutomationSettingsView: View {
                     Label("Scheduled Transactions", systemImage: "calendar.badge.clock")
                 }
 
-                Toggle("Post Scheduled Transactions", isOn: $budgetStore.postScheduledTransactions)
             } header: {
                 Text("Scheduled Transactions")
             } footer: {
-                Text("When enabled, scheduled transactions that are due are posted automatically when the app opens — the same as opening the Actual web app. Transactions are created on your server.")
+                Text("Scheduled transactions that are due are posted automatically when the app opens — the same as opening the Actual web app. Transactions are created on your server.")
             }
 
             Section {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSchedulePostingTriggerTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSchedulePostingTriggerTests.swift
@@ -159,14 +159,11 @@ struct BudgetStoreSchedulePostingTriggerTests {
         // carry over between test runs; scrub both UserDefaults keys after.
         let budgetId = "test-\(UUID().uuidString)"
         let savedBudgetId = UserDefaults.standard.string(forKey: "currentBudgetId")
-        let savedToggle = UserDefaults.standard.object(forKey: "postScheduledTransactions")
         defer {
             UserDefaults.standard.set(savedBudgetId, forKey: "currentBudgetId")
-            UserDefaults.standard.set(savedToggle, forKey: "postScheduledTransactions")
             UserDefaults.standard.removeObject(forKey: "lastScheduleRun-\(budgetId)")
         }
         store.currentBudgetId = budgetId
-        store.postScheduledTransactions = true
 
         #expect(try postedTransactionCount(database) == 0)
 


### PR DESCRIPTION
## Why

I'm not sure why anyone would want to turn this option off, as Actual also automatically posts scheduled transactions.

## What

Removes the **Post Scheduled Transaction** option and makes it always enabled.

## How it was tested

Tested on an iPhone 17 Pro simulator.
