### PR TITLE
Credit cards UI: compact card rows with urgency borders and due pills

### DIFF
--- a/Actuali/Actuali/Models/CreditCardCycle.swift
+++ b/Actuali/Actuali/Models/CreditCardCycle.swift
@@ -108,12 +108,11 @@ struct CreditCardCycle: Equatable, Hashable {
         return "Due \(dueStr) (\(days)d)"
     }
 
-    /// Compact variant of `dueSummary` for pill badges ("Due in 27d").
+    /// Compact variant of `dueSummary` for pill badges ("Due in 27d"). Defers to
+    /// `dueSummary` within a day of the due date, so the two can't drift on the
+    /// wording that matters most.
     func dueShortSummary(for today: DayDate = .today()) -> String {
-        switch daysUntilDue(for: today) {
-        case 0: "Due today"
-        case 1: "Due tomorrow"
-        case let days: "Due in \(days)d"
-        }
+        let days = daysUntilDue(for: today)
+        return days <= 1 ? dueSummary(for: today) : "Due in \(days)d"
     }
 }

--- a/Actuali/Actuali/Models/CreditCardCycle.swift
+++ b/Actuali/Actuali/Models/CreditCardCycle.swift
@@ -107,4 +107,13 @@ struct CreditCardCycle: Equatable, Hashable {
         let dueStr = Transaction.formattedDate(from: upcomingDueDate(for: today).yyyymmdd, style: .abbreviated)
         return "Due \(dueStr) (\(days)d)"
     }
+
+    /// Compact variant of `dueSummary` for pill badges ("Due in 27d").
+    func dueShortSummary(for today: DayDate = .today()) -> String {
+        switch daysUntilDue(for: today) {
+        case 0: "Due today"
+        case 1: "Due tomorrow"
+        case let days: "Due in \(days)d"
+        }
+    }
 }

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -29,6 +29,7 @@ struct AccountsListView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var path = NavigationPath()
     @State private var showingAddAccount = false
+    @State private var showingCreditCards = false
     @State private var showingPendingImports = false
     @StateObject private var pendingImportStore = PendingImportStore.shared
     /// Split layout only. Starts on All Accounts so the detail column has
@@ -328,6 +329,12 @@ struct AccountsListView: View {
                             }
                             .disabled(budgetStore.isBankSyncing)
                         }
+                        Button {
+                            showingCreditCards = true
+                        } label: {
+                            Label("Credit Cards", systemImage: "creditcard")
+                        }
+                        Divider()
                         Toggle(isOn: $budgetStore.hideClosedAccounts) {
                             Label("Hide Closed", systemImage: "archivebox")
                         }
@@ -376,6 +383,12 @@ struct AccountsListView: View {
             .sheet(isPresented: $showingPendingImports) {
                 PendingImportsView()
                     .environmentObject(budgetStore)
+            }
+            .sheet(isPresented: $showingCreditCards) {
+                NavigationStack {
+                    CreditCardsSettingsView()
+                        .environmentObject(budgetStore)
+                }
             }
             .onAppear {
                 consumePendingAllAccountsNavigation()

--- a/Actuali/Actuali/Views/Accounts/AccountsListView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountsListView.swift
@@ -388,6 +388,11 @@ struct AccountsListView: View {
                 NavigationStack {
                     CreditCardsSettingsView()
                         .environmentObject(budgetStore)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { showingCreditCards = false }
+                            }
+                        }
                 }
             }
             .onAppear {
@@ -466,8 +471,8 @@ struct AccountsListView: View {
 }
 
 /// Green over positive, red over negative, primary at exactly zero — shared
-/// by every balance-displaying view in this file so the three don't drift.
-private func balanceColor(for balance: Int) -> Color {
+/// by every balance-displaying view so the copies don't drift.
+func balanceColor(for balance: Int) -> Color {
     if balance > 0 { return .green }
     if balance < 0 { return .red }
     return .primary

--- a/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
@@ -18,7 +18,7 @@ struct CreditCardsSettingsView: View {
             guard let account = accountsById[accountId],
                   let cycle = budgetStore.creditCardCycle(for: accountId) else { return nil }
             return (account: account, cycle: cycle)
-        }.sorted { $0.account.name < $1.account.name }
+        }.sorted { $0.cycle.daysUntilDue() < $1.cycle.daysUntilDue() }
     }
 
     private var unconfiguredAccounts: [Account] {
@@ -30,15 +30,10 @@ struct CreditCardsSettingsView: View {
 
     var body: some View {
         List {
-            Section {
-                Text("Mark accounts as credit cards and track their monthly billing cycles, cycle spend, and upcoming payment due dates.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-
             Section("Configured Credit Cards") {
                 if configuredCards.isEmpty {
-                    Text("No credit cards configured yet.")
+                    Text("Mark accounts as credit cards and track their monthly billing cycles, cycle spend, and upcoming payment due dates.")
+                        .font(.footnote)
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(configuredCards, id: \.account.id) { item in
@@ -52,6 +47,13 @@ struct CreditCardsSettingsView: View {
                             CreditCardCycleRow(account: item.account, cycle: item.cycle)
                         }
                         .buttonStyle(.plain)
+                        .listRowBackground(
+                            CreditCardCycleRow.cardBackground(
+                                daysUntilDue: item.cycle.daysUntilDue()
+                            )
+                        )
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: 5, leading: 16, bottom: 5, trailing: 16))
                     }
                     .onDelete(perform: deleteCard)
                 }
@@ -197,7 +199,9 @@ struct CreditCardsSettingsView: View {
     }
 }
 
-/// Row displaying card balance, current billing cycle dates, cycle spend, and payment due date.
+/// Compact card row: name + balance on top, spend + due pill on bottom.
+/// The colored left border and card background are applied by the parent via
+/// `listRowBackground` using `cardBackground(daysUntilDue:)`.
 private struct CreditCardCycleRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let account: Account
@@ -209,44 +213,74 @@ private struct CreditCardCycleRow: View {
         cycle.cycleRange()
     }
 
-    private var cycleDateText: String {
-        let startStr = Transaction.formattedDate(from: cycleRange.start.yyyymmdd, style: .abbreviated)
-        let endStr = Transaction.formattedDate(from: cycleRange.end.yyyymmdd, style: .abbreviated)
-        return "\(startStr) – \(endStr)"
+    /// Urgency color: red ≤3d, orange ≤7d, yellow otherwise.
+    private static func urgencyColor(days: Int) -> Color {
+        if days <= 3 { return .red }
+        if days <= 7 { return .orange }
+        return .yellow
+    }
+
+    private var dueColor: Color {
+        Self.urgencyColor(days: cycle.daysUntilDue())
+    }
+
+    private var balanceColor: Color {
+        if account.balance > 0 { return .green }
+        if account.balance < 0 { return .red }
+        return .primary
+    }
+
+    /// Short due text for the pill badge.
+    private var duePillText: String {
+        let days = cycle.daysUntilDue()
+        if days == 0 { return "Due today" }
+        if days == 1 { return "Tomorrow" }
+        return "Due in \(days)d"
+    }
+
+    /// Card background with a colored left urgency border strip.
+    @MainActor static func cardBackground(daysUntilDue days: Int) -> some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color(.secondarySystemGroupedBackground))
+            .overlay(alignment: .leading) {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 10, bottomLeadingRadius: 10,
+                    bottomTrailingRadius: 0, topTrailingRadius: 0
+                )
+                .fill(urgencyColor(days: days))
+                .frame(width: 3)
+            }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
+        VStack(alignment: .leading, spacing: 3) {
+            // Row 1: name + balance
+            HStack(alignment: .firstTextBaseline) {
                 Text(account.name)
-                    .font(.headline)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
                 Spacer()
                 Text(budgetStore.displayBalance(account.balance))
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(account.balance < 0 ? .red : .primary)
+                    .foregroundStyle(balanceColor)
             }
 
+            // Row 2: cycle spend + due pill
             HStack {
-                Label(cycleDateText, systemImage: "calendar")
+                Text("Spend \(budgetStore.displayBalance(cycleSpend))")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
-                Text("\(cycle.daysRemainingInCycle())d left")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack {
-                Label("Cycle spend: \(budgetStore.displayBalance(cycleSpend))", systemImage: "cart")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Label(cycle.dueSummary(), systemImage: "clock")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.orange)
+                Text(duePillText)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(dueColor.opacity(0.15))
+                    .foregroundStyle(dueColor)
+                    .clipShape(Capsule())
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 2)
         // dataVersion is in the key so a transaction landing while this screen
         // is open refreshes the spend, the way AccountDetailView's reload does.
         .task(id: [cycle.statementDay, budgetStore.dataVersion]) {

--- a/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
@@ -14,12 +14,25 @@ struct CreditCardsSettingsView: View {
 
     private var configuredCards: [(account: Account, cycle: CreditCardCycle)] {
         let accountsById = Dictionary(uniqueKeysWithValues: budgetStore.accounts.map { ($0.id, $0) })
-        return budgetStore.activeCreditCardStatementDays.compactMap { accountId, _ in
+        return Self.sortedCards(budgetStore.activeCreditCardStatementDays.compactMap { accountId, _ in
             guard let account = accountsById[accountId],
                   let cycle = budgetStore.creditCardCycle(for: accountId) else { return nil }
             return (account: account, cycle: cycle)
-        }.sorted {
-            ($0.cycle.daysUntilDue(), $0.account.name) < ($1.cycle.daysUntilDue(), $1.account.name)
+        })
+    }
+
+    /// Soonest payment first. The name tie-break is what makes this a total
+    /// order: `daysUntilDue` clamps at 0, so every past-due card ties there, and
+    /// the input arrives from a `Dictionary` whose order is reseeded per launch.
+    /// `today` is sampled once rather than per comparison so the ordering can't
+    /// change underneath `sorted` at midnight.
+    nonisolated static func sortedCards(
+        _ cards: [(account: Account, cycle: CreditCardCycle)],
+        today: DayDate = .today()
+    ) -> [(account: Account, cycle: CreditCardCycle)] {
+        cards.sorted {
+            ($0.cycle.daysUntilDue(for: today), $0.account.name)
+                < ($1.cycle.daysUntilDue(for: today), $1.account.name)
         }
     }
 
@@ -38,7 +51,12 @@ struct CreditCardsSettingsView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(configuredCards, id: \.account.id) { item in
+                    // Bound once so the delete closure indexes the exact array
+                    // the rows were built from. The sort key is a day count, so
+                    // recomputing it inside the closure could reorder the list
+                    // out from under a swipe that started before midnight.
+                    let cards = configuredCards
+                    ForEach(cards, id: \.account.id) { item in
                         Button {
                             selectedAccountId = item.account.id
                             selectedStatementDay = item.cycle.statementDay
@@ -57,7 +75,11 @@ struct CreditCardsSettingsView: View {
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets(top: 5, leading: 16, bottom: 5, trailing: 16))
                     }
-                    .onDelete(perform: deleteCard)
+                    .onDelete { offsets in
+                        for accountId in offsets.map({ cards[$0].account.id }) {
+                            budgetStore.setCreditCard(accountId: accountId, statementDay: nil)
+                        }
+                    }
                 }
             }
 
@@ -87,13 +109,6 @@ struct CreditCardsSettingsView: View {
             set: { if !$0 { editingAccountId = nil } }
         )) {
             cardSheet(isEditing: true)
-        }
-    }
-
-    private func deleteCard(at offsets: IndexSet) {
-        let cards = configuredCards
-        for accountId in offsets.map({ cards[$0].account.id }) {
-            budgetStore.setCreditCard(accountId: accountId, statementDay: nil)
         }
     }
 
@@ -204,7 +219,7 @@ struct CreditCardsSettingsView: View {
 /// Compact card row: name + balance on top, spend + due pill on bottom.
 /// The colored left border and card background are applied by the parent via
 /// `listRowBackground` using `cardBackground(daysUntilDue:)`.
-private struct CreditCardCycleRow: View {
+struct CreditCardCycleRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let account: Account
     let cycle: CreditCardCycle
@@ -215,8 +230,11 @@ private struct CreditCardCycleRow: View {
         cycle.cycleRange()
     }
 
-    /// Urgency color: red ≤3d, orange ≤7d, yellow otherwise.
-    nonisolated private static func urgencyColor(days: Int) -> Color {
+    /// Urgency color: red ≤3d, orange ≤7d, yellow otherwise. Used at full
+    /// strength for the border strip and heavily faded behind the pill — the
+    /// pill's own text stays `.primary`, because system yellow on a light
+    /// background is about 1.4:1 and unreadable at caption size.
+    nonisolated static func urgencyColor(days: Int) -> Color {
         if days <= 3 { return .red }
         if days <= 7 { return .orange }
         return .yellow
@@ -261,14 +279,23 @@ private struct CreditCardCycleRow: View {
                 Spacer()
                 Text(cycle.dueShortSummary())
                     .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.primary)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
-                    .background(dueColor.opacity(0.15))
-                    .foregroundStyle(dueColor)
-                    .clipShape(Capsule())
+                    .background(dueColor.opacity(0.22), in: .capsule)
+                    // The pill is the actionable half of this line, so the
+                    // spend text takes the squeeze at large Dynamic Type sizes.
+                    .fixedSize()
             }
         }
         .padding(.vertical, 2)
+        // One element per card, worded like AccountDetailView's billing cycle
+        // header — the long `dueSummary` carries the date the pill drops.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "\(account.name), balance \(budgetStore.displayBalance(account.balance)), "
+                + "cycle spend \(budgetStore.displayBalance(cycleSpend)), \(cycle.dueSummary())"
+        )
         // dataVersion is in the key so a transaction landing while this screen
         // is open refreshes the spend, the way AccountDetailView's reload does.
         .task(id: [cycle.statementDay, budgetStore.dataVersion]) {

--- a/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
@@ -18,7 +18,9 @@ struct CreditCardsSettingsView: View {
             guard let account = accountsById[accountId],
                   let cycle = budgetStore.creditCardCycle(for: accountId) else { return nil }
             return (account: account, cycle: cycle)
-        }.sorted { $0.cycle.daysUntilDue() < $1.cycle.daysUntilDue() }
+        }.sorted {
+            ($0.cycle.daysUntilDue(), $0.account.name) < ($1.cycle.daysUntilDue(), $1.account.name)
+        }
     }
 
     private var unconfiguredAccounts: [Account] {
@@ -214,7 +216,7 @@ private struct CreditCardCycleRow: View {
     }
 
     /// Urgency color: red ≤3d, orange ≤7d, yellow otherwise.
-    private static func urgencyColor(days: Int) -> Color {
+    nonisolated private static func urgencyColor(days: Int) -> Color {
         if days <= 3 { return .red }
         if days <= 7 { return .orange }
         return .yellow
@@ -224,22 +226,8 @@ private struct CreditCardCycleRow: View {
         Self.urgencyColor(days: cycle.daysUntilDue())
     }
 
-    private var balanceColor: Color {
-        if account.balance > 0 { return .green }
-        if account.balance < 0 { return .red }
-        return .primary
-    }
-
-    /// Short due text for the pill badge.
-    private var duePillText: String {
-        let days = cycle.daysUntilDue()
-        if days == 0 { return "Due today" }
-        if days == 1 { return "Tomorrow" }
-        return "Due in \(days)d"
-    }
-
     /// Card background with a colored left urgency border strip.
-    @MainActor static func cardBackground(daysUntilDue days: Int) -> some View {
+    nonisolated static func cardBackground(daysUntilDue days: Int) -> some View {
         RoundedRectangle(cornerRadius: 10)
             .fill(Color(.secondarySystemGroupedBackground))
             .overlay(alignment: .leading) {
@@ -262,16 +250,16 @@ private struct CreditCardCycleRow: View {
                 Spacer()
                 Text(budgetStore.displayBalance(account.balance))
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(balanceColor)
+                    .foregroundStyle(balanceColor(for: account.balance))
             }
 
-            // Row 2: cycle spend + due pill
+            // Row 2: cycle spend + days left + due pill
             HStack {
-                Text("Spend \(budgetStore.displayBalance(cycleSpend))")
+                Text("Spend \(budgetStore.displayBalance(cycleSpend)) · \(cycle.daysRemainingInCycle())d left")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
-                Text(duePillText)
+                Text(cycle.dueShortSummary())
                     .font(.caption2.weight(.semibold))
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -152,6 +152,14 @@ struct CreditCardCycleTests {
         #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 20)).hasSuffix("(10d)"))
     }
 
+    @Test func dueShortSummaryMatchesTheLongFormNearTheDueDate() {
+        let cycle = CreditCardCycle(statementDay: 15)
+        // Feb 15 statement + 15 days = Mar 2, 2026.
+        #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 3, day: 2)) == "Due today")
+        #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 3, day: 1)) == "Due tomorrow")
+        #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due in 10d")
+    }
+
     // MARK: - Store Persistence
 
     /// Points the store at throwaway budget ids and clears every key they touch,

--- a/Actuali/ActualiTests/Views/CreditCardsSettingsViewTests.swift
+++ b/Actuali/ActualiTests/Views/CreditCardsSettingsViewTests.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Testing
+
+@testable import Actuali
+
+/// The Credit Cards list orders by urgency rather than by name, and colors each
+/// row off the same day count. Both are pure functions so they can be pinned to
+/// a fixed `today` here instead of whatever day the suite happens to run on.
+@Suite("Credit cards settings")
+struct CreditCardsSettingsViewTests {
+    private func account(_ name: String) -> Account {
+        Account(id: name, name: name, type: .credit, offBudget: false, closed: false, sortOrder: 0, balance: 0)
+    }
+
+    // MARK: - Sort order
+
+    /// Feb 20 2026, statement day 15, default 15-day offset: the Feb 15
+    /// statement is due Mar 2, ten days out. Statement day 25 is still mid-cycle
+    /// on Feb 20, so its next payment is the Feb 25 statement, due Mar 12.
+    @Test func sortsBySoonestPaymentNotByName() {
+        let today = DayDate(year: 2026, month: 2, day: 20)
+        let soon = CreditCardCycle(statementDay: 15)
+        let later = CreditCardCycle(statementDay: 25)
+        #expect(soon.daysUntilDue(for: today) == 10)
+        #expect(later.daysUntilDue(for: today) == 20)
+
+        let sorted = CreditCardsSettingsView.sortedCards(
+            [(account: account("Alpha"), cycle: later), (account: account("Zeta"), cycle: soon)],
+            today: today
+        )
+        #expect(sorted.map(\.account.name) == ["Zeta", "Alpha"])
+    }
+
+    /// `daysUntilDue` clamps at 0, so past-due cards all tie there. Without the
+    /// name tie-break the surviving order comes from a Dictionary, which Swift
+    /// reseeds every launch.
+    @Test func breaksTiesByNameSoTheOrderIsStable() {
+        let today = DayDate(year: 2026, month: 2, day: 20)
+        let cycle = CreditCardCycle(statementDay: 15)
+        let cards = [
+            (account: account("Zeta"), cycle: cycle),
+            (account: account("Alpha"), cycle: cycle),
+            (account: account("Mid"), cycle: cycle),
+        ]
+        #expect(CreditCardsSettingsView.sortedCards(cards, today: today).map(\.account.name)
+            == ["Alpha", "Mid", "Zeta"])
+        // Same set, different input order, same result.
+        #expect(CreditCardsSettingsView.sortedCards(cards.reversed(), today: today).map(\.account.name)
+            == ["Alpha", "Mid", "Zeta"])
+    }
+
+    @Test func sortingAnEmptyListIsEmpty() {
+        #expect(CreditCardsSettingsView.sortedCards([]).isEmpty)
+    }
+
+    // MARK: - Urgency color
+
+    @Test func urgencyColorSwitchesAtThreeAndSevenDays() {
+        #expect(CreditCardCycleRow.urgencyColor(days: 0) == .red)
+        #expect(CreditCardCycleRow.urgencyColor(days: 3) == .red)
+        #expect(CreditCardCycleRow.urgencyColor(days: 4) == .orange)
+        #expect(CreditCardCycleRow.urgencyColor(days: 7) == .orange)
+        #expect(CreditCardCycleRow.urgencyColor(days: 8) == .yellow)
+        #expect(CreditCardCycleRow.urgencyColor(days: 60) == .yellow)
+    }
+}


### PR DESCRIPTION
## Why

The credit cards settings screen was bulky — each card took 3 lines with cycle date ranges and SF Symbol icons, requiring lots of scrolling with 9+ cards. Cards were sorted alphabetically, burying urgent due dates.

## What

- Sort cards by due date (soonest first) so the most actionable card is always on top
- Compact 2-line layout: name + balance, spend + due pill badge (was 3 lines with icons)
- Colored left border strip for at-a-glance urgency (red ≤3d, orange ≤7d, yellow)
- Green balance color for overpayments (was white/primary)
- Description banner moved to empty state only
- Credit Cards shortcut added to accounts triple-dot menu for quick access

## How it was tested

Visual review on device. No behavior changes to data or sync — purely UI.