### PR TITLE
GH-352: Add showCategoryStatusDots user preference

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -330,6 +330,14 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether Budget rows show their compact category-status dot.
+    /// Persisted to UserDefaults, defaults to on.
+    @Published var showCategoryStatusDots: Bool = true {
+        didSet {
+            UserDefaults.standard.set(showCategoryStatusDots, forKey: "showCategoryStatusDots")
+        }
+    }
+
     /// Whether Budget shows the status filter strip above the category list.
     /// Persisted to UserDefaults, defaults to on. It costs a row of vertical
     /// space on a phone, so a budget that never needs the filters can reclaim
@@ -1065,6 +1073,8 @@ final class BudgetStore: ObservableObject {
         _uncategorizedTapAction = Published(initialValue: UncategorizedTapAction.persisted)
         _showBudgetProgressBars = Published(initialValue: UserDefaults.standard
             .object(forKey: "showBudgetProgressBars") as? Bool ?? true)
+        _showCategoryStatusDots = Published(initialValue: UserDefaults.standard
+            .object(forKey: "showCategoryStatusDots") as? Bool ?? true)
         _showGroupTotals = Published(initialValue: UserDefaults.standard
             .object(forKey: "showGroupTotals") as? Bool ?? true)
         _showBudgetCheckInStrip = Published(initialValue: UserDefaults.standard

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -791,7 +791,9 @@ struct CategoryBudgetRow: View {
                     onShowDetails(category)
                 } label: {
                     HStack(spacing: 5) {
-                        CompactCategoryStatusDot(state: category.progressState)
+                        if budgetStore.showCategoryStatusDots {
+                            CompactCategoryStatusDot(state: category.progressState)
+                        }
                         TwoLineName(
                             text: category.categoryName,
                             font: .subheadline,
@@ -876,7 +878,9 @@ struct CleanCategoryBudgetRow: View {
                     onShowDetails(category)
                 } label: {
                     HStack(spacing: 6) {
-                        CompactCategoryStatusDot(state: category.progressState)
+                        if budgetStore.showCategoryStatusDots {
+                            CompactCategoryStatusDot(state: category.progressState)
+                        }
                         Text(category.categoryName)
                             .font(.body)
                     }
@@ -1545,6 +1549,7 @@ struct CompactCategoryStatusDot: View {
             .fill(state.tint)
             .frame(width: 7, height: 7)
             .accessibilityLabel(state.statusText)
+            .accessibilityIdentifier("categoryStatusDot")
     }
 }
 

--- a/Actuali/Actuali/Views/Settings/BudgetViewSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/BudgetViewSettingsView.swift
@@ -20,6 +20,7 @@ struct BudgetViewSettingsView: View {
 
                 Toggle("Status Filters", isOn: $budgetStore.showBudgetCheckInStrip)
                 Toggle("Hide Spent Categories", isOn: $budgetStore.hideZeroBudgetCategories)
+                Toggle("Category Status Dots", isOn: $budgetStore.showCategoryStatusDots)
                 Toggle("Budget Progress Bars", isOn: $budgetStore.showBudgetProgressBars)
                 Toggle("Overspent Badge", isOn: $budgetStore.showOverspentBadge)
             } header: {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCategoryStatusDotsTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCategoryStatusDotsTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetStoreCategoryStatusDotsTests {
+
+    @Test func categoryStatusDotsShowByDefault() {
+        #expect(BudgetStore.previewInstance().showCategoryStatusDots)
+    }
+
+    @Test func togglePersistsToUserDefaults() {
+        let key = "showCategoryStatusDots"
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved {
+                UserDefaults.standard.set(saved, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let store = BudgetStore.previewInstance()
+        store.showCategoryStatusDots = false
+        #expect(UserDefaults.standard.object(forKey: key) as? Bool == false)
+        store.showCategoryStatusDots = true
+        #expect(UserDefaults.standard.object(forKey: key) as? Bool == true)
+    }
+}

--- a/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
+++ b/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
@@ -11,6 +11,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
         showGroupTotals: Bool = true,
         showBudgetCheckInStrip: Bool = true,
         hideZeroBudgetCategories: Bool = false,
+        showCategoryStatusDots: Bool = true,
         showBudgetProgressBars: Bool = true
     ) -> XCUIApplication {
         let app = XCUIApplication()
@@ -21,6 +22,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
             "-showGroupTotals", showGroupTotals ? "YES" : "NO",
             "-showBudgetCheckInStrip", showBudgetCheckInStrip ? "YES" : "NO",
             "-hideZeroBudgetCategories", hideZeroBudgetCategories ? "YES" : "NO",
+            "-showCategoryStatusDots", showCategoryStatusDots ? "YES" : "NO",
             "-showBudgetProgressBars", showBudgetProgressBars ? "YES" : "NO",
         ]
         app.launch()
@@ -182,6 +184,38 @@ final class BudgetViewSettingsUITests: XCTestCase {
         XCTAssertTrue(
             firstBudgetProgressBar(in: app).waitForExistence(timeout: 5),
             "Turning Budget Progress Bars back on should restore them"
+        )
+    }
+
+    @MainActor
+    func testCategoryStatusDotsToggleControlsBudgetRows() throws {
+        let app = launchSettings(showCategoryStatusDots: true)
+        openBudgetViewSettings(in: app)
+
+        let toggle = app.switches["Category Status Dots"]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5), "Category Status Dots toggle not found")
+
+        app.tabBars.buttons["Budget"].tap()
+        let statusDot = app.descendants(matching: .any)["categoryStatusDot"].firstMatch
+        XCTAssertTrue(
+            statusDot.waitForExistence(timeout: 10),
+            "The demo budget should start with visible category status dots"
+        )
+
+        openBudgetViewSettings(in: app)
+        tapSwitch(toggle)
+        app.tabBars.buttons["Budget"].tap()
+        XCTAssertTrue(
+            statusDot.waitForNonExistence(timeout: 5),
+            "Turning Category Status Dots off should remove them from category rows"
+        )
+
+        openBudgetViewSettings(in: app)
+        tapSwitch(toggle)
+        app.tabBars.buttons["Budget"].tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["categoryStatusDot"].firstMatch.waitForExistence(timeout: 5),
+            "Turning Category Status Dots back on should restore them"
         )
     }
 }


### PR DESCRIPTION
## Why

Give users the option to reduce visual noise in budget category rows by hiding the compact status dots. Closes #352.

## What

- Added a persisted Category Status Dots toggle under Settings -> Budget View.
- Applied the setting to both Clean and Detailed budget row styles.
- Status dots remain visible by default to preserve existing behavior.

## How it was tested

- Added unit tests covering the default value and `UserDefaults` persistence.
- Added a UI test verifying the dots can be hidden and restored.
- Ran the full unit suite on an iPhone 17 Pro simulator: 1,373 tests passed.
- Ran the focused UI test successfully.