### PR TITLE
Change Paintbrush to iphone icon for display settings

### DIFF
--- a/Actuali/Actuali/Views/Settings/SettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
                     NavigationLink {
                         DisplaySettingsView()
                     } label: {
-                        Label("Display", systemImage: "paintbrush")
+                        Label("Display", systemImage: "iphone")
                     }
 
                     NavigationLink {


### PR DESCRIPTION
<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->

## Why

For Display preference the icon was a paintbrush 

## What

Changed paintbrush icon to iphone

## How it was tested

Tested on iphone 17 pro sim
