### PR TITLE
Pin CI to iOS 26, move UI tests to a nightly run

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,7 +1,7 @@
 # Companion to ci.yml: PRs that don't touch app code (website, docs) still get
-# passing "Unit Tests (iOS 26)", "Unit Tests (iOS 18)" and "UI Tests (iOS 26)"
-# checks, so branch protection can require them unconditionally. The
-# paths-ignore list must mirror ci.yml's paths list.
+# passing "Unit Tests (iOS 26)" and "Unit Tests (iOS 18)" checks, so branch
+# protection can require them unconditionally. The paths-ignore list must
+# mirror ci.yml's paths list.
 #
 # ponytail: mirroring the lists stops both workflows firing on a workflow-only
 # PR, but not on a mixed one (a workflow file plus a doc), which still reports
@@ -32,9 +32,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No app code changed — skipping iOS 18 tests."
-
-  ui-test:
-    name: UI Tests (iOS 26)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No app code changed — skipping UI tests."

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,12 +1,12 @@
 # Companion to ci.yml: PRs that don't touch app code (website, docs) still get
 # passing "Unit Tests (iOS 26)" and "Unit Tests (iOS 18)" checks, so branch
 # protection can require them unconditionally. The paths-ignore list must
-# mirror ci.yml's paths list.
+# mirror ci.yml's paths list exactly.
 #
-# ponytail: mirroring the lists stops both workflows firing on a workflow-only
-# PR, but not on a mixed one (a workflow file plus a doc), which still reports
-# each check name twice. Collapse to one workflow with a changed-files gate on
-# the macOS jobs if that duplication ever actually gates a merge.
+# ponytail: mirrored lists stop both workflows firing on a workflow-only PR,
+# but not on a mixed one (a workflow file plus a doc), which still reports each
+# check name twice. Collapse to one workflow with a changed-files gate on the
+# macOS jobs if that duplication ever actually gates a merge.
 name: CI (no app changes)
 
 on:
@@ -14,8 +14,7 @@ on:
     branches: [main]
     paths-ignore:
       - "Actuali/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/ci-noop.yml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -2,6 +2,11 @@
 # passing "Unit Tests (iOS 26)", "Unit Tests (iOS 18)" and "UI Tests (iOS 26)"
 # checks, so branch protection can require them unconditionally. The
 # paths-ignore list must mirror ci.yml's paths list.
+#
+# ponytail: mirroring the lists stops both workflows firing on a workflow-only
+# PR, but not on a mixed one (a workflow file plus a doc), which still reports
+# each check name twice. Collapse to one workflow with a changed-files gate on
+# the macOS jobs if that duplication ever actually gates a merge.
 name: CI (no app changes)
 
 on:
@@ -10,6 +15,7 @@ on:
     paths-ignore:
       - "Actuali/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/ci-noop.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,7 +1,7 @@
 # Companion to ci.yml: PRs that don't touch app code (website, docs) still get
-# passing "Build and Test", "Unit Tests (iOS 18)" and "UI Tests" checks, so
-# branch protection can require them unconditionally. The paths-ignore list
-# must mirror ci.yml's paths list.
+# passing "Unit Tests (iOS 26)", "Unit Tests (iOS 18)" and "UI Tests (iOS 26)"
+# checks, so branch protection can require them unconditionally. The
+# paths-ignore list must mirror ci.yml's paths list.
 name: CI (no app changes)
 
 on:
@@ -15,11 +15,11 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Build and Test
+  test-ios26:
+    name: Unit Tests (iOS 26)
     runs-on: ubuntu-latest
     steps:
-      - run: echo "No app code changed — skipping build and tests."
+      - run: echo "No app code changed — skipping iOS 26 tests."
 
   test-ios18:
     name: Unit Tests (iOS 18)
@@ -28,7 +28,7 @@ jobs:
       - run: echo "No app code changed — skipping iOS 18 tests."
 
   ui-test:
-    name: UI Tests
+    name: UI Tests (iOS 26)
     runs-on: ubuntu-latest
     steps:
       - run: echo "No app code changed — skipping UI tests."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # The whole workflows directory rather than this file and its noop twin:
+    # naming files individually means ci-noop.yml's paths-ignore has to be kept
+    # in lockstep, and any file missed from both fires *both* workflows, which
+    # reports each required check twice — a 5-second ubuntu noop can then
+    # satisfy a check the real macOS job is still running.
     paths:
       - "Actuali/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/ci-noop.yml"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
-# Builds the app and runs unit tests and UI tests on every PR that touches
-# app code. Branch protection requires the "Unit Tests (iOS 26)", "Unit Tests
-# (iOS 18)" and "UI Tests (iOS 26)" checks; ci-noop.yml provides the same check
-# names for PRs that don't touch app code.
+# Builds the app and runs unit tests on every PR that touches app code. Branch
+# protection requires the "Unit Tests (iOS 26)" and "Unit Tests (iOS 18)"
+# checks; ci-noop.yml provides the same check names for PRs that don't touch
+# app code. UI tests are too slow to gate a PR (~50 min) — they run nightly in
+# ui-tests.yml.
 name: CI
 
 on:
@@ -43,8 +44,8 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      # UI tests run in the separate ui-test job so the unit-test signal stays
-      # fast. Simulator builds are ad-hoc signed, so no certificate is needed —
+      # UI tests run nightly in ui-tests.yml so the PR signal stays fast.
+      # Simulator builds are ad-hoc signed, so no certificate is needed —
       # but don't pass CODE_SIGNING_ALLOWED=NO: an unsigned test host can't
       # reach the simulator keychain (errSecMissingEntitlement in
       # EncryptionKeyManager tests).
@@ -108,63 +109,3 @@ jobs:
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
             -skip-testing:ActualiUITests \
             | xcbeautify --quiet
-
-  ui-test:
-    name: UI Tests (iOS 26)
-    runs-on: macos-26
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-
-      # Same iOS 26 pin as the unit-test job.
-      - name: Select iOS 26 simulator
-        id: sim
-        run: |
-          SIM_ID=$(xcrun simctl list devices available --json \
-            | jq -r '[.devices | to_entries[] | select(.key | contains("iOS-26")) | .value[] | select(.name | startswith("iPhone"))][0].udid')
-          if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
-            echo "No available iOS 26 iPhone simulator on this runner" >&2
-            exit 1
-          fi
-          echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
-
-      # A connected hardware keyboard makes the simulator minimize the
-      # software keyboard, so keypad taps land on off-screen keys; the tests
-      # drive budget amounts through the keypad. This host-side pref only
-      # protects a device that has never seen a hardware keyboard (true for
-      # fresh runner sims) — a device that already remembers one needs its
-      # device-side com.apple.keyboard.preferences reset instead.
-      - name: Disable simulator hardware keyboard
-        run: |
-          defaults write com.apple.iphonesimulator DevicePreferences \
-            -dict-add "${{ steps.sim.outputs.id }}" \
-            "<dict><key>ConnectHardwareKeyboard</key><false/></dict>"
-
-      # UI tests are slower and flakier on shared runners, so failed tests
-      # retry up to 3 runs before the job fails. Two parallel workers (sim
-      # clones) roughly halve the test-execution phase.
-      - name: Build and run UI tests on iOS 26
-        run: |
-          set -o pipefail
-          xcodebuild test \
-            -project Actuali/Actuali.xcodeproj \
-            -scheme Actuali \
-            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
-            -only-testing:ActualiUITests \
-            -retry-tests-on-failure \
-            -test-iterations 3 \
-            -parallel-testing-enabled YES \
-            -parallel-testing-worker-count 2 \
-            -resultBundlePath TestResults/ActualiUITests.xcresult \
-            | xcbeautify --quiet
-
-      # The tests attach screenshots at each checkpoint; keep them (and the
-      # full activity log) when a run fails on the runner but not locally.
-      - name: Upload result bundle
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-test-results
-          path: TestResults
-          if-no-files-found: ignore
-          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Builds the app and runs unit tests and UI tests on every PR that touches
-# app code. Branch protection requires the "Build and Test", "Unit Tests
-# (iOS 18)" and "UI Tests" checks; ci-noop.yml provides the same check names
-# for PRs that don't touch app code.
+# app code. Branch protection requires the "Unit Tests (iOS 26)", "Unit Tests
+# (iOS 18)" and "UI Tests (iOS 26)" checks; ci-noop.yml provides the same check
+# names for PRs that don't touch app code.
 name: CI
 
 on:
@@ -21,20 +21,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Build and Test
+  test-ios26:
+    name: Unit Tests (iOS 26)
     runs-on: macos-26
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 
-      - name: Select simulator
+      # Pinned to iOS 26 rather than "first available iPhone": paired with the
+      # test-ios18 job, that names which runtime each leg actually covers. The
+      # runner image ships iOS 26, so this never needs a runtime download.
+      - name: Select iOS 26 simulator
         id: sim
         run: |
           SIM_ID=$(xcrun simctl list devices available --json \
-            | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid')
+            | jq -r '[.devices | to_entries[] | select(.key | contains("iOS-26")) | .value[] | select(.name | startswith("iPhone"))][0].udid')
           if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
-            echo "No available iPhone simulator on this runner" >&2
+            echo "No available iOS 26 iPhone simulator on this runner" >&2
             exit 1
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
@@ -47,7 +50,7 @@ jobs:
       # xcbeautify (preinstalled on macOS runners) keeps the log readable;
       # --quiet drops passing-task noise but keeps warnings and errors;
       # pipefail preserves xcodebuild's exit code through the pipe.
-      - name: Build and run unit tests
+      - name: Build and run unit tests on iOS 26
         run: |
           set -o pipefail
           xcodebuild test \
@@ -71,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Select iOS 18 simulator
-        id: sim18
+        id: sim
         run: |
           runtime() {
             xcrun simctl list runtimes --json \
@@ -95,30 +98,31 @@ jobs:
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Build and run unit tests on iOS 18 (minimum supported)
+      - name: Build and run unit tests on iOS 18
         run: |
           set -o pipefail
           xcodebuild test \
             -project Actuali/Actuali.xcodeproj \
             -scheme Actuali \
-            -destination "platform=iOS Simulator,id=${{ steps.sim18.outputs.id }}" \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
             -skip-testing:ActualiUITests \
             | xcbeautify --quiet
 
   ui-test:
-    name: UI Tests
+    name: UI Tests (iOS 26)
     runs-on: macos-26
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 
-      - name: Select simulator
+      # Same iOS 26 pin as the unit-test job.
+      - name: Select iOS 26 simulator
         id: sim
         run: |
           SIM_ID=$(xcrun simctl list devices available --json \
-            | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid')
+            | jq -r '[.devices | to_entries[] | select(.key | contains("iOS-26")) | .value[] | select(.name | startswith("iPhone"))][0].udid')
           if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
-            echo "No available iPhone simulator on this runner" >&2
+            echo "No available iOS 26 iPhone simulator on this runner" >&2
             exit 1
           fi
           echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
@@ -138,7 +142,7 @@ jobs:
       # UI tests are slower and flakier on shared runners, so failed tests
       # retry up to 3 runs before the job fails. Two parallel workers (sim
       # clones) roughly halve the test-execution phase.
-      - name: Build and run UI tests
+      - name: Build and run UI tests on iOS 26
         run: |
           set -o pipefail
           xcodebuild test \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "Actuali/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/ci-noop.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,78 @@
+# UI tests, nightly rather than per-PR: the suite takes ~50 minutes, which is
+# too slow to gate a PR on. Run it by hand from the Actions tab (or with
+# `gh workflow run ui-tests.yml --ref <branch>`) when a change touches the
+# flows it covers.
+name: UI Tests
+
+on:
+  schedule:
+    # 14:00 UTC — midnight AEST, so the run is finished by the morning.
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ui-test:
+    name: UI Tests (iOS 26)
+    runs-on: macos-26
+    # A green run is ~50 min; failures spend longer because each failed test
+    # retries up to 3 times. 60 wasn't enough headroom for a bad night.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same iOS 26 pin as ci.yml's unit-test job: the runner image ships iOS
+      # 26, so this never needs a runtime download.
+      - name: Select iOS 26 simulator
+        id: sim
+        run: |
+          SIM_ID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices | to_entries[] | select(.key | contains("iOS-26")) | .value[] | select(.name | startswith("iPhone"))][0].udid')
+          if [ -z "$SIM_ID" ] || [ "$SIM_ID" = "null" ]; then
+            echo "No available iOS 26 iPhone simulator on this runner" >&2
+            exit 1
+          fi
+          echo "id=$SIM_ID" >> "$GITHUB_OUTPUT"
+
+      # A connected hardware keyboard makes the simulator minimize the
+      # software keyboard, so keypad taps land on off-screen keys; the tests
+      # drive budget amounts through the keypad. This host-side pref only
+      # protects a device that has never seen a hardware keyboard (true for
+      # fresh runner sims) — a device that already remembers one needs its
+      # device-side com.apple.keyboard.preferences reset instead.
+      - name: Disable simulator hardware keyboard
+        run: |
+          defaults write com.apple.iphonesimulator DevicePreferences \
+            -dict-add "${{ steps.sim.outputs.id }}" \
+            "<dict><key>ConnectHardwareKeyboard</key><false/></dict>"
+
+      # UI tests are slower and flakier on shared runners, so failed tests
+      # retry up to 3 runs before the job fails. Two parallel workers (sim
+      # clones) roughly halve the test-execution phase.
+      - name: Build and run UI tests on iOS 26
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Actuali/Actuali.xcodeproj \
+            -scheme Actuali \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+            -only-testing:ActualiUITests \
+            -retry-tests-on-failure \
+            -test-iterations 3 \
+            -parallel-testing-enabled YES \
+            -parallel-testing-worker-count 2 \
+            -resultBundlePath TestResults/ActualiUITests.xcresult \
+            | xcbeautify --quiet
+
+      # The tests attach screenshots at each checkpoint; keep them (and the
+      # full activity log) when a run fails on the runner but not locally.
+      - name: Upload result bundle
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results
+          path: TestResults
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
+++ b/Actuali/ActualiUITests/IPadSplitLayoutUITests.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 
 /// Coverage for the iPad-only layouts. Skipped on iPhone, which keeps the
@@ -9,8 +10,15 @@ final class IPadSplitLayoutUITests: XCTestCase {
     /// the split-view tests. Run them on a 13-inch, or in landscape.
     private let wideLayoutThreshold: CGFloat = 1000
 
+    /// Skip before launching, not after: on a phone every test here ends in a
+    /// skip anyway, and paying for four app launches to learn that is what
+    /// times them out ("Timed out while launching application via Xcode") on a
+    /// loaded runner. A retry that skips doesn't clear the first run's failure,
+    /// so the suite fails the job.
     @MainActor
-    private func launch(initialTab: Int) -> XCUIApplication {
+    private func launch(initialTab: Int) throws -> XCUIApplication {
+        try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .pad,
+                          "iPad-only layouts; this device is a phone")
         let app = XCUIApplication()
         app.launchArguments = ["-loadDemoData", "-initialTab", String(initialTab)]
         app.launch()
@@ -19,7 +27,7 @@ final class IPadSplitLayoutUITests: XCTestCase {
 
     @MainActor
     private func launchWide(initialTab: Int) throws -> XCUIApplication {
-        let app = launch(initialTab: initialTab)
+        let app = try launch(initialTab: initialTab)
         try XCTSkipUnless(
             app.windows.firstMatch.frame.width >= wideLayoutThreshold,
             "split layouts only; this window is too narrow for side-by-side columns"
@@ -86,7 +94,7 @@ final class IPadSplitLayoutUITests: XCTestCase {
     /// sidebar would otherwise open as a drawer under the floating tab bar).
     @MainActor
     func testRotatingIntoLandscapeBringsUpTheSplitLayout() throws {
-        let app = launch(initialTab: 0)
+        let app = try launch(initialTab: 0)
 
         XCTAssertTrue(app.staticTexts["Chase Checking"].waitForExistence(timeout: 15))
         let portraitWidth = app.windows.firstMatch.frame.width
@@ -112,7 +120,7 @@ final class IPadSplitLayoutUITests: XCTestCase {
     func testBudgetTableIsWidthCapped() throws {
         // Launched straight onto the tab: in the sidebar layout the tab
         // controls aren't the tab-bar buttons the phone tests tap.
-        let app = launch(initialTab: 1)
+        let app = try launch(initialTab: 1)
         // Capping applies at any regular width, not just wide enough for
         // columns — it just needs a window wider than the 700 pt cap.
         try XCTSkipUnless(app.windows.firstMatch.frame.width > 760,


### PR DESCRIPTION
The unit-test and UI-test jobs picked whatever the first available iPhone simulator happened to be, so nothing said which runtime they actually covered. Both now select an iOS 26 sim explicitly and fail loudly if none is there — same shape as the iOS 18 leg, minus the runtime download it needs.

Three more things came out of that first run.

**UI tests now run nightly, not per PR.** The suite takes ~50 minutes, which is far too slow to sit in front of a merge. It moves to `ui-tests.yml` on a 14:00 UTC schedule (midnight AEST) plus `workflow_dispatch`, with the timeout raised 60 → 120 min: 60 left no headroom once failing tests start retrying. The schedule only starts once this is on `main`.

**`IPadSplitLayoutUITests` was the only real failure.** Every other red test in that run went green on retry. The iPad suite skips on a phone, but it launched the app first and skipped afterwards — four full launches to learn the window is 402 pt wide. On the runner those launches timed out (`Timed out while launching application via Xcode`), and a retry that *skips* doesn't clear the first run's failure, so the suite failed the job. It now checks `userInterfaceIdiom` before launching. Locally the suite went from ~5 min of timing-out launches to 0.3 s.

Worth knowing: CI only ever runs this on an iPhone, so the iPad assertions have never actually executed anywhere but a developer machine. Adding an iPad leg is a separate call.

**Both path filters now match `.github/workflows/**` wholesale.** Naming files one by one meant the new `ui-tests.yml` was in neither `ci.yml`'s `paths` nor `ci-noop.yml`'s `paths-ignore`, so both workflows fired and every required check was reported twice — which is how #173 merged with a red UI suite: the 5-second ubuntu noop reported last and satisfied the check. Confirmed fixed on this PR's latest run: one check run per name.

Names and ids line up, in both `ci.yml` and `ci-noop.yml`:

| job id | check name |
|-|-|
| `test-ios26` | Unit Tests (iOS 26) |
| `test-ios18` | Unit Tests (iOS 18) |

Branch protection is already on those two names and does not require a UI check, so nothing to change there — just don't add `UI Tests (iOS 26)` back, since it is no longer reported on PRs.

Ran `-only-testing:ActualiUITests/IPadSplitLayoutUITests` locally on iPhone 17 Pro / iOS 26.5: 4 skipped, 0 failures, TEST SUCCEEDED. Verified the jq selector against a local `simctl list devices available --json`; it resolves the iOS 26.5 iPhone.