### PR TITLE
Hide and show budget categories

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -15,6 +15,19 @@ struct BudgetMonth: Identifiable, Hashable {
     /// for envelope budgets — nil for tracking budgets.
     var toBudget: Int?
 
+    /// Hidden rows stay available to the Budget tab without changing the
+    /// visible-row totals or leaking into widgets and intents.
+    var hiddenCategoryBudgets: [CategoryBudget] = []
+    var hiddenIncomeCategories: [IncomeCategory] = []
+
+    var allCategoryBudgets: [CategoryBudget] {
+        categoryBudgets + hiddenCategoryBudgets
+    }
+
+    var allIncomeCategories: [IncomeCategory] {
+        incomeCategories + hiddenIncomeCategories
+    }
+
     var isTrackingBudget: Bool {
         toBudget == nil
     }
@@ -73,6 +86,10 @@ struct IncomeCategory: Identifiable, Hashable {
     var sortOrder: Double
     var budgeted: Int // In cents; only meaningful for tracking budgets
     var received: Int // In cents (positive when money came in)
+    var hidden = false
+    var groupHidden = false
+
+    var isEffectivelyHidden: Bool { hidden || groupHidden }
 }
 
 struct CategoryBudget: Identifiable, Hashable {
@@ -88,6 +105,10 @@ struct CategoryBudget: Identifiable, Hashable {
     var spent: Int // In cents (negative value, net of inflows)
     var available: Int // In cents (budgeted + spent + carryover)
     var carryover: Int
+    var hidden = false
+    var groupHidden = false
+
+    var isEffectivelyHidden: Bool { hidden || groupHidden }
 
     var isOverspent: Bool {
         available < 0

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -462,7 +462,13 @@ final class BudgetStore: ObservableObject {
     /// exactly-zero available drops out: overspent (negative) categories stay
     /// visible so problems that need fixing are never masked.
     func visibleCategoryBudgets(_ categories: [CategoryBudget]) -> [CategoryBudget] {
-        hideZeroBudgetCategories ? categories.filter { $0.available != 0 } : categories
+        let visible = categories.filter { !$0.isEffectivelyHidden }
+        let filtered = hideZeroBudgetCategories
+            ? visible.filter { $0.available != 0 }
+            : visible
+        return showHiddenCategories
+            ? filtered + categories.filter(\.isEffectivelyHidden)
+            : filtered
     }
 
     /// Closed accounts the Accounts list should show — none when the hide
@@ -1675,13 +1681,7 @@ final class BudgetStore: ObservableObject {
             let fetchedGroups = try await openedDb.fetchCategoryGroups()
             let fetchedPayees = try await openedDb.fetchPayees()
             let currentMonth = currentMonthString()
-            let fetchedBudgetMonth = try await openedDb.fetchBudgetMonth(
-                month: currentMonth,
-                includeHiddenCategories: showHiddenCategories
-            )
-            let fetchedWidgetBudgetMonth = showHiddenCategories
-                ? try await openedDb.fetchBudgetMonth(month: currentMonth)
-                : fetchedBudgetMonth
+            let fetchedBudgetMonth = try await openedDb.fetchBudgetMonth(month: currentMonth)
 
             // If a concurrent load replaced the database while we were
             // fetching (e.g. demo seed during launch), drop our stale snapshot.
@@ -1716,7 +1716,7 @@ final class BudgetStore: ObservableObject {
                 requestedBudgetMonth = currentMonth
                 currentBudgetMonth = fetchedBudgetMonth
             }
-            widgetBudgetMonth = fetchedWidgetBudgetMonth
+            widgetBudgetMonth = fetchedBudgetMonth
             dataVersion += 1
             publishWidgetSnapshot()
 
@@ -1857,12 +1857,9 @@ final class BudgetStore: ObservableObject {
             // with the current calendar month while the toolbar still shows
             // the user's selection (GH #328).
             let displayedMonth = requestedBudgetMonth ?? currentMonth
-            let fetchedBudgetMonth = try await database.fetchBudgetMonth(
-                month: displayedMonth,
-                includeHiddenCategories: showHiddenCategories
-            )
+            let fetchedBudgetMonth = try await database.fetchBudgetMonth(month: displayedMonth)
             let fetchedWidgetBudgetMonth: BudgetMonth
-            if displayedMonth == currentMonth, !showHiddenCategories {
+            if displayedMonth == currentMonth {
                 fetchedWidgetBudgetMonth = fetchedBudgetMonth
             } else {
                 fetchedWidgetBudgetMonth = try await database.fetchBudgetMonth(month: currentMonth)
@@ -4487,10 +4484,7 @@ final class BudgetStore: ObservableObject {
     func fetchBudgetMonth(_ month: String) async {
         requestedBudgetMonth = month
         do {
-            let fetched = try await database?.fetchBudgetMonth(
-                month: month,
-                includeHiddenCategories: showHiddenCategories
-            )
+            let fetched = try await database?.fetchBudgetMonth(month: month)
             // If a newer month was requested while we were fetching (rapid
             // month flips), this result is stale — drop it.
             guard requestedBudgetMonth == month else { return }
@@ -4515,7 +4509,7 @@ final class BudgetStore: ObservableObject {
             guard let previous = Self.shiftBudgetMonth(month, by: -1) else { break }
             month = previous
             guard let budget = try? await database.fetchBudgetMonth(month: previous),
-                  let priorCategory = budget.categoryBudgets.first(where: {
+                  let priorCategory = budget.allCategoryBudgets.first(where: {
                       $0.categoryId == category.categoryId
                   }) else { continue }
             result.append(priorCategory)

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -431,6 +431,15 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether hidden categories and groups are included on the Budget tab.
+    /// Persisted locally so an item stays reachable until the user turns the
+    /// view option off again.
+    @Published var showHiddenCategories: Bool = false {
+        didSet {
+            UserDefaults.standard.set(showHiddenCategories, forKey: "showHiddenCategories")
+        }
+    }
+
     /// Whether transaction lists show only uncleared transactions, so long
     /// histories don't bury the items that still need attention (GH #133).
     /// Persisted to UserDefaults, defaults to off.
@@ -1131,6 +1140,8 @@ final class BudgetStore: ObservableObject {
         // bool(forKey:) defaults to false — the correct opt-in default.
         _hideZeroBudgetCategories = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideZeroBudgetCategories"))
+        _showHiddenCategories = Published(initialValue: UserDefaults.standard
+            .bool(forKey: "showHiddenCategories"))
         _hideClearedTransactions = Published(initialValue: UserDefaults.standard
             .bool(forKey: "hideClearedTransactions"))
         _hideClosedAccounts = Published(initialValue: UserDefaults.standard
@@ -1664,7 +1675,13 @@ final class BudgetStore: ObservableObject {
             let fetchedGroups = try await openedDb.fetchCategoryGroups()
             let fetchedPayees = try await openedDb.fetchPayees()
             let currentMonth = currentMonthString()
-            let fetchedBudgetMonth = try await openedDb.fetchBudgetMonth(month: currentMonth)
+            let fetchedBudgetMonth = try await openedDb.fetchBudgetMonth(
+                month: currentMonth,
+                includeHiddenCategories: showHiddenCategories
+            )
+            let fetchedWidgetBudgetMonth = showHiddenCategories
+                ? try await openedDb.fetchBudgetMonth(month: currentMonth)
+                : fetchedBudgetMonth
 
             // If a concurrent load replaced the database while we were
             // fetching (e.g. demo seed during launch), drop our stale snapshot.
@@ -1699,7 +1716,7 @@ final class BudgetStore: ObservableObject {
                 requestedBudgetMonth = currentMonth
                 currentBudgetMonth = fetchedBudgetMonth
             }
-            widgetBudgetMonth = fetchedBudgetMonth
+            widgetBudgetMonth = fetchedWidgetBudgetMonth
             dataVersion += 1
             publishWidgetSnapshot()
 
@@ -1840,9 +1857,12 @@ final class BudgetStore: ObservableObject {
             // with the current calendar month while the toolbar still shows
             // the user's selection (GH #328).
             let displayedMonth = requestedBudgetMonth ?? currentMonth
-            let fetchedBudgetMonth = try await database.fetchBudgetMonth(month: displayedMonth)
+            let fetchedBudgetMonth = try await database.fetchBudgetMonth(
+                month: displayedMonth,
+                includeHiddenCategories: showHiddenCategories
+            )
             let fetchedWidgetBudgetMonth: BudgetMonth
-            if displayedMonth == currentMonth {
+            if displayedMonth == currentMonth, !showHiddenCategories {
                 fetchedWidgetBudgetMonth = fetchedBudgetMonth
             } else {
                 fetchedWidgetBudgetMonth = try await database.fetchBudgetMonth(month: currentMonth)
@@ -2194,6 +2214,36 @@ final class BudgetStore: ObservableObject {
             try await syncClient.renameCategory(id: id, name: trimmedName)
         } catch let error as BudgetDatabase.CategoryWriteError {
             throw error
+        } catch {
+            throw BudgetStoreError.categoryUpdateFailed(error.localizedDescription)
+        }
+
+        await refreshDataOnly()
+        await fetchBudgetMonth(month)
+    }
+
+    func setCategoryHidden(id: String, hidden: Bool, month: String) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+
+        do {
+            try await syncClient.setCategoryHidden(id: id, hidden: hidden)
+        } catch {
+            throw BudgetStoreError.categoryUpdateFailed(error.localizedDescription)
+        }
+
+        await refreshDataOnly()
+        await fetchBudgetMonth(month)
+    }
+
+    func setCategoryGroupHidden(id: String, hidden: Bool, month: String) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+
+        do {
+            try await syncClient.setCategoryGroupHidden(id: id, hidden: hidden)
         } catch {
             throw BudgetStoreError.categoryUpdateFailed(error.localizedDescription)
         }
@@ -4437,7 +4487,10 @@ final class BudgetStore: ObservableObject {
     func fetchBudgetMonth(_ month: String) async {
         requestedBudgetMonth = month
         do {
-            let fetched = try await database?.fetchBudgetMonth(month: month)
+            let fetched = try await database?.fetchBudgetMonth(
+                month: month,
+                includeHiddenCategories: showHiddenCategories
+            )
             // If a newer month was requested while we were fetching (rapid
             // month flips), this result is stale — drop it.
             guard requestedBudgetMonth == month else { return }

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1395,7 +1395,10 @@ final class BudgetDatabase: Sendable {
 
     // MARK: - Budget Data
 
-    func fetchBudgetMonth(month: String) async throws -> BudgetMonth {
+    func fetchBudgetMonth(
+        month: String,
+        includeHiddenCategories: Bool = false
+    ) async throws -> BudgetMonth {
         try await dbQueue.read { db in
             let targetMonthInt = Self.monthStringToInt(month)
 
@@ -1605,12 +1608,14 @@ final class BudgetDatabase: Sendable {
             let groups = try CategoryGroupRecord
                 .filter(Column("tombstone") == 0 || Column("tombstone") == nil)
                 .fetchAll(db)
-            let visibleGroupIds = Set(groups.filter { $0.hidden != 1 }.map { $0.id })
+            let visibleGroupIds = Set(groups
+                .filter { includeHiddenCategories || $0.hidden != 1 }
+                .map { $0.id })
             let groupsById = Dictionary(uniqueKeysWithValues: groups.map { ($0.id, $0) })
 
             let categoryBudgets = categories.compactMap { cat -> CategoryBudget? in
                 guard cat.isIncome != 1 else { return nil }
-                guard cat.hidden != 1 else { return nil }
+                guard includeHiddenCategories || cat.hidden != 1 else { return nil }
                 guard visibleGroupIds.contains(cat.catGroup ?? "") else { return nil }
                 let budgeted = targetBudgets[cat.id]?.amount ?? 0
                 let spent = targetSpent[cat.id] ?? 0
@@ -1638,7 +1643,7 @@ final class BudgetDatabase: Sendable {
             // the category (income transactions are positive amounts).
             let incomeCategories = categories.compactMap { cat -> IncomeCategory? in
                 guard cat.isIncome == 1 else { return nil }
-                guard cat.hidden != 1 else { return nil }
+                guard includeHiddenCategories || cat.hidden != 1 else { return nil }
                 guard visibleGroupIds.contains(cat.catGroup ?? "") else { return nil }
                 let group = groupsById[cat.catGroup ?? ""]
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1395,10 +1395,7 @@ final class BudgetDatabase: Sendable {
 
     // MARK: - Budget Data
 
-    func fetchBudgetMonth(
-        month: String,
-        includeHiddenCategories: Bool = false
-    ) async throws -> BudgetMonth {
+    func fetchBudgetMonth(month: String) async throws -> BudgetMonth {
         try await dbQueue.read { db in
             let targetMonthInt = Self.monthStringToInt(month)
 
@@ -1608,62 +1605,61 @@ final class BudgetDatabase: Sendable {
             let groups = try CategoryGroupRecord
                 .filter(Column("tombstone") == 0 || Column("tombstone") == nil)
                 .fetchAll(db)
-            let visibleGroupIds = Set(groups
-                .filter { includeHiddenCategories || $0.hidden != 1 }
-                .map { $0.id })
             let groupsById = Dictionary(uniqueKeysWithValues: groups.map { ($0.id, $0) })
 
-            let categoryBudgets = categories.compactMap { cat -> CategoryBudget? in
+            let allCategoryBudgets = categories.compactMap { cat -> CategoryBudget? in
                 guard cat.isIncome != 1 else { return nil }
-                guard includeHiddenCategories || cat.hidden != 1 else { return nil }
-                guard visibleGroupIds.contains(cat.catGroup ?? "") else { return nil }
+                guard let group = groupsById[cat.catGroup ?? ""] else { return nil }
                 let budgeted = targetBudgets[cat.id]?.amount ?? 0
                 let spent = targetSpent[cat.id] ?? 0
                 let available = runningLeftover[cat.id] ?? (budgeted + spent)
                 let priorContribution = available - budgeted - spent
-                let group = groupsById[cat.catGroup ?? ""]
 
                 return CategoryBudget(
                     month: month,
                     categoryId: cat.id,
                     categoryName: cat.name ?? "Unknown",
                     groupId: cat.catGroup ?? "",
-                    groupName: group?.name ?? "Unknown",
-                    groupSortOrder: group?.sortOrder ?? .greatestFiniteMagnitude,
+                    groupName: group.name ?? "Unknown",
+                    groupSortOrder: group.sortOrder ?? .greatestFiniteMagnitude,
                     categorySortOrder: cat.sortOrder ?? .greatestFiniteMagnitude,
                     budgeted: budgeted,
                     spent: spent,
                     available: available,
-                    carryover: priorContribution
+                    carryover: priorContribution,
+                    hidden: cat.hidden == 1,
+                    groupHidden: group.hidden == 1
                 )
             }
 
             // Income categories, shown as their own section like the web
             // UI's Income group. "Received" is the month's net activity on
             // the category (income transactions are positive amounts).
-            let incomeCategories = categories.compactMap { cat -> IncomeCategory? in
+            let allIncomeCategories = categories.compactMap { cat -> IncomeCategory? in
                 guard cat.isIncome == 1 else { return nil }
-                guard includeHiddenCategories || cat.hidden != 1 else { return nil }
-                guard visibleGroupIds.contains(cat.catGroup ?? "") else { return nil }
-                let group = groupsById[cat.catGroup ?? ""]
+                guard let group = groupsById[cat.catGroup ?? ""] else { return nil }
 
                 return IncomeCategory(
                     month: month,
                     categoryId: cat.id,
                     categoryName: cat.name ?? "Unknown",
-                    groupName: group?.name ?? "Income",
+                    groupName: group.name ?? "Income",
                     sortOrder: cat.sortOrder ?? .greatestFiniteMagnitude,
                     budgeted: targetBudgets[cat.id]?.amount ?? 0,
-                    received: targetSpent[cat.id] ?? 0
+                    received: targetSpent[cat.id] ?? 0,
+                    hidden: cat.hidden == 1,
+                    groupHidden: group.hidden == 1
                 )
             }
             .sorted { $0.sortOrder < $1.sortOrder }
 
             return BudgetMonth(
                 month: month,
-                categoryBudgets: categoryBudgets,
-                incomeCategories: incomeCategories,
-                toBudget: isEnvelope ? runningToBudget : nil
+                categoryBudgets: allCategoryBudgets.filter { !$0.isEffectivelyHidden },
+                incomeCategories: allIncomeCategories.filter { !$0.isEffectivelyHidden },
+                toBudget: isEnvelope ? runningToBudget : nil,
+                hiddenCategoryBudgets: allCategoryBudgets.filter(\.isEffectivelyHidden),
+                hiddenIncomeCategories: allIncomeCategories.filter(\.isEffectivelyHidden)
             )
         }
     }

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -746,6 +746,33 @@ actor SyncClient {
         await automaticSync()
     }
 
+    func setCategoryHidden(id: String, hidden: Bool) async throws {
+        try await setHidden(dataset: Category.datasetName, id: id, hidden: hidden)
+    }
+
+    func setCategoryGroupHidden(id: String, hidden: Bool) async throws {
+        try await setHidden(dataset: CategoryGroup.datasetName, id: id, hidden: hidden)
+    }
+
+    private func setHidden(dataset: String, id: String, hidden: Bool) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        let messages = try await messageGenerator.messages(
+            dataset: dataset,
+            row: id,
+            fields: [("hidden", hidden ? 1 : 0)]
+        )
+        try database.applyMessages(messages)
+
+        for message in try database.insertMessages(messages) {
+            merkle = merkle.inserting(message.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+
+        await automaticSync()
+    }
+
     /// Record a location for a payee (optimistic local-first). Callers are
     /// responsible for the server-version guard and 500 m dedupe — this
     /// method just writes.

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -83,6 +83,9 @@ struct BudgetOptionsMenu: View {
                     Label("Hide Spent", systemImage: "line.3.horizontal.decrease")
                 }
                 .accessibilityLabel("Hide Spent Categories")
+                Toggle(isOn: $budgetStore.showHiddenCategories) {
+                    Label("Show Hidden Categories", systemImage: "eye")
+                }
             }
         } label: {
             Image(systemName: "ellipsis.circle")

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -99,7 +99,9 @@ struct BudgetView: View {
     private func collapseAllGroups() {
         let displayedGroupIDs = Self.displayedGroupIDs(
             groupIDs: groupedCategories.map(\.id),
-            hasIncome: budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false
+            hasIncome: budgetStore.currentBudgetMonth.map {
+                !displayedIncomeCategories(in: $0).isEmpty
+            } ?? false
         )
         let groups = collapsedGroups.union(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
@@ -108,7 +110,9 @@ struct BudgetView: View {
     private func expandAllGroups() {
         let displayedGroupIDs = Self.displayedGroupIDs(
             groupIDs: groupedCategories.map(\.id),
-            hasIncome: budgetStore.currentBudgetMonth?.incomeCategories.isEmpty == false
+            hasIncome: budgetStore.currentBudgetMonth.map {
+                !displayedIncomeCategories(in: $0).isEmpty
+            } ?? false
         )
         let groups = collapsedGroups.subtracting(displayedGroupIDs)
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
@@ -155,9 +159,6 @@ struct BudgetView: View {
             .onChange(of: budgetStore.showBudgetCheckInStrip) { _, isShown in
                 if !isShown { categoryFilter = .all }
             }
-            .onChange(of: budgetStore.showHiddenCategories) {
-                _, _ in Task { await budgetStore.fetchBudgetMonth(selectedMonth) }
-            }
             .sheet(item: $editingCategory) { category in
                 EditBudgetAmountSheet(category: category)
             }
@@ -203,9 +204,8 @@ struct BudgetView: View {
                     ForEach(group.categories) { category in
                         CleanCategoryBudgetRow(
                             category: category,
-                            isHidden: categoryMetadata(category.categoryId)?.hidden == true,
-                            isDimmed: group.isHidden
-                                || categoryMetadata(category.categoryId)?.hidden == true,
+                            isHidden: category.hidden,
+                            isDimmed: category.isEffectivelyHidden,
                             onSetHidden: {
                                 setCategoryHidden(category.categoryId, hidden: $0)
                             },
@@ -252,9 +252,8 @@ struct BudgetView: View {
                     ForEach(group.categories) { category in
                         CategoryBudgetRow(
                             category: category,
-                            isHidden: categoryMetadata(category.categoryId)?.hidden == true,
-                            isDimmed: group.isHidden
-                                || categoryMetadata(category.categoryId)?.hidden == true,
+                            isHidden: category.hidden,
+                            isDimmed: category.isEffectivelyHidden,
                             onSetHidden: {
                                 setCategoryHidden(category.categoryId, hidden: $0)
                             },
@@ -279,16 +278,16 @@ struct BudgetView: View {
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
         let group = budgetStore.categoryGroups.first(where: \.isIncome)
-        let name = group?.name ?? budget.incomeCategories.first?.groupName ?? "Income"
+        let categories = displayedIncomeCategories(in: budget)
+        let name = group?.name ?? categories.first?.groupName ?? "Income"
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
-                    ForEach(budget.incomeCategories) { income in
+                    ForEach(categories) { income in
                         IncomeCategoryRow(
                             income: income,
-                            isHidden: categoryMetadata(income.categoryId)?.hidden == true,
-                            isDimmed: group?.hidden == true
-                                || categoryMetadata(income.categoryId)?.hidden == true,
+                            isHidden: income.hidden,
+                            isDimmed: income.isEffectivelyHidden,
                             onSetHidden: {
                                 setCategoryHidden(income.categoryId, hidden: $0)
                             },
@@ -332,12 +331,11 @@ struct BudgetView: View {
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
                 if !isCollapsed {
-                    ForEach(budget.incomeCategories) { income in
+                    ForEach(categories) { income in
                         IncomeCategoryRow(
                             income: income,
-                            isHidden: categoryMetadata(income.categoryId)?.hidden == true,
-                            isDimmed: group?.hidden == true
-                                || categoryMetadata(income.categoryId)?.hidden == true,
+                            isHidden: income.hidden,
+                            isDimmed: income.isEffectivelyHidden,
                             onSetHidden: {
                                 setCategoryHidden(income.categoryId, hidden: $0)
                             },
@@ -545,7 +543,7 @@ struct BudgetView: View {
 
                 // Income group last, matching the bottom of the web UI's
                 // budget table.
-                if categoryFilter == .all, !budget.incomeCategories.isEmpty {
+                if categoryFilter == .all, !displayedIncomeCategories(in: budget).isEmpty {
                     incomeSection(budget)
                 }
             }
@@ -635,8 +633,8 @@ struct BudgetView: View {
         return visible.min { $0.sortOrder < $1.sortOrder }?.id
     }
 
-    private func categoryMetadata(_ id: String) -> Category? {
-        budgetStore.categoryGroups.lazy.flatMap(\.categories).first { $0.id == id }
+    private func displayedIncomeCategories(in budget: BudgetMonth) -> [IncomeCategory] {
+        budgetStore.showHiddenCategories ? budget.allIncomeCategories : budget.incomeCategories
     }
 
     private func setCategoryHidden(_ id: String, hidden: Bool) {
@@ -691,28 +689,24 @@ struct BudgetView: View {
         let isHidden: Bool
         /// The rows to draw, after "Hide Spent Categories" filtering.
         let categories: [CategoryBudget]
-        /// Totals over the group's whole category list, hidden rows included.
+        /// Totals over the group's non-hidden category list.
         let totals: CategoryGroupTotals
     }
 
     var groupedCategories: [CategoryGroupSection] {
         guard let budget = budgetStore.currentBudgetMonth else { return [] }
-        let byGroup = Dictionary(grouping: budget.categoryBudgets, by: { $0.groupId })
+        let categories = budgetStore.showHiddenCategories
+            ? budget.allCategoryBudgets
+            : budget.categoryBudgets
+        let byGroup = Dictionary(grouping: categories, by: { $0.groupId })
         var sections = byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }
                 // An explicit filter is its own visibility rule: "Not Funded"
                 // must still match zero-available categories even when the
                 // Hide Spent Categories setting would drop them from "All".
-                let groupHidden = budgetStore.categoryGroups
-                    .first { $0.id == groupId }?.hidden == true
                 let base = categoryFilter == .all
-                    ? items.filter {
-                        !budgetStore.hideZeroBudgetCategories || $0.available != 0
-                            || (budgetStore.showHiddenCategories
-                                && (groupHidden
-                                    || categoryMetadata($0.categoryId)?.hidden == true))
-                    }
+                    ? budgetStore.visibleCategoryBudgets(items)
                     : items.filter(categoryFilter.includes)
                 let visible = base
                     .sorted { $0.categorySortOrder < $1.categorySortOrder }
@@ -724,10 +718,12 @@ struct BudgetView: View {
                     CategoryGroupSection(
                         id: groupId,
                         name: first.groupName,
-                        isHidden: budgetStore.categoryGroups
-                            .first { $0.id == groupId }?.hidden == true,
+                        isHidden: first.groupHidden,
                         categories: visible,
-                        totals: CategoryGroupTotals(categoryFilter == .all ? items : visible)
+                        totals: CategoryGroupTotals(
+                            (categoryFilter == .all ? items : visible)
+                                .filter { !$0.isEffectivelyHidden }
+                        )
                     )
                 )
             }
@@ -949,7 +945,7 @@ struct CategoryBudgetRow: View {
             trailing: 16
         ))
         .opacity(isDimmed ? 0.5 : 1)
-        .swipeActions {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if let onSetHidden {
                 Button {
                     onSetHidden(!isHidden)
@@ -1053,7 +1049,7 @@ struct CleanCategoryBudgetRow: View {
             }
         }
         .opacity(isDimmed ? 0.5 : 1)
-        .swipeActions {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if let onSetHidden {
                 Button {
                     onSetHidden(!isHidden)
@@ -1440,7 +1436,7 @@ struct IncomeCategoryRow: View {
             trailing: 16
         ))
         .opacity(isDimmed ? 0.5 : 1)
-        .swipeActions {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if let onSetHidden {
                 Button {
                     onSetHidden(!isHidden)

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -155,6 +155,9 @@ struct BudgetView: View {
             .onChange(of: budgetStore.showBudgetCheckInStrip) { _, isShown in
                 if !isShown { categoryFilter = .all }
             }
+            .onChange(of: budgetStore.showHiddenCategories) {
+                _, _ in Task { await budgetStore.fetchBudgetMonth(selectedMonth) }
+            }
             .sheet(item: $editingCategory) { category in
                 EditBudgetAmountSheet(category: category)
             }
@@ -200,6 +203,12 @@ struct BudgetView: View {
                     ForEach(group.categories) { category in
                         CleanCategoryBudgetRow(
                             category: category,
+                            isHidden: categoryMetadata(category.categoryId)?.hidden == true,
+                            isDimmed: group.isHidden
+                                || categoryMetadata(category.categoryId)?.hidden == true,
+                            onSetHidden: {
+                                setCategoryHidden(category.categoryId, hidden: $0)
+                            },
                             onShowDetails: { selectedCategory = $0 },
                             onEditBudget: { editingCategory = $0 },
                             // Name shows all time, Spent shows
@@ -213,6 +222,10 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
+                    isHidden: group.isHidden,
+                    onSetHidden: {
+                        setCategoryGroupHidden(group.id, hidden: $0)
+                    },
                     onToggleCollapse: { toggleCollapsed(group.id) }
                 )
                 .textCase(nil)
@@ -225,6 +238,10 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
+                    isHidden: group.isHidden,
+                    onSetHidden: {
+                        setCategoryGroupHidden(group.id, hidden: $0)
+                    },
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
                     reservesTwoLines: true
@@ -235,6 +252,12 @@ struct BudgetView: View {
                     ForEach(group.categories) { category in
                         CategoryBudgetRow(
                             category: category,
+                            isHidden: categoryMetadata(category.categoryId)?.hidden == true,
+                            isDimmed: group.isHidden
+                                || categoryMetadata(category.categoryId)?.hidden == true,
+                            onSetHidden: {
+                                setCategoryHidden(category.categoryId, hidden: $0)
+                            },
                             addsGroupBottomPadding:
                                 category.id == group.categories.last?.id,
                             onShowDetails: { selectedCategory = $0 },
@@ -255,13 +278,20 @@ struct BudgetView: View {
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
-        let name = budget.incomeCategories.first?.groupName ?? "Income"
+        let group = budgetStore.categoryGroups.first(where: \.isIncome)
+        let name = group?.name ?? budget.incomeCategories.first?.groupName ?? "Income"
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
                     ForEach(budget.incomeCategories) { income in
                         IncomeCategoryRow(
                             income: income,
+                            isHidden: categoryMetadata(income.categoryId)?.hidden == true,
+                            isDimmed: group?.hidden == true
+                                || categoryMetadata(income.categoryId)?.hidden == true,
+                            onSetHidden: {
+                                setCategoryHidden(income.categoryId, hidden: $0)
+                            },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: false,
                             onShowTransactions: showTransactions
@@ -272,6 +302,10 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
+                    isHidden: group?.hidden == true,
+                    onSetHidden: group.map { group in
+                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
@@ -284,6 +318,10 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
+                    isHidden: group?.hidden == true,
+                    onSetHidden: group.map { group in
+                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
@@ -297,6 +335,12 @@ struct BudgetView: View {
                     ForEach(budget.incomeCategories) { income in
                         IncomeCategoryRow(
                             income: income,
+                            isHidden: categoryMetadata(income.categoryId)?.hidden == true,
+                            isDimmed: group?.hidden == true
+                                || categoryMetadata(income.categoryId)?.hidden == true,
+                            onSetHidden: {
+                                setCategoryHidden(income.categoryId, hidden: $0)
+                            },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: true,
                             onShowTransactions: showTransactions
@@ -591,6 +635,38 @@ struct BudgetView: View {
         return visible.min { $0.sortOrder < $1.sortOrder }?.id
     }
 
+    private func categoryMetadata(_ id: String) -> Category? {
+        budgetStore.categoryGroups.lazy.flatMap(\.categories).first { $0.id == id }
+    }
+
+    private func setCategoryHidden(_ id: String, hidden: Bool) {
+        Task {
+            do {
+                try await budgetStore.setCategoryHidden(
+                    id: id,
+                    hidden: hidden,
+                    month: selectedMonth
+                )
+            } catch {
+                budgetStore.error = error.localizedDescription
+            }
+        }
+    }
+
+    private func setCategoryGroupHidden(_ id: String, hidden: Bool) {
+        Task {
+            do {
+                try await budgetStore.setCategoryGroupHidden(
+                    id: id,
+                    hidden: hidden,
+                    month: selectedMonth
+                )
+            } catch {
+                budgetStore.error = error.localizedDescription
+            }
+        }
+    }
+
     /// Push the category's transactions: month narrows to one "yyyy-MM",
     /// nil means all time (GH #56).
     private func showTransactions(_ category: CategoryBudget, month: String?) {
@@ -612,6 +688,7 @@ struct BudgetView: View {
     struct CategoryGroupSection {
         let id: String
         let name: String
+        let isHidden: Bool
         /// The rows to draw, after "Hide Spent Categories" filtering.
         let categories: [CategoryBudget]
         /// Totals over the group's whole category list, hidden rows included.
@@ -627,8 +704,15 @@ struct BudgetView: View {
                 // An explicit filter is its own visibility rule: "Not Funded"
                 // must still match zero-available categories even when the
                 // Hide Spent Categories setting would drop them from "All".
+                let groupHidden = budgetStore.categoryGroups
+                    .first { $0.id == groupId }?.hidden == true
                 let base = categoryFilter == .all
-                    ? budgetStore.visibleCategoryBudgets(items)
+                    ? items.filter {
+                        !budgetStore.hideZeroBudgetCategories || $0.available != 0
+                            || (budgetStore.showHiddenCategories
+                                && (groupHidden
+                                    || categoryMetadata($0.categoryId)?.hidden == true))
+                    }
                     : items.filter(categoryFilter.includes)
                 let visible = base
                     .sorted { $0.categorySortOrder < $1.categorySortOrder }
@@ -640,6 +724,8 @@ struct BudgetView: View {
                     CategoryGroupSection(
                         id: groupId,
                         name: first.groupName,
+                        isHidden: budgetStore.categoryGroups
+                            .first { $0.id == groupId }?.hidden == true,
                         categories: visible,
                         totals: CategoryGroupTotals(categoryFilter == .all ? items : visible)
                     )
@@ -653,13 +739,18 @@ struct BudgetView: View {
         // Empty placeholders only belong in the unfiltered table: a filter
         // that matches nothing should show the empty state, not bare headers.
         sections += budgetStore.categoryGroups
-            .filter { categoryFilter == .all && !$0.isIncome && !$0.hidden && $0.categories.isEmpty }
+            .filter {
+                categoryFilter == .all && !$0.isIncome
+                    && (budgetStore.showHiddenCategories || !$0.hidden)
+                    && $0.categories.isEmpty
+            }
             .map { group -> (Double, CategoryGroupSection) in
                 (
                     group.sortOrder,
                     CategoryGroupSection(
                         id: group.id,
                         name: group.name,
+                        isHidden: group.hidden,
                         categories: [],
                         totals: CategoryGroupTotals([])
                     )
@@ -772,6 +863,9 @@ struct BudgetCheckInStrip: View {
 struct CategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
+    var isHidden = false
+    var isDimmed = false
+    var onSetHidden: ((Bool) -> Void)?
     var addsGroupBottomPadding = false
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
@@ -854,6 +948,17 @@ struct CategoryBudgetRow: View {
                 && category.showsProgressBar ? 10 : 4,
             trailing: 16
         ))
+        .opacity(isDimmed ? 0.5 : 1)
+        .swipeActions {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
+            }
+        }
     }
 }
 
@@ -863,6 +968,9 @@ struct CategoryBudgetRow: View {
 struct CleanCategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
+    var isHidden = false
+    var isDimmed = false
+    var onSetHidden: ((Bool) -> Void)?
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
     /// Push the category's transactions: month narrows to one "yyyy-MM",
@@ -942,6 +1050,17 @@ struct CleanCategoryBudgetRow: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Transactions for \(category.categoryName) in \(MonthPicker.title(for: category.month))")
+            }
+        }
+        .opacity(isDimmed ? 0.5 : 1)
+        .swipeActions {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
             }
         }
         .padding(.vertical, 2)
@@ -1153,6 +1272,8 @@ struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
     let isCollapsed: Bool
+    var isHidden = false
+    var onSetHidden: ((Bool) -> Void)?
     /// The detailed style totals its columns here; the clean style's header
     /// is a plain section title above the card, so it leaves this nil.
     var totals: CategoryGroupTotals?
@@ -1170,52 +1291,74 @@ struct BudgetGroupHeader: View {
     var reservesTwoLines = false
 
     var body: some View {
-        Button(action: onToggleCollapse) {
-            HStack(spacing: BudgetColumn.spacing) {
-                DisclosureChevron(
-                    isExpanded: !isCollapsed,
-                    font: .caption2.weight(.semibold)
-                )
-                .foregroundStyle(.secondary)
-                if reservesTwoLines {
-                    TwoLineName(
-                        text: name,
-                        font: .subheadline.weight(.semibold),
-                        minimumScaleFactor: 0.85
+        HStack(spacing: 8) {
+            Button(action: onToggleCollapse) {
+                HStack(spacing: BudgetColumn.spacing) {
+                    DisclosureChevron(
+                        isExpanded: !isCollapsed,
+                        font: .caption2.weight(.semibold)
                     )
-                    .foregroundStyle(.primary)
-                } else {
-                    Text(name)
-                        .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    if reservesTwoLines {
+                        TwoLineName(
+                            text: name,
+                            font: .subheadline.weight(.semibold),
+                            minimumScaleFactor: 0.85
+                        )
                         .foregroundStyle(.primary)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.85)
+                    } else {
+                        Text(name)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.85)
+                    }
+                    Spacer(minLength: 4)
+                    if let totals {
+                        BudgetAmountPill(
+                            text: budgetStore.displayBudgetCell(totals.spent),
+                            dimmed: totals.spent == 0
+                        )
+                        BudgetAmountPill(
+                            text: budgetStore.displayBudgetCell(totals.balance),
+                            // Same three-way treatment as the category rows, so a
+                            // group that lands on zero doesn't read as healthy.
+                            color: totals.balance < 0
+                                ? .red
+                                : (totals.balance == 0 ? .secondary : .green)
+                        )
+                    } else if let receivedTotal {
+                        Text("Received \(receivedText(receivedTotal))")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
                 }
-                Spacer(minLength: 4)
-                if let totals {
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(totals.spent),
-                        dimmed: totals.spent == 0
-                    )
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(totals.balance),
-                        // Same three-way treatment as the category rows, so a
-                        // group that lands on zero doesn't read as healthy.
-                        color: totals.balance < 0 ? .red : (totals.balance == 0 ? .secondary : .green)
-                    )
-                } else if let receivedTotal {
-                    Text("Received \(receivedText(receivedTotal))")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint("Toggles the group's categories")
+
+            if let onSetHidden {
+                Menu {
+                    Button {
+                        onSetHidden(!isHidden)
+                    } label: {
+                        Label(
+                            isHidden ? "Show Group" : "Hide Group",
+                            systemImage: isHidden ? "eye" : "eye.slash"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .frame(minWidth: 32, minHeight: 44)
+                }
+                .accessibilityLabel("Options for \(name)")
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Toggles the group's categories")
+        .opacity(isHidden ? 0.5 : 1)
     }
 
     /// The pills are decoration to VoiceOver once the button carries its own
@@ -1246,6 +1389,9 @@ struct BudgetGroupHeader: View {
 struct IncomeCategoryRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let income: IncomeCategory
+    var isHidden = false
+    var isDimmed = false
+    var onSetHidden: ((Bool) -> Void)?
     var showsBudgeted = false
     var isDetailed = false
     var onShowTransactions: (IncomeCategory, String?) -> Void = { _, _ in }
@@ -1293,6 +1439,17 @@ struct IncomeCategoryRow: View {
             bottom: 4,
             trailing: 16
         ))
+        .opacity(isDimmed ? 0.5 : 1)
+        .swipeActions {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
+            }
+        }
     }
 }
 

--- a/Actuali/ActualiTests/Models/WidgetSnapshotTests.swift
+++ b/Actuali/ActualiTests/Models/WidgetSnapshotTests.swift
@@ -131,6 +131,22 @@ struct WidgetSnapshotTests {
         #expect(store.read()?.categories.map(\.id) == ["dining"])
     }
 
+    @Test @MainActor func publishExcludesHiddenCategoryRows() throws {
+        let budgetStore = BudgetStore.previewInstance()
+        let store = try makeStore()
+        budgetStore.widgetSnapshotStore = store
+        budgetStore.widgetBudgetMonth = BudgetMonth(
+            month: "2026-08",
+            categoryBudgets: [makeBudget(id: "visible", name: "Visible", month: "2026-08")],
+            toBudget: 0,
+            hiddenCategoryBudgets: [makeBudget(id: "hidden", name: "Hidden", month: "2026-08")]
+        )
+
+        budgetStore.publishWidgetSnapshot()
+
+        #expect(store.read()?.categories.map(\.id) == ["visible"])
+    }
+
     @Test @MainActor func publishIsNoOpBeforeAnyBudgetLoads() throws {
         let budgetStore = BudgetStore.previewInstance()
         let store = try makeStore()

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreateCategoryTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreateCategoryTests.swift
@@ -237,4 +237,34 @@ struct BudgetStoreCreateCategoryTests {
         }
         #expect(try count(path: url, sql: "SELECT COUNT(*) FROM messages_crdt") == 0)
     }
+
+    @Test func hidingACategoryAndGroupWritesOnlyHiddenMessages() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database)
+
+        try await store.setCategoryHidden(id: "cat-groceries", hidden: true, month: "2026-07")
+        try await store.setCategoryGroupHidden(id: "grp-daily", hidden: true, month: "2026-07")
+
+        let categoryHidden: Int = try rows(
+            path: url,
+            sql: "SELECT hidden FROM categories WHERE id = 'cat-groceries'"
+        )[0]["hidden"]
+        let groupHidden: Int = try rows(
+            path: url,
+            sql: "SELECT hidden FROM category_groups WHERE id = 'grp-daily'"
+        )[0]["hidden"]
+        #expect(categoryHidden == 1)
+        #expect(groupHidden == 1)
+        #expect(try messagedColumns(
+            path: url,
+            dataset: "categories",
+            row: "cat-groceries"
+        ) == ["hidden"])
+        #expect(try messagedColumns(
+            path: url,
+            dataset: "category_groups",
+            row: "grp-daily"
+        ) == ["hidden"])
+    }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreHideSpentCategoriesTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreHideSpentCategoriesTests.swift
@@ -58,4 +58,20 @@ struct BudgetStoreHideSpentCategoriesTests {
         let visible = store.visibleCategoryBudgets(makeCategories(availables: [-100, 0, 500]))
         #expect(visible.count == 3)
     }
+
+    @Test func showHiddenKeepsHiddenRowsReachableWhenSpentRowsAreHidden() {
+        let store = BudgetStore.previewInstance()
+        store.hideZeroBudgetCategories = true
+        store.showHiddenCategories = true
+        defer {
+            UserDefaults.standard.removeObject(forKey: "hideZeroBudgetCategories")
+            UserDefaults.standard.removeObject(forKey: "showHiddenCategories")
+        }
+        var categories = makeCategories(availables: [0, 0])
+        categories[1].hidden = true
+
+        let visible = store.visibleCategoryBudgets(categories)
+
+        #expect(visible.map(\.categoryId) == ["cat1"])
+    }
 }

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseIncomeTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseIncomeTests.swift
@@ -160,6 +160,22 @@ struct BudgetDatabaseIncomeTests {
         #expect(june.incomeCategories.map(\.categoryId) == ["cat-salary"])
     }
 
+    @Test func hiddenCategoriesAndGroupsCanBeIncluded() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try execSQL(db, "UPDATE categories SET hidden = 1 WHERE id = 'cat-bonus'")
+        try execSQL(db, "UPDATE category_groups SET hidden = 1 WHERE id = 'grp-1'")
+
+        let june = try await db.fetchBudgetMonth(
+            month: "2026-06",
+            includeHiddenCategories: true
+        )
+
+        #expect(june.incomeCategories.contains { $0.categoryId == "cat-bonus" })
+        #expect(june.categoryBudgets.contains { $0.categoryId == "cat-groceries" })
+    }
+
     @Test func transactionsOnADeletedAccountAreExcluded() async throws {
         // Deleting an account takes its transactions with it; one left alive on
         // a tombstoned account is a sync-race orphan, and counting it would put

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseIncomeTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseIncomeTests.swift
@@ -160,20 +160,41 @@ struct BudgetDatabaseIncomeTests {
         #expect(june.incomeCategories.map(\.categoryId) == ["cat-salary"])
     }
 
-    @Test func hiddenCategoriesAndGroupsCanBeIncluded() async throws {
+    @Test func hiddenCategoriesAndGroupsAreKeptSeparate() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }
 
         try execSQL(db, "UPDATE categories SET hidden = 1 WHERE id = 'cat-bonus'")
         try execSQL(db, "UPDATE category_groups SET hidden = 1 WHERE id = 'grp-1'")
 
-        let june = try await db.fetchBudgetMonth(
-            month: "2026-06",
-            includeHiddenCategories: true
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+
+        #expect(june.hiddenIncomeCategories.contains { $0.categoryId == "cat-bonus" })
+        #expect(june.hiddenCategoryBudgets.contains { $0.categoryId == "cat-groceries" })
+        #expect(june.incomeCategories.allSatisfy { $0.categoryId != "cat-bonus" })
+        #expect(june.categoryBudgets.allSatisfy { $0.categoryId != "cat-groceries" })
+    }
+
+    @Test func quickAssignHistoryIncludesHiddenCategories() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try execSQL(db, "UPDATE categories SET hidden = 1 WHERE id = 'cat-groceries'")
+        try insertTransaction(db, date: 20260501, category: "cat-groceries", amount: -25_000)
+        let june = try await db.fetchBudgetMonth(month: "2026-06")
+        let category = try #require(june.hiddenCategoryBudgets.first {
+            $0.categoryId == "cat-groceries"
+        })
+        let store = BudgetStore.previewInstance()
+        store.configureForTesting(
+            database: db,
+            syncClient: SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         )
 
-        #expect(june.incomeCategories.contains { $0.categoryId == "cat-bonus" })
-        #expect(june.categoryBudgets.contains { $0.categoryId == "cat-groceries" })
+        let history = await store.budgetHistory(for: category, monthCount: 1)
+
+        #expect(history.count == 1)
+        #expect(history[0].spent == -25_000)
     }
 
     @Test func transactionsOnADeletedAccountAreExcluded() async throws {

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseToBudgetTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseToBudgetTests.swift
@@ -258,6 +258,8 @@ struct BudgetDatabaseToBudgetTests {
 
         let june = try await db.fetchBudgetMonth(month: "2026-06")
         #expect(june.categoryBudgets.first { $0.categoryId == "cat-hidden" } == nil)
+        #expect(june.hiddenCategoryBudgets.contains { $0.categoryId == "cat-hidden" })
+        #expect(june.totalBudgeted == 0)
         #expect(june.toBudget == 40_000)
     }
 


### PR DESCRIPTION
Adds category and category-group visibility controls to the Budget screen. Categories use native swipe actions, groups use their header menu, and the persisted Show Hidden Categories option keeps hidden rows reachable for restoring them.

Visibility changes are applied locally through the existing CRDT message path and sync back to other Actual clients.

Verified with:
- xcodebuild build (iPhone 17 Pro simulator): BUILD SUCCEEDED
- CI-equivalent unit suite with UI tests skipped: 1448 tests in 181 suites passed
- git diff --check

There is no separate lint configuration in this repository. Bulk visibility actions, deletion, and category-group renaming remain out of scope.

Fixes #356