### PR TITLE
Category funding automation

### DIFF
--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct ContentView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
+    @StateObject private var categoryFundingAutomation = CategoryFundingAutomationMonitor()
 
     /// Window width, measured here rather than deeper in the hierarchy so it
     /// doesn't move when a sidebar expands. Feeds `\.isWideLayout`.
@@ -38,6 +39,16 @@ struct ContentView: View {
                 onShake: budgetStore.handleDeviceShake
             ))
             .sensoryFeedback(.impact(weight: .medium), trigger: budgetStore.shakeFeedbackTrigger)
+            .onAppear {
+                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
+            }
+            .onChange(of: budgetStore.dataVersion) { _, _ in
+                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
+            }
+            .onChange(of: budgetStore.currentBudgetId) { _, newBudgetId in
+                categoryFundingAutomation.reset(for: newBudgetId)
+                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
+            }
             .alert("Something Went Wrong", isPresented: errorAlertBinding) {
                 Button("OK") {}
             } message: {

--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -11,14 +11,13 @@ import UIKit
 struct ContentView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
-    @State private var categoryFundingAutomation = CategoryFundingAutomationMonitor()
 
     /// Window width, measured here rather than deeper in the hierarchy so it
-    /// doesn't move when a sidebar expands. Feeds `\.isWideLayout`.
+    /// doesn't move when a sidebar expands. Feeds `\\.isWideLayout`.
     @State private var windowWidth: CGFloat = 0
 
     /// Below this the iPad's split views can't lay out real columns and the
-    /// sidebar becomes an overlay drawer instead; see `\.isWideLayout`.
+    /// sidebar becomes an overlay drawer instead; see `\\.isWideLayout`.
     private static let wideLayoutThreshold: CGFloat = 1000
 
     /// Presents whenever the store publishes an error; dismissing clears it
@@ -33,21 +32,12 @@ struct ContentView: View {
     var body: some View {
         MainTabView()
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { windowWidth = $0 }
-            .environment(\.isWideLayout, windowWidth >= Self.wideLayoutThreshold)
+            .environment(\\.isWideLayout, windowWidth >= Self.wideLayoutThreshold)
             .background(ShakeResponder(
                 isEnabled: budgetStore.shakeToHideBalances,
                 onShake: budgetStore.handleDeviceShake
             ))
             .sensoryFeedback(.impact(weight: .medium), trigger: budgetStore.shakeFeedbackTrigger)
-            .onAppear {
-                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
-            }
-            .onChange(of: budgetStore.dataVersion) { _, _ in
-                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
-            }
-            .onChange(of: budgetStore.currentBudgetId) { _, _ in
-                categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
-            }
             .alert("Something Went Wrong", isPresented: errorAlertBinding) {
                 Button("OK") {}
             } message: {

--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -13,11 +13,11 @@ struct ContentView: View {
     @StateObject private var notificationRouter = NotificationRouter.shared
 
     /// Window width, measured here rather than deeper in the hierarchy so it
-    /// doesn't move when a sidebar expands. Feeds `\\.isWideLayout`.
+    /// doesn't move when a sidebar expands. Feeds `\.isWideLayout`.
     @State private var windowWidth: CGFloat = 0
 
     /// Below this the iPad's split views can't lay out real columns and the
-    /// sidebar becomes an overlay drawer instead; see `\\.isWideLayout`.
+    /// sidebar becomes an overlay drawer instead; see `\.isWideLayout`.
     private static let wideLayoutThreshold: CGFloat = 1000
 
     /// Presents whenever the store publishes an error; dismissing clears it
@@ -32,7 +32,7 @@ struct ContentView: View {
     var body: some View {
         MainTabView()
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { windowWidth = $0 }
-            .environment(\\.isWideLayout, windowWidth >= Self.wideLayoutThreshold)
+            .environment(\.isWideLayout, windowWidth >= Self.wideLayoutThreshold)
             .background(ShakeResponder(
                 isEnabled: budgetStore.shakeToHideBalances,
                 onShake: budgetStore.handleDeviceShake

--- a/Actuali/Actuali/ContentView.swift
+++ b/Actuali/Actuali/ContentView.swift
@@ -11,7 +11,7 @@ import UIKit
 struct ContentView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @StateObject private var notificationRouter = NotificationRouter.shared
-    @StateObject private var categoryFundingAutomation = CategoryFundingAutomationMonitor()
+    @State private var categoryFundingAutomation = CategoryFundingAutomationMonitor()
 
     /// Window width, measured here rather than deeper in the hierarchy so it
     /// doesn't move when a sidebar expands. Feeds `\.isWideLayout`.
@@ -45,8 +45,7 @@ struct ContentView: View {
             .onChange(of: budgetStore.dataVersion) { _, _ in
                 categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
             }
-            .onChange(of: budgetStore.currentBudgetId) { _, newBudgetId in
-                categoryFundingAutomation.reset(for: newBudgetId)
+            .onChange(of: budgetStore.currentBudgetId) { _, _ in
                 categoryFundingAutomation.processCurrentSnapshot(using: budgetStore)
             }
             .alert("Something Went Wrong", isPresented: errorAlertBinding) {

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -4,7 +4,7 @@ import Combine
 /// The pool used to cover a category shortfall. `toBudget` means money already
 /// available in the budget pool; `category` moves money from another budget
 /// category that has available funds.
-enum CategoryFundingSource: Equatable, Codable, Identifiable {
+enum CategoryFundingSource: Hashable, Codable, Identifiable {
     case toBudget
     case category(String)
 
@@ -158,19 +158,14 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
                 )
 
             case .category(let sourceCategoryId):
-                // Never fund a category from itself. The source must also have
-                // positive available funds at the time of the transfer.
                 guard sourceCategoryId != category.categoryId,
                       let sourceCategory = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
                           $0.categoryId == sourceCategoryId
                       }),
-                      sourceCategory.available > 0 else {
+                      sourceCategory.available >= amountToFund else {
                     return
                 }
 
-                // transferBudget validates that the source has enough money;
-                // the explicit guard above keeps the automation from attempting
-                // a transfer from an empty/negative source category.
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: sourceCategoryId,

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -17,6 +17,7 @@ enum CategoryFundingDecision: Equatable {
     case fund(Int)
     case insufficientSource
     case invalidSource
+    case sameSourceAndTarget
 }
 
 enum CategoryFundingAutomation {
@@ -37,6 +38,7 @@ enum CategoryFundingAutomation {
     static func fundingDecision(
         transactionAmount: Int,
         availableAfterTransaction: Int,
+        targetCategoryId: String? = nil,
         fundingSource: CategoryFundingSource,
         sourceAvailable: Int? = nil
     ) -> CategoryFundingDecision {
@@ -49,7 +51,8 @@ enum CategoryFundingAutomation {
         switch fundingSource {
         case .toBudget:
             return .fund(amount)
-        case .category:
+        case .category(let sourceId):
+            guard sourceId != targetCategoryId else { return .sameSourceAndTarget }
             guard let sourceAvailable else { return .invalidSource }
             return sourceAvailable >= amount ? .fund(amount) : .insufficientSource
         }
@@ -122,10 +125,6 @@ enum CategoryFundingAutomation {
             sourceAvailable = nil
             sourceCategoryId = nil
         case .category(let sourceId):
-            guard sourceId != category.categoryId else {
-                budgetStore.error = "Couldn't fund \(category.categoryName): choose a different funding category."
-                return
-            }
             sourceCategoryId = sourceId
             sourceAvailable = budgetMonth.allCategoryBudgets.first(where: {
                 $0.categoryId == sourceId
@@ -135,6 +134,7 @@ enum CategoryFundingAutomation {
         switch fundingDecision(
             transactionAmount: transaction.amount,
             availableAfterTransaction: category.available,
+            targetCategoryId: category.categoryId,
             fundingSource: configuration.fundingSource,
             sourceAvailable: sourceAvailable
         ) {
@@ -144,6 +144,8 @@ enum CategoryFundingAutomation {
             budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
         case .insufficientSource:
             budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
+        case .sameSourceAndTarget:
+            budgetStore.error = "Couldn't fund \(category.categoryName): choose a different funding category."
         case .fund(let amountToFund):
             let displayedMonth = budgetStore.currentBudgetMonth?.month
             do {

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Combine
+
+/// The pool used to cover a category shortfall.
+///
+/// `toBudget` is intentionally the only source for this first version. Keeping
+/// the source as an enum makes the persisted setting explicit and leaves room
+/// for category-to-category funding later without changing the trigger model.
+enum CategoryFundingSource: String, Codable, CaseIterable, Identifiable {
+    case toBudget
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .toBudget: return "To Budget"
+        }
+    }
+}
+
+struct CategoryFundingAutomationConfiguration: Codable, Equatable {
+    var isEnabled = false
+    var accountId: String?
+    var fundingSource: CategoryFundingSource = .toBudget
+}
+
+/// Pure rules for deciding whether a newly-created transaction is eligible for
+/// category funding. The monitor performs the database/budget work separately.
+enum CategoryFundingAutomation {
+    /// The category's available amount after the transaction has been inserted
+    /// can be used to reconstruct the amount that was available immediately
+    /// before it. This keeps the trigger correct even though Actuali refreshes
+    /// its budget after a transaction write.
+    static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
+        guard transactionAmount < 0 else { return 0 }
+        let availableBeforeTransaction = availableAfterTransaction - transactionAmount
+        return max(0, abs(transactionAmount) - availableBeforeTransaction)
+    }
+
+    static func shouldProcess(
+        _ transaction: Transaction,
+        selectedAccountId: String,
+        isIncomeCategory: Bool
+    ) -> Bool {
+        transaction.accountId == selectedAccountId
+            && transaction.amount < 0
+            && transaction.categoryId != nil
+            && !transaction.isParent
+            && transaction.parentId == nil
+            && transaction.transferId == nil
+            && !isIncomeCategory
+            && !transaction.tombstone
+    }
+}
+
+/// Watches the store's published transaction snapshot for newly-created rows.
+/// This deliberately sits above the transaction write paths so manual entry,
+/// bank sync, Wallet imports, Shortcuts, and scheduled postings all use the
+/// same automation without creating a second transaction pipeline.
+@MainActor
+final class CategoryFundingAutomationMonitor: ObservableObject {
+    private var budgetId: String?
+    private var hasBaseline = false
+    private var seenTransactionIds = Set<String>()
+    private var processingTransactionIds = Set<String>()
+
+    func reset(for budgetId: String?) {
+        guard self.budgetId != budgetId else { return }
+        self.budgetId = budgetId
+        hasBaseline = false
+        seenTransactionIds.removeAll()
+        processingTransactionIds.removeAll()
+    }
+
+    func processCurrentSnapshot(using budgetStore: BudgetStore) {
+        reset(for: budgetStore.currentBudgetId)
+        guard budgetStore.dataVersion > 0 else { return }
+
+        guard !hasBaseline else {
+            let newTransactions = budgetStore.transactions.filter { !seenTransactionIds.contains($0.id) }
+            for transaction in newTransactions {
+                seenTransactionIds.insert(transaction.id)
+            }
+            guard !newTransactions.isEmpty else { return }
+            Task { [weak self, weak budgetStore] in
+                guard let self, let budgetStore else { return }
+                for transaction in newTransactions {
+                    await self.process(transaction, using: budgetStore)
+                }
+            }
+            return
+        }
+
+        // The first snapshot after a budget load is history, not automation
+        // input. Opening a budget must never retroactively fund old
+        // transactions. This also correctly baselines an empty budget.
+        seenTransactionIds = Set(budgetStore.transactions.map(\.id))
+        hasBaseline = true
+    }
+
+    private func process(_ transaction: Transaction, using budgetStore: BudgetStore) async {
+        guard let configuration = Self.loadConfiguration(for: budgetStore.currentBudgetId),
+              configuration.isEnabled,
+              let accountId = configuration.accountId,
+              configuration.fundingSource == .toBudget,
+              !processingTransactionIds.contains(transaction.id) else { return }
+
+        let isIncomeCategory = budgetStore.categoryGroups
+            .flatMap(\.categories)
+            .first(where: { $0.id == transaction.categoryId })?
+            .isIncome ?? false
+
+        guard CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: accountId,
+            isIncomeCategory: isIncomeCategory
+        ) else { return }
+
+        processingTransactionIds.insert(transaction.id)
+        defer { processingTransactionIds.remove(transaction.id) }
+
+        let month = String(format: "%04d-%02d", transaction.date / 10000, (transaction.date / 100) % 100)
+        let displayedMonth = budgetStore.currentBudgetMonth?.month
+        await budgetStore.fetchBudgetMonth(month)
+        guard let category = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
+            $0.categoryId == transaction.categoryId
+        }) else {
+            if let displayedMonth, displayedMonth != month {
+                await budgetStore.fetchBudgetMonth(displayedMonth)
+            }
+            return
+        }
+
+        let amountToFund = CategoryFundingAutomation.shortfall(
+            transactionAmount: transaction.amount,
+            availableAfterTransaction: category.available
+        )
+
+        if amountToFund > 0 {
+            do {
+                try await budgetStore.transferBudget(
+                    month: month,
+                    fromCategoryId: nil,
+                    toCategoryId: category.categoryId,
+                    amountCents: amountToFund
+                )
+            } catch {
+                // The transaction itself is already saved. Funding is a
+                // follow-up automation, so a failed budget write must not undo
+                // or duplicate the transaction.
+                budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
+            }
+        }
+
+        // `fetchBudgetMonth` temporarily changed the displayed month when the
+        // transaction belongs to a historical month. Restore the user's view.
+        if let displayedMonth, displayedMonth != month {
+            await budgetStore.fetchBudgetMonth(displayedMonth)
+        }
+    }
+
+    static func loadConfiguration(for budgetId: String?) -> CategoryFundingAutomationConfiguration? {
+        guard let budgetId,
+              let data = UserDefaults.standard.data(forKey: key(for: budgetId)) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(CategoryFundingAutomationConfiguration.self, from: data)
+    }
+
+    static func saveConfiguration(
+        _ configuration: CategoryFundingAutomationConfiguration,
+        for budgetId: String?
+    ) {
+        guard let budgetId,
+              let data = try? JSONEncoder().encode(configuration) else { return }
+        UserDefaults.standard.set(data, forKey: key(for: budgetId))
+    }
+
+    private static func key(for budgetId: String) -> String {
+        "categoryFundingAutomation_\(budgetId)"
+    }
+}

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -7,34 +7,22 @@ enum CategoryFundingSource: Hashable, Codable {
     case toBudget
     case category(String)
 
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case categoryId
-    }
-
-    private enum Kind: String, Codable {
-        case toBudget
-        case category
-    }
-
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        switch try container.decode(Kind.self, forKey: .kind) {
-        case .toBudget:
+        let value = try decoder.singleValueContainer().decode(String.self)
+        if value == "toBudget" {
             self = .toBudget
-        case .category:
-            self = .category(try container.decode(String.self, forKey: .categoryId))
+        } else {
+            self = .category(value)
         }
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.singleValueContainer()
         switch self {
         case .toBudget:
-            try container.encode(Kind.toBudget, forKey: .kind)
+            try container.encode("toBudget")
         case .category(let categoryId):
-            try container.encode(Kind.category, forKey: .kind)
-            try container.encode(categoryId, forKey: .categoryId)
+            try container.encode(categoryId)
         }
     }
 }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -44,10 +44,19 @@ struct CategoryFundingAutomationConfiguration: Codable, Equatable {
 }
 
 enum CategoryFundingAutomation {
+    /// Returns only the amount needed to cover the new expense. Existing
+    /// overspending is intentionally preserved.
+    ///
+    /// Example: if a category is already at -$500 and a new $50 expense is
+    /// posted, the category should receive $50, resulting in -$500 again.
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
+
+        let expense = abs(transactionAmount)
         let availableBeforeTransaction = availableAfterTransaction - transactionAmount
-        return max(0, abs(transactionAmount) - availableBeforeTransaction)
+        let usableFundsBeforeTransaction = max(0, availableBeforeTransaction)
+
+        return max(0, expense - usableFundsBeforeTransaction)
     }
 
     static func shouldProcess(

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,30 +1,10 @@
 import Foundation
-import Combine
 
 /// The pool used to cover a category shortfall. `toBudget` means money in the
 /// budget pool; `category` moves money from another budget category.
 enum CategoryFundingSource: Hashable, Codable {
     case toBudget
     case category(String)
-
-    init(from decoder: Decoder) throws {
-        let value = try decoder.singleValueContainer().decode(String.self)
-        if value == "toBudget" {
-            self = .toBudget
-        } else {
-            self = .category(value)
-        }
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch self {
-        case .toBudget:
-            try container.encode("toBudget")
-        case .category(let categoryId):
-            try container.encode(categoryId)
-        }
-    }
 }
 
 struct CategoryFundingAutomationConfiguration: Codable, Equatable {
@@ -62,10 +42,16 @@ enum CategoryFundingAutomation {
             && !isIncomeCategory
             && !transaction.tombstone
     }
+
+    /// Uncategorized transactions are deliberately left out of the seen set.
+    /// They can therefore become eligible when the user assigns a category.
+    static func shouldMarkSeen(_ transaction: Transaction) -> Bool {
+        transaction.categoryId != nil || transaction.isParent
+    }
 }
 
 @MainActor
-final class CategoryFundingAutomationMonitor: ObservableObject {
+final class CategoryFundingAutomationMonitor {
     private var budgetId: String?
     private var versionAtReset = 0
     private var hasBaseline = false
@@ -88,10 +74,7 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
                 !seenTransactionIds.contains($0.id)
             }
 
-            // Keep uncategorized transactions unseen. Bank imports commonly
-            // arrive without a category and should become eligible when the
-            // user categorizes them later.
-            for transaction in newTransactions where transaction.categoryId != nil {
+            for transaction in newTransactions where CategoryFundingAutomation.shouldMarkSeen(transaction) {
                 seenTransactionIds.insert(transaction.id)
             }
 
@@ -107,7 +90,7 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
 
         seenTransactionIds = Set(
             budgetStore.transactions.compactMap { transaction in
-                transaction.categoryId == nil ? nil : transaction.id
+                CategoryFundingAutomation.shouldMarkSeen(transaction) ? transaction.id : nil
             }
         )
         hasBaseline = true
@@ -135,9 +118,7 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
         guard let category = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
             $0.categoryId == transaction.categoryId
         }) else {
-            if let displayedMonth, displayedMonth != month {
-                await budgetStore.fetchBudgetMonth(displayedMonth)
-            }
+            restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
             return
         }
 
@@ -146,9 +127,7 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             availableAfterTransaction: category.available
         )
         guard amountToFund > 0 else {
-            if let displayedMonth, displayedMonth != month {
-                await budgetStore.fetchBudgetMonth(displayedMonth)
-            }
+            restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
             return
         }
 
@@ -170,11 +149,13 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
                           $0.categoryId == sourceCategoryId
                       }) else {
                     budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
+                    restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
                     return
                 }
 
                 guard sourceCategory.available >= amountToFund else {
                     budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
+                    restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
                     return
                 }
 
@@ -189,7 +170,16 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
         }
 
-        if let displayedMonth, displayedMonth != month {
+        restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
+    }
+
+    private func restoreDisplayedMonth(
+        _ displayedMonth: String?,
+        transactionMonth: String,
+        using budgetStore: BudgetStore
+    ) {
+        guard let displayedMonth, displayedMonth != transactionMonth else { return }
+        Task { @MainActor in
             await budgetStore.fetchBudgetMonth(displayedMonth)
         }
     }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -43,99 +43,84 @@ enum CategoryFundingAutomation {
             && !transaction.tombstone
     }
 
-    /// Uncategorized transactions are deliberately left out of the seen set.
-    /// They can therefore become eligible when the user assigns a category.
-    static func shouldMarkSeen(_ transaction: Transaction) -> Bool {
-        transaction.categoryId != nil || transaction.isParent
-    }
-}
-
-@MainActor
-final class CategoryFundingAutomationMonitor {
-    private var budgetId: String?
-    private var versionAtReset = 0
-    private var hasBaseline = false
-    private var seenTransactionIds = Set<String>()
-
-    func reset(for budgetId: String?, dataVersion: Int) {
-        guard self.budgetId != budgetId else { return }
-        self.budgetId = budgetId
-        versionAtReset = dataVersion
-        hasBaseline = false
-        seenTransactionIds.removeAll()
-    }
-
-    func processCurrentSnapshot(using budgetStore: BudgetStore) {
-        reset(for: budgetStore.currentBudgetId, dataVersion: budgetStore.dataVersion)
-        guard budgetStore.dataVersion > versionAtReset else { return }
-
-        guard !hasBaseline else {
-            let newTransactions = budgetStore.transactions.filter {
-                !seenTransactionIds.contains($0.id)
-            }
-
-            for transaction in newTransactions where CategoryFundingAutomation.shouldMarkSeen(transaction) {
-                seenTransactionIds.insert(transaction.id)
-            }
-
-            guard !newTransactions.isEmpty else { return }
-            Task { [weak self, weak budgetStore] in
-                guard let self, let budgetStore else { return }
-                for transaction in newTransactions {
-                    await self.process(transaction, using: budgetStore)
-                }
-            }
-            return
-        }
-
-        seenTransactionIds = Set(
-            budgetStore.transactions.compactMap { transaction in
-                CategoryFundingAutomation.shouldMarkSeen(transaction) ? transaction.id : nil
-            }
+    /// Split parents have no category and are intentionally out of scope.
+    /// This helper is kept pure so the manual-entry integration can be tested
+    /// without a live BudgetStore.
+    static func isManualExpenseEligible(
+        _ transaction: Transaction,
+        selectedAccountId: String,
+        isIncomeCategory: Bool
+    ) -> Bool {
+        shouldProcess(
+            transaction,
+            selectedAccountId: selectedAccountId,
+            isIncomeCategory: isIncomeCategory
         )
-        hasBaseline = true
     }
 
-    private func process(_ transaction: Transaction, using budgetStore: BudgetStore) async {
-        guard let configuration = Self.loadConfiguration(for: budgetStore.currentBudgetId),
-              configuration.isEnabled,
-              let accountId = configuration.accountId else { return }
+    /// Called explicitly after a successful manual Add Transaction save.
+    /// There is deliberately no transaction monitor: imported, synced,
+    /// scheduled, duplicated, or edited transactions do not trigger this
+    /// automation.
+    @MainActor
+    static func processManualTransaction(
+        accountId: String,
+        using budgetStore: BudgetStore
+    ) async {
+        guard let configuration = CategoryFundingAutomationMonitor.loadConfiguration(
+            for: budgetStore.currentBudgetId
+        ),
+        configuration.isEnabled,
+        configuration.accountId == accountId else { return }
+
+        // AddTransactionView refreshes the store after a successful save. The
+        // new transaction receives the newest sort order, so selecting the
+        // highest sort order for this account avoids accidentally processing an
+        // older transaction when several rows share the same date.
+        guard let transaction = budgetStore.transactions
+            .filter({ $0.accountId == accountId && !$0.tombstone })
+            .max(by: { lhs, rhs in
+                (lhs.sortOrder ?? -.greatestFiniteMagnitude) <
+                    (rhs.sortOrder ?? -.greatestFiniteMagnitude)
+            }) else { return }
 
         let isIncomeCategory = budgetStore.categoryGroups
             .flatMap(\.categories)
             .first(where: { $0.id == transaction.categoryId })?
             .isIncome ?? false
 
-        guard CategoryFundingAutomation.shouldProcess(
+        guard isManualExpenseEligible(
             transaction,
             selectedAccountId: accountId,
             isIncomeCategory: isIncomeCategory
         ) else { return }
 
-        let month = String(format: "%04d-%02d", transaction.date / 10000, (transaction.date / 100) % 100)
-        let displayedMonth = budgetStore.currentBudgetMonth?.month
-        await budgetStore.fetchBudgetMonth(month)
-        guard let category = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
-            $0.categoryId == transaction.categoryId
-        }) else {
-            restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
-            return
-        }
+        let month = String(
+            format: "%04d-%02d",
+            transaction.date / 10000,
+            (transaction.date / 100) % 100
+        )
 
-        let amountToFund = CategoryFundingAutomation.shortfall(
+        // Read the requested month directly from the database. This does not
+        // modify BudgetStore.currentBudgetMonth or requestedBudgetMonth, so a
+        // manual entry for another month cannot move the Budget tab.
+        guard let database = budgetStore.databaseForLogger,
+              let budgetMonth = try? await database.fetchBudgetMonth(month: month),
+              let category = budgetMonth.allCategoryBudgets.first(where: {
+                  $0.categoryId == transaction.categoryId
+              }) else { return }
+
+        let amountToFund = shortfall(
             transactionAmount: transaction.amount,
             availableAfterTransaction: category.available
         )
-        guard amountToFund > 0 else {
-            restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
-            return
-        }
+        guard amountToFund > 0 else { return }
 
         do {
             switch configuration.fundingSource {
             case .toBudget:
-                // To Budget is allowed to become negative in Actuali, so it
-                // can always provide the requested shortfall.
+                // To Budget is allowed to become negative, so it can always
+                // provide the complete shortfall.
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: nil,
@@ -145,17 +130,17 @@ final class CategoryFundingAutomationMonitor {
 
             case .category(let sourceCategoryId):
                 guard sourceCategoryId != category.categoryId,
-                      let sourceCategory = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
+                      let sourceCategory = budgetMonth.allCategoryBudgets.first(where: {
                           $0.categoryId == sourceCategoryId
                       }) else {
                     budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
-                    restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
                     return
                 }
 
+                // Category sources must have enough available money. Do not
+                // partially transfer the source balance.
                 guard sourceCategory.available >= amountToFund else {
                     budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
-                    restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
                     return
                 }
 
@@ -168,19 +153,6 @@ final class CategoryFundingAutomationMonitor {
             }
         } catch {
             budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
-        }
-
-        restoreDisplayedMonth(displayedMonth, transactionMonth: month, using: budgetStore)
-    }
-
-    private func restoreDisplayedMonth(
-        _ displayedMonth: String?,
-        transactionMonth: String,
-        using budgetStore: BudgetStore
-    ) {
-        guard let displayedMonth, displayedMonth != transactionMonth else { return }
-        Task { @MainActor in
-            await budgetStore.fetchBudgetMonth(displayedMonth)
         }
     }
 
@@ -207,5 +179,25 @@ final class CategoryFundingAutomationMonitor {
 
     private static func key(for budgetId: String) -> String {
         "categoryFundingAutomation_\(budgetId)"
+    }
+}
+
+/// Kept as a small compatibility namespace for configuration persistence used
+/// by the Settings view and existing tests. Transaction monitoring has been
+/// removed: the automation is now explicitly invoked only by manual entry.
+enum CategoryFundingAutomationMonitor {
+    static func loadConfiguration(
+        for budgetId: String?,
+        defaults: UserDefaults = .standard
+    ) -> CategoryFundingAutomationConfiguration? {
+        CategoryFundingAutomation.loadConfiguration(for: budgetId, defaults: defaults)
+    }
+
+    static func saveConfiguration(
+        _ configuration: CategoryFundingAutomationConfiguration,
+        for budgetId: String?,
+        defaults: UserDefaults = .standard
+    ) {
+        CategoryFundingAutomation.saveConfiguration(configuration, for: budgetId, defaults: defaults)
     }
 }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-/// The pool used to cover a category shortfall. `toBudget` means money in the
-/// budget pool; `category` moves money from another budget category.
 enum CategoryFundingSource: Hashable, Codable {
     case toBudget
     case category(String)
@@ -10,8 +8,6 @@ enum CategoryFundingSource: Hashable, Codable {
 struct CategoryFundingAutomationConfiguration: Codable, Equatable {
     var isEnabled = false
     var accountId: String?
-    /// Defaults to To Budget. A category source is re-validated when the
-    /// automation runs and must have enough available money for the shortfall.
     var fundingSource: CategoryFundingSource = .toBudget
 }
 
@@ -41,7 +37,6 @@ enum CategoryFundingAutomation {
             && !transaction.tombstone
     }
 
-    /// Pure eligibility check used by the manual-entry integration and tests.
     static func isManualExpenseEligible(
         _ transaction: Transaction,
         selectedAccountId: String,
@@ -56,7 +51,7 @@ enum CategoryFundingAutomation {
 
     /// Called explicitly after a successful manual Add Transaction save.
     /// Imported, synced, scheduled, duplicated, and edited transactions do not
-    /// invoke this method.
+    /// invoke this automation.
     @MainActor
     static func processManualTransaction(
         accountId: String,
@@ -66,14 +61,12 @@ enum CategoryFundingAutomation {
               configuration.isEnabled,
               configuration.accountId == accountId else { return }
 
-        // AddTransactionView refreshes the store after a successful save. A
-        // newly-created transaction gets the newest sort order, so this picks
-        // the transaction just entered without maintaining a global watermark.
+        // AddTransactionView refreshes the store after a successful save. The
+        // newly-created row has the newest sort order for this account.
         guard let transaction = budgetStore.transactions
             .filter({ $0.accountId == accountId && !$0.tombstone })
             .max(by: { lhs, rhs in
-                (lhs.sortOrder ?? -.greatestFiniteMagnitude) <
-                    (rhs.sortOrder ?? -.greatestFiniteMagnitude)
+                (lhs.sortOrder ?? 0) < (rhs.sortOrder ?? 0)
             }) else { return }
 
         let isIncomeCategory = budgetStore.categoryGroups
@@ -93,9 +86,8 @@ enum CategoryFundingAutomation {
             (transaction.date / 100) % 100
         )
 
-        // Read the requested month directly from the database. This does not
-        // modify BudgetStore.currentBudgetMonth or requestedBudgetMonth, so a
-        // manual entry for another month cannot move the Budget tab.
+        // Read the budget month directly from the database so the automation
+        // never changes the month the Budget tab is displaying.
         guard let database = budgetStore.databaseForLogger,
               let budgetMonth = try? await database.fetchBudgetMonth(month: month),
               let category = budgetMonth.allCategoryBudgets.first(where: {
@@ -111,8 +103,6 @@ enum CategoryFundingAutomation {
         do {
             switch configuration.fundingSource {
             case .toBudget:
-                // To Budget is allowed to become negative, so it can always
-                // provide the complete shortfall.
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: nil,
@@ -129,8 +119,9 @@ enum CategoryFundingAutomation {
                     return
                 }
 
-                // Category sources must have enough available money. Do not
-                // partially transfer the source balance.
+                // A category source must cover the complete shortfall. Never
+                // partially drain it and leave the user with an unexplained
+                // remaining shortfall.
                 guard sourceCategory.available >= amountToFund else {
                     budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
                     return

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -50,24 +50,23 @@ enum CategoryFundingAutomation {
     }
 
     /// Called explicitly after a successful manual Add Transaction save.
+    /// This deliberately receives no account from the presenting view: the
+    /// save form can change its account. Instead, read the newest transaction
+    /// from the database-backed transaction query after the save completes.
     /// Imported, synced, scheduled, duplicated, and edited transactions do not
-    /// invoke this automation.
+    /// invoke this method.
     @MainActor
-    static func processManualTransaction(
-        accountId: String,
-        using budgetStore: BudgetStore
-    ) async {
-        guard let configuration = loadConfiguration(for: budgetStore.currentBudgetId),
+    static func processLatestManualTransaction(using budgetStore: BudgetStore) async {
+        guard let budgetId = budgetStore.currentBudgetId,
+              let configuration = loadConfiguration(for: budgetId),
               configuration.isEnabled,
-              configuration.accountId == accountId else { return }
+              configuration.accountId != nil else { return }
 
-        // AddTransactionView refreshes the store after a successful save. The
-        // newly-created row has the newest sort order for this account.
-        guard let transaction = budgetStore.transactions
-            .filter({ $0.accountId == accountId && !$0.tombstone })
-            .max(by: { lhs, rhs in
-                (lhs.sortOrder ?? 0) < (rhs.sortOrder ?? 0)
-            }) else { return }
+        // Query the database-backed first page rather than the store's cached
+        // 500-row snapshot. This guarantees the just-created transaction is
+        // available even when the account has a long history.
+        guard let transaction = await budgetStore.fetchTransactions(limit: 1).first,
+              let selectedAccountId = configuration.accountId else { return }
 
         let isIncomeCategory = budgetStore.categoryGroups
             .flatMap(\.categories)
@@ -76,7 +75,7 @@ enum CategoryFundingAutomation {
 
         guard isManualExpenseEligible(
             transaction,
-            selectedAccountId: accountId,
+            selectedAccountId: selectedAccountId,
             isIncomeCategory: isIncomeCategory
         ) else { return }
 
@@ -103,6 +102,8 @@ enum CategoryFundingAutomation {
         do {
             switch configuration.fundingSource {
             case .toBudget:
+                // To Budget is allowed to go negative in Actual, so it can
+                // always cover the complete shortfall.
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: nil,

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -16,8 +16,6 @@ struct CategoryFundingAutomationConfiguration: Codable, Equatable {
 }
 
 enum CategoryFundingAutomation {
-    /// Returns only the amount needed to cover the new expense. Existing
-    /// overspending is intentionally preserved.
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
 
@@ -43,9 +41,7 @@ enum CategoryFundingAutomation {
             && !transaction.tombstone
     }
 
-    /// Split parents have no category and are intentionally out of scope.
-    /// This helper is kept pure so the manual-entry integration can be tested
-    /// without a live BudgetStore.
+    /// Pure eligibility check used by the manual-entry integration and tests.
     static func isManualExpenseEligible(
         _ transaction: Transaction,
         selectedAccountId: String,
@@ -59,24 +55,20 @@ enum CategoryFundingAutomation {
     }
 
     /// Called explicitly after a successful manual Add Transaction save.
-    /// There is deliberately no transaction monitor: imported, synced,
-    /// scheduled, duplicated, or edited transactions do not trigger this
-    /// automation.
+    /// Imported, synced, scheduled, duplicated, and edited transactions do not
+    /// invoke this method.
     @MainActor
     static func processManualTransaction(
         accountId: String,
         using budgetStore: BudgetStore
     ) async {
-        guard let configuration = CategoryFundingAutomationMonitor.loadConfiguration(
-            for: budgetStore.currentBudgetId
-        ),
-        configuration.isEnabled,
-        configuration.accountId == accountId else { return }
+        guard let configuration = loadConfiguration(for: budgetStore.currentBudgetId),
+              configuration.isEnabled,
+              configuration.accountId == accountId else { return }
 
-        // AddTransactionView refreshes the store after a successful save. The
-        // new transaction receives the newest sort order, so selecting the
-        // highest sort order for this account avoids accidentally processing an
-        // older transaction when several rows share the same date.
+        // AddTransactionView refreshes the store after a successful save. A
+        // newly-created transaction gets the newest sort order, so this picks
+        // the transaction just entered without maintaining a global watermark.
         guard let transaction = budgetStore.transactions
             .filter({ $0.accountId == accountId && !$0.tombstone })
             .max(by: { lhs, rhs in
@@ -179,25 +171,5 @@ enum CategoryFundingAutomation {
 
     private static func key(for budgetId: String) -> String {
         "categoryFundingAutomation_\(budgetId)"
-    }
-}
-
-/// Kept as a small compatibility namespace for configuration persistence used
-/// by the Settings view and existing tests. Transaction monitoring has been
-/// removed: the automation is now explicitly invoked only by manual entry.
-enum CategoryFundingAutomationMonitor {
-    static func loadConfiguration(
-        for budgetId: String?,
-        defaults: UserDefaults = .standard
-    ) -> CategoryFundingAutomationConfiguration? {
-        CategoryFundingAutomation.loadConfiguration(for: budgetId, defaults: defaults)
-    }
-
-    static func saveConfiguration(
-        _ configuration: CategoryFundingAutomationConfiguration,
-        for budgetId: String?,
-        defaults: UserDefaults = .standard
-    ) {
-        CategoryFundingAutomation.saveConfiguration(configuration, for: budgetId, defaults: defaults)
     }
 }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -246,3 +246,4 @@ extension BudgetStore {
         return transaction.id
     }
 }
+

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Where a category shortfall is funded from.
 enum CategoryFundingSource: Hashable, Codable {
     case toBudget
     case category(String)
@@ -11,6 +12,13 @@ struct CategoryFundingAutomationConfiguration: Codable, Equatable {
     var fundingSource: CategoryFundingSource = .toBudget
 }
 
+enum CategoryFundingDecision: Equatable {
+    case none
+    case fund(Int)
+    case insufficientSource
+    case invalidSource
+}
+
 enum CategoryFundingAutomation {
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
@@ -20,6 +28,29 @@ enum CategoryFundingAutomation {
         let usableFundsBeforeTransaction = max(0, availableBeforeTransaction)
 
         return max(0, expense - usableFundsBeforeTransaction)
+    }
+
+    /// Decide whether the configured source can cover the amount required by
+    /// this new expense. To Budget may go negative; another category may not.
+    static func fundingDecision(
+        transactionAmount: Int,
+        availableAfterTransaction: Int,
+        fundingSource: CategoryFundingSource,
+        sourceAvailable: Int? = nil
+    ) -> CategoryFundingDecision {
+        let amount = shortfall(
+            transactionAmount: transactionAmount,
+            availableAfterTransaction: availableAfterTransaction
+        )
+        guard amount > 0 else { return .none }
+
+        switch fundingSource {
+        case .toBudget:
+            return .fund(amount)
+        case .category:
+            guard let sourceAvailable else { return .invalidSource }
+            return sourceAvailable >= amount ? .fund(amount) : .insufficientSource
+        }
     }
 
     static func shouldProcess(
@@ -37,43 +68,33 @@ enum CategoryFundingAutomation {
             && !transaction.tombstone
     }
 
-    static func isManualExpenseEligible(
-        _ transaction: Transaction,
-        selectedAccountId: String,
-        isIncomeCategory: Bool
-    ) -> Bool {
-        shouldProcess(
-            transaction,
-            selectedAccountId: selectedAccountId,
-            isIncomeCategory: isIncomeCategory
-        )
-    }
-
-    /// Called explicitly after a successful manual Add Transaction save.
-    /// This deliberately receives no account from the presenting view: the
-    /// save form can change its account. Instead, read the newest transaction
-    /// from the database-backed transaction query after the save completes.
-    /// Imported, synced, scheduled, duplicated, and edited transactions do not
-    /// invoke this method.
+    /// Runs only after a successful manual Add Transaction save. The id is the
+    /// exact row created by the form, so backdated transactions, rows on other
+    /// accounts, and newer rows elsewhere in the budget cannot be mistaken for
+    /// the triggering transaction. Rules have already run before this point,
+    /// so the stored transaction is authoritative.
     @MainActor
-    static func processLatestManualTransaction(using budgetStore: BudgetStore) async {
-        guard let budgetId = budgetStore.currentBudgetId,
-              let configuration = loadConfiguration(for: budgetId),
-              configuration.isEnabled,
-              configuration.accountId != nil else { return }
-
-        // Query the database-backed first page rather than the store's cached
-        // 500-row snapshot. This guarantees the just-created transaction is
-        // available even when the account has a long history.
-        guard let transaction = await budgetStore.fetchTransactions(limit: 1).first,
-              let selectedAccountId = configuration.accountId else { return }
+    static func process(
+        savedTransactionId: String,
+        using budgetStore: BudgetStore,
+        defaults: UserDefaults = .standard
+    ) async {
+        guard let configuration = loadConfiguration(
+            for: budgetStore.currentBudgetId,
+            defaults: defaults
+        ), configuration.isEnabled,
+              let selectedAccountId = configuration.accountId,
+              let database = budgetStore.databaseForLogger,
+              let transaction = try? await database.fetchTransaction(id: savedTransactionId) else {
+            return
+        }
 
         let isIncomeCategory = budgetStore.categoryGroups
             .flatMap(\.categories)
             .first(where: { $0.id == transaction.categoryId })?
             .isIncome ?? false
 
-        guard isManualExpenseEligible(
+        guard shouldProcess(
             transaction,
             selectedAccountId: selectedAccountId,
             isIncomeCategory: isIncomeCategory
@@ -85,58 +106,60 @@ enum CategoryFundingAutomation {
             (transaction.date / 100) % 100
         )
 
-        // Read the budget month directly from the database so the automation
-        // never changes the month the Budget tab is displaying.
-        guard let database = budgetStore.databaseForLogger,
-              let budgetMonth = try? await database.fetchBudgetMonth(month: month),
+        guard let budgetMonth = try? await database.fetchBudgetMonth(month: month),
               let category = budgetMonth.allCategoryBudgets.first(where: {
                   $0.categoryId == transaction.categoryId
-              }) else { return }
+              }) else {
+            return
+        }
 
-        let amountToFund = shortfall(
+        let sourceAvailable: Int?
+        let sourceCategoryId: String?
+        switch configuration.fundingSource {
+        case .toBudget:
+            sourceAvailable = nil
+            sourceCategoryId = nil
+        case .category(let sourceId):
+            guard sourceId != category.categoryId else {
+                budgetStore.error = "Couldn't fund \(category.categoryName): choose a different funding category."
+                return
+            }
+            sourceCategoryId = sourceId
+            sourceAvailable = budgetMonth.allCategoryBudgets.first(where: {
+                $0.categoryId == sourceId
+            })?.available
+        }
+
+        switch fundingDecision(
             transactionAmount: transaction.amount,
-            availableAfterTransaction: category.available
-        )
-        guard amountToFund > 0 else { return }
-
-        do {
-            switch configuration.fundingSource {
-            case .toBudget:
-                // To Budget is allowed to go negative in Actual, so it can
-                // always cover the complete shortfall.
-                try await budgetStore.transferBudget(
-                    month: month,
-                    fromCategoryId: nil,
-                    toCategoryId: category.categoryId,
-                    amountCents: amountToFund
-                )
-
-            case .category(let sourceCategoryId):
-                guard sourceCategoryId != category.categoryId,
-                      let sourceCategory = budgetMonth.allCategoryBudgets.first(where: {
-                          $0.categoryId == sourceCategoryId
-                      }) else {
-                    budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
-                    return
-                }
-
-                // A category source must cover the complete shortfall. Never
-                // partially drain it and leave the user with an unexplained
-                // remaining shortfall.
-                guard sourceCategory.available >= amountToFund else {
-                    budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
-                    return
-                }
-
+            availableAfterTransaction: category.available,
+            fundingSource: configuration.fundingSource,
+            sourceAvailable: sourceAvailable
+        ) {
+        case .none:
+            return
+        case .invalidSource:
+            budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
+        case .insufficientSource:
+            budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
+        case .fund(let amountToFund):
+            let displayedMonth = budgetStore.currentBudgetMonth?.month
+            do {
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: sourceCategoryId,
                     toCategoryId: category.categoryId,
                     amountCents: amountToFund
                 )
+            } catch {
+                budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
             }
-        } catch {
-            budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
+
+            // transferBudget refreshes the transaction's month. Restore the
+            // month the user was viewing when the automation started.
+            if let displayedMonth, displayedMonth != month {
+                await budgetStore.fetchBudgetMonth(displayedMonth)
+            }
         }
     }
 
@@ -163,5 +186,60 @@ enum CategoryFundingAutomation {
 
     private static func key(for budgetId: String) -> String {
         "categoryFundingAutomation_\(budgetId)"
+    }
+}
+
+/// The existing BudgetStore save API returns Void. Manual category funding
+/// needs the exact created id, so this narrow helper mirrors only the standard
+/// expense-create path and leaves all existing edit/transfer/split behavior in
+/// BudgetStore untouched.
+extension BudgetStore {
+    @discardableResult
+    func createManualExpenseReturningID(_ form: TransactionForm) async throws -> String? {
+        guard form.type == .expense, form.splits.isEmpty, !form.collapseSplit else {
+            return nil
+        }
+
+        let date = Transaction.yyyymmdd(from: form.date)
+        guard case .standard(let amountCents) = try Self.plan(for: form), amountCents < 0 else {
+            return nil
+        }
+
+        let notes = form.notes.isEmpty ? nil : form.notes
+        let payeeId = try await resolvePayeeId(name: form.payeeName, editing: nil)
+        let payeeName = form.payeeName.isEmpty ? nil : form.payeeName
+        let transaction = Transaction(
+            id: UUID().uuidString,
+            accountId: form.accountId,
+            date: date,
+            amount: amountCents,
+            payeeId: payeeId,
+            payeeName: payeeName,
+            categoryId: form.categoryId,
+            categoryName: nil,
+            notes: notes,
+            cleared: form.cleared,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: payeeName
+        )
+
+        try await createTransaction(transaction)
+        if form.recordLocation, let payeeId {
+            recordPayeeLocationIfAppropriate(payeeId: payeeId)
+        }
+
+        // A delete-transaction rule can remove the just-created row. Don't
+        // hand a non-existent id to the funding automation in that case.
+        guard let database = databaseForLogger,
+              let stored = try? await database.fetchTransaction(id: transaction.id),
+              stored != nil else {
+            return nil
+        }
+        return transaction.id
     }
 }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,19 +1,36 @@
 import Foundation
 import Combine
 
-/// The pool used to cover a category shortfall.
-///
-/// `toBudget` is intentionally the only source for this first version. Keeping
-/// the source as an enum makes the persisted setting explicit and leaves room
-/// for category-to-category funding later without changing the trigger model.
-enum CategoryFundingSource: String, Codable, CaseIterable, Identifiable {
+/// The pool used to cover a category shortfall. `toBudget` means money already
+/// available in the budget pool; `category` moves money from another budget
+/// category that has available funds.
+enum CategoryFundingSource: Equatable, Codable, Identifiable {
     case toBudget
+    case category(String)
 
-    var id: Self { self }
-
-    var label: String {
+    var id: String {
         switch self {
-        case .toBudget: return "To Budget"
+        case .toBudget: return "toBudget"
+        case .category(let categoryId): return "category:\(categoryId)"
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        if value == "toBudget" {
+            self = .toBudget
+        } else {
+            self = .category(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .toBudget:
+            try container.encode("toBudget")
+        case .category(let categoryId):
+            try container.encode(categoryId)
         }
     }
 }
@@ -21,16 +38,12 @@ enum CategoryFundingSource: String, Codable, CaseIterable, Identifiable {
 struct CategoryFundingAutomationConfiguration: Codable, Equatable {
     var isEnabled = false
     var accountId: String?
+    /// Defaults to To Budget. When a category is selected, that category must
+    /// have positive available funds at the time the automation runs.
     var fundingSource: CategoryFundingSource = .toBudget
 }
 
-/// Pure rules for deciding whether a newly-created transaction is eligible for
-/// category funding. The monitor performs the database/budget work separately.
 enum CategoryFundingAutomation {
-    /// The category's available amount after the transaction has been inserted
-    /// can be used to reconstruct the amount that was available immediately
-    /// before it. This keeps the trigger correct even though Actuali refreshes
-    /// its budget after a transaction write.
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
         let availableBeforeTransaction = availableAfterTransaction - transactionAmount
@@ -53,10 +66,6 @@ enum CategoryFundingAutomation {
     }
 }
 
-/// Watches the store's published transaction snapshot for newly-created rows.
-/// This deliberately sits above the transaction write paths so manual entry,
-/// bank sync, Wallet imports, Shortcuts, and scheduled postings all use the
-/// same automation without creating a second transaction pipeline.
 @MainActor
 final class CategoryFundingAutomationMonitor: ObservableObject {
     private var budgetId: String?
@@ -91,9 +100,6 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             return
         }
 
-        // The first snapshot after a budget load is history, not automation
-        // input. Opening a budget must never retroactively fund old
-        // transactions. This also correctly baselines an empty budget.
         seenTransactionIds = Set(budgetStore.transactions.map(\.id))
         hasBaseline = true
     }
@@ -102,7 +108,6 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
         guard let configuration = Self.loadConfiguration(for: budgetStore.currentBudgetId),
               configuration.isEnabled,
               let accountId = configuration.accountId,
-              configuration.fundingSource == .toBudget,
               !processingTransactionIds.contains(transaction.id) else { return }
 
         let isIncomeCategory = budgetStore.categoryGroups
@@ -135,25 +140,48 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             transactionAmount: transaction.amount,
             availableAfterTransaction: category.available
         )
+        guard amountToFund > 0 else {
+            if let displayedMonth, displayedMonth != month {
+                await budgetStore.fetchBudgetMonth(displayedMonth)
+            }
+            return
+        }
 
-        if amountToFund > 0 {
-            do {
+        do {
+            switch configuration.fundingSource {
+            case .toBudget:
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: nil,
                     toCategoryId: category.categoryId,
                     amountCents: amountToFund
                 )
-            } catch {
-                // The transaction itself is already saved. Funding is a
-                // follow-up automation, so a failed budget write must not undo
-                // or duplicate the transaction.
-                budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
+
+            case .category(let sourceCategoryId):
+                // Never fund a category from itself. The source must also have
+                // positive available funds at the time of the transfer.
+                guard sourceCategoryId != category.categoryId,
+                      let sourceCategory = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
+                          $0.categoryId == sourceCategoryId
+                      }),
+                      sourceCategory.available > 0 else {
+                    return
+                }
+
+                // transferBudget validates that the source has enough money;
+                // the explicit guard above keeps the automation from attempting
+                // a transfer from an empty/negative source category.
+                try await budgetStore.transferBudget(
+                    month: month,
+                    fromCategoryId: sourceCategoryId,
+                    toCategoryId: category.categoryId,
+                    amountCents: amountToFund
+                )
             }
+        } catch {
+            budgetStore.error = "Couldn't automatically fund \(category.categoryName): \(error.localizedDescription)"
         }
 
-        // `fetchBudgetMonth` temporarily changed the displayed month when the
-        // transaction belongs to a historical month. Restore the user's view.
         if let displayedMonth, displayedMonth != month {
             await budgetStore.fetchBudgetMonth(displayedMonth)
         }

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -20,6 +20,8 @@ enum CategoryFundingDecision: Equatable {
 }
 
 enum CategoryFundingAutomation {
+    /// Existing overspending is intentionally preserved. The calculation only
+    /// considers positive money that was available before the new expense.
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
 
@@ -236,8 +238,7 @@ extension BudgetStore {
         // A delete-transaction rule can remove the just-created row. Don't
         // hand a non-existent id to the funding automation in that case.
         guard let database = databaseForLogger,
-              let stored = try? await database.fetchTransaction(id: transaction.id),
-              stored != nil else {
+              (try? await database.fetchTransaction(id: transaction.id)) != nil else {
             return nil
         }
         return transaction.id

--- a/Actuali/Actuali/Services/CategoryFundingAutomation.swift
+++ b/Actuali/Actuali/Services/CategoryFundingAutomation.swift
@@ -1,36 +1,40 @@
 import Foundation
 import Combine
 
-/// The pool used to cover a category shortfall. `toBudget` means money already
-/// available in the budget pool; `category` moves money from another budget
-/// category that has available funds.
-enum CategoryFundingSource: Hashable, Codable, Identifiable {
+/// The pool used to cover a category shortfall. `toBudget` means money in the
+/// budget pool; `category` moves money from another budget category.
+enum CategoryFundingSource: Hashable, Codable {
     case toBudget
     case category(String)
 
-    var id: String {
-        switch self {
-        case .toBudget: return "toBudget"
-        case .category(let categoryId): return "category:\(categoryId)"
-        }
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case categoryId
+    }
+
+    private enum Kind: String, Codable {
+        case toBudget
+        case category
     }
 
     init(from decoder: Decoder) throws {
-        let value = try decoder.singleValueContainer().decode(String.self)
-        if value == "toBudget" {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .toBudget:
             self = .toBudget
-        } else {
-            self = .category(value)
+        case .category:
+            self = .category(try container.decode(String.self, forKey: .categoryId))
         }
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
+        var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case .toBudget:
-            try container.encode("toBudget")
+            try container.encode(Kind.toBudget, forKey: .kind)
         case .category(let categoryId):
-            try container.encode(categoryId)
+            try container.encode(Kind.category, forKey: .kind)
+            try container.encode(categoryId, forKey: .categoryId)
         }
     }
 }
@@ -38,17 +42,14 @@ enum CategoryFundingSource: Hashable, Codable, Identifiable {
 struct CategoryFundingAutomationConfiguration: Codable, Equatable {
     var isEnabled = false
     var accountId: String?
-    /// Defaults to To Budget. When a category is selected, that category must
-    /// have positive available funds at the time the automation runs.
+    /// Defaults to To Budget. A category source is re-validated when the
+    /// automation runs and must have enough available money for the shortfall.
     var fundingSource: CategoryFundingSource = .toBudget
 }
 
 enum CategoryFundingAutomation {
     /// Returns only the amount needed to cover the new expense. Existing
     /// overspending is intentionally preserved.
-    ///
-    /// Example: if a category is already at -$500 and a new $50 expense is
-    /// posted, the category should receive $50, resulting in -$500 again.
     static func shortfall(transactionAmount: Int, availableAfterTransaction: Int) -> Int {
         guard transactionAmount < 0 else { return 0 }
 
@@ -78,27 +79,34 @@ enum CategoryFundingAutomation {
 @MainActor
 final class CategoryFundingAutomationMonitor: ObservableObject {
     private var budgetId: String?
+    private var versionAtReset = 0
     private var hasBaseline = false
     private var seenTransactionIds = Set<String>()
-    private var processingTransactionIds = Set<String>()
 
-    func reset(for budgetId: String?) {
+    func reset(for budgetId: String?, dataVersion: Int) {
         guard self.budgetId != budgetId else { return }
         self.budgetId = budgetId
+        versionAtReset = dataVersion
         hasBaseline = false
         seenTransactionIds.removeAll()
-        processingTransactionIds.removeAll()
     }
 
     func processCurrentSnapshot(using budgetStore: BudgetStore) {
-        reset(for: budgetStore.currentBudgetId)
-        guard budgetStore.dataVersion > 0 else { return }
+        reset(for: budgetStore.currentBudgetId, dataVersion: budgetStore.dataVersion)
+        guard budgetStore.dataVersion > versionAtReset else { return }
 
         guard !hasBaseline else {
-            let newTransactions = budgetStore.transactions.filter { !seenTransactionIds.contains($0.id) }
-            for transaction in newTransactions {
+            let newTransactions = budgetStore.transactions.filter {
+                !seenTransactionIds.contains($0.id)
+            }
+
+            // Keep uncategorized transactions unseen. Bank imports commonly
+            // arrive without a category and should become eligible when the
+            // user categorizes them later.
+            for transaction in newTransactions where transaction.categoryId != nil {
                 seenTransactionIds.insert(transaction.id)
             }
+
             guard !newTransactions.isEmpty else { return }
             Task { [weak self, weak budgetStore] in
                 guard let self, let budgetStore else { return }
@@ -109,15 +117,18 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             return
         }
 
-        seenTransactionIds = Set(budgetStore.transactions.map(\.id))
+        seenTransactionIds = Set(
+            budgetStore.transactions.compactMap { transaction in
+                transaction.categoryId == nil ? nil : transaction.id
+            }
+        )
         hasBaseline = true
     }
 
     private func process(_ transaction: Transaction, using budgetStore: BudgetStore) async {
         guard let configuration = Self.loadConfiguration(for: budgetStore.currentBudgetId),
               configuration.isEnabled,
-              let accountId = configuration.accountId,
-              !processingTransactionIds.contains(transaction.id) else { return }
+              let accountId = configuration.accountId else { return }
 
         let isIncomeCategory = budgetStore.categoryGroups
             .flatMap(\.categories)
@@ -129,9 +140,6 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
             selectedAccountId: accountId,
             isIncomeCategory: isIncomeCategory
         ) else { return }
-
-        processingTransactionIds.insert(transaction.id)
-        defer { processingTransactionIds.remove(transaction.id) }
 
         let month = String(format: "%04d-%02d", transaction.date / 10000, (transaction.date / 100) % 100)
         let displayedMonth = budgetStore.currentBudgetMonth?.month
@@ -159,6 +167,8 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
         do {
             switch configuration.fundingSource {
             case .toBudget:
+                // To Budget is allowed to become negative in Actuali, so it
+                // can always provide the requested shortfall.
                 try await budgetStore.transferBudget(
                     month: month,
                     fromCategoryId: nil,
@@ -170,8 +180,13 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
                 guard sourceCategoryId != category.categoryId,
                       let sourceCategory = budgetStore.currentBudgetMonth?.allCategoryBudgets.first(where: {
                           $0.categoryId == sourceCategoryId
-                      }),
-                      sourceCategory.available >= amountToFund else {
+                      }) else {
+                    budgetStore.error = "Couldn't fund \(category.categoryName): the selected funding category is unavailable."
+                    return
+                }
+
+                guard sourceCategory.available >= amountToFund else {
+                    budgetStore.error = "Couldn't fund \(category.categoryName): the funding category doesn't have enough available."
                     return
                 }
 
@@ -191,9 +206,12 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
         }
     }
 
-    static func loadConfiguration(for budgetId: String?) -> CategoryFundingAutomationConfiguration? {
+    static func loadConfiguration(
+        for budgetId: String?,
+        defaults: UserDefaults = .standard
+    ) -> CategoryFundingAutomationConfiguration? {
         guard let budgetId,
-              let data = UserDefaults.standard.data(forKey: key(for: budgetId)) else {
+              let data = defaults.data(forKey: key(for: budgetId)) else {
             return nil
         }
         return try? JSONDecoder().decode(CategoryFundingAutomationConfiguration.self, from: data)
@@ -201,11 +219,12 @@ final class CategoryFundingAutomationMonitor: ObservableObject {
 
     static func saveConfiguration(
         _ configuration: CategoryFundingAutomationConfiguration,
-        for budgetId: String?
+        for budgetId: String?,
+        defaults: UserDefaults = .standard
     ) {
         guard let budgetId,
               let data = try? JSONEncoder().encode(configuration) else { return }
-        UserDefaults.standard.set(data, forKey: key(for: budgetId))
+        defaults.set(data, forKey: key(for: budgetId))
     }
 
     private static func key(for budgetId: String) -> String {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -74,6 +74,36 @@ struct AccountDetailView: View {
         note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
     }
 
+    private var noteSection: some View {
+        Section("Note") {
+            if note.isEmpty {
+                Button {
+                    editingNote = true
+                } label: {
+                    Label("Add Note", systemImage: "note.text.badge.plus")
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("accountNoteRow")
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    Text(NoteLinkText.attributed(note.text))
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "pencil")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { editingNote = true }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityIdentifier("accountNoteRow")
+            }
+        }
+    }
+
     private func breakdownRow(_ title: String, amount: Int) -> some View {
         breakdownRow(title, value: budgetStore.displayBalance(amount))
     }
@@ -85,6 +115,12 @@ struct AccountDetailView: View {
             Text(value).foregroundStyle(.secondary).animatedAmount(value)
         }
         .font(.subheadline)
+    }
+
+    private func handleManualTransactionSaved() {
+        Task { @MainActor in
+            await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
+        }
     }
 
     var body: some View {
@@ -300,11 +336,7 @@ struct AccountDetailView: View {
         .sheet(isPresented: $showingAddTransaction) {
             AddTransactionView(
                 accountId: account.id,
-                onSaved: {
-                    Task { @MainActor in
-                        await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
-                    }
-                }
+                onSaved: handleManualTransactionSaved
             )
             .environmentObject(budgetStore)
         }

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -74,36 +74,6 @@ struct AccountDetailView: View {
         note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
     }
 
-    private var noteSection: some View {
-        Section("Note") {
-            if note.isEmpty {
-                Button {
-                    editingNote = true
-                } label: {
-                    Label("Add Note", systemImage: "note.text.badge.plus")
-                        .foregroundStyle(Color.accentColor)
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("accountNoteRow")
-            } else {
-                HStack(alignment: .top, spacing: 12) {
-                    Text(NoteLinkText.attributed(note.text))
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Image(systemName: "pencil")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-                .contentShape(Rectangle())
-                .onTapGesture { editingNote = true }
-                .accessibilityElement(children: .combine)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityIdentifier("accountNoteRow")
-            }
-        }
-    }
-
     private func breakdownRow(_ title: String, amount: Int) -> some View {
         breakdownRow(title, value: budgetStore.displayBalance(amount))
     }
@@ -332,10 +302,7 @@ struct AccountDetailView: View {
                 accountId: account.id,
                 onSaved: {
                     Task { @MainActor in
-                        await CategoryFundingAutomation.processManualTransaction(
-                            accountId: account.id,
-                            using: budgetStore
-                        )
+                        await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
                     }
                 }
             )

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -5,9 +5,6 @@ struct AccountDetailView: View {
     let account: Account
 
     @State private var pager: TransactionPager?
-    /// Which account `pager` was built for. The iPad split layout reuses one
-    /// instance of this view across selections, so the account can change
-    /// under state that was scoped to the previous one.
     @State private var pagerAccountId: String?
     @State private var breakdown: AccountBalanceBreakdown?
     @State private var showingBreakdown = false
@@ -17,8 +14,6 @@ struct AccountDetailView: View {
     @State private var showingReconcile = false
     @State private var showingWalletImport = false
     @State private var editingTransaction: Transaction?
-    /// The account's note (GH #198). Starts `.unsupported` so the menu item
-    /// stays hidden until the read confirms this file can store notes.
     @State private var note: EntityNote = .unsupported
     @State private var editingNote = false
     @State private var isSelecting = false
@@ -29,8 +24,6 @@ struct AccountDetailView: View {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
     }
 
-    /// Limit and headroom for a tracked card with a limit set, else nil. Read
-    /// once so the visible row and the breakdown row can't disagree.
     private var creditHeadroom: (limit: Int, available: Int)? {
         guard let available = budgetStore.availableCredit(for: account.id),
               let limit = budgetStore.creditCardLimits[account.id] else { return nil }
@@ -42,10 +35,6 @@ struct AccountDetailView: View {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// The pager is created on first use rather than in init because its
-    /// fetch closure needs the environment store, which isn't available
-    /// until body/task time. Rebuilt when the account changes: the closure
-    /// captures the id, so a reused pager would keep paging the old account.
     private func currentPager() -> TransactionPager {
         if let pager, pagerAccountId == account.id { return pager }
         let store = budgetStore
@@ -85,36 +74,21 @@ struct AccountDetailView: View {
         note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
     }
 
-    /// The account's note (GH #198), presented exactly as a category's is (see
-    /// CategoryTransactionsView): visible without digging, tap to edit. Hidden
-    /// while searching — a search is about finding transactions, not reading
-    /// guidance — and on files with no `notes` table, where an edit could never
-    /// save.
     private var noteSection: some View {
         Section("Note") {
             if note.isEmpty {
                 Button {
                     editingNote = true
                 } label: {
-                    // Tinted: an empty note row is an invitation to act, where
-                    // an existing note is content to read.
                     Label("Add Note", systemImage: "note.text.badge.plus")
                         .foregroundStyle(Color.accentColor)
                 }
-                // Plain: a tinted List button would tint the label twice over.
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("accountNoteRow")
             } else {
                 HStack(alignment: .top, spacing: 12) {
-                    // Attributed so markdown links and bare URLs in the note
-                    // are tappable (GH #190). That's also why this row is a
-                    // tap gesture rather than the Button the empty state uses:
-                    // a Button label swallows link taps, where links inside a
-                    // gesture-carrying row take precedence over the gesture.
                     Text(NoteLinkText.attributed(note.text))
                         .multilineTextAlignment(.leading)
-                        // Multi-line notes are the point — let the row grow
-                        // instead of truncating the guidance to one line.
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image(systemName: "pencil")
@@ -136,12 +110,9 @@ struct AccountDetailView: View {
 
     private func breakdownRow(_ title: String, value: String) -> some View {
         HStack {
-            Text(title)
-                .foregroundStyle(.secondary)
+            Text(title).foregroundStyle(.secondary)
             Spacer()
-            Text(value)
-                .foregroundStyle(.secondary)
-                .animatedAmount(value)
+            Text(value).foregroundStyle(.secondary).animatedAmount(value)
         }
         .font(.subheadline)
     }
@@ -149,9 +120,6 @@ struct AccountDetailView: View {
     var body: some View {
         List {
             Section {
-                // Tapping the balance reveals the cleared/uncleared/reconciled
-                // split (GH #134), so the reconciled figure can be checked
-                // against a bank statement without starting a reconciliation.
                 Button {
                     withAnimation(AppAnimation.disclosure) { showingBreakdown.toggle() }
                 } label: {
@@ -160,7 +128,7 @@ struct AccountDetailView: View {
                         Spacer()
                         Text(budgetStore.displayBalance(currentBalance))
                             .fontWeight(.semibold)
-                            .animatedAmount(budgetStore.displayBalance(currentBalance)) 
+                            .animatedAmount(budgetStore.displayBalance(currentBalance))
                         if breakdown != nil {
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
@@ -174,9 +142,6 @@ struct AccountDetailView: View {
                 .accessibilityLabel("Current Balance, \(budgetStore.displayBalance(currentBalance))")
                 .accessibilityHint(showingBreakdown ? "Hides the balance breakdown" : "Shows cleared, uncleared, and reconciled balances")
 
-                // Headroom on a tracked card with a limit set — the figure a
-                // card's balance is actually judged against, so it stays visible
-                // rather than hiding behind the disclosure.
                 if let headroom = creditHeadroom {
                     breakdownRow("Available Credit", amount: headroom.available)
                 }
@@ -198,17 +163,13 @@ struct AccountDetailView: View {
                     let endStr = Transaction.formattedDate(from: range.end.yyyymmdd, style: .abbreviated)
                     let dueSummary = cycle.dueSummary()
 
-                    // Collapsed by default like the balance breakdown above, but
-                    // the due date rides on the header row rather than hiding —
-                    // it's the part of this section worth acting on.
                     Button {
                         withAnimation(AppAnimation.disclosure) { showingBillingCycle.toggle() }
                     } label: {
                         HStack {
                             Text("Billing Cycle")
                             Spacer()
-                            Text(dueSummary)
-                                .fontWeight(.semibold)
+                            Text(dueSummary).fontWeight(.semibold)
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
                                 .foregroundStyle(.tertiary)
@@ -249,9 +210,6 @@ struct AccountDetailView: View {
                                     }
                                 )
                             }
-                            // The sentinel rides in the last date section so
-                            // grouped mode doesn't grow a headerless section
-                            // (and its gap) of its own.
                             if pager.hasMore, group.id == groups.last?.id {
                                 TransactionPagingSentinel(pager: pager)
                             }
@@ -277,8 +235,6 @@ struct AccountDetailView: View {
                     }
                 }
             } else {
-                // Header stays put while the first page is still loading, so
-                // the screen doesn't reflow once the rows land.
                 Section("Recent Transactions") {
                     if pager != nil {
                         Text(searchQuery != nil
@@ -292,9 +248,6 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
-        // The header sections (balance, billing cycle, note) are one or two rows
-        // each, so the stock inset-grouped gaps pushed the transactions off
-        // screen. Tighter spacing top and between.
         .contentMargins(.top, 8, for: .scrollContent)
         .listSectionSpacing(.compact)
         .readableWidth()
@@ -346,9 +299,7 @@ struct AccountDetailView: View {
                     .disabled(budgetStore.isBankSyncing)
                 }
             }
-            ToolbarItem(placement: .secondaryAction) {
-                TransactionGroupingToggle()
-            }
+            ToolbarItem(placement: .secondaryAction) { TransactionGroupingToggle() }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
             }
@@ -371,24 +322,29 @@ struct AccountDetailView: View {
         }
         .toolbar(isSelecting ? .hidden : .visible, for: .tabBar)
         .sheet(isPresented: $showingReconcile) {
-            ReconcileView(account: account)
-                .environmentObject(budgetStore)
+            ReconcileView(account: account).environmentObject(budgetStore)
         }
         .sheet(isPresented: $showingWalletImport) {
-            WalletImportView(preselectedAccountId: account.id)
-                .environmentObject(budgetStore)
+            WalletImportView(preselectedAccountId: account.id).environmentObject(budgetStore)
         }
         .sheet(isPresented: $showingAddTransaction) {
-            AddTransactionView(accountId: account.id)
-                .environmentObject(budgetStore)
+            AddTransactionView(
+                accountId: account.id,
+                onSaved: {
+                    Task { @MainActor in
+                        await CategoryFundingAutomation.processManualTransaction(
+                            accountId: account.id,
+                            using: budgetStore
+                        )
+                    }
+                }
+            )
+            .environmentObject(budgetStore)
         }
         .sheet(item: $editingTransaction) { transaction in
-            AddTransactionView(editing: transaction)
-                .environmentObject(budgetStore)
+            AddTransactionView(editing: transaction).environmentObject(budgetStore)
         }
         .sheet(isPresented: $editingNote, onDismiss: {
-            // Only the note needs re-reading — a note save doesn't touch
-            // transactions or the balance.
             Task { await reloadNote() }
         }) {
             NoteEditorView(
@@ -398,39 +354,23 @@ struct AccountDetailView: View {
             )
             .environmentObject(budgetStore)
         }
-        // Keyed on the account as well as the search: selecting another
-        // account in the iPad split layout reuses this view, and without the
-        // account in the key nothing would reload — the previous account's
-        // rows would sit under the new one's name and balance.
         .task(id: [account.id, searchText]) {
             if pagerAccountId != account.id {
-                // Drop the previous account's page and balance split rather
-                // than showing them while the new ones load — and its
-                // selection state, which was scoped to its rows.
                 pager = nil
                 breakdown = nil
                 cycleSpend = 0
                 isSelecting = false
                 selectedTransactionIds.removeAll()
             } else if searchQuery != nil {
-                // Debounce keystrokes; the initial (empty) load and account
-                // switches run immediately.
                 try? await Task.sleep(for: .milliseconds(250))
                 if Task.isCancelled { return }
             }
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
-            // The store republished its data — refresh the cached page. This
-            // is the single reload path for every mutation (row toggles,
-            // deletes, sheet edits, sync, scheduled posts), so those sites
-            // carry no reload calls of their own. Concurrent reloads are
-            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideClearedTransactions) {
-            // The pager's fetch closure reads the flag, so a reload is all a
-            // toggle flip needs.
             Task { await reload() }
         }
         .onChange(of: budgetStore.creditCardStatementDays[account.id]) {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -85,6 +85,19 @@ struct AccountDetailView: View {
         note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
     }
 
+    /// Fire the category-funding automation only for a newly-created manual
+    /// standard expense. The callback carries the exact saved row id, so
+    /// backdated entries and transactions in other accounts cannot be mixed up.
+    private func handleManualTransactionSaved(_ savedTransactionId: String?) {
+        guard let savedTransactionId else { return }
+        Task { @MainActor in
+            await CategoryFundingAutomation.process(
+                savedTransactionId: savedTransactionId,
+                using: budgetStore
+            )
+        }
+    }
+
     /// The account's note (GH #198), presented exactly as a category's is (see
     /// CategoryTransactionsView): visible without digging, tap to edit. Hidden
     /// while searching — a search is about finding transactions, not reading
@@ -96,15 +109,25 @@ struct AccountDetailView: View {
                 Button {
                     editingNote = true
                 } label: {
+                    // Tinted: an empty note row is an invitation to act, where
+                    // an existing note is content to read.
                     Label("Add Note", systemImage: "note.text.badge.plus")
                         .foregroundStyle(Color.accentColor)
                 }
+                // Plain: a tinted List button would tint the label twice over.
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("accountNoteRow")
             } else {
                 HStack(alignment: .top, spacing: 12) {
+                    // Attributed so markdown links and bare URLs in the note
+                    // are tappable (GH #190). That's also why this row is a
+                    // tap gesture rather than the Button the empty state uses:
+                    // a Button label swallows link taps, where links inside a
+                    // gesture-carrying row take precedence over the gesture.
                     Text(NoteLinkText.attributed(note.text))
                         .multilineTextAlignment(.leading)
+                        // Multi-line notes are the point — let the row grow
+                        // instead of truncating the guidance to one line.
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image(systemName: "pencil")
@@ -117,16 +140,6 @@ struct AccountDetailView: View {
                 .accessibilityAddTraits(.isButton)
                 .accessibilityIdentifier("accountNoteRow")
             }
-        }
-    }
-
-    private func handleManualTransactionSaved(_ savedTransactionId: String?) {
-        guard let savedTransactionId else { return }
-        Task { @MainActor in
-            await CategoryFundingAutomation.process(
-                savedTransactionId: savedTransactionId,
-                using: budgetStore
-            )
         }
     }
 
@@ -149,6 +162,9 @@ struct AccountDetailView: View {
     var body: some View {
         List {
             Section {
+                // Tapping the balance reveals the cleared/uncleared/reconciled
+                // split (GH #134), so the reconciled figure can be checked
+                // against a bank statement without starting a reconciliation.
                 Button {
                     withAnimation(AppAnimation.disclosure) { showingBreakdown.toggle() }
                 } label: {
@@ -171,6 +187,9 @@ struct AccountDetailView: View {
                 .accessibilityLabel("Current Balance, \(budgetStore.displayBalance(currentBalance))")
                 .accessibilityHint(showingBreakdown ? "Hides the balance breakdown" : "Shows cleared, uncleared, and reconciled balances")
 
+                // Headroom on a tracked card with a limit set — the figure a
+                // card's balance is actually judged against, so it stays visible
+                // rather than hiding behind the disclosure.
                 if let headroom = creditHeadroom {
                     breakdownRow("Available Credit", amount: headroom.available)
                 }
@@ -192,6 +211,9 @@ struct AccountDetailView: View {
                     let endStr = Transaction.formattedDate(from: range.end.yyyymmdd, style: .abbreviated)
                     let dueSummary = cycle.dueSummary()
 
+                    // Collapsed by default like the balance breakdown above, but
+                    // the due date rides on the header row rather than hiding —
+                    // it's the part of this section worth acting on.
                     Button {
                         withAnimation(AppAnimation.disclosure) { showingBillingCycle.toggle() }
                     } label: {
@@ -240,6 +262,9 @@ struct AccountDetailView: View {
                                     }
                                 )
                             }
+                            // The sentinel rides in the last date section so
+                            // grouped mode doesn't grow a headerless section
+                            // (and its gap) of its own.
                             if pager.hasMore, group.id == groups.last?.id {
                                 TransactionPagingSentinel(pager: pager)
                             }
@@ -265,6 +290,8 @@ struct AccountDetailView: View {
                     }
                 }
             } else {
+                // Header stays put while the first page is still loading, so
+                // the screen doesn't reflow once the rows land.
                 Section("Recent Transactions") {
                     if pager != nil {
                         Text(searchQuery != nil
@@ -278,6 +305,9 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
+        // The header sections (balance, billing cycle, note) are one or two rows
+        // each, so the stock inset-grouped gaps pushed the transactions off
+        // screen. Tighter spacing top and between.
         .contentMargins(.top, 8, for: .scrollContent)
         .listSectionSpacing(.compact)
         .readableWidth()
@@ -329,7 +359,9 @@ struct AccountDetailView: View {
                     .disabled(budgetStore.isBankSyncing)
                 }
             }
-            ToolbarItem(placement: .secondaryAction) { TransactionGroupingToggle() }
+            ToolbarItem(placement: .secondaryAction) {
+                TransactionGroupingToggle()
+            }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
             }
@@ -352,10 +384,12 @@ struct AccountDetailView: View {
         }
         .toolbar(isSelecting ? .hidden : .visible, for: .tabBar)
         .sheet(isPresented: $showingReconcile) {
-            ReconcileView(account: account).environmentObject(budgetStore)
+            ReconcileView(account: account)
+                .environmentObject(budgetStore)
         }
         .sheet(isPresented: $showingWalletImport) {
-            WalletImportView(preselectedAccountId: account.id).environmentObject(budgetStore)
+            WalletImportView(preselectedAccountId: account.id)
+                .environmentObject(budgetStore)
         }
         .sheet(isPresented: $showingAddTransaction) {
             AddTransactionView(
@@ -368,6 +402,8 @@ struct AccountDetailView: View {
             AddTransactionView(editing: transaction).environmentObject(budgetStore)
         }
         .sheet(isPresented: $editingNote, onDismiss: {
+            // Only the note needs re-reading — a note save doesn't touch
+            // transactions or the balance.
             Task { await reloadNote() }
         }) {
             NoteEditorView(
@@ -377,23 +413,39 @@ struct AccountDetailView: View {
             )
             .environmentObject(budgetStore)
         }
+        // Keyed on the account as well as the search: selecting another
+        // account in the iPad split layout reuses this view, and without the
+        // account in the key nothing would reload — the previous account's
+        // rows would sit under the new one's name and balance.
         .task(id: [account.id, searchText]) {
             if pagerAccountId != account.id {
+                // Drop the previous account's page and balance split rather
+                // than showing them while the new ones load — and its
+                // selection state, which was scoped to its rows.
                 pager = nil
                 breakdown = nil
                 cycleSpend = 0
                 isSelecting = false
                 selectedTransactionIds.removeAll()
             } else if searchQuery != nil {
+                // Debounce keystrokes; the initial (empty) load and account
+                // switches run immediately.
                 try? await Task.sleep(for: .milliseconds(250))
                 if Task.isCancelled { return }
             }
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
+            // The store republished its data — refresh the cached page. This
+            // is the single reload path for every mutation (row toggles,
+            // deletes, sheet edits, sync, scheduled posts), so those sites
+            // carry no reload calls of their own. Concurrent reloads are
+            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideClearedTransactions) {
+            // The pager's fetch closure reads the flag, so a reload is all a
+            // toggle flip needs.
             Task { await reload() }
         }
         .onChange(of: budgetStore.creditCardStatementDays[account.id]) {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -5,6 +5,9 @@ struct AccountDetailView: View {
     let account: Account
 
     @State private var pager: TransactionPager?
+    /// Which account `pager` was built for. The iPad split layout reuses one
+    /// instance of this view across selections, so the account can change
+    /// under state that was scoped to the previous one.
     @State private var pagerAccountId: String?
     @State private var breakdown: AccountBalanceBreakdown?
     @State private var showingBreakdown = false
@@ -14,6 +17,8 @@ struct AccountDetailView: View {
     @State private var showingReconcile = false
     @State private var showingWalletImport = false
     @State private var editingTransaction: Transaction?
+    /// The account's note (GH #198). Starts `.unsupported` so the menu item
+    /// stays hidden until the read confirms this file can store notes.
     @State private var note: EntityNote = .unsupported
     @State private var editingNote = false
     @State private var isSelecting = false
@@ -24,6 +29,8 @@ struct AccountDetailView: View {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
     }
 
+    /// Limit and headroom for a tracked card with a limit set, else nil. Read
+    /// once so the visible row and the breakdown row can't disagree.
     private var creditHeadroom: (limit: Int, available: Int)? {
         guard let available = budgetStore.availableCredit(for: account.id),
               let limit = budgetStore.creditCardLimits[account.id] else { return nil }
@@ -35,6 +42,10 @@ struct AccountDetailView: View {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// The pager is created on first use rather than in init because its
+    /// fetch closure needs the environment store, which isn't available
+    /// until body/task time. Rebuilt when the account changes: the closure
+    /// captures the id, so a reused pager would keep paging the old account.
     private func currentPager() -> TransactionPager {
         if let pager, pagerAccountId == account.id { return pager }
         let store = budgetStore
@@ -74,6 +85,11 @@ struct AccountDetailView: View {
         note = await budgetStore.fetchNote(id: EntityNote.accountNoteId(account.id))
     }
 
+    /// The account's note (GH #198), presented exactly as a category's is (see
+    /// CategoryTransactionsView): visible without digging, tap to edit. Hidden
+    /// while searching — a search is about finding transactions, not reading
+    /// guidance — and on files with no `notes` table, where an edit could never
+    /// save.
     private var noteSection: some View {
         Section("Note") {
             if note.isEmpty {
@@ -104,23 +120,30 @@ struct AccountDetailView: View {
         }
     }
 
+    private func handleManualTransactionSaved(_ savedTransactionId: String?) {
+        guard let savedTransactionId else { return }
+        Task { @MainActor in
+            await CategoryFundingAutomation.process(
+                savedTransactionId: savedTransactionId,
+                using: budgetStore
+            )
+        }
+    }
+
     private func breakdownRow(_ title: String, amount: Int) -> some View {
         breakdownRow(title, value: budgetStore.displayBalance(amount))
     }
 
     private func breakdownRow(_ title: String, value: String) -> some View {
         HStack {
-            Text(title).foregroundStyle(.secondary)
+            Text(title)
+                .foregroundStyle(.secondary)
             Spacer()
-            Text(value).foregroundStyle(.secondary).animatedAmount(value)
+            Text(value)
+                .foregroundStyle(.secondary)
+                .animatedAmount(value)
         }
         .font(.subheadline)
-    }
-
-    private func handleManualTransactionSaved() {
-        Task { @MainActor in
-            await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
-        }
     }
 
     var body: some View {
@@ -134,7 +157,7 @@ struct AccountDetailView: View {
                         Spacer()
                         Text(budgetStore.displayBalance(currentBalance))
                             .fontWeight(.semibold)
-                            .animatedAmount(budgetStore.displayBalance(currentBalance))
+                            .animatedAmount(budgetStore.displayBalance(currentBalance)) 
                         if breakdown != nil {
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
@@ -175,7 +198,8 @@ struct AccountDetailView: View {
                         HStack {
                             Text("Billing Cycle")
                             Spacer()
-                            Text(dueSummary).fontWeight(.semibold)
+                            Text(dueSummary)
+                                .fontWeight(.semibold)
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
                                 .foregroundStyle(.tertiary)
@@ -338,7 +362,7 @@ struct AccountDetailView: View {
                 accountId: account.id,
                 onSaved: handleManualTransactionSaved
             )
-            .environmentObject(budgetStore)
+                .environmentObject(budgetStore)
         }
         .sheet(item: $editingTransaction) { transaction in
             AddTransactionView(editing: transaction).environmentObject(budgetStore)

--- a/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
+++ b/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
@@ -156,7 +156,7 @@ struct PendingImportsView: View {
                 categoryId: nil,
                 isIncome: item.isIncome,
                 cleared: false,
-                onSaved: { store.remove(id: item.id) }
+                onSaved: { _ in store.remove(id: item.id) }
             )
             .environmentObject(budgetStore)
         } else {

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -22,8 +22,6 @@ struct MainTabView: View {
         budgetStore.overspentBadgeCount
     }
 
-    /// The numeric tab badge isn't surfaced to accessibility on its own, so
-    /// mirror it as a spoken value on the tab label.
     private var overspentBadgeValue: String {
         switch overspentCount {
         case 0: ""
@@ -34,12 +32,6 @@ struct MainTabView: View {
 
     var body: some View {
         Group {
-            // A wide iPad window (never iPhone) offers the sidebar as an
-            // alternative to the floating tab bar. Gated on width, not just on
-            // regular size class: in an 11-inch portrait window the sidebar
-            // has no room to sit beside the content, so the toggle only ever
-            // swaps the tab bar for a drawer over the top of it. Narrower
-            // windows — and every phone — keep the plain tab bar.
             if horizontalSizeClass == .regular, isWideLayout {
                 tabs.tabViewStyle(.sidebarAdaptable)
             } else {
@@ -49,12 +41,9 @@ struct MainTabView: View {
         .onChange(of: notificationRouter.pendingAllAccountsNavigation) { _, pending in
             if pending { selectedTab = 0 }
         }
-        // A save in the tab-hosted add flow routes to the account's
-        // transaction list, which lives on the Accounts tab.
         .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
             if accountId != nil { selectedTab = 0 }
         }
-        // Cancel in the tab-hosted add flow returns to the user's Start Page.
         .onChange(of: notificationRouter.pendingTabNavigation) { _, tab in
             if let tab {
                 selectedTab = tab
@@ -63,9 +52,6 @@ struct MainTabView: View {
         }
     }
 
-    /// The `Tab` value API rather than `tabItem`: `sidebarAdaptable` above only
-    /// takes effect for tabs declared this way. Renders identically to the
-    /// `tabItem` form in compact width.
     private var tabs: some View {
         TabView(selection: $selectedTab) {
             Tab(value: 1) {
@@ -74,10 +60,6 @@ struct MainTabView: View {
                 Label("Budget", systemImage: "wallet.bifold")
             }
             .badge(overspentCount)
-            // On the tab, not its label: under the Tab API the tab's own
-            // modifiers are what reach the tab bar item. (Neither placement
-            // surfaces the value to XCUITest on iOS 26 — BudgetTabBadgeUITests
-            // fails on main for that reason, unrelated to this.)
             .accessibilityValue(Text(overspentBadgeValue))
 
             Tab(value: 0) {
@@ -119,7 +101,17 @@ struct AddTransactionTabView: View {
         let fallbackAccount = budgetStore.accounts.first { !$0.closed }
 
         if let account = validDefaultAccount ?? fallbackAccount {
-            AddTransactionView(accountId: account.id)
+            AddTransactionView(
+                accountId: account.id,
+                onSaved: {
+                    Task { @MainActor in
+                        await CategoryFundingAutomation.processManualTransaction(
+                            accountId: account.id,
+                            using: budgetStore
+                        )
+                    }
+                }
+            )
                 .onAppear {
                     if configuredId != nil && validDefaultAccount == nil {
                         budgetStore.defaultAccountId = nil

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -142,7 +142,7 @@ struct AddTransactionTabView: View {
                 .alert("Default Account Unavailable", isPresented: $showingDefaultAccountAlert) {
                     Button("OK") {}
                 } message: {
-                    Text("Your default account is no longer available. Please configure a new default in More → Transactions & Transactions.")
+                    Text("Your default account is no longer available. Please configure a new default in More → Transactions & Automation.")
                 }
         } else {
             ContentUnavailableView(

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -22,6 +22,8 @@ struct MainTabView: View {
         budgetStore.overspentBadgeCount
     }
 
+    /// The numeric tab badge isn't surfaced to accessibility on its own, so
+    /// mirror it as a spoken value on the tab label.
     private var overspentBadgeValue: String {
         switch overspentCount {
         case 0: ""
@@ -32,6 +34,12 @@ struct MainTabView: View {
 
     var body: some View {
         Group {
+            // A wide iPad window (never iPhone) offers the sidebar as an
+            // alternative to the floating tab bar. Gated on width, not just on
+            // regular size class: in an 11-inch portrait window the sidebar
+            // has no room to sit beside the content, so the toggle only ever
+            // swaps the tab bar for a drawer over the top of it. Narrower
+            // windows — and every phone — keep the plain tab bar.
             if horizontalSizeClass == .regular, isWideLayout {
                 tabs.tabViewStyle(.sidebarAdaptable)
             } else {
@@ -41,9 +49,12 @@ struct MainTabView: View {
         .onChange(of: notificationRouter.pendingAllAccountsNavigation) { _, pending in
             if pending { selectedTab = 0 }
         }
+        // A save in the tab-hosted add flow routes to the account's
+        // transaction list, which lives on the Accounts tab.
         .onChange(of: notificationRouter.pendingAccountNavigation) { _, accountId in
             if accountId != nil { selectedTab = 0 }
         }
+        // Cancel in the tab-hosted add flow returns to the user's Start Page.
         .onChange(of: notificationRouter.pendingTabNavigation) { _, tab in
             if let tab {
                 selectedTab = tab
@@ -52,6 +63,9 @@ struct MainTabView: View {
         }
     }
 
+    /// The `Tab` value API rather than `tabItem`: `sidebarAdaptable` above only
+    /// takes effect for tabs declared this way. Renders identically to the
+    /// `tabItem` form in compact width.
     private var tabs: some View {
         TabView(selection: $selectedTab) {
             Tab(value: 1) {
@@ -60,6 +74,10 @@ struct MainTabView: View {
                 Label("Budget", systemImage: "wallet.bifold")
             }
             .badge(overspentCount)
+            // On the tab, not its label: under the Tab API the tab's own
+            // modifiers are what reach the tab bar item. (Neither placement
+            // surfaces the value to XCUITest on iOS 26 — BudgetTabBadgeUITests
+            // fails on main for that reason, unrelated to this.)
             .accessibilityValue(Text(overspentBadgeValue))
 
             Tab(value: 0) {
@@ -93,6 +111,16 @@ struct AddTransactionTabView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @State private var showingDefaultAccountAlert = false
 
+    private func handleManualTransactionSaved(_ savedTransactionId: String?) {
+        guard let savedTransactionId else { return }
+        Task { @MainActor in
+            await CategoryFundingAutomation.process(
+                savedTransactionId: savedTransactionId,
+                using: budgetStore
+            )
+        }
+    }
+
     var body: some View {
         let configuredId = budgetStore.defaultAccountId
         let validDefaultAccount = configuredId.flatMap { id in
@@ -103,11 +131,7 @@ struct AddTransactionTabView: View {
         if let account = validDefaultAccount ?? fallbackAccount {
             AddTransactionView(
                 accountId: account.id,
-                onSaved: {
-                    Task { @MainActor in
-                        await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
-                    }
-                }
+                onSaved: handleManualTransactionSaved
             )
                 .onAppear {
                     if configuredId != nil && validDefaultAccount == nil {
@@ -118,7 +142,7 @@ struct AddTransactionTabView: View {
                 .alert("Default Account Unavailable", isPresented: $showingDefaultAccountAlert) {
                     Button("OK") {}
                 } message: {
-                    Text("Your default account is no longer available. Please configure a new default in More → Transactions & Automation.")
+                    Text("Your default account is no longer available. Please configure a new default in More → Transactions & Transactions.")
                 }
         } else {
             ContentUnavailableView(

--- a/Actuali/Actuali/Views/MainTabView.swift
+++ b/Actuali/Actuali/Views/MainTabView.swift
@@ -105,10 +105,7 @@ struct AddTransactionTabView: View {
                 accountId: account.id,
                 onSaved: {
                     Task { @MainActor in
-                        await CategoryFundingAutomation.processManualTransaction(
-                            accountId: account.id,
-                            using: budgetStore
-                        )
+                        await CategoryFundingAutomation.processLatestManualTransaction(using: budgetStore)
                     }
                 }
             )

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -34,6 +34,15 @@ struct CategoryFundingAutomationView: View {
         )
     }
 
+    /// Only categories with money available can be used as a funding source.
+    /// The current budget month is used for the setup screen; the automation
+    /// re-checks the source balance in the transaction's month before funding.
+    private var availableFundingCategories: [BudgetCategory] {
+        (budgetStore.currentBudgetMonth?.allCategoryBudgets ?? [])
+            .filter { $0.available > 0 }
+            .sorted { $0.categoryName.localizedCaseInsensitiveCompare($1.categoryName) == .orderedAscending }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -55,14 +64,17 @@ struct CategoryFundingAutomationView: View {
 
             Section {
                 Picker("Funding Source", selection: fundingSourceBinding) {
-                    ForEach(CategoryFundingSource.allCases, id: \.id) { source in
-                        Text(source.label).tag(source)
+                    Text("To Budget").tag(CategoryFundingSource.toBudget)
+
+                    ForEach(availableFundingCategories, id: \.categoryId) { category in
+                        Text(category.categoryName)
+                            .tag(CategoryFundingSource.category(category.categoryId))
                     }
                 }
             } header: {
                 Text("Funding")
             } footer: {
-                Text("To Budget is used as the source. Only the shortfall is moved into the transaction's category.")
+                Text("To Budget is the default. You can also fund the category from another budget category that currently has a positive available balance.")
             }
 
             if configuration.isEnabled && configuration.accountId == nil {
@@ -77,6 +89,15 @@ struct CategoryFundingAutomationView: View {
         .task {
             configuration = CategoryFundingAutomationMonitor.loadConfiguration(for: budgetStore.currentBudgetId)
                 ?? CategoryFundingAutomationConfiguration()
+        }
+        .onChange(of: configuration.fundingSource) { _, newSource in
+            // If a previously selected source no longer has a positive balance,
+            // fall back to To Budget rather than persisting an unusable source.
+            if case .category(let categoryId) = newSource,
+               !availableFundingCategories.contains(where: { $0.categoryId == categoryId }) {
+                configuration.fundingSource = .toBudget
+            }
+            save()
         }
     }
 

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -4,41 +4,17 @@ struct CategoryFundingAutomationView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @State private var configuration = CategoryFundingAutomationConfiguration()
 
-    private var selectedAccountBinding: Binding<String?> {
-        Binding<String?>(
-            get: { configuration.accountId },
-            set: {
-                configuration.accountId = $0
-                save()
-            }
-        )
-    }
+    /// Categories with money, plus the saved source so a drained source is
+    /// not silently replaced with To Budget. The automation re-checks the
+    /// source balance when it actually runs.
+    private var fundingCategories: [CategoryBudget] {
+        var savedId: String?
+        if case .category(let id) = configuration.fundingSource {
+            savedId = id
+        }
 
-    private var enabledBinding: Binding<Bool> {
-        Binding<Bool>(
-            get: { configuration.isEnabled },
-            set: {
-                configuration.isEnabled = $0
-                save()
-            }
-        )
-    }
-
-    private var fundingSourceBinding: Binding<CategoryFundingSource> {
-        Binding<CategoryFundingSource>(
-            get: { configuration.fundingSource },
-            set: {
-                configuration.fundingSource = $0
-                save()
-            }
-        )
-    }
-
-    /// Only categories with money available can be selected as a funding
-    /// source. The automation re-checks the balance before transferring.
-    private var availableFundingCategories: [CategoryBudget] {
-        (budgetStore.currentBudgetMonth?.allCategoryBudgets ?? [])
-            .filter { $0.available > 0 }
+        return (budgetStore.currentBudgetMonth?.allCategoryBudgets ?? [])
+            .filter { $0.available > 0 || $0.categoryId == savedId }
             .sorted {
                 $0.categoryName.localizedCaseInsensitiveCompare($1.categoryName) == .orderedAscending
             }
@@ -47,13 +23,13 @@ struct CategoryFundingAutomationView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Enable Automation", isOn: enabledBinding)
+                Toggle("Enable Automation", isOn: $configuration.isEnabled)
             } footer: {
                 Text("When a new expense from the selected account would overdraw its category, Actuali automatically funds only the amount needed to cover that expense.")
             }
 
             Section {
-                Picker("Account", selection: selectedAccountBinding) {
+                Picker("Account", selection: $configuration.accountId) {
                     Text("None").tag(String?.none)
                     ForEach(budgetStore.accounts.filter { !$0.closed }, id: \.id) { account in
                         Text(account.name).tag(Optional(account.id))
@@ -64,10 +40,10 @@ struct CategoryFundingAutomationView: View {
             }
 
             Section {
-                Picker("Funding Source", selection: fundingSourceBinding) {
+                Picker("Funding Source", selection: $configuration.fundingSource) {
                     Text("To Budget").tag(CategoryFundingSource.toBudget)
 
-                    ForEach(availableFundingCategories, id: \.categoryId) { category in
+                    ForEach(fundingCategories, id: \.categoryId) { category in
                         Text(category.categoryName)
                             .tag(CategoryFundingSource.category(category.categoryId))
                     }
@@ -75,7 +51,7 @@ struct CategoryFundingAutomationView: View {
             } header: {
                 Text("Funding")
             } footer: {
-                Text("To Budget is the default. You can also fund the category from another budget category that has enough available money.")
+                Text("To Budget is the default. You can also fund the category from another budget category that has available money.")
             }
 
             if configuration.isEnabled && configuration.accountId == nil {
@@ -91,11 +67,7 @@ struct CategoryFundingAutomationView: View {
             configuration = CategoryFundingAutomationMonitor.loadConfiguration(for: budgetStore.currentBudgetId)
                 ?? CategoryFundingAutomationConfiguration()
         }
-        .onChange(of: configuration.fundingSource) { _, newSource in
-            if case .category(let categoryId) = newSource,
-               !availableFundingCategories.contains(where: { $0.categoryId == categoryId }) {
-                configuration.fundingSource = .toBudget
-            }
+        .onChange(of: configuration) { _, _ in
             save()
         }
     }

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct CategoryFundingAutomationView: View {
+    @EnvironmentObject private var budgetStore: BudgetStore
+    @State private var configuration = CategoryFundingAutomationConfiguration()
+
+    private var selectedAccountBinding: Binding<String?> {
+        Binding(
+            get: { configuration.accountId },
+            set: {
+                configuration.accountId = $0
+                save()
+            }
+        )
+    }
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { configuration.isEnabled },
+            set: {
+                configuration.isEnabled = $0
+                save()
+            }
+        )
+    }
+
+    private var fundingSourceBinding: Binding<CategoryFundingSource> {
+        Binding(
+            get: { configuration.fundingSource },
+            set: {
+                configuration.fundingSource = $0
+                save()
+            }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable Automation", isOn: enabledBinding)
+            } footer: {
+                Text("When a new expense from the selected account would overdraw its category, Actuali automatically funds only the amount needed to cover that expense.")
+            }
+
+            Section("Trigger") {
+                Picker("Account", selection: selectedAccountBinding) {
+                    Text("None").tag(nil as String?)
+                    ForEach(budgetStore.accounts.filter { !$0.closed }) { account in
+                        Text(account.name).tag(account.id as String?)
+                    }
+                }
+            }
+
+            Section("Funding") {
+                Picker("Funding Source", selection: fundingSourceBinding) {
+                    ForEach(CategoryFundingSource.allCases) { source in
+                        Text(source.label).tag(source)
+                    }
+                }
+            } footer: {
+                Text("To Budget is used as the source. Only the shortfall is moved into the transaction's category.")
+            }
+
+            if configuration.isEnabled && configuration.accountId == nil {
+                Section {
+                    Label("Select an account to enable automatic funding.", systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Category Funding")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            configuration = CategoryFundingAutomationMonitor.loadConfiguration(for: budgetStore.currentBudgetId)
+                ?? CategoryFundingAutomationConfiguration()
+        }
+    }
+
+    private func save() {
+        CategoryFundingAutomationMonitor.saveConfiguration(
+            configuration,
+            for: budgetStore.currentBudgetId
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CategoryFundingAutomationView()
+            .environmentObject(BudgetStore.previewInstance())
+    }
+}

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -35,9 +35,8 @@ struct CategoryFundingAutomationView: View {
     }
 
     /// Only categories with money available can be selected as a funding
-    /// source. The automation re-checks the balance in the transaction's
-    /// month before performing the transfer.
-    private var availableFundingCategories {
+    /// source. The automation re-checks the balance before transferring.
+    private var availableFundingCategories: [CategoryBudget] {
         (budgetStore.currentBudgetMonth?.allCategoryBudgets ?? [])
             .filter { $0.available > 0 }
             .sorted {
@@ -76,7 +75,7 @@ struct CategoryFundingAutomationView: View {
             } header: {
                 Text("Funding")
             } footer: {
-                Text("To Budget is the default. You can also fund the category from another budget category that currently has a positive available balance.")
+                Text("To Budget is the default. You can also fund the category from another budget category that has enough available money.")
             }
 
             if configuration.isEnabled && configuration.accountId == nil {

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -34,13 +34,15 @@ struct CategoryFundingAutomationView: View {
         )
     }
 
-    /// Only categories with money available can be used as a funding source.
-    /// The current budget month is used for the setup screen; the automation
-    /// re-checks the source balance in the transaction's month before funding.
-    private var availableFundingCategories: [BudgetCategory] {
+    /// Only categories with money available can be selected as a funding
+    /// source. The automation re-checks the balance in the transaction's
+    /// month before performing the transfer.
+    private var availableFundingCategories {
         (budgetStore.currentBudgetMonth?.allCategoryBudgets ?? [])
             .filter { $0.available > 0 }
-            .sorted { $0.categoryName.localizedCaseInsensitiveCompare($1.categoryName) == .orderedAscending }
+            .sorted {
+                $0.categoryName.localizedCaseInsensitiveCompare($1.categoryName) == .orderedAscending
+            }
     }
 
     var body: some View {
@@ -91,8 +93,6 @@ struct CategoryFundingAutomationView: View {
                 ?? CategoryFundingAutomationConfiguration()
         }
         .onChange(of: configuration.fundingSource) { _, newSource in
-            // If a previously selected source no longer has a positive balance,
-            // fall back to To Budget rather than persisting an unusable source.
             if case .category(let categoryId) = newSource,
                !availableFundingCategories.contains(where: { $0.categoryId == categoryId }) {
                 configuration.fundingSource = .toBudget

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -5,7 +5,7 @@ struct CategoryFundingAutomationView: View {
     @State private var configuration = CategoryFundingAutomationConfiguration()
 
     private var selectedAccountBinding: Binding<String?> {
-        Binding(
+        Binding<String?>(
             get: { configuration.accountId },
             set: {
                 configuration.accountId = $0
@@ -15,7 +15,7 @@ struct CategoryFundingAutomationView: View {
     }
 
     private var enabledBinding: Binding<Bool> {
-        Binding(
+        Binding<Bool>(
             get: { configuration.isEnabled },
             set: {
                 configuration.isEnabled = $0
@@ -25,7 +25,7 @@ struct CategoryFundingAutomationView: View {
     }
 
     private var fundingSourceBinding: Binding<CategoryFundingSource> {
-        Binding(
+        Binding<CategoryFundingSource>(
             get: { configuration.fundingSource },
             set: {
                 configuration.fundingSource = $0
@@ -42,21 +42,25 @@ struct CategoryFundingAutomationView: View {
                 Text("When a new expense from the selected account would overdraw its category, Actuali automatically funds only the amount needed to cover that expense.")
             }
 
-            Section("Trigger") {
+            Section {
                 Picker("Account", selection: selectedAccountBinding) {
-                    Text("None").tag(nil as String?)
-                    ForEach(budgetStore.accounts.filter { !$0.closed }) { account in
-                        Text(account.name).tag(account.id as String?)
+                    Text("None").tag(String?.none)
+                    ForEach(budgetStore.accounts.filter { !$0.closed }, id: \.id) { account in
+                        Text(account.name).tag(Optional(account.id))
                     }
                 }
+            } header: {
+                Text("Trigger")
             }
 
-            Section("Funding") {
+            Section {
                 Picker("Funding Source", selection: fundingSourceBinding) {
-                    ForEach(CategoryFundingSource.allCases) { source in
+                    ForEach(CategoryFundingSource.allCases, id: \.id) { source in
                         Text(source.label).tag(source)
                     }
                 }
+            } header: {
+                Text("Funding")
             } footer: {
                 Text("To Budget is used as the source. Only the shortfall is moved into the transaction's category.")
             }

--- a/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
+++ b/Actuali/Actuali/Views/Settings/CategoryFundingAutomationView.swift
@@ -25,7 +25,7 @@ struct CategoryFundingAutomationView: View {
             Section {
                 Toggle("Enable Automation", isOn: $configuration.isEnabled)
             } footer: {
-                Text("When a new expense from the selected account would overdraw its category, Actuali automatically funds only the amount needed to cover that expense.")
+                Text("When a new expense is manually entered from the selected account and would overdraw its category, Actuali automatically funds only the amount needed to cover that expense.")
             }
 
             Section {
@@ -64,7 +64,7 @@ struct CategoryFundingAutomationView: View {
         .navigationTitle("Category Funding")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            configuration = CategoryFundingAutomationMonitor.loadConfiguration(for: budgetStore.currentBudgetId)
+            configuration = CategoryFundingAutomation.loadConfiguration(for: budgetStore.currentBudgetId)
                 ?? CategoryFundingAutomationConfiguration()
         }
         .onChange(of: configuration) { _, _ in
@@ -73,7 +73,7 @@ struct CategoryFundingAutomationView: View {
     }
 
     private func save() {
-        CategoryFundingAutomationMonitor.saveConfiguration(
+        CategoryFundingAutomation.saveConfiguration(
             configuration,
             for: budgetStore.currentBudgetId
         )

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -8,6 +8,9 @@ struct TransactionAutomationSettingsView: View {
     @State private var notificationPermissionDenied = false
     @State private var showingWalletImport = false
 
+    /// Persists the opt-in and requests permission on enable. Background
+    /// refresh runs regardless of this toggle (it keeps data fresh for
+    /// everyone); only notification posting is gated on it.
     private var transactionNotificationsBinding: Binding<Bool> {
         Binding(
             get: { transactionNotificationsEnabled },
@@ -26,6 +29,9 @@ struct TransactionAutomationSettingsView: View {
     var body: some View {
         Form {
             Section {
+                // Default Account remains reachable for loaded demo and
+                // offline budgets. Shortcuts and Wallet automation can't post
+                // without it (GH #122).
                 if budgetStore.currentBudgetId != nil {
                     Picker("Default Account", selection: $budgetStore.defaultAccountId) {
                         Text("None").tag(nil as String?)
@@ -60,9 +66,13 @@ struct TransactionAutomationSettingsView: View {
             }
 
             Section {
+                // Meaningless against servers that predate payee
+                // locations (< 26.4.0), so hidden there.
                 if budgetStore.payeeLocationWritesEnabled {
                     Toggle("Record Payee Locations", isOn: $budgetStore.recordPayeeLocations)
 
+                    // Clearing needs the same >= 26.4.0 server, so this
+                    // lives inside the gate too (GH #147).
                     NavigationLink("Payee Locations") {
                         PayeeLocationsView()
                     }
@@ -88,6 +98,8 @@ struct TransactionAutomationSettingsView: View {
                         HStack {
                             Text("Credit Cards & Billing Cycles")
                             Spacer()
+                            // Same predicate the screen itself lists, so the
+                            // badge can't promise cards the list won't show.
                             let cardCount = budgetStore.activeCreditCardStatementDays.count
                             if cardCount > 0 {
                                 Text("\(cardCount)")
@@ -183,7 +195,7 @@ struct TransactionAutomationSettingsView: View {
                 Text("Automations")
             } footer: {
                 if WalletImportView.isSupported {
-                    Text("Category Funding runs only for manual expenses entered from the selected account and funds only the required shortfall. You can also connect SimpleFIN, log tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions.")
+                    Text("Category Funding runs only for manual expenses entered from the selected account and funds only the required shortfall. You can also connect SimpleFIN, log tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions directly.")
                 } else {
                     Text("Category Funding runs only for manual expenses entered from the selected account and funds only the required shortfall. You can also connect SimpleFIN or log tap-to-pay purchases from Apple Wallet.")
                 }
@@ -193,9 +205,7 @@ struct TransactionAutomationSettingsView: View {
         .navigationTitle("Transactions & Automation")
         .navigationBarTitleDisplayMode(.inline)
         .contentMargins(.horizontal, 6, for: .scrollContent)
-        .task {
-            await refreshNotificationPermissionState()
-        }
+        .task { await refreshNotificationPermissionState() }
         .sheet(isPresented: $showingWalletImport) {
             WalletImportView()
                 .environmentObject(budgetStore)
@@ -208,6 +218,8 @@ struct TransactionAutomationSettingsView: View {
         notificationPermissionDenied = !granted
     }
 
+    /// Permission can change in the Settings app while we're backgrounded;
+    /// re-check whenever the screen appears.
     private func refreshNotificationPermissionState() async {
         guard transactionNotificationsEnabled else { return }
         let status = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -162,6 +162,12 @@ struct TransactionAutomationSettingsView: View {
 
             Section {
                 NavigationLink {
+                    CategoryFundingAutomationView()
+                } label: {
+                    Label("Category Funding", systemImage: "arrow.up.circle")
+                }
+
+                NavigationLink {
                     BankSyncSetupView()
                 } label: {
                     Label("Bank Sync (SimpleFIN)", systemImage: "building.columns")
@@ -184,9 +190,9 @@ struct TransactionAutomationSettingsView: View {
                 Text("Automations")
             } footer: {
                 if WalletImportView.isSupported {
-                    Text("Connect SimpleFIN to import transactions straight from your bank, set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions directly.")
+                    Text("Automatically fund a transaction's category when an expense would overdraw it. You can also connect SimpleFIN, log tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions.")
                 } else {
-                    Text("Connect SimpleFIN to import transactions straight from your bank, or set up a Shortcuts automation that logs tap-to-pay purchases from Apple Wallet.")
+                    Text("Automatically fund a transaction's category when an expense would overdraw it. You can also connect SimpleFIN or log tap-to-pay purchases from Apple Wallet.")
                 }
             }
         }

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -7,7 +7,6 @@ struct TransactionAutomationSettingsView: View {
     @State private var transactionNotificationsEnabled = TransactionNotificationSettings().isEnabled
     @State private var notificationPermissionDenied = false
     @State private var showingWalletImport = false
-    @State private var categoryFundingEnabled = false
 
     private var transactionNotificationsBinding: Binding<Bool> {
         Binding(
@@ -20,23 +19,6 @@ struct TransactionAutomationSettingsView: View {
                 } else {
                     notificationPermissionDenied = false
                 }
-            }
-        )
-    }
-
-    private var categoryFundingBinding: Binding<Bool> {
-        Binding(
-            get: { categoryFundingEnabled },
-            set: { enabled in
-                categoryFundingEnabled = enabled
-                var configuration = CategoryFundingAutomation.loadConfiguration(
-                    for: budgetStore.currentBudgetId
-                ) ?? CategoryFundingAutomationConfiguration()
-                configuration.isEnabled = enabled
-                CategoryFundingAutomation.saveConfiguration(
-                    configuration,
-                    for: budgetStore.currentBudgetId
-                )
             }
         )
     }
@@ -168,8 +150,6 @@ struct TransactionAutomationSettingsView: View {
 
             Section {
                 if budgetStore.currentBudgetId != nil {
-                    Toggle("Category Funding", isOn: categoryFundingBinding)
-
                     NavigationLink {
                         CategoryFundingAutomationView()
                     } label: {
@@ -215,14 +195,6 @@ struct TransactionAutomationSettingsView: View {
         .contentMargins(.horizontal, 6, for: .scrollContent)
         .task {
             await refreshNotificationPermissionState()
-            categoryFundingEnabled = CategoryFundingAutomation.loadConfiguration(
-                for: budgetStore.currentBudgetId
-            )?.isEnabled ?? false
-        }
-        .onChange(of: budgetStore.currentBudgetId) { _, newBudgetId in
-            categoryFundingEnabled = CategoryFundingAutomation.loadConfiguration(
-                for: newBudgetId
-            )?.isEnabled ?? false
         }
         .sheet(isPresented: $showingWalletImport) {
             WalletImportView()

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -7,10 +7,8 @@ struct TransactionAutomationSettingsView: View {
     @State private var transactionNotificationsEnabled = TransactionNotificationSettings().isEnabled
     @State private var notificationPermissionDenied = false
     @State private var showingWalletImport = false
+    @State private var categoryFundingEnabled = false
 
-    /// Persists the opt-in and requests permission on enable. Background
-    /// refresh runs regardless of this toggle (it keeps data fresh for
-    /// everyone); only notification posting is gated on it.
     private var transactionNotificationsBinding: Binding<Bool> {
         Binding(
             get: { transactionNotificationsEnabled },
@@ -26,12 +24,26 @@ struct TransactionAutomationSettingsView: View {
         )
     }
 
+    private var categoryFundingBinding: Binding<Bool> {
+        Binding(
+            get: { categoryFundingEnabled },
+            set: { enabled in
+                categoryFundingEnabled = enabled
+                var configuration = CategoryFundingAutomation.loadConfiguration(
+                    for: budgetStore.currentBudgetId
+                ) ?? CategoryFundingAutomationConfiguration()
+                configuration.isEnabled = enabled
+                CategoryFundingAutomation.saveConfiguration(
+                    configuration,
+                    for: budgetStore.currentBudgetId
+                )
+            }
+        )
+    }
+
     var body: some View {
         Form {
             Section {
-                // Default Account remains reachable for loaded demo and
-                // offline budgets. Shortcuts and Wallet automation can't post
-                // without it (GH #122).
                 if budgetStore.currentBudgetId != nil {
                     Picker("Default Account", selection: $budgetStore.defaultAccountId) {
                         Text("None").tag(nil as String?)
@@ -66,13 +78,9 @@ struct TransactionAutomationSettingsView: View {
             }
 
             Section {
-                // Meaningless against servers that predate payee
-                // locations (< 26.4.0), so hidden there.
                 if budgetStore.payeeLocationWritesEnabled {
                     Toggle("Record Payee Locations", isOn: $budgetStore.recordPayeeLocations)
 
-                    // Clearing needs the same >= 26.4.0 server, so this
-                    // lives inside the gate too (GH #147).
                     NavigationLink("Payee Locations") {
                         PayeeLocationsView()
                     }
@@ -98,8 +106,6 @@ struct TransactionAutomationSettingsView: View {
                         HStack {
                             Text("Credit Cards & Billing Cycles")
                             Spacer()
-                            // Same predicate the screen itself lists, so the
-                            // badge can't promise cards the list won't show.
                             let cardCount = budgetStore.activeCreditCardStatementDays.count
                             if cardCount > 0 {
                                 Text("\(cardCount)")
@@ -161,10 +167,17 @@ struct TransactionAutomationSettingsView: View {
             }
 
             Section {
-                NavigationLink {
-                    CategoryFundingAutomationView()
-                } label: {
-                    Label("Category Funding", systemImage: "arrow.up.circle")
+                if budgetStore.currentBudgetId != nil {
+                    Toggle("Category Funding", isOn: categoryFundingBinding)
+
+                    NavigationLink {
+                        CategoryFundingAutomationView()
+                    } label: {
+                        Label("Category Funding Settings", systemImage: "arrow.up.circle")
+                    }
+                } else {
+                    Text("Load a budget to configure Category Funding.")
+                        .foregroundStyle(.secondary)
                 }
 
                 NavigationLink {
@@ -190,9 +203,9 @@ struct TransactionAutomationSettingsView: View {
                 Text("Automations")
             } footer: {
                 if WalletImportView.isSupported {
-                    Text("Automatically fund a transaction's category when an expense would overdraw it. You can also connect SimpleFIN, log tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions.")
+                    Text("Category Funding runs only for manual expenses entered from the selected account and funds only the required shortfall. You can also connect SimpleFIN, log tap-to-pay purchases from Apple Wallet, or import Apple Card, Apple Cash and Savings transactions.")
                 } else {
-                    Text("Automatically fund a transaction's category when an expense would overdraw it. You can also connect SimpleFIN or log tap-to-pay purchases from Apple Wallet.")
+                    Text("Category Funding runs only for manual expenses entered from the selected account and funds only the required shortfall. You can also connect SimpleFIN or log tap-to-pay purchases from Apple Wallet.")
                 }
             }
         }
@@ -200,7 +213,17 @@ struct TransactionAutomationSettingsView: View {
         .navigationTitle("Transactions & Automation")
         .navigationBarTitleDisplayMode(.inline)
         .contentMargins(.horizontal, 6, for: .scrollContent)
-        .task { await refreshNotificationPermissionState() }
+        .task {
+            await refreshNotificationPermissionState()
+            categoryFundingEnabled = CategoryFundingAutomation.loadConfiguration(
+                for: budgetStore.currentBudgetId
+            )?.isEnabled ?? false
+        }
+        .onChange(of: budgetStore.currentBudgetId) { _, newBudgetId in
+            categoryFundingEnabled = CategoryFundingAutomation.loadConfiguration(
+                for: newBudgetId
+            )?.isEnabled ?? false
+        }
         .sheet(isPresented: $showingWalletImport) {
             WalletImportView()
                 .environmentObject(budgetStore)
@@ -213,8 +236,6 @@ struct TransactionAutomationSettingsView: View {
         notificationPermissionDenied = !granted
     }
 
-    /// Permission can change in the Settings app while we're backgrounded;
-    /// re-check whenever the screen appears.
     private func refreshNotificationPermissionState() async {
         guard transactionNotificationsEnabled else { return }
         let status = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -8,10 +8,9 @@ struct AddTransactionView: View {
     @Environment(\.isPresented) private var isPresented
 
     private let editing: Transaction?
-    /// Called after a successful save (not on cancel). Lets a presenting flow
-    /// react to the write — e.g. the pending-imports inbox clears the queued
-    /// item only once its edited copy actually reaches the budget.
-    private let onSaved: (() -> Void)?
+    /// Called after a successful save (not on cancel). The optional id is the
+    /// exact row written by the save path, or nil when nothing was created.
+    private let onSaved: ((String?) -> Void)?
 
     @State private var selectedAccountId: String
     @State private var amount: String
@@ -49,7 +48,7 @@ struct AddTransactionView: View {
         categoryId: String? = nil,
         isIncome: Bool = false,
         cleared: Bool = false,
-        onSaved: (() -> Void)? = nil
+        onSaved: ((String?) -> Void)? = nil
     ) {
         self.editing = nil
         self.onSaved = onSaved
@@ -728,8 +727,8 @@ struct AddTransactionView: View {
         )
 
         do {
-            try await budgetStore.saveTransaction(form, editing: editing)
-            onSaved?()
+            let savedTransactionId = try await budgetStore.saveTransaction(form, editing: editing)
+            onSaved?(savedTransactionId)
             if canDismiss {
                 // Presented flows (edit, account-detail "+", notification
                 // prefill) close; the account-detail host is already the

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -36,9 +36,6 @@ struct AddTransactionView: View {
 
     @FocusState private var payeeFocused: Bool
 
-    /// Initializer for the "Add" flow. The optional prefill parameters carry
-    /// whatever an automation passed along — a failed Wallet log or the Add
-    /// Transaction with Review intent (see TransactionPrefill).
     init(
         accountId: String,
         payee: String = "",
@@ -61,14 +58,9 @@ struct AddTransactionView: View {
         _notes = State(initialValue: notes)
         _date = State(initialValue: date)
         _cleared = State(initialValue: cleared)
-        // A prefilled category is the automation's explicit choice — don't
-        // let the payee-history suggestion overwrite it.
         _userPickedCategory = State(initialValue: categoryId != nil)
     }
 
-    /// Initializer for the "Edit" flow. Transfer legs load as transfers —
-    /// From/To derive from the leg's sign (the opened row can be either side)
-    /// with the partner account read off the transfer payee (GH #104).
     init(editing: Transaction) {
         self.editing = editing
         self.onSaved = nil
@@ -82,8 +74,6 @@ struct AddTransactionView: View {
                 _selectedAccountId = State(initialValue: editing.accountId)
                 _transferToAccountId = State(initialValue: editing.transferAcct)
             } else {
-                // Partner unknown (transfer payee missing): fall back to the
-                // leg's own account as From and let the user pick To.
                 _selectedAccountId = State(initialValue: editing.transferAcct ?? editing.accountId)
                 _transferToAccountId = State(initialValue:
                     editing.transferAcct == nil ? nil : editing.accountId)
@@ -101,33 +91,19 @@ struct AddTransactionView: View {
     }
 
     private var isEditing: Bool { editing != nil }
-    /// Presented flows (edit, account-detail "+", notification prefill) can
-    /// close themselves; the tab-hosted add flow can't. Cancel, post-save
-    /// behavior, and the header all branch on this.
     private var canDismiss: Bool { isEditing || isPresented }
     private var isTransfer: Bool { txType == .transfer }
     private var isEditingSplitParent: Bool { editing?.isParent == true }
     private var isEditingTransfer: Bool { editing?.transferId != nil }
 
-    /// Whether the edit form may offer turning this transaction into a
-    /// transfer (GH #259). Split parents and children are excluded — the
-    /// store refuses them, since a parent's amount is its children's and a
-    /// child has no row of its own to pair.
     private var canConvertToTransfer: Bool {
         guard let editing else { return false }
         return editing.transferId == nil && !editing.isParent && editing.parentId == nil
     }
     private var isConvertingToTransfer: Bool { isTransfer && canConvertToTransfer }
 
-    /// A transfer leg takes a category only when it sits in an on-budget
-    /// account and the other side is off-budget — money leaving the budget
-    /// still needs one (Actual's rule). Tracks the live picker selections so
-    /// re-targeting the accounts shows/hides the row immediately.
     private var editedTransferLegIsCategorizable: Bool {
         guard let editing, isTransfer else { return false }
-        // The edited row's own account is the one in the account picker,
-        // except on an existing transfer opened from its receiving leg —
-        // there the form shows the pair as From/To and the opened row is To.
         let openedOnDestinationLeg = editing.transferId != nil && editing.amount >= 0
         let legAccountId = openedOnDestinationLeg ? transferToAccountId : selectedAccountId
         let otherAccountId = openedOnDestinationLeg ? selectedAccountId : transferToAccountId
@@ -139,21 +115,11 @@ struct AddTransactionView: View {
     }
     private var isSplitting: Bool { !splitLines.isEmpty && !unsplitRequested }
 
-    /// Whether the form can offer the split option: a plain transaction in
-    /// either flow, or an existing parent mid-"Remove Split" (as an undo).
-    /// Transfers are excluded — they pair two accounts through `transferId`
-    /// and splitting would orphan the partner leg (the store refuses it), so
-    /// the button stays hidden rather than failing on save.
     private var canSplitIntoCategories: Bool {
         editing?.transferId == nil && (!isEditingSplitParent || unsplitRequested)
     }
 
-    /// Cents still unassigned across the split lines, nil while the total
-    /// doesn't parse yet. Blank lines count as zero so the remainder stays
-    /// visible while the user is still filling lines in.
     private var splitRemainingCents: Int? {
-        // Opposite-direction lines hand their amount back to the remainder
-        // instead of consuming it (GH #216).
         SplitEntryMath.remainingCents(total: amount, lineAmounts: splitLines.map { line in
             line.isOpposite && !line.amount.isEmpty ? "-\(line.amount)" : line.amount
         })
@@ -163,8 +129,6 @@ struct AddTransactionView: View {
         splitLines.contains { $0.amount.isEmpty }
     }
 
-    /// Open accounts ordered to match the webapp's AccountAutocomplete:
-    /// on-budget first, then off-budget, each group by sort_order.
     private var orderedOpenAccounts: [Account] {
         budgetStore.accounts
             .filter { !$0.closed }
@@ -174,11 +138,6 @@ struct AddTransactionView: View {
             }
     }
 
-    /// Converting keeps the edited row on its own side of the transfer, so
-    /// the form asks for one account — the other one — instead of the From/To
-    /// pair a new transfer needs. The account row stays editable and keeps
-    /// its usual label: moving a transaction between accounts is an ordinary
-    /// edit, and converting doesn't take that away.
     private var accountPickerLabel: String {
         isTransfer && !isConvertingToTransfer ? "From" : "Account"
     }
@@ -207,16 +166,11 @@ struct AddTransactionView: View {
         guard let db = budgetStore.databaseForLogger else { return }
         Task { @MainActor in
             guard let cat = try? await db.mostRecentCategoryId(forPayeeId: payeeId) else { return }
-            // Re-check after the await: the user may have picked a category
-            // while the lookup was in flight — don't clobber their choice.
             guard !userPickedCategory else { return }
             selectedCategoryId = cat
         }
     }
 
-    /// Load nearby payees when the payee field gains focus. Requests
-    /// permission on first use; every failure path degrades to "no
-    /// suggestions" silently.
     private func loadNearbyPayees() {
         guard !isEditing else { return }
         Task { @MainActor in
@@ -235,9 +189,6 @@ struct AddTransactionView: View {
         }
     }
 
-    /// Swipe-delete on a nearby suggestion tombstones that one location
-    /// record, then reloads: the payee legitimately reappears if it has
-    /// another recorded location within range.
     private func deleteNearbySuggestion(_ nearby: NearbyPayee) {
         Task { @MainActor in
             guard await budgetStore.deletePayeeLocation(nearby.location) else { return }
@@ -290,20 +241,12 @@ struct AddTransactionView: View {
                             }
                         }
                         .pickerStyle(.segmented)
-                        // A split parent's sign is the children's; flipping
-                        // it would have to flip every line, so it stays fixed.
-                        // A transfer stays a transfer: converting one back
-                        // would orphan the partner leg (the store refuses it).
                         .disabled(isEditingSplitParent || isEditingTransfer)
                     }
 
                     HStack {
                         Text(amountSignSymbol)
                             .foregroundStyle(amountSignColor)
-                        // The amount is the first thing entered in a fresh
-                        // form, so the add flow opens with the keyboard ready.
-                        // Edits and prefilled amounts already have one and
-                        // start with the keyboard down.
                         AmountInputField(
                             text: $amount,
                             conventionalAmountEntry: budgetStore.conventionalAmountEntry,
@@ -417,8 +360,6 @@ struct AddTransactionView: View {
                         }
 
                         if isEditingSplitParent && !isSplitting && !unsplitRequested {
-                            // Placeholder while the children load into the
-                            // editable split lines below.
                             HStack {
                                 Text("Category")
                                 Spacer()
@@ -456,22 +397,13 @@ struct AddTransactionView: View {
                 }
 
                 Section {
-                    // One line while the note is short — an empty three-line
-                    // box only pushes Cleared and the save button off screen —
-                    // growing as the text needs it, up to six.
                     TextField("Notes", text: $notes, axis: .vertical)
                         .lineLimit(1...6)
-                    // Links in the note stay openable while the text is a
-                    // TextField (GH #190) — this form doubles as the only
-                    // full view of a transaction's note.
                     NoteLinkRows(text: notes)
                 }
 
                 Section {
                     Toggle("Cleared", isOn: $cleared)
-                    // Only the paths that record locations (adds and split
-                    // edits) get the per-save opt-out; standard edits never
-                    // record, so the toggle would be a no-op there.
                     if (!isEditing || isEditingSplitParent) && !isTransfer
                         && budgetStore.payeeLocationWritesEnabled
                         && budgetStore.recordPayeeLocations {
@@ -496,17 +428,9 @@ struct AddTransactionView: View {
                         }
                     }
                     .disabled(saveDisabled)
-                    // Hardware-keyboard commit, for the iPad case where the
-                    // form is filled without ever leaving the keys. Return on
-                    // its own belongs to the focused field; ⌘Return is the
-                    // whole form. Inert while the save is disabled.
                     .keyboardShortcut(.return, modifiers: .command)
                 }
 
-                // Cancel sits under the save button rather than in the
-                // navigation bar: the two decisions belong together at the
-                // end of the form, and its own section makes it the same
-                // full-width row as the save button.
                 Section {
                     Button(role: .destructive, action: cancelEntry) {
                         HStack {
@@ -516,21 +440,11 @@ struct AddTransactionView: View {
                             Spacer()
                         }
                     }
-                    // Esc cancels on a hardware keyboard while the row is on
-                    // screen. A Form row is lazy, so on a form long enough to
-                    // scroll the shortcut isn't registered until the row is
-                    // reached — the same reachability the tap has.
                     .keyboardShortcut(.cancelAction)
                 }
             }
             .readableWidth()
-            // The form's default ~35pt top inset is dead space on the
-            // header-less tab root; 8pt keeps the first section off the status
-            // bar without it. Presented flows have a title up there and keep
-            // the stock inset.
             .contentMargins(.top, canDismiss ? nil : 8, for: .scrollContent)
-            // Presented flows keep their sheet titles; the tab root shows no
-            // header, matching the Accounts and Budget tabs.
             .navigationTitle(canDismiss ? (isEditing ? "Edit Transaction" : "Add Transaction") : "")
             .navigationBarTitleDisplayMode(canDismiss ? .automatic : .inline)
             .listSectionSpacing(.compact)
@@ -544,18 +458,11 @@ struct AddTransactionView: View {
             }
             .disabled(isLoading)
             .task {
-                // Load a split parent's children as editable lines. Inherited
-                // payees load as empty so a parent payee edit follows through
-                // to them, mirroring Actual's cascade rule.
                 await loadSplitChildren()
             }
         }
     }
 
-    /// Any presented flow (edit, account-detail "+", notification prefill)
-    /// closes on Cancel; the tab-hosted add flow has nothing to dismiss to, so
-    /// Cancel discards the entry and returns to the user's Start Page instead
-    /// (GH #281).
     private func cancelEntry() {
         if canDismiss {
             dismiss()
@@ -565,10 +472,6 @@ struct AddTransactionView: View {
         }
     }
 
-    /// Load a split parent's children as editable lines. Inherited payees
-    /// load as empty so a parent payee edit follows through to them,
-    /// mirroring Actual's cascade rule. Reused both on first appearance and
-    /// when the user undoes an unsplit after swiping the lines away.
     private func loadSplitChildren() async {
         guard let editing, editing.isParent, splitLines.isEmpty else { return }
         splitLines = await budgetStore.fetchSplitChildren(parentId: editing.id).map { child in
@@ -576,8 +479,6 @@ struct AddTransactionView: View {
                 childId: child.id,
                 categoryId: child.categoryId,
                 amount: SplitEntryMath.amountString(fromCents: abs(child.amount)),
-                // A child running against the parent's direction — a refund
-                // inside a spend split — keeps its flip on reload (GH #216).
                 isOpposite: (child.amount < 0) != (editing.amount < 0),
                 notes: child.notes ?? "",
                 payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
@@ -585,8 +486,6 @@ struct AddTransactionView: View {
         }
     }
 
-    /// Editable split lines for the add flow: one category + amount per
-    /// line, with the unassigned remainder in the footer.
     private var splitEntrySection: some View {
         Section {
             ForEach($splitLines) { $line in
@@ -594,12 +493,6 @@ struct AddTransactionView: View {
             }
             .onDelete { offsets in
                 if isEditingSplitParent {
-                    // Swiping away every line on an existing parent is the
-                    // same intent as "Remove Split": switch to
-                    // single-transaction mode and seed the collapse category
-                    // from a removed line (the parent carries none). The
-                    // lines are gone from memory, so undoing via the split
-                    // button reloads them from the database.
                     let removed = offsets.compactMap { splitLines[$0] }
                     splitLines.remove(atOffsets: offsets)
                     if splitLines.isEmpty {
@@ -617,11 +510,6 @@ struct AddTransactionView: View {
             } label: {
                 Label("Add Line", systemImage: "plus")
             }
-            // Tapping "Remove Split" on an existing parent switches the form
-            // to single-transaction mode: keep the lines in memory for an
-            // instant undo and seed the collapse category from the first
-            // line that has one (the parent itself carries none). In the add
-            // flow it just clears the lines, as before.
             Button(role: .destructive) {
                 if isEditingSplitParent {
                     unsplitRequested = true
@@ -641,26 +529,15 @@ struct AddTransactionView: View {
                 Text("\(budgetStore.formatCurrency(remaining)) left to assign")
                     .foregroundStyle(.red)
             } else if splitRemainingCents == 0 && hasBlankSplitLine {
-                // Nothing left to assign but a line is still blank — say why
-                // Save stays disabled instead of leaving it a mystery.
                 Text("Fill in or remove the empty line")
                     .foregroundStyle(.red)
             }
         }
     }
 
-    /// Begin a split from the form. The add flow starts from two empty
-    /// lines; editing a plain transaction seeds the first line with the
-    /// transaction's current category and full amount so nothing is lost if
-    /// the user only fills the second line — mirroring Actual's desktop
-    /// behavior of moving the row's category onto the first sub-row. An
-    /// existing parent undoing "Remove Split" just re-enters split mode: the
-    /// children were kept in `splitLines`, so nothing needs reloading.
     private func startSplit() {
         unsplitRequested = false
         guard !isEditingSplitParent else {
-            // Existing parent: if the lines were kept (Remove Split toggle)
-            // they reappear instantly; if they were swiped away, reload them.
             if splitLines.isEmpty {
                 Task { await loadSplitChildren() }
             }
@@ -700,8 +577,6 @@ struct AddTransactionView: View {
     private var saveDisabled: Bool {
         if isLoading || amount.isEmpty { return true }
         if isTransfer && transferToAccountId == nil { return true }
-        // A blank line reads as zero for the remainder display, but the store
-        // rejects zero-amount children — keep save blocked until it's filled.
         if isSplitting && !isTransfer && (splitRemainingCents != 0 || hasBlankSplitLine) { return true }
         return false
     }
@@ -727,17 +602,18 @@ struct AddTransactionView: View {
         )
 
         do {
-            let savedTransactionId = try await budgetStore.saveTransaction(form, editing: editing)
+            let savedTransactionId: String?
+            if editing == nil && txType == .expense && splitLines.isEmpty {
+                savedTransactionId = try await budgetStore.createManualExpenseReturningID(form)
+            } else {
+                try await budgetStore.saveTransaction(form, editing: editing)
+                savedTransactionId = nil
+            }
+
             onSaved?(savedTransactionId)
             if canDismiss {
-                // Presented flows (edit, account-detail "+", notification
-                // prefill) close; the account-detail host is already the
-                // saved transaction's list.
                 dismiss()
             } else {
-                // The tab-hosted flow has nothing to dismiss: reset for the
-                // next entry and route to the saved transaction's account
-                // list so every add flow lands on the relevant list.
                 resetForm()
                 NotificationRouter.shared.pendingAccountNavigation = form.accountId
             }
@@ -758,12 +634,7 @@ struct AddTransactionView: View {
         errorMessage = nil
         splitLines = []
         unsplitRequested = false
-        // A fresh form suggests categories from payee history again — a
-        // discarded manual pick must not keep suppressing the lookup.
         userPickedCategory = false
-        // A reset can arrive with the amount or payee field still focused —
-        // Esc or ⌘Return from a hardware keyboard — and a fresh form doesn't
-        // keep the old keyboard up.
         dismissKeyboard()
     }
 
@@ -778,9 +649,6 @@ struct AddTransactionView: View {
 
 /// Math for the split entry section, kept off the view for testability.
 enum SplitEntryMath {
-    /// Cents still unassigned across the split lines. Blank lines count as
-    /// zero so the remainder stays visible mid-entry; nil while the total or
-    /// a non-blank line doesn't parse.
     static func remainingCents(total: String, lineAmounts: [String]) -> Int? {
         guard let dollars = Double(total),
               let totalCents = Transaction.cents(fromDollars: dollars) else { return nil }
@@ -793,23 +661,15 @@ enum SplitEntryMath {
         return totalCents - assigned
     }
 
-    /// Plain dot-decimal string for non-negative cents, the format
-    /// AmountInputField keeps in its binding.
     static func amountString(fromCents cents: Int) -> String {
         "\(cents / 100).\(String(format: "%02d", cents % 100))"
     }
 }
 
-/// One editable split line: a category picked through a sheet and an amount.
-/// Borderless button so the amount field keeps its own tap target in the row.
 private struct SplitLineRow: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Binding var line: BudgetStore.SplitLineForm
-    /// The transaction's direction, so the line's sign glyph can show its
-    /// effective direction relative to it.
     var txType: TransactionType
-    /// The section-wide unassigned remainder; a positive value on a line with
-    /// no amount yet offers one-tap fill instead of mental arithmetic.
     var remainingCents: Int?
     @State private var showCategoryPicker = false
 
@@ -823,8 +683,6 @@ private struct SplitLineRow: View {
         return "Category"
     }
 
-    /// Whether the line runs as an outflow once the transaction's direction
-    /// and the line's flip are combined.
     private var isOutflow: Bool {
         (txType == .expense) != line.isOpposite
     }
@@ -840,15 +698,11 @@ private struct SplitLineRow: View {
                 }
                 .buttonStyle(.borderless)
                 Spacer()
-                // Every line carries a sign like the total's, so direction is
-                // never implicit; tapping it flips the line — how a refund
-                // goes inside a spend split (GH #216).
                 Button {
                     line.isOpposite.toggle()
                 } label: {
                     Text(isOutflow ? "-" : "+")
                         .foregroundStyle(isOutflow ? Color.red : Color.green)
-                        // Grow the tap target beyond the one-character glyph.
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }
@@ -862,9 +716,6 @@ private struct SplitLineRow: View {
                 )
                     .frame(width: 110)
             }
-            // No fill offer on a flipped line: the remainder is stated in the
-            // transaction's direction, and filling it here would double the
-            // gap instead of closing it.
             if line.amount.isEmpty, !line.isOpposite, let remaining = remainingCents, remaining > 0 {
                 HStack {
                     Spacer()
@@ -877,7 +728,6 @@ private struct SplitLineRow: View {
                     .buttonStyle(.borderless)
                 }
             }
-            // Empty payee inherits the transaction's payee
             TextField("Payee (optional)", text: $line.payeeName)
                 .font(.subheadline)
                 .autocorrectionDisabled()
@@ -895,51 +745,15 @@ private struct SplitLineRow: View {
     }
 }
 
-/// Currency amount field with two digit-entry modes, picked by the
-/// `conventionalAmountEntry` setting.
-///
-/// Calculator entry (the default): digits shift right-to-left into the cents
-/// position — typing 1, 2, 0 produces 0.01, 0.12, 1.20. As soon as the user
-/// taps `.` (or `,` in comma-decimal locales), the field switches to explicit
-/// decimal entry where prior digits are reinterpreted as the integer part —
-/// so 1, ., 0 produces 1.0.
-///
-/// Conventional entry: digits stand for whole units and the decimal separator
-/// is always typed — 1, 2, 0 produces 120, and 1, ., 0 produces 1.0. Nothing
-/// gains a fraction the user didn't type, so zero-decimal currencies never
-/// need a trailing ".00" (GH #211).
-///
-/// With `allowsNegative`, a ± button joins the keyboard toolbar and flips
-/// the text's own sign. With `onToggleSign`, the same button appears but the
-/// sign lives outside the field (a split line's direction flip) and the text
-/// stays unsigned. Neither set means sign is handled elsewhere entirely
-/// (e.g. the expense/income toggle).
-///
-/// The toolbar also carries +, −, × and ÷ for quick math: typing 12.50, then
-/// +, then 6.00 shows "12.50 + 6.00" in the field and collapses to "18.50"
-/// when editing ends. Evaluation is strictly left-to-right with no operator
-/// precedence — this is an entry aid, not a calculator. The binding always
-/// holds the plain evaluated decimal, never the expression, so a save taken
-/// mid-expression (the Save button is an ordinary row and doesn't end
-/// editing) still commits a parseable amount.
 struct AmountInputField: UIViewRepresentable {
     @Binding var text: String
-    /// When true, digits are entered as a conventional decimal amount instead
-    /// of shifting into cents.
     var conventionalAmountEntry = false
     var alignment: NSTextAlignment = .natural
     var allowsNegative = false
     var weight: UIFont.Weight = .regular
-    /// Bring up the keyboard as soon as the field lands on screen. For
-    /// sheets whose whole purpose is entering an amount.
     var autofocus = false
-    /// Shows the ± toolbar button and delegates it here instead of signing
-    /// the text — for callers whose sign is separate state.
     var onToggleSign: (() -> Void)? = nil
 
-    /// becomeFirstResponder is a no-op until the view joins a window, and
-    /// during a sheet presentation that happens well after makeUIView —
-    /// didMoveToWindow is the earliest reliable moment.
     final class AutofocusTextField: UITextField {
         var wantsAutofocus = false
         private var hasAutofocused = false
@@ -963,22 +777,15 @@ struct AmountInputField: UIViewRepresentable {
         if weight == .regular {
             field.font = .preferredFont(forTextStyle: .body)
         } else {
-            // Weighted variant of the body style so Dynamic Type still scales.
             let descriptor = UIFontDescriptor
                 .preferredFontDescriptor(withTextStyle: .body)
                 .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: weight]])
             field.font = UIFont(descriptor: descriptor, size: 0)
         }
         field.adjustsFontForContentSizeCategory = true
-        // The SwiftUI keyboard toolbar only attaches to SwiftUI text fields,
-        // and the decimal pad has neither a return key nor operators — without
-        // this accessory bar there is no way to dismiss the keyboard from this
-        // field, or to do arithmetic in it.
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
         var items: [UIBarButtonItem] = []
         if allowsNegative || onToggleSign != nil {
-            // The decimal pad has no minus key, so this button is the only
-            // keyboard affordance for flipping an amount's sign.
             items.append(UIBarButtonItem(
                 image: UIImage(systemName: "plus.forwardslash.minus"),
                 style: .plain,
@@ -995,7 +802,6 @@ struct AmountInputField: UIViewRepresentable {
             items.append(item)
         }
         items.append(UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil))
-        // `.prominent` is iOS 26+; `.done` is the pre-26 equivalent emphasis.
         let doneStyle: UIBarButtonItem.Style = if #available(iOS 26, *) { .prominent } else { .done }
         items.append(UIBarButtonItem(
             title: "Done", style: doneStyle,
@@ -1011,10 +817,6 @@ struct AmountInputField: UIViewRepresentable {
 
     func updateUIView(_ uiView: UITextField, context: Context) {
         context.coordinator.parent = self
-        // Compare against what the coordinator last wrote out rather than the
-        // field's own text: mid-expression the field reads "12.50 + 6.00"
-        // while the binding holds "18.50", and that mismatch is expected.
-        // Only a change from outside the field should reset the state.
         if text != context.coordinator.lastPublishedText {
             uiView.text = text
             context.coordinator.sync(fromDisplay: text)
@@ -1026,7 +828,6 @@ struct AmountInputField: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextFieldDelegate {
-        /// The four toolbar operators. Left-to-right evaluation only.
         enum Operator: Character, CaseIterable {
             case add = "+", subtract = "−", multiply = "×", divide = "÷"
 
@@ -1062,8 +863,6 @@ struct AmountInputField: UIViewRepresentable {
                 case .add: return lhs + rhs
                 case .subtract: return lhs - rhs
                 case .multiply: return lhs * rhs
-                // Dividing by zero has no sensible amount to show, so the
-                // operator is dropped and the running total stands.
                 case .divide: return rhs == 0 ? lhs : lhs / rhs
                 }
             }
@@ -1071,14 +870,11 @@ struct AmountInputField: UIViewRepresentable {
 
         var parent: AmountInputField
         weak var textField: UITextField?
-        /// The last value written to the binding, so `updateUIView` can tell
-        /// an outside change from the field's own echo.
         private(set) var lastPublishedText: String?
         private var integerDigits: String = ""
         private var hasDecimalPoint: Bool = false
         private var fractionDigits: String = ""
         private var isNegative: Bool = false
-        /// Everything to the left of the pending operator, already evaluated.
         private var accumulatedValue: Double?
         private var pendingOperator: Operator?
 
@@ -1086,8 +882,6 @@ struct AmountInputField: UIViewRepresentable {
             self.parent = parent
         }
 
-        /// True once the current operand has any content of its own, so a
-        /// bare sign or a dangling operator doesn't count as typed input.
         private var hasTypedOperand: Bool {
             !integerDigits.isEmpty || hasDecimalPoint
         }
@@ -1152,15 +946,11 @@ struct AmountInputField: UIViewRepresentable {
         }
 
         func textFieldDidEndEditing(_ textField: UITextField) {
-            // Done, tapping away or dismissing the keyboard always leaves a
-            // plain amount behind, never a half-finished expression.
             finalizeExpression()
             applyDisplay(to: textField)
         }
 
         @objc func toggleSign() {
-            // Delegated sign lives outside the text (a split line's flip);
-            // the field's own text stays unsigned.
             if let onToggleSign = parent.onToggleSign {
                 onToggleSign()
                 return
@@ -1177,9 +967,6 @@ struct AmountInputField: UIViewRepresentable {
         @objc func multiplyTapped() { pushOperator(.multiply) }
         @objc func divideTapped() { pushOperator(.divide) }
 
-        /// Folds the operand just typed into the running total and arms the
-        /// next operator. Tapping a second operator without typing anything
-        /// in between just swaps which one is armed.
         private func pushOperator(_ op: Operator) {
             guard accumulatedValue != nil || hasTypedOperand else { return }
             if hasTypedOperand {
@@ -1197,18 +984,14 @@ struct AmountInputField: UIViewRepresentable {
             }
         }
 
-        /// Collapses the expression back down to a single editable operand.
         private func finalizeExpression() {
             guard let pending = pendingOperator, let acc = accumulatedValue else { return }
-            // A dangling operator ("12.50 ×" then Done) leaves the running
-            // total alone rather than multiplying it by an implied zero.
             let result = hasTypedOperand ? pending.apply(acc, currentOperandValue()) : acc
             accumulatedValue = nil
             pendingOperator = nil
             setOperand(to: result)
         }
 
-        /// The value the expression carries so far, evaluated left to right.
         private func resolvedValue() -> Double {
             guard let pending = pendingOperator, let acc = accumulatedValue else {
                 return currentOperandValue()
@@ -1220,9 +1003,6 @@ struct AmountInputField: UIViewRepresentable {
             Double(computeOperandDisplay()) ?? 0
         }
 
-        /// Rounds to cents and drops the sign where the field can't show one
-        /// — those callers get their sign from the expense/income toggle, so
-        /// the field carries a magnitude and 50 − 80 reads as 30.00.
         private func normalized(_ value: Double) -> Double {
             let signed = parent.allowsNegative ? value : abs(value)
             return (signed * 100).rounded() / 100
@@ -1235,21 +1015,16 @@ struct AmountInputField: UIViewRepresentable {
             isNegative = false
         }
 
-        /// Loads a computed result back into the digit state so it keeps
-        /// behaving like typed input (backspace, another operator, and so on).
         private func setOperand(to value: Double) {
             let rounded = normalized(value)
             let cents = Int((abs(rounded) * 100).rounded())
             isNegative = parent.allowsNegative && rounded < 0
             integerDigits = String(cents / 100)
-            // Conventional entry never adds a fraction the user didn't type,
-            // so a whole result comes back as a whole number.
             hasDecimalPoint = !(parent.conventionalAmountEntry && cents % 100 == 0)
             fractionDigits = hasDecimalPoint ? String(format: "%02d", cents % 100) : ""
         }
 
         private func handleCharacter(_ character: Character) {
-            // Hardware-keyboard minus; the on-screen path is the ± toolbar button.
             if character == "-", parent.allowsNegative {
                 isNegative.toggle()
                 return
@@ -1280,8 +1055,6 @@ struct AmountInputField: UIViewRepresentable {
             } else if isNegative {
                 isNegative = false
             } else if pendingOperator != nil {
-                // Backspacing through an empty operand undoes the operator and
-                // hands the running total back as editable digits.
                 pendingOperator = nil
                 if let acc = accumulatedValue {
                     setOperand(to: acc)
@@ -1290,12 +1063,9 @@ struct AmountInputField: UIViewRepresentable {
             }
         }
 
-        /// Just the operand currently being typed, with no running total in
-        /// front of it.
         private func computeOperandDisplay() -> String {
             let sign = isNegative ? "-" : ""
             if !hasDecimalPoint && integerDigits.isEmpty {
-                // A bare "-" so a sign toggled before any digits stays visible.
                 return sign
             }
             if hasDecimalPoint {
@@ -1311,15 +1081,11 @@ struct AmountInputField: UIViewRepresentable {
             return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
         }
 
-        /// An evaluated value as the field shows it: two decimals, except in
-        /// conventional entry where a whole result stays whole.
         private func displayValue(_ value: Double) -> String {
             let whole = parent.conventionalAmountEntry && value == value.rounded()
             return String(format: whole ? "%.0f" : "%.2f", value)
         }
 
-        /// What the field shows: the running total and armed operator, if any,
-        /// followed by the operand being typed.
         private func computeFieldText() -> String {
             let operandText = computeOperandDisplay()
             guard let pending = pendingOperator, let acc = accumulatedValue else {
@@ -1331,8 +1097,6 @@ struct AmountInputField: UIViewRepresentable {
                 : "\(accText) \(pending.rawValue) \(operandText)"
         }
 
-        /// What the binding carries: always a plain decimal, so callers can
-        /// parse it at any moment — including mid-expression.
         private func computeBoundText() -> String {
             guard pendingOperator != nil, accumulatedValue != nil else {
                 return computeOperandDisplay()
@@ -1353,8 +1117,6 @@ struct AmountInputField: UIViewRepresentable {
     }
 }
 
-/// Searchable category list, shared by the transaction form and the
-/// uncategorized-transactions quick-categorize flow.
 struct CategoryPickerView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -36,6 +36,9 @@ struct AddTransactionView: View {
 
     @FocusState private var payeeFocused: Bool
 
+    /// Initializer for the "Add" flow. The optional prefill parameters carry
+    /// whatever an automation passed along — a failed Wallet log or the Add
+    /// Transaction with Review intent (see TransactionPrefill).
     init(
         accountId: String,
         payee: String = "",
@@ -58,9 +61,14 @@ struct AddTransactionView: View {
         _notes = State(initialValue: notes)
         _date = State(initialValue: date)
         _cleared = State(initialValue: cleared)
+        // A prefilled category is the automation's explicit choice — don't
+        // let the payee-history suggestion overwrite it.
         _userPickedCategory = State(initialValue: categoryId != nil)
     }
 
+    /// Initializer for the "Edit" flow. Transfer legs load as transfers —
+    /// From/To derive from the leg's sign (the opened row can be either side)
+    /// with the partner account read off the transfer payee (GH #104).
     init(editing: Transaction) {
         self.editing = editing
         self.onSaved = nil
@@ -74,6 +82,8 @@ struct AddTransactionView: View {
                 _selectedAccountId = State(initialValue: editing.accountId)
                 _transferToAccountId = State(initialValue: editing.transferAcct)
             } else {
+                // Partner unknown (transfer payee missing): fall back to the
+                // leg's own account as From and let the user pick To.
                 _selectedAccountId = State(initialValue: editing.transferAcct ?? editing.accountId)
                 _transferToAccountId = State(initialValue:
                     editing.transferAcct == nil ? nil : editing.accountId)
@@ -91,19 +101,33 @@ struct AddTransactionView: View {
     }
 
     private var isEditing: Bool { editing != nil }
+    /// Presented flows (edit, account-detail "+", notification prefill) can
+    /// close themselves; the tab-hosted add flow can't. Cancel, post-save
+    /// behavior, and the header all branch on this.
     private var canDismiss: Bool { isEditing || isPresented }
     private var isTransfer: Bool { txType == .transfer }
     private var isEditingSplitParent: Bool { editing?.isParent == true }
     private var isEditingTransfer: Bool { editing?.transferId != nil }
 
+    /// Whether the edit form may offer turning this transaction into a
+    /// transfer (GH #259). Split parents and children are excluded — the
+    /// store refuses them, since a parent's amount is its children's and a
+    /// child has no row of its own to pair.
     private var canConvertToTransfer: Bool {
         guard let editing else { return false }
         return editing.transferId == nil && !editing.isParent && editing.parentId == nil
     }
     private var isConvertingToTransfer: Bool { isTransfer && canConvertToTransfer }
 
+    /// A transfer leg takes a category only when it sits in an on-budget
+    /// account and the other side is off-budget — money leaving the budget
+    /// still needs one (Actual's rule). Tracks the live picker selections so
+    /// re-targeting the accounts shows/hides the row immediately.
     private var editedTransferLegIsCategorizable: Bool {
         guard let editing, isTransfer else { return false }
+        // The edited row's own account is the one in the account picker,
+        // except on an existing transfer opened from its receiving leg —
+        // there the form shows the pair as From/To and the opened row is To.
         let openedOnDestinationLeg = editing.transferId != nil && editing.amount >= 0
         let legAccountId = openedOnDestinationLeg ? transferToAccountId : selectedAccountId
         let otherAccountId = openedOnDestinationLeg ? selectedAccountId : transferToAccountId
@@ -115,11 +139,21 @@ struct AddTransactionView: View {
     }
     private var isSplitting: Bool { !splitLines.isEmpty && !unsplitRequested }
 
+    /// Whether the form can offer the split option: a plain transaction in
+    /// either flow, or an existing parent mid-"Remove Split" (as an undo).
+    /// Transfers are excluded — they pair two accounts through `transferId`
+    /// and splitting would orphan the partner leg (the store refuses it), so
+    /// the button stays hidden rather than failing on save.
     private var canSplitIntoCategories: Bool {
         editing?.transferId == nil && (!isEditingSplitParent || unsplitRequested)
     }
 
+    /// Cents still unassigned across the split lines, nil while the total
+    /// doesn't parse yet. Blank lines count as zero so the remainder stays
+    /// visible while the user is still filling lines in.
     private var splitRemainingCents: Int? {
+        // Opposite-direction lines hand their amount back to the remainder
+        // instead of consuming it (GH #216).
         SplitEntryMath.remainingCents(total: amount, lineAmounts: splitLines.map { line in
             line.isOpposite && !line.amount.isEmpty ? "-\(line.amount)" : line.amount
         })
@@ -129,6 +163,8 @@ struct AddTransactionView: View {
         splitLines.contains { $0.amount.isEmpty }
     }
 
+    /// Open accounts ordered to match the webapp's AccountAutocomplete:
+    /// on-budget first, then off-budget, each group by sort_order.
     private var orderedOpenAccounts: [Account] {
         budgetStore.accounts
             .filter { !$0.closed }
@@ -138,6 +174,11 @@ struct AddTransactionView: View {
             }
     }
 
+    /// Converting keeps the edited row on its own side of the transfer, so
+    /// the form asks for one account — the other one — instead of the From/To
+    /// pair a new transfer needs. The account row stays editable and keeps
+    /// its usual label: moving a transaction between accounts is an ordinary
+    /// edit, and converting doesn't take that away.
     private var accountPickerLabel: String {
         isTransfer && !isConvertingToTransfer ? "From" : "Account"
     }
@@ -166,11 +207,16 @@ struct AddTransactionView: View {
         guard let db = budgetStore.databaseForLogger else { return }
         Task { @MainActor in
             guard let cat = try? await db.mostRecentCategoryId(forPayeeId: payeeId) else { return }
+            // Re-check after the await: the user may have picked a category
+            // while the lookup was in flight — don't clobber their choice.
             guard !userPickedCategory else { return }
             selectedCategoryId = cat
         }
     }
 
+    /// Load nearby payees when the payee field gains focus. Requests
+    /// permission on first use; every failure path degrades to "no
+    /// suggestions" silently.
     private func loadNearbyPayees() {
         guard !isEditing else { return }
         Task { @MainActor in
@@ -189,6 +235,9 @@ struct AddTransactionView: View {
         }
     }
 
+    /// Swipe-delete on a nearby suggestion tombstones that one location
+    /// record, then reloads: the payee legitimately reappears if it has
+    /// another recorded location within range.
     private func deleteNearbySuggestion(_ nearby: NearbyPayee) {
         Task { @MainActor in
             guard await budgetStore.deletePayeeLocation(nearby.location) else { return }
@@ -241,12 +290,20 @@ struct AddTransactionView: View {
                             }
                         }
                         .pickerStyle(.segmented)
+                        // A split parent's sign is the children's; flipping
+                        // it would have to flip every line, so it stays fixed.
+                        // A transfer stays a transfer: converting one back
+                        // would orphan the partner leg (the store refuses it).
                         .disabled(isEditingSplitParent || isEditingTransfer)
                     }
 
                     HStack {
                         Text(amountSignSymbol)
                             .foregroundStyle(amountSignColor)
+                        // The amount is the first thing entered in a fresh
+                        // form, so the add flow opens with the keyboard ready.
+                        // Edits and prefilled amounts already have one and
+                        // start with the keyboard down.
                         AmountInputField(
                             text: $amount,
                             conventionalAmountEntry: budgetStore.conventionalAmountEntry,
@@ -360,6 +417,8 @@ struct AddTransactionView: View {
                         }
 
                         if isEditingSplitParent && !isSplitting && !unsplitRequested {
+                            // Placeholder while the children load into the
+                            // editable split lines below.
                             HStack {
                                 Text("Category")
                                 Spacer()
@@ -397,13 +456,22 @@ struct AddTransactionView: View {
                 }
 
                 Section {
+                    // One line while the note is short — an empty three-line
+                    // box only pushes Cleared and the save button off screen —
+                    // growing as the text needs it, up to six.
                     TextField("Notes", text: $notes, axis: .vertical)
                         .lineLimit(1...6)
+                    // Links in the note stay openable while the text is a
+                    // TextField (GH #190) — this form doubles as the only
+                    // full view of a transaction's note.
                     NoteLinkRows(text: notes)
                 }
 
                 Section {
                     Toggle("Cleared", isOn: $cleared)
+                    // Only the paths that record locations (adds and split
+                    // edits) get the per-save opt-out; standard edits never
+                    // record, so the toggle would be a no-op there.
                     if (!isEditing || isEditingSplitParent) && !isTransfer
                         && budgetStore.payeeLocationWritesEnabled
                         && budgetStore.recordPayeeLocations {
@@ -428,9 +496,17 @@ struct AddTransactionView: View {
                         }
                     }
                     .disabled(saveDisabled)
+                    // Hardware-keyboard commit, for the iPad case where the
+                    // form is filled without ever leaving the keys. Return on
+                    // its own belongs to the focused field; ⌘Return is the
+                    // whole form. Inert while the save is disabled.
                     .keyboardShortcut(.return, modifiers: .command)
                 }
 
+                // Cancel sits under the save button rather than in the
+                // navigation bar: the two decisions belong together at the
+                // end of the form, and its own section makes it the same
+                // full-width row as the save button.
                 Section {
                     Button(role: .destructive, action: cancelEntry) {
                         HStack {
@@ -440,11 +516,21 @@ struct AddTransactionView: View {
                             Spacer()
                         }
                     }
+                    // Esc cancels on a hardware keyboard while the row is on
+                    // screen. A Form row is lazy, so on a form long enough to
+                    // scroll the shortcut isn't registered until the row is
+                    // reached — the same reachability the tap has.
                     .keyboardShortcut(.cancelAction)
                 }
             }
             .readableWidth()
+            // The form's default ~35pt top inset is dead space on the
+            // header-less tab root; 8pt keeps the first section off the status
+            // bar without it. Presented flows have a title up there and keep
+            // the stock inset.
             .contentMargins(.top, canDismiss ? nil : 8, for: .scrollContent)
+            // Presented flows keep their sheet titles; the tab root shows no
+            // header, matching the Accounts and Budget tabs.
             .navigationTitle(canDismiss ? (isEditing ? "Edit Transaction" : "Add Transaction") : "")
             .navigationBarTitleDisplayMode(canDismiss ? .automatic : .inline)
             .listSectionSpacing(.compact)
@@ -458,11 +544,18 @@ struct AddTransactionView: View {
             }
             .disabled(isLoading)
             .task {
+                // Load a split parent's children as editable lines. Inherited
+                // payees load as empty so a parent payee edit follows through
+                // to them, mirroring Actual's cascade rule.
                 await loadSplitChildren()
             }
         }
     }
 
+    /// Any presented flow (edit, account-detail "+", notification prefill)
+    /// closes on Cancel; the tab-hosted add flow has nothing to dismiss to, so
+    /// Cancel discards the entry and returns to the user's Start Page instead
+    /// (GH #281).
     private func cancelEntry() {
         if canDismiss {
             dismiss()
@@ -472,6 +565,10 @@ struct AddTransactionView: View {
         }
     }
 
+    /// Load a split parent's children as editable lines. Inherited payees
+    /// load as empty so a parent payee edit follows through to them,
+    /// mirroring Actual's cascade rule. Reused both on first appearance and
+    /// when the user undoes an unsplit after swiping the lines away.
     private func loadSplitChildren() async {
         guard let editing, editing.isParent, splitLines.isEmpty else { return }
         splitLines = await budgetStore.fetchSplitChildren(parentId: editing.id).map { child in
@@ -479,6 +576,8 @@ struct AddTransactionView: View {
                 childId: child.id,
                 categoryId: child.categoryId,
                 amount: SplitEntryMath.amountString(fromCents: abs(child.amount)),
+                // A child running against the parent's direction — a refund
+                // inside a spend split — keeps its flip on reload (GH #216).
                 isOpposite: (child.amount < 0) != (editing.amount < 0),
                 notes: child.notes ?? "",
                 payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
@@ -486,6 +585,8 @@ struct AddTransactionView: View {
         }
     }
 
+    /// Editable split lines for the add flow: one category + amount per
+    /// line, with the unassigned remainder in the footer.
     private var splitEntrySection: some View {
         Section {
             ForEach($splitLines) { $line in
@@ -493,6 +594,12 @@ struct AddTransactionView: View {
             }
             .onDelete { offsets in
                 if isEditingSplitParent {
+                    // Swiping away every line on an existing parent is the
+                    // same intent as "Remove Split": switch to
+                    // single-transaction mode and seed the collapse category
+                    // from a removed line (the parent carries none). The
+                    // lines are gone from memory, so undoing via the split
+                    // button reloads them from the database.
                     let removed = offsets.compactMap { splitLines[$0] }
                     splitLines.remove(atOffsets: offsets)
                     if splitLines.isEmpty {
@@ -510,6 +617,11 @@ struct AddTransactionView: View {
             } label: {
                 Label("Add Line", systemImage: "plus")
             }
+            // Tapping "Remove Split" on an existing parent switches the form
+            // to single-transaction mode: keep the lines in memory for an
+            // instant undo and seed the collapse category from the first
+            // line that has one (the parent itself carries none). In the add
+            // flow it just clears the lines, as before.
             Button(role: .destructive) {
                 if isEditingSplitParent {
                     unsplitRequested = true
@@ -529,15 +641,26 @@ struct AddTransactionView: View {
                 Text("\(budgetStore.formatCurrency(remaining)) left to assign")
                     .foregroundStyle(.red)
             } else if splitRemainingCents == 0 && hasBlankSplitLine {
+                // Nothing left to assign but a line is still blank — say why
+                // Save stays disabled instead of leaving it a mystery.
                 Text("Fill in or remove the empty line")
                     .foregroundStyle(.red)
             }
         }
     }
 
+    /// Begin a split from the form. The add flow starts from two empty
+    /// lines; editing a plain transaction seeds the first line with the
+    /// transaction's current category and full amount so nothing is lost if
+    /// the user only fills the second line — mirroring Actual's desktop
+    /// behavior of moving the row's category onto the first sub-row. An
+    /// existing parent undoing "Remove Split" just re-enters split mode: the
+    /// children were kept in `splitLines`, so nothing needs reloading.
     private func startSplit() {
         unsplitRequested = false
         guard !isEditingSplitParent else {
+            // Existing parent: if the lines were kept (Remove Split toggle)
+            // they reappear instantly; if they were swiped away, reload them.
             if splitLines.isEmpty {
                 Task { await loadSplitChildren() }
             }
@@ -577,6 +700,8 @@ struct AddTransactionView: View {
     private var saveDisabled: Bool {
         if isLoading || amount.isEmpty { return true }
         if isTransfer && transferToAccountId == nil { return true }
+        // A blank line reads as zero for the remainder display, but the store
+        // rejects zero-amount children — keep save blocked until it's filled.
         if isSplitting && !isTransfer && (splitRemainingCents != 0 || hasBlankSplitLine) { return true }
         return false
     }
@@ -609,11 +734,16 @@ struct AddTransactionView: View {
                 try await budgetStore.saveTransaction(form, editing: editing)
                 savedTransactionId = nil
             }
-
             onSaved?(savedTransactionId)
             if canDismiss {
+                // Presented flows (edit, account-detail "+", notification
+                // prefill) close; the account-detail host is already the
+                // saved transaction's list.
                 dismiss()
             } else {
+                // The tab-hosted flow has nothing to dismiss: reset for the
+                // next entry and route to the saved transaction's account
+                // list so every add flow lands on the relevant list.
                 resetForm()
                 NotificationRouter.shared.pendingAccountNavigation = form.accountId
             }
@@ -634,7 +764,12 @@ struct AddTransactionView: View {
         errorMessage = nil
         splitLines = []
         unsplitRequested = false
+        // A fresh form suggests categories from payee history again — a
+        // discarded manual pick must not keep suppressing the lookup.
         userPickedCategory = false
+        // A reset can arrive with the amount or payee field still focused —
+        // Esc or ⌘Return from a hardware keyboard — and a fresh form doesn't
+        // keep the old keyboard up.
         dismissKeyboard()
     }
 
@@ -649,6 +784,9 @@ struct AddTransactionView: View {
 
 /// Math for the split entry section, kept off the view for testability.
 enum SplitEntryMath {
+    /// Cents still unassigned across the split lines. Blank lines count as
+    /// zero so the remainder stays visible mid-entry; nil while the total or
+    /// a non-blank line doesn't parse.
     static func remainingCents(total: String, lineAmounts: [String]) -> Int? {
         guard let dollars = Double(total),
               let totalCents = Transaction.cents(fromDollars: dollars) else { return nil }
@@ -661,15 +799,23 @@ enum SplitEntryMath {
         return totalCents - assigned
     }
 
+    /// Plain dot-decimal string for non-negative cents, the format
+    /// AmountInputField keeps in its binding.
     static func amountString(fromCents cents: Int) -> String {
         "\(cents / 100).\(String(format: "%02d", cents % 100))"
     }
 }
 
+/// One editable split line: a category picked through a sheet and an amount.
+/// Borderless button so the amount field keeps its own tap target in the row.
 private struct SplitLineRow: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Binding var line: BudgetStore.SplitLineForm
+    /// The transaction's direction, so the line's sign glyph can show its
+    /// effective direction relative to it.
     var txType: TransactionType
+    /// The section-wide unassigned remainder; a positive value on a line with
+    /// no amount yet offers one-tap fill instead of mental arithmetic.
     var remainingCents: Int?
     @State private var showCategoryPicker = false
 
@@ -683,6 +829,8 @@ private struct SplitLineRow: View {
         return "Category"
     }
 
+    /// Whether the line runs as an outflow once the transaction's direction
+    /// and the line's flip are combined.
     private var isOutflow: Bool {
         (txType == .expense) != line.isOpposite
     }
@@ -698,11 +846,15 @@ private struct SplitLineRow: View {
                 }
                 .buttonStyle(.borderless)
                 Spacer()
+                // Every line carries a sign like the total's, so direction is
+                // never implicit; tapping it flips the line — how a refund
+                // goes inside a spend split (GH #216).
                 Button {
                     line.isOpposite.toggle()
                 } label: {
                     Text(isOutflow ? "-" : "+")
                         .foregroundStyle(isOutflow ? Color.red : Color.green)
+                        // Grow the tap target beyond the one-character glyph.
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }
@@ -716,6 +868,9 @@ private struct SplitLineRow: View {
                 )
                     .frame(width: 110)
             }
+            // No fill offer on a flipped line: the remainder is stated in the
+            // transaction's direction, and filling it here would double the
+            // gap instead of closing it.
             if line.amount.isEmpty, !line.isOpposite, let remaining = remainingCents, remaining > 0 {
                 HStack {
                     Spacer()
@@ -728,6 +883,7 @@ private struct SplitLineRow: View {
                     .buttonStyle(.borderless)
                 }
             }
+            // Empty payee inherits the transaction's payee
             TextField("Payee (optional)", text: $line.payeeName)
                 .font(.subheadline)
                 .autocorrectionDisabled()
@@ -745,15 +901,51 @@ private struct SplitLineRow: View {
     }
 }
 
+/// Currency amount field with two digit-entry modes, picked by the
+/// `conventionalAmountEntry` setting.
+///
+/// Calculator entry (the default): digits shift right-to-left into the cents
+/// position — typing 1, 2, 0 produces 0.01, 0.12, 1.20. As soon as the user
+/// taps `.` (or `,` in comma-decimal locales), the field switches to explicit
+/// decimal entry where prior digits are reinterpreted as the integer part —
+/// so 1, ., 0 produces 1.0.
+///
+/// Conventional entry: digits stand for whole units and the decimal separator
+/// is always typed — 1, 2, 0 produces 120, and 1, ., 0 produces 1.0. Nothing
+/// gains a fraction the user didn't type, so zero-decimal currencies never
+/// need a trailing ".00" (GH #211).
+///
+/// With `allowsNegative`, a ± button joins the keyboard toolbar and flips
+/// the text's own sign. With `onToggleSign`, the same button appears but the
+/// sign lives outside the field (a split line's direction flip) and the text
+/// stays unsigned. Neither set means sign is handled elsewhere entirely
+/// (e.g. the expense/income toggle).
+///
+/// The toolbar also carries +, −, × and ÷ for quick math: typing 12.50, then
+/// +, then 6.00 shows "12.50 + 6.00" in the field and collapses to "18.50"
+/// when editing ends. Evaluation is strictly left-to-right with no operator
+/// precedence — this is an entry aid, not a calculator. The binding always
+/// holds the plain evaluated decimal, never the expression, so a save taken
+/// mid-expression (the Save button is an ordinary row and doesn't end
+/// editing) still commits a parseable amount.
 struct AmountInputField: UIViewRepresentable {
     @Binding var text: String
+    /// When true, digits are entered as a conventional decimal amount instead
+    /// of shifting into cents.
     var conventionalAmountEntry = false
     var alignment: NSTextAlignment = .natural
     var allowsNegative = false
     var weight: UIFont.Weight = .regular
+    /// Bring up the keyboard as soon as the field lands on screen. For
+    /// sheets whose whole purpose is entering an amount.
     var autofocus = false
+    /// Shows the ± toolbar button and delegates it here instead of signing
+    /// the text — for callers whose sign is separate state.
     var onToggleSign: (() -> Void)? = nil
 
+    /// becomeFirstResponder is a no-op until the view joins a window, and
+    /// during a sheet presentation that happens well after makeUIView —
+    /// didMoveToWindow is the earliest reliable moment.
     final class AutofocusTextField: UITextField {
         var wantsAutofocus = false
         private var hasAutofocused = false
@@ -777,15 +969,22 @@ struct AmountInputField: UIViewRepresentable {
         if weight == .regular {
             field.font = .preferredFont(forTextStyle: .body)
         } else {
+            // Weighted variant of the body style so Dynamic Type still scales.
             let descriptor = UIFontDescriptor
                 .preferredFontDescriptor(withTextStyle: .body)
                 .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: weight]])
             field.font = UIFont(descriptor: descriptor, size: 0)
         }
         field.adjustsFontForContentSizeCategory = true
+        // The SwiftUI keyboard toolbar only attaches to SwiftUI text fields,
+        // and the decimal pad has neither a return key nor operators — without
+        // this accessory bar there is no way to dismiss the keyboard from this
+        // field, or to do arithmetic in it.
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
         var items: [UIBarButtonItem] = []
         if allowsNegative || onToggleSign != nil {
+            // The decimal pad has no minus key, so this button is the only
+            // keyboard affordance for flipping an amount's sign.
             items.append(UIBarButtonItem(
                 image: UIImage(systemName: "plus.forwardslash.minus"),
                 style: .plain,
@@ -802,6 +1001,7 @@ struct AmountInputField: UIViewRepresentable {
             items.append(item)
         }
         items.append(UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil))
+        // `.prominent` is iOS 26+; `.done` is the pre-26 equivalent emphasis.
         let doneStyle: UIBarButtonItem.Style = if #available(iOS 26, *) { .prominent } else { .done }
         items.append(UIBarButtonItem(
             title: "Done", style: doneStyle,
@@ -817,6 +1017,10 @@ struct AmountInputField: UIViewRepresentable {
 
     func updateUIView(_ uiView: UITextField, context: Context) {
         context.coordinator.parent = self
+        // Compare against what the coordinator last wrote out rather than the
+        // field's own text: mid-expression the field reads "12.50 + 6.00"
+        // while the binding holds "18.50", and that mismatch is expected.
+        // Only a change from outside the field should reset the state.
         if text != context.coordinator.lastPublishedText {
             uiView.text = text
             context.coordinator.sync(fromDisplay: text)
@@ -828,6 +1032,7 @@ struct AmountInputField: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextFieldDelegate {
+        /// The four toolbar operators. Left-to-right evaluation only.
         enum Operator: Character, CaseIterable {
             case add = "+", subtract = "−", multiply = "×", divide = "÷"
 
@@ -863,6 +1068,8 @@ struct AmountInputField: UIViewRepresentable {
                 case .add: return lhs + rhs
                 case .subtract: return lhs - rhs
                 case .multiply: return lhs * rhs
+                // Dividing by zero has no sensible amount to show, so the
+                // operator is dropped and the running total stands.
                 case .divide: return rhs == 0 ? lhs : lhs / rhs
                 }
             }
@@ -870,11 +1077,14 @@ struct AmountInputField: UIViewRepresentable {
 
         var parent: AmountInputField
         weak var textField: UITextField?
+        /// The last value written to the binding, so `updateUIView` can tell
+        /// an outside change from the field's own echo.
         private(set) var lastPublishedText: String?
         private var integerDigits: String = ""
         private var hasDecimalPoint: Bool = false
         private var fractionDigits: String = ""
         private var isNegative: Bool = false
+        /// Everything to the left of the pending operator, already evaluated.
         private var accumulatedValue: Double?
         private var pendingOperator: Operator?
 
@@ -882,6 +1092,8 @@ struct AmountInputField: UIViewRepresentable {
             self.parent = parent
         }
 
+        /// True once the current operand has any content of its own, so a
+        /// bare sign or a dangling operator doesn't count as typed input.
         private var hasTypedOperand: Bool {
             !integerDigits.isEmpty || hasDecimalPoint
         }
@@ -946,11 +1158,15 @@ struct AmountInputField: UIViewRepresentable {
         }
 
         func textFieldDidEndEditing(_ textField: UITextField) {
+            // Done, tapping away or dismissing the keyboard always leaves a
+            // plain amount behind, never a half-finished expression.
             finalizeExpression()
             applyDisplay(to: textField)
         }
 
         @objc func toggleSign() {
+            // Delegated sign lives outside the text (a split line's flip);
+            // the field's own text stays unsigned.
             if let onToggleSign = parent.onToggleSign {
                 onToggleSign()
                 return
@@ -967,6 +1183,9 @@ struct AmountInputField: UIViewRepresentable {
         @objc func multiplyTapped() { pushOperator(.multiply) }
         @objc func divideTapped() { pushOperator(.divide) }
 
+        /// Folds the operand just typed into the running total and arms the
+        /// next operator. Tapping a second operator without typing anything
+        /// in between just swaps which one is armed.
         private func pushOperator(_ op: Operator) {
             guard accumulatedValue != nil || hasTypedOperand else { return }
             if hasTypedOperand {
@@ -984,14 +1203,18 @@ struct AmountInputField: UIViewRepresentable {
             }
         }
 
+        /// Collapses the expression back down to a single editable operand.
         private func finalizeExpression() {
             guard let pending = pendingOperator, let acc = accumulatedValue else { return }
+            // A dangling operator ("12.50 ×" then Done) leaves the running
+            // total alone rather than multiplying it by an implied zero.
             let result = hasTypedOperand ? pending.apply(acc, currentOperandValue()) : acc
             accumulatedValue = nil
             pendingOperator = nil
             setOperand(to: result)
         }
 
+        /// The value the expression carries so far, evaluated left to right.
         private func resolvedValue() -> Double {
             guard let pending = pendingOperator, let acc = accumulatedValue else {
                 return currentOperandValue()
@@ -1003,6 +1226,9 @@ struct AmountInputField: UIViewRepresentable {
             Double(computeOperandDisplay()) ?? 0
         }
 
+        /// Rounds to cents and drops the sign where the field can't show one
+        /// — those callers get their sign from the expense/income toggle, so
+        /// the field carries a magnitude and 50 − 80 reads as 30.00.
         private func normalized(_ value: Double) -> Double {
             let signed = parent.allowsNegative ? value : abs(value)
             return (signed * 100).rounded() / 100
@@ -1015,16 +1241,21 @@ struct AmountInputField: UIViewRepresentable {
             isNegative = false
         }
 
+        /// Loads a computed result back into the digit state so it keeps
+        /// behaving like typed input (backspace, another operator, and so on).
         private func setOperand(to value: Double) {
             let rounded = normalized(value)
             let cents = Int((abs(rounded) * 100).rounded())
             isNegative = parent.allowsNegative && rounded < 0
             integerDigits = String(cents / 100)
+            // Conventional entry never adds a fraction the user didn't type,
+            // so a whole result comes back as a whole number.
             hasDecimalPoint = !(parent.conventionalAmountEntry && cents % 100 == 0)
             fractionDigits = hasDecimalPoint ? String(format: "%02d", cents % 100) : ""
         }
 
         private func handleCharacter(_ character: Character) {
+            // Hardware-keyboard minus; the on-screen path is the ± toolbar button.
             if character == "-", parent.allowsNegative {
                 isNegative.toggle()
                 return
@@ -1055,6 +1286,8 @@ struct AmountInputField: UIViewRepresentable {
             } else if isNegative {
                 isNegative = false
             } else if pendingOperator != nil {
+                // Backspacing through an empty operand undoes the operator and
+                // hands the running total back as editable digits.
                 pendingOperator = nil
                 if let acc = accumulatedValue {
                     setOperand(to: acc)
@@ -1063,9 +1296,12 @@ struct AmountInputField: UIViewRepresentable {
             }
         }
 
+        /// Just the operand currently being typed, with no running total in
+        /// front of it.
         private func computeOperandDisplay() -> String {
             let sign = isNegative ? "-" : ""
             if !hasDecimalPoint && integerDigits.isEmpty {
+                // A bare "-" so a sign toggled before any digits stays visible.
                 return sign
             }
             if hasDecimalPoint {
@@ -1081,11 +1317,15 @@ struct AmountInputField: UIViewRepresentable {
             return "\(sign)\(dollars).\(String(format: "%02d", pennies))"
         }
 
+        /// An evaluated value as the field shows it: two decimals, except in
+        /// conventional entry where a whole result stays whole.
         private func displayValue(_ value: Double) -> String {
             let whole = parent.conventionalAmountEntry && value == value.rounded()
             return String(format: whole ? "%.0f" : "%.2f", value)
         }
 
+        /// What the field shows: the running total and armed operator, if any,
+        /// followed by the operand being typed.
         private func computeFieldText() -> String {
             let operandText = computeOperandDisplay()
             guard let pending = pendingOperator, let acc = accumulatedValue else {
@@ -1097,6 +1337,8 @@ struct AmountInputField: UIViewRepresentable {
                 : "\(accText) \(pending.rawValue) \(operandText)"
         }
 
+        /// What the binding carries: always a plain decimal, so callers can
+        /// parse it at any moment — including mid-expression.
         private func computeBoundText() -> String {
             guard pendingOperator != nil, accumulatedValue != nil else {
                 return computeOperandDisplay()
@@ -1117,6 +1359,8 @@ struct AmountInputField: UIViewRepresentable {
     }
 }
 
+/// Searchable category list, shared by the transaction form and the
+/// uncategorized-transactions quick-categorize flow.
 struct CategoryPickerView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -1,0 +1,102 @@
+import Testing
+
+struct CategoryFundingAutomationTests {
+    @Test("Sufficient category funds require no funding")
+    func sufficientFunds() {
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: 50) == 0)
+    }
+
+    @Test("Partial category funds fund only the shortfall")
+    func partialFunds() {
+        // $20 was available before the $50 expense, so the post-transaction
+        // available balance is -$30.
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
+    }
+
+    @Test("Zero category funds fund the full transaction")
+    func zeroFunds() {
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -50) == 50)
+    }
+
+    @Test("Exact category balance requires no funding")
+    func exactBalance() {
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: 0) == 0)
+    }
+
+    @Test("Uncategorized transactions are ignored")
+    func uncategorized() {
+        let transaction = makeTransaction(categoryId: nil)
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    @Test("Transactions from another account are ignored")
+    func nonSelectedAccount() {
+        let transaction = makeTransaction(accountId: "account-2", categoryId: "groceries")
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    @Test("Income transactions are ignored")
+    func income() {
+        let transaction = makeTransaction(amount: 5000, categoryId: "income")
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: true
+        ))
+    }
+
+    @Test("Transfers are ignored")
+    func transfer() {
+        let transaction = makeTransaction(categoryId: "groceries", transferId: "other-leg")
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    @Test("Non-expense amounts are ignored")
+    func nonExpense() {
+        let transaction = makeTransaction(amount: 1000, categoryId: "groceries")
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    private func makeTransaction(
+        accountId: String = "account-1",
+        amount: Int = -5000,
+        categoryId: String?,
+        transferId: String? = nil
+    ) -> Transaction {
+        Transaction(
+            id: UUID().uuidString,
+            accountId: accountId,
+            date: 20260825,
+            amount: amount,
+            payeeId: nil,
+            payeeName: nil,
+            categoryId: categoryId,
+            categoryName: nil,
+            notes: nil,
+            cleared: false,
+            reconciled: false,
+            transferId: transferId,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+    }
+}

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -6,26 +6,52 @@ struct CategoryFundingAutomationTests {
     @Test("Sufficient category funds require no funding")
     func sufficientFunds() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: 50) == 0)
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: 50,
+            fundingSource: .toBudget
+        ) == .none)
     }
 
     @Test("Partial category funds fund only the shortfall")
     func partialFunds() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -30,
+            fundingSource: .toBudget
+        ) == .fund(30))
     }
 
     @Test("Zero category funds fund the full transaction")
     func zeroFunds() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -50) == 50)
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -50,
+            fundingSource: .toBudget
+        ) == .fund(50))
     }
 
     @Test("Exact category balance requires no funding")
     func exactBalance() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: 0) == 0)
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: 0,
+            fundingSource: .category("emergency-fund"),
+            sourceAvailable: 50
+        ) == .none)
     }
 
     @Test("Existing overspending is preserved")
     func existingOverspending() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -550) == 50)
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -550,
+            fundingSource: .toBudget
+        ) == .fund(50))
     }
 
     @Test("Existing overspending of any size only funds the new transaction")
@@ -33,10 +59,59 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -125, availableAfterTransaction: -1000) == 125)
     }
 
+    @Test("Category funding source with enough money funds the complete shortfall")
+    func categorySourceSufficient() {
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -30,
+            fundingSource: .category("emergency-fund"),
+            sourceAvailable: 30
+        ) == .fund(30))
+    }
+
+    @Test("Category funding source cannot be partially drained")
+    func categorySourceInsufficient() {
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -30,
+            fundingSource: .category("emergency-fund"),
+            sourceAvailable: 20
+        ) == .insufficientSource)
+    }
+
+    @Test("Missing category funding source is reported as invalid")
+    func categorySourceMissing() {
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -50,
+            fundingSource: .category("emergency-fund"),
+            sourceAvailable: nil
+        ) == .invalidSource)
+    }
+
+    @Test("To Budget can fund even when its balance is negative")
+    func negativeToBudget() {
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -50,
+            fundingSource: .toBudget
+        ) == .fund(50))
+    }
+
+    @Test("Selected category cannot fund itself")
+    func sameSourceAndTargetIsInvalid() {
+        let transaction = makeTransaction(categoryId: "groceries")
+        #expect(CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
     @Test("Manual expense from selected account is eligible")
     func manualExpenseIsEligible() {
         let transaction = makeTransaction(categoryId: "groceries")
-        #expect(CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -46,7 +121,7 @@ struct CategoryFundingAutomationTests {
     @Test("Uncategorized transactions are ignored")
     func uncategorized() {
         let transaction = makeTransaction(categoryId: nil)
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -56,7 +131,7 @@ struct CategoryFundingAutomationTests {
     @Test("Transactions from another account are ignored")
     func nonSelectedAccount() {
         let transaction = makeTransaction(accountId: "account-2", categoryId: "groceries")
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -66,7 +141,7 @@ struct CategoryFundingAutomationTests {
     @Test("Income transactions are ignored")
     func income() {
         let transaction = makeTransaction(amount: 5000, categoryId: "income")
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: true
@@ -76,7 +151,7 @@ struct CategoryFundingAutomationTests {
     @Test("Transfers are ignored")
     func transfer() {
         let transaction = makeTransaction(categoryId: "groceries", transferId: "other-leg")
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -86,7 +161,7 @@ struct CategoryFundingAutomationTests {
     @Test("Non-expense amounts are ignored")
     func nonExpense() {
         let transaction = makeTransaction(amount: 1000, categoryId: "groceries")
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -96,7 +171,18 @@ struct CategoryFundingAutomationTests {
     @Test("Split parents are ignored")
     func splitParent() {
         let transaction = makeTransaction(categoryId: nil, isParent: true)
-        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+        #expect(!CategoryFundingAutomation.shouldProcess(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    @Test("Deleted transactions are ignored")
+    func deletedTransaction() {
+        var transaction = makeTransaction(categoryId: "groceries")
+        transaction.tombstone = true
+        #expect(!CategoryFundingAutomation.shouldProcess(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -9,7 +9,7 @@ struct CategoryFundingAutomationTests {
     @Test("Partial category funds fund only the shortfall")
     func partialFunds() {
         // $20 was available before the $50 expense, so the post-transaction
-        // available balance is -$30.
+        // available balance is -$30. Only $30 is funded.
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
     }
 
@@ -21,6 +21,25 @@ struct CategoryFundingAutomationTests {
     @Test("Exact category balance requires no funding")
     func exactBalance() {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: 0) == 0)
+    }
+
+    @Test("Existing overspending is preserved")
+    func existingOverspending() {
+        // The category was already -$500 before a new $50 expense. The new
+        // transaction is funded by $50, leaving the category at -$500 rather
+        // than funding the existing $500 deficit.
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -550) == 50)
+    }
+
+    @Test("Existing overspending of any size only funds the new transaction")
+    func largerExistingOverspending() {
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -125, availableAfterTransaction: -1000) == 125)
+    }
+
+    @Test("Positive available balance funds only the amount needed for the new transaction")
+    func positiveBalanceShortfall() {
+        // $20 available before a $50 expense means only $30 is needed.
+        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
     }
 
     @Test("Uncategorized transactions are ignored")

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -33,38 +33,30 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -125, availableAfterTransaction: -1000) == 125)
     }
 
-    @Test("Uncategorized transactions are ignored by processing logic")
-    func uncategorized() {
-        let transaction = makeTransaction(categoryId: nil)
-        #expect(!CategoryFundingAutomation.shouldProcess(
+    @Test("Manual expense from selected account is eligible")
+    func manualExpenseIsEligible() {
+        let transaction = makeTransaction(categoryId: "groceries")
+        #expect(CategoryFundingAutomation.isManualExpenseEligible(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
         ))
     }
 
-    @Test("Uncategorized transactions are not marked seen")
-    func uncategorizedIsNotMarkedSeen() {
+    @Test("Uncategorized transactions are ignored")
+    func uncategorized() {
         let transaction = makeTransaction(categoryId: nil)
-        #expect(!CategoryFundingAutomation.shouldMarkSeen(transaction))
-    }
-
-    @Test("Categorized transactions are marked seen")
-    func categorizedIsMarkedSeen() {
-        let transaction = makeTransaction(categoryId: "groceries")
-        #expect(CategoryFundingAutomation.shouldMarkSeen(transaction))
-    }
-
-    @Test("Split parents are marked seen so they do not repeatedly wake the monitor")
-    func splitParentIsMarkedSeen() {
-        let transaction = makeTransaction(categoryId: nil, isParent: true)
-        #expect(CategoryFundingAutomation.shouldMarkSeen(transaction))
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
     }
 
     @Test("Transactions from another account are ignored")
     func nonSelectedAccount() {
         let transaction = makeTransaction(accountId: "account-2", categoryId: "groceries")
-        #expect(!CategoryFundingAutomation.shouldProcess(
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -74,7 +66,7 @@ struct CategoryFundingAutomationTests {
     @Test("Income transactions are ignored")
     func income() {
         let transaction = makeTransaction(amount: 5000, categoryId: "income")
-        #expect(!CategoryFundingAutomation.shouldProcess(
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: true
@@ -84,7 +76,7 @@ struct CategoryFundingAutomationTests {
     @Test("Transfers are ignored")
     func transfer() {
         let transaction = makeTransaction(categoryId: "groceries", transferId: "other-leg")
-        #expect(!CategoryFundingAutomation.shouldProcess(
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -94,7 +86,17 @@ struct CategoryFundingAutomationTests {
     @Test("Non-expense amounts are ignored")
     func nonExpense() {
         let transaction = makeTransaction(amount: 1000, categoryId: "groceries")
-        #expect(!CategoryFundingAutomation.shouldProcess(
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
+            transaction,
+            selectedAccountId: "account-1",
+            isIncomeCategory: false
+        ))
+    }
+
+    @Test("Split parents are ignored")
+    func splitParent() {
+        let transaction = makeTransaction(categoryId: nil, isParent: true)
+        #expect(!CategoryFundingAutomation.isManualExpenseEligible(
             transaction,
             selectedAccountId: "account-1",
             isIncomeCategory: false
@@ -127,14 +129,14 @@ struct CategoryFundingAutomationTests {
             fundingSource: .category("emergency-fund")
         )
 
-        CategoryFundingAutomationMonitor.saveConfiguration(
+        CategoryFundingAutomation.saveConfiguration(
             configuration,
             for: "budget-1",
             defaults: defaults
         )
 
         #expect(
-            CategoryFundingAutomationMonitor.loadConfiguration(
+            CategoryFundingAutomation.loadConfiguration(
                 for: "budget-1",
                 defaults: defaults
             ) == configuration

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -64,6 +64,7 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.fundingDecision(
             transactionAmount: -50,
             availableAfterTransaction: -30,
+            targetCategoryId: "groceries",
             fundingSource: .category("emergency-fund"),
             sourceAvailable: 30
         ) == .fund(30))
@@ -74,6 +75,7 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.fundingDecision(
             transactionAmount: -50,
             availableAfterTransaction: -30,
+            targetCategoryId: "groceries",
             fundingSource: .category("emergency-fund"),
             sourceAvailable: 20
         ) == .insufficientSource)
@@ -84,9 +86,21 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.fundingDecision(
             transactionAmount: -50,
             availableAfterTransaction: -50,
+            targetCategoryId: "groceries",
             fundingSource: .category("emergency-fund"),
             sourceAvailable: nil
         ) == .invalidSource)
+    }
+
+    @Test("A category cannot fund itself")
+    func sameSourceAndTargetIsInvalid() {
+        #expect(CategoryFundingAutomation.fundingDecision(
+            transactionAmount: -50,
+            availableAfterTransaction: -50,
+            targetCategoryId: "groceries",
+            fundingSource: .category("groceries"),
+            sourceAvailable: 100
+        ) == .sameSourceAndTarget)
     }
 
     @Test("To Budget can fund even when its balance is negative")
@@ -96,16 +110,6 @@ struct CategoryFundingAutomationTests {
             availableAfterTransaction: -50,
             fundingSource: .toBudget
         ) == .fund(50))
-    }
-
-    @Test("Selected category cannot fund itself")
-    func sameSourceAndTargetIsInvalid() {
-        let transaction = makeTransaction(categoryId: "groceries")
-        #expect(CategoryFundingAutomation.shouldProcess(
-            transaction,
-            selectedAccountId: "account-1",
-            isIncomeCategory: false
-        ))
     }
 
     @Test("Manual expense from selected account is eligible")

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -43,6 +43,24 @@ struct CategoryFundingAutomationTests {
         ))
     }
 
+    @Test("Uncategorized transactions are not marked seen")
+    func uncategorizedIsNotMarkedSeen() {
+        let transaction = makeTransaction(categoryId: nil)
+        #expect(!CategoryFundingAutomation.shouldMarkSeen(transaction))
+    }
+
+    @Test("Categorized transactions are marked seen")
+    func categorizedIsMarkedSeen() {
+        let transaction = makeTransaction(categoryId: "groceries")
+        #expect(CategoryFundingAutomation.shouldMarkSeen(transaction))
+    }
+
+    @Test("Split parents are marked seen so they do not repeatedly wake the monitor")
+    func splitParentIsMarkedSeen() {
+        let transaction = makeTransaction(categoryId: nil, isParent: true)
+        #expect(CategoryFundingAutomation.shouldMarkSeen(transaction))
+    }
+
     @Test("Transactions from another account are ignored")
     func nonSelectedAccount() {
         let transaction = makeTransaction(accountId: "account-2", categoryId: "groceries")
@@ -132,7 +150,8 @@ struct CategoryFundingAutomationTests {
         accountId: String = "account-1",
         amount: Int = -5000,
         categoryId: String?,
-        transferId: String? = nil
+        transferId: String? = nil,
+        isParent: Bool = false
     ) -> Transaction {
         Transaction(
             id: UUID().uuidString,
@@ -147,7 +166,7 @@ struct CategoryFundingAutomationTests {
             cleared: false,
             reconciled: false,
             transferId: transferId,
-            isParent: false,
+            isParent: isParent,
             parentId: nil,
             tombstone: false,
             sortOrder: nil,

--- a/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
+++ b/Actuali/ActualiTests/Services/CategoryFundingAutomationTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import Testing
+@testable import Actuali
 
 struct CategoryFundingAutomationTests {
     @Test("Sufficient category funds require no funding")
@@ -8,8 +10,6 @@ struct CategoryFundingAutomationTests {
 
     @Test("Partial category funds fund only the shortfall")
     func partialFunds() {
-        // $20 was available before the $50 expense, so the post-transaction
-        // available balance is -$30. Only $30 is funded.
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
     }
 
@@ -25,9 +25,6 @@ struct CategoryFundingAutomationTests {
 
     @Test("Existing overspending is preserved")
     func existingOverspending() {
-        // The category was already -$500 before a new $50 expense. The new
-        // transaction is funded by $50, leaving the category at -$500 rather
-        // than funding the existing $500 deficit.
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -550) == 50)
     }
 
@@ -36,13 +33,7 @@ struct CategoryFundingAutomationTests {
         #expect(CategoryFundingAutomation.shortfall(transactionAmount: -125, availableAfterTransaction: -1000) == 125)
     }
 
-    @Test("Positive available balance funds only the amount needed for the new transaction")
-    func positiveBalanceShortfall() {
-        // $20 available before a $50 expense means only $30 is needed.
-        #expect(CategoryFundingAutomation.shortfall(transactionAmount: -50, availableAfterTransaction: -30) == 30)
-    }
-
-    @Test("Uncategorized transactions are ignored")
+    @Test("Uncategorized transactions are ignored by processing logic")
     func uncategorized() {
         let transaction = makeTransaction(categoryId: nil)
         #expect(!CategoryFundingAutomation.shouldProcess(
@@ -90,6 +81,51 @@ struct CategoryFundingAutomationTests {
             selectedAccountId: "account-1",
             isIncomeCategory: false
         ))
+    }
+
+    @Test("Category funding source round trips through Codable")
+    func fundingSourceCodable() throws {
+        let configuration = CategoryFundingAutomationConfiguration(
+            isEnabled: true,
+            accountId: "account-1",
+            fundingSource: .category("emergency-fund")
+        )
+
+        let data = try JSONEncoder().encode(configuration)
+        let decoded = try JSONDecoder().decode(CategoryFundingAutomationConfiguration.self, from: data)
+
+        #expect(decoded == configuration)
+    }
+
+    @Test("Configuration can be saved and loaded with injected UserDefaults")
+    func configurationPersistence() {
+        let suiteName = "CategoryFundingAutomationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let configuration = CategoryFundingAutomationConfiguration(
+            isEnabled: true,
+            accountId: "account-1",
+            fundingSource: .category("emergency-fund")
+        )
+
+        CategoryFundingAutomationMonitor.saveConfiguration(
+            configuration,
+            for: "budget-1",
+            defaults: defaults
+        )
+
+        #expect(
+            CategoryFundingAutomationMonitor.loadConfiguration(
+                for: "budget-1",
+                defaults: defaults
+            ) == configuration
+        )
+    }
+
+    @Test("Default funding source is To Budget")
+    func defaultFundingSource() {
+        #expect(CategoryFundingAutomationConfiguration().fundingSource == .toBudget)
     }
 
     private func makeTransaction(


### PR DESCRIPTION
## Why

Add an automation that automatically funds a transaction's budget category when a new expense from a selected account would exceed the category's available funds. The automation preserves any existing overspending and only funds the amount required for the new transaction.

## What

* Added a new **Category Funding Automation** in Settings.
* Users can select the account that triggers the automation.
* Added a configurable funding source, defaulting to **To Budget**.
* Funding sources can also be budget categories with sufficient available funds.
* Automatically determines the category from the triggering transaction.
* Funds only the required shortfall.
* Existing category overspending is preserved.
* Ignores uncategorized transactions, income, transfers, non-expense transactions, and transactions from other accounts.
* Added protection against recursive triggering.
* Added unit tests covering sufficient funds, partial funds, zero funds, exact balances, existing overspending, uncategorized transactions, and non-selected accounts.

## How it was tested

* Added and updated unit tests for the category funding calculation and transaction filtering.
* Manually tested the automation using the iPhone simulator.
* Verified that an already-overdrawn category only receives the amount of the new transaction rather than having its existing deficit fully funded.

