### PR TITLE
Slide to hide category groups

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -222,13 +222,18 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
-                    isHidden: group.isHidden,
-                    onSetHidden: {
-                        setCategoryGroupHidden(group.id, hidden: $0)
-                    },
                     onToggleCollapse: { toggleCollapsed(group.id) }
                 )
                 .textCase(nil)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button {
+                        setCategoryGroupHidden(group.id, hidden: !group.isHidden)
+                    } label: {
+                        Label(group.isHidden ? "Show" : "Hide",
+                              systemImage: group.isHidden ? "eye" : "eye.slash")
+                    }
+                    .tint(group.isHidden ? .accentColor : .secondary)
+                }
             }
         } else {
             // The group row lives inside the card (first row, tinted) like
@@ -238,16 +243,21 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
-                    isHidden: group.isHidden,
-                    onSetHidden: {
-                        setCategoryGroupHidden(group.id, hidden: $0)
-                    },
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
                     reservesTwoLines: true
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button {
+                        setCategoryGroupHidden(group.id, hidden: !group.isHidden)
+                    } label: {
+                        Label(group.isHidden ? "Show" : "Hide",
+                              systemImage: group.isHidden ? "eye" : "eye.slash")
+                    }
+                    .tint(group.isHidden ? .accentColor : .secondary)
+                }
                 if !isCollapsed {
                     ForEach(group.categories) { category in
                         CategoryBudgetRow(
@@ -301,10 +311,6 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
-                    isHidden: group?.hidden == true,
-                    onSetHidden: group.map { group in
-                        { setCategoryGroupHidden(group.id, hidden: $0) }
-                    },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
@@ -317,10 +323,6 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
-                    isHidden: group?.hidden == true,
-                    onSetHidden: group.map { group in
-                        { setCategoryGroupHidden(group.id, hidden: $0) }
-                    },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
@@ -1287,8 +1289,6 @@ struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
     let isCollapsed: Bool
-    var isHidden = false
-    var onSetHidden: ((Bool) -> Void)?
     /// The detailed style totals its columns here; the clean style's header
     /// is a plain section title above the card, so it leaves this nil.
     var totals: CategoryGroupTotals?
@@ -1368,25 +1368,7 @@ struct BudgetGroupHeader: View {
             .buttonStyle(.plain)
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the group's categories")
-
-            if let onSetHidden {
-                Menu {
-                    Button {
-                        onSetHidden(!isHidden)
-                    } label: {
-                        Label(
-                            isHidden ? "Show Group" : "Hide Group",
-                            systemImage: isHidden ? "eye" : "eye.slash"
-                        )
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .frame(minWidth: 32, minHeight: 44)
-                }
-                .accessibilityLabel("Options for \(name)")
-            }
         }
-        .opacity(isHidden ? 0.5 : 1)
     }
 
     /// The pills are decoration to VoiceOver once the button carries its own

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -188,7 +188,6 @@ struct BudgetView: View {
         .initialSyncBanner()
     }
 
-
     /// One group's rows, extracted from the `List` so the body stays within
     /// the compiler's type-check budget.
     @ViewBuilder
@@ -226,7 +225,8 @@ struct BudgetView: View {
                     onSetHidden: {
                         setCategoryGroupHidden(group.id, hidden: $0)
                     },
-                    onToggleCollapse: { toggleCollapsed(group.id) }
+                    onToggleCollapse: { toggleCollapsed(group.id) },
+                    showsEllipsisMenu: true   // clean style uses ellipsis
                 )
                 .textCase(nil)
             }
@@ -244,7 +244,8 @@ struct BudgetView: View {
                     },
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
-                    reservesTwoLines: true
+                    reservesTwoLines: true,
+                    showsEllipsisMenu: false  // detailed style uses swipe
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
@@ -315,19 +316,13 @@ struct BudgetView: View {
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
-                    }
+                    },
+                    showsEllipsisMenu: true   // clean style uses ellipsis
                 )
                 .textCase(nil)
             }
         } else {
             Section {
-                // The Income group can be swiped only to UNhide, never to
-                // hide: hiding it would drop the app's only income total
-                // from the budget table entirely. `onSetHidden` is passed
-                // only when the group is already hidden (e.g. leftover
-                // state from before this restriction existed), so the
-                // swipe button never offers "Hide" — only "Show" when
-                // needed. (GH #130's collapse control still applies.)
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
@@ -340,7 +335,8 @@ struct BudgetView: View {
                         toggleCollapsed(Self.incomeGroupCollapseID)
                     },
                     usesTableNumberFormat: true,
-                    reservesTwoLines: true
+                    reservesTwoLines: true,
+                    showsEllipsisMenu: false  // detailed style uses swipe
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
@@ -1298,10 +1294,10 @@ private struct CaptionedAmountPill: View {
 /// Budgeted, Spent and Balance totals in the table's three rightmost
 /// columns, each captioned the same way the pinned summary bar is.
 ///
-/// Hiding the group uses the same swipe-to-hide gesture as category rows
-/// (`CategoryBudgetRow` / `CleanCategoryBudgetRow`) rather than an inline
-/// "..." menu, so hide behavior is consistent everywhere in the budget
-/// table.
+/// The way to hide/show the group depends on the display style:
+/// - **Clean style** uses a three‑dot ellipsis menu (because section headers
+///   don't support swipe actions reliably).
+/// - **Detailed style** uses a swipe‑to‑hide gesture, matching category rows.
 struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
@@ -1323,28 +1319,63 @@ struct BudgetGroupHeader: View {
     /// whether names wrap or not (GH #252); the clean style's plain section
     /// titles keep their natural height.
     var reservesTwoLines = false
+    /// If true, an ellipsis menu is shown for hide/show (clean style).
+    /// If false, swipe‑to‑hide is used instead (detailed style).
+    var showsEllipsisMenu: Bool = false
 
     var body: some View {
-        Button(action: onToggleCollapse) {
-            HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-                // Nested so the chevron centers against the name (which can
-                // run one or two lines) rather than pinning to the top of
-                // the row alongside the totals' captions.
-                HStack(spacing: BudgetColumn.spacing) {
-                    DisclosureChevron(
-                        isExpanded: !isCollapsed,
-                        font: .caption2.weight(.semibold)
-                    )
-                    .foregroundStyle(.secondary)
-                    if reservesTwoLines {
-                        TwoLineName(
-                            text: name,
-                            font: .subheadline.weight(.semibold),
-                            minimumScaleFactor: 0.85
+        HStack(spacing: 8) {
+            // Collapse button (chevron + name + totals)
+            Button(action: onToggleCollapse) {
+                HStack(alignment: .top, spacing: BudgetColumn.spacing) {
+                    // Nested so the chevron centers against the name (which can
+                    // run one or two lines) rather than pinning to the top of
+                    // the row alongside the totals' captions.
+                    HStack(spacing: BudgetColumn.spacing) {
+                        DisclosureChevron(
+                            isExpanded: !isCollapsed,
+                            font: .caption2.weight(.semibold)
                         )
-                        .foregroundStyle(.primary)
-                    } else {
-                        Text(name)
+                        .foregroundStyle(.secondary)
+                        if reservesTwoLines {
+                            TwoLineName(
+                                text: name,
+                                font: .subheadline.weight(.semibold),
+                                minimumScaleFactor: 0.85
+                            )
+                            .foregroundStyle(.primary)
+                        } else {
+                            Text(name)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
+                                .frame(maxHeight: .infinity, alignment: .center)
+                        }
+                    }
+                    Spacer(minLength: 4)
+                    if let totals {
+                        CaptionedAmountPill(
+                            label: "Budgeted",
+                            text: budgetStore.displayBudgetCell(totals.budgeted),
+                            dimmed: totals.budgeted == 0
+                        )
+                        CaptionedAmountPill(
+                            label: "Spent",
+                            text: budgetStore.displayBudgetCell(totals.spent),
+                            dimmed: totals.spent == 0
+                        )
+                        CaptionedAmountPill(
+                            label: "Balance",
+                            text: budgetStore.displayBudgetCell(totals.balance),
+                            // Same three-way treatment as the category rows, so a
+                            // group that lands on zero doesn't read as healthy.
+                            color: totals.balance < 0
+                                ? .red
+                                : (totals.balance == 0 ? .secondary : .green)
+                        )
+                    } else if let receivedTotal {
+                        Text("Received \(receivedText(receivedTotal))")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -1352,43 +1383,34 @@ struct BudgetGroupHeader: View {
                             .frame(maxHeight: .infinity, alignment: .center)
                     }
                 }
-                Spacer(minLength: 4)
-                if let totals {
-                    CaptionedAmountPill(
-                        label: "Budgeted",
-                        text: budgetStore.displayBudgetCell(totals.budgeted),
-                        dimmed: totals.budgeted == 0
-                    )
-                    CaptionedAmountPill(
-                        label: "Spent",
-                        text: budgetStore.displayBudgetCell(totals.spent),
-                        dimmed: totals.spent == 0
-                    )
-                    CaptionedAmountPill(
-                        label: "Balance",
-                        text: budgetStore.displayBudgetCell(totals.balance),
-                        // Same three-way treatment as the category rows, so a
-                        // group that lands on zero doesn't read as healthy.
-                        color: totals.balance < 0
-                            ? .red
-                            : (totals.balance == 0 ? .secondary : .green)
-                    )
-                } else if let receivedTotal {
-                    Text("Received \(receivedText(receivedTotal))")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint("Toggles the group's categories")
+
+            // Ellipsis menu only in clean style
+            if showsEllipsisMenu, let onSetHidden {
+                Menu {
+                    Button {
+                        onSetHidden(!isHidden)
+                    } label: {
+                        Label(
+                            isHidden ? "Show Group" : "Hide Group",
+                            systemImage: isHidden ? "eye" : "eye.slash"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .frame(minWidth: 32, minHeight: 44)
+                }
+                .accessibilityLabel("Options for \(name)")
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Toggles the group's categories")
         .opacity(isHidden ? 0.5 : 1)
+        // Swipe‑to‑hide only in detailed style
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if let onSetHidden {
+            if !showsEllipsisMenu, let onSetHidden {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -298,12 +298,19 @@ struct BudgetView: View {
                     }
                 }
             } header: {
+                // The Income group can be swiped only to UNhide, never to
+                // hide: hiding it would drop the app's only income total
+                // from the budget table entirely. `onSetHidden` is passed
+                // only when the group is already hidden (e.g. leftover
+                // state from before this restriction existed), so the
+                // swipe button never offers "Hide" — only "Show" when
+                // needed. (GH #130's collapse control still applies.)
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: group.map { group in
-                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    onSetHidden: (group?.hidden == true ? group : nil).map { hiddenGroup in
+                        { hidden in setCategoryGroupHidden(hiddenGroup.id, hidden: hidden) }
                     },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
@@ -314,12 +321,19 @@ struct BudgetView: View {
             }
         } else {
             Section {
+                // The Income group can be swiped only to UNhide, never to
+                // hide: hiding it would drop the app's only income total
+                // from the budget table entirely. `onSetHidden` is passed
+                // only when the group is already hidden (e.g. leftover
+                // state from before this restriction existed), so the
+                // swipe button never offers "Hide" — only "Show" when
+                // needed. (GH #130's collapse control still applies.)
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: group.map { group in
-                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    onSetHidden: (group?.hidden == true ? group : nil).map { hiddenGroup in
+                        { hidden in setCategoryGroupHidden(hiddenGroup.id, hidden: hidden) }
                     },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -47,6 +47,18 @@ enum BudgetColumn {
     }
 }
 
+/// One source of truth for the hide/show swipe action labels and icons used
+/// on rows and group headers throughout the budget table.
+enum HideShowAction {
+    static func title(isHidden: Bool) -> String {
+        isHidden ? "Show" : "Hide"
+    }
+
+    static func systemImage(isHidden: Bool) -> String {
+        isHidden ? "eye" : "eye.slash"
+    }
+}
+
 private extension BudgetStore {
     /// Masked variant of `BudgetColumn.text` for the budget table's cells.
     /// Lives here rather than on the store proper so the table's
@@ -310,8 +322,8 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: (group?.hidden == true ? group : nil).map { hiddenGroup in
-                        { hidden in setCategoryGroupHidden(hiddenGroup.id, hidden: hidden) }
+                    onSetHidden: BudgetView.incomeGroupHideAction(isHidden: group?.hidden == true) { hidden in
+                        if let group { setCategoryGroupHidden(group.id, hidden: hidden) }
                     },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
@@ -327,8 +339,8 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: (group?.hidden == true ? group : nil).map { hiddenGroup in
-                        { hidden in setCategoryGroupHidden(hiddenGroup.id, hidden: hidden) }
+                    onSetHidden: BudgetView.incomeGroupHideAction(isHidden: group?.hidden == true) { hidden in
+                        if let group { setCategoryGroupHidden(group.id, hidden: hidden) }
                     },
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
@@ -960,7 +972,10 @@ struct CategoryBudgetRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                    Label(
+                        HideShowAction.title(isHidden: isHidden),
+                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
+                    )
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1064,7 +1079,10 @@ struct CleanCategoryBudgetRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                    Label(
+                        HideShowAction.title(isHidden: isHidden),
+                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
+                    )
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1347,10 +1365,9 @@ struct BudgetGroupHeader: View {
                         } else {
                             Text(name)
                                 .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.75)
-                                .frame(maxHeight: .infinity, alignment: .center)
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.85)
                         }
                     }
                     Spacer(minLength: 4)
@@ -1396,8 +1413,8 @@ struct BudgetGroupHeader: View {
                         onSetHidden(!isHidden)
                     } label: {
                         Label(
-                            isHidden ? "Show Group" : "Hide Group",
-                            systemImage: isHidden ? "eye" : "eye.slash"
+                            HideShowAction.title(isHidden: isHidden),
+                            systemImage: HideShowAction.systemImage(isHidden: isHidden)
                         )
                     }
                 } label: {
@@ -1414,7 +1431,10 @@ struct BudgetGroupHeader: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                    Label(
+                        HideShowAction.title(isHidden: isHidden),
+                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
+                    )
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1453,6 +1473,15 @@ struct BudgetGroupHeader: View {
         usesTableNumberFormat
             ? budgetStore.displayBudgetCell(amount)
             : budgetStore.displayBalance(amount)
+    }
+}
+
+extension BudgetView {
+    nonisolated static func incomeGroupHideAction(
+        isHidden: Bool,
+        setter: @escaping (Bool) -> Void
+    ) -> ((Bool) -> Void)? {
+        isHidden ? setter : nil
     }
 }
 
@@ -1517,7 +1546,10 @@ struct IncomeCategoryRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                    Label(
+                        HideShowAction.title(isHidden: isHidden),
+                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
+                    )
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -47,18 +47,6 @@ enum BudgetColumn {
     }
 }
 
-/// One source of truth for the hide/show swipe action labels and icons used
-/// on rows and group headers throughout the budget table.
-enum HideShowAction {
-    static func title(isHidden: Bool) -> String {
-        isHidden ? "Show" : "Hide"
-    }
-
-    static func systemImage(isHidden: Bool) -> String {
-        isHidden ? "eye" : "eye.slash"
-    }
-}
-
 private extension BudgetStore {
     /// Masked variant of `BudgetColumn.text` for the budget table's cells.
     /// Lives here rather than on the store proper so the table's
@@ -237,8 +225,7 @@ struct BudgetView: View {
                     onSetHidden: {
                         setCategoryGroupHidden(group.id, hidden: $0)
                     },
-                    onToggleCollapse: { toggleCollapsed(group.id) },
-                    showsEllipsisMenu: true   // clean style uses ellipsis
+                    onToggleCollapse: { toggleCollapsed(group.id) }
                 )
                 .textCase(nil)
             }
@@ -256,8 +243,7 @@ struct BudgetView: View {
                     },
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
-                    reservesTwoLines: true,
-                    showsEllipsisMenu: false  // detailed style uses swipe
+                    reservesTwoLines: true
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
@@ -293,6 +279,9 @@ struct BudgetView: View {
         let group = budgetStore.categoryGroups.first(where: \.isIncome)
         let categories = displayedIncomeCategories(in: budget)
         let name = group?.name ?? categories.first?.groupName ?? "Income"
+        let onSetHidden = group.flatMap { group -> ((Bool) -> Void)? in
+            group.hidden ? { setCategoryGroupHidden(group.id, hidden: $0) } : nil
+        }
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
@@ -311,25 +300,21 @@ struct BudgetView: View {
                     }
                 }
             } header: {
-                // The Income group can be swiped only to UNhide, never to
-                // hide: hiding it would drop the app's only income total
+                // The Income group can only be unhidden, never hidden:
+                // hiding it would drop the app's only income total
                 // from the budget table entirely. `onSetHidden` is passed
                 // only when the group is already hidden (e.g. leftover
-                // state from before this restriction existed), so the
-                // swipe button never offers "Hide" — only "Show" when
-                // needed. (GH #130's collapse control still applies.)
+                // state from before this restriction existed). GH #130's
+                // collapse control still applies.
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: BudgetView.incomeGroupHideAction(isHidden: group?.hidden == true) { hidden in
-                        if let group { setCategoryGroupHidden(group.id, hidden: hidden) }
-                    },
+                    onSetHidden: onSetHidden,
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
-                    },
-                    showsEllipsisMenu: true   // clean style uses ellipsis
+                    }
                 )
                 .textCase(nil)
             }
@@ -339,16 +324,13 @@ struct BudgetView: View {
                     name: name,
                     isCollapsed: isCollapsed,
                     isHidden: group?.hidden == true,
-                    onSetHidden: BudgetView.incomeGroupHideAction(isHidden: group?.hidden == true) { hidden in
-                        if let group { setCategoryGroupHidden(group.id, hidden: hidden) }
-                    },
+                    onSetHidden: onSetHidden,
                     receivedTotal: budget.totalIncome,
                     onToggleCollapse: {
                         toggleCollapsed(Self.incomeGroupCollapseID)
                     },
                     usesTableNumberFormat: true,
-                    reservesTwoLines: true,
-                    showsEllipsisMenu: false  // detailed style uses swipe
+                    reservesTwoLines: true
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
@@ -972,10 +954,7 @@ struct CategoryBudgetRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(
-                        HideShowAction.title(isHidden: isHidden),
-                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
-                    )
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1079,10 +1058,7 @@ struct CleanCategoryBudgetRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(
-                        HideShowAction.title(isHidden: isHidden),
-                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
-                    )
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1337,13 +1313,8 @@ struct BudgetGroupHeader: View {
     /// whether names wrap or not (GH #252); the clean style's plain section
     /// titles keep their natural height.
     var reservesTwoLines = false
-    /// If true, an ellipsis menu is shown for hide/show (clean style).
-    /// If false, swipe‑to‑hide is used instead (detailed style).
-    var showsEllipsisMenu: Bool = false
-
     var body: some View {
         HStack(spacing: 8) {
-            // Collapse button (chevron + name + totals)
             Button(action: onToggleCollapse) {
                 HStack(alignment: .top, spacing: BudgetColumn.spacing) {
                     // Nested so the chevron centers against the name (which can
@@ -1406,15 +1377,14 @@ struct BudgetGroupHeader: View {
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the group's categories")
 
-            // Ellipsis menu only in clean style
-            if showsEllipsisMenu, let onSetHidden {
+            if budgetStore.budgetDisplayStyle == .clean, let onSetHidden {
                 Menu {
                     Button {
                         onSetHidden(!isHidden)
                     } label: {
                         Label(
-                            HideShowAction.title(isHidden: isHidden),
-                            systemImage: HideShowAction.systemImage(isHidden: isHidden)
+                            isHidden ? "Show Group" : "Hide Group",
+                            systemImage: isHidden ? "eye" : "eye.slash"
                         )
                     }
                 } label: {
@@ -1425,16 +1395,12 @@ struct BudgetGroupHeader: View {
             }
         }
         .opacity(isHidden ? 0.5 : 1)
-        // Swipe‑to‑hide only in detailed style
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if !showsEllipsisMenu, let onSetHidden {
+            if budgetStore.budgetDisplayStyle == .detailed, let onSetHidden {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(
-                        HideShowAction.title(isHidden: isHidden),
-                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
-                    )
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }
@@ -1473,15 +1439,6 @@ struct BudgetGroupHeader: View {
         usesTableNumberFormat
             ? budgetStore.displayBudgetCell(amount)
             : budgetStore.displayBalance(amount)
-    }
-}
-
-extension BudgetView {
-    nonisolated static func incomeGroupHideAction(
-        isHidden: Bool,
-        setter: @escaping (Bool) -> Void
-    ) -> ((Bool) -> Void)? {
-        isHidden ? setter : nil
     }
 }
 
@@ -1546,10 +1503,7 @@ struct IncomeCategoryRow: View {
                 Button {
                     onSetHidden(!isHidden)
                 } label: {
-                    Label(
-                        HideShowAction.title(isHidden: isHidden),
-                        systemImage: HideShowAction.systemImage(isHidden: isHidden)
-                    )
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
                 }
                 .tint(isHidden ? .accentColor : .secondary)
             }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
-/// Cached formatters for the "yyyy-MM" month keys used by the budget tables
-/// and the month title shown in the toolbar. DateFormatter construction is
-/// expensive, so these are built once rather than per render.
+// MARK: - Formatters
+
 private let yearMonthFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM"
@@ -15,32 +14,18 @@ private let monthTitleFormatter: DateFormatter = {
     return formatter
 }()
 
-/// Abbreviated variant for the navigation bar's month stepper only. A
-/// centered `.principal` toolbar item is centered in the whole bar, but only
-/// while it clears the trailing buttons — one point wider and UIKit stops
-/// centering and jams it against the leading edge. "September 2026" between
-/// two chevrons is well past that limit, so the bar would centre some months
-/// and left-align others. Every abbreviated month fits, so the stepper holds
-/// still all year (GH #305 review).
 private let monthShortTitleFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "MMM yyyy"
     return formatter
 }()
 
-/// Shared metrics for the budget table's three numeric columns, so the
-/// summary captions, group totals and category pills line up vertically
-/// like the PWA's table.
+// MARK: - Shared Column Metrics
+
 enum BudgetColumn {
     static let width: CGFloat = 70
-    // Tight: every point between the columns comes out of the category
-    // name, which wraps early on a phone ("Caravan Parks 🏕" drops its
-    // emoji to a second line).
     static let spacing: CGFloat = 4
 
-    /// Cell text for the budget table: a plain grouped number without the
-    /// currency symbol, like the PWA's budget table — "USD 1,850.00" in
-    /// every cell would drown the category names on a phone.
     static func text(_ cents: Int, wholeUnits: Bool = false) -> String {
         (Double(cents) / 100.0).formatted(
             .number.precision(.fractionLength(wholeUnits ? 0 : 2)))
@@ -48,19 +33,16 @@ enum BudgetColumn {
 }
 
 private extension BudgetStore {
-    /// Masked variant of `BudgetColumn.text` for the budget table's cells.
-    /// Lives here rather than on the store proper so the table's
-    /// symbol-less number format stays private to this file.
     func displayBudgetCell(_ cents: Int) -> String {
         hideBalances ? Self.hiddenBalanceText : BudgetColumn.text(cents, wholeUnits: hideDecimalPlaces)
     }
 }
 
+// MARK: - BudgetView
+
 struct BudgetView: View {
     nonisolated static let incomeGroupCollapseID = "__income_group__"
 
-    /// IDs controlled by Expand/Collapse All for the budget currently shown.
-    /// Kept pure so the income-group participation has non-UI test coverage.
     nonisolated static func displayedGroupIDs(
         groupIDs: [String],
         hasIncome: Bool
@@ -78,8 +60,6 @@ struct BudgetView: View {
     @State private var transactionsDestination: CategoryTransactionsDestination?
     @State private var newBudgetItem: NewBudgetItem?
     @State private var categoryFilter: BudgetCategoryFilter = .all
-    /// Comma-joined group ids the user has collapsed, PWA-style. Stored as a
-    /// string because @AppStorage can't hold a Set directly.
     @AppStorage("collapsedBudgetGroups") private var collapsedGroupsStorage = ""
 
     private var collapsedGroups: Set<String> {
@@ -94,8 +74,6 @@ struct BudgetView: View {
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
-    // Expand/collapse all touch only the displayed budget's groups; ids
-    // remembered for other budget files stay put (GH #130).
     private func collapseAllGroups() {
         let displayedGroupIDs = Self.displayedGroupIDs(
             groupIDs: groupedCategories.map(\.id),
@@ -140,22 +118,11 @@ struct BudgetView: View {
                 }
             }
             .navigationTitle("Budget")
-            // The summary bar is pinned outside the List (GH #155), so it
-            // can't move with an overscroll the way list content does. A
-            // large title stretches on that overscroll and draws straight
-            // over the card, and collapses on scroll-up, jolting it (GH
-            // #253). Inline keeps the bar a fixed height; the month stepper
-            // below already occupies the centre, and the tab bar says
-            // "Budget" anyway.
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { budgetToolbar }
             .onChange(of: selectedMonth) { _, newMonth in
-                Task {
-                    await budgetStore.fetchBudgetMonth(newMonth)
-                }
+                Task { await budgetStore.fetchBudgetMonth(newMonth) }
             }
-            // Hiding the strip takes its filter with it — otherwise the table
-            // stays filtered with no visible control to clear it.
             .onChange(of: budgetStore.showBudgetCheckInStrip) { _, isShown in
                 if !isShown { categoryFilter = .all }
             }
@@ -170,35 +137,28 @@ struct BudgetView: View {
             }
             .sheet(item: $newBudgetItem) { item in
                 switch item {
-                case .category:
-                    NewCategorySheet(groupId: firstSelectableGroupId ?? "")
-                case .group:
-                    NewCategoryGroupSheet()
+                case .category: NewCategorySheet(groupId: firstSelectableGroupId ?? "")
+                case .group: NewCategoryGroupSheet()
                 }
             }
             .navigationDestination(item: $transactionsDestination) { destination in
                 CategoryTransactionsView(destination: destination)
             }
             .overlay {
-                if budgetStore.isLoading {
-                    ProgressView()
-                }
+                if budgetStore.isLoading { ProgressView() }
             }
         }
         .initialSyncBanner()
     }
 
+    // MARK: - Group Sections
 
-    /// One group's rows, extracted from the `List` so the body stays within
-    /// the compiler's type-check budget.
     @ViewBuilder
     private func groupSection(_ group: CategoryGroupSection) -> some View {
         let isCollapsed = collapsedGroups.contains(group.id)
+
         if budgetStore.budgetDisplayStyle == .clean {
-            // Clean style: the group name sits above the card as a section
-            // header, like the App Store screenshots. The same collapse
-            // control lives there so collapsing behaves identically in both
-            // styles.
+            // Clean style: section header with the original ellipsis menu
             Section {
                 if !isCollapsed {
                     ForEach(group.categories) { category in
@@ -206,13 +166,9 @@ struct BudgetView: View {
                             category: category,
                             isHidden: category.hidden,
                             isDimmed: category.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(category.categoryId, hidden: $0)
-                            },
+                            onSetHidden: { setCategoryHidden(category.categoryId, hidden: $0) },
                             onShowDetails: { selectedCategory = $0 },
                             onEditBudget: { editingCategory = $0 },
-                            // Name shows all time, Spent shows
-                            // the displayed month (GH #56).
                             onShowTransactions: showTransactions,
                             onMoveMoney: moveMoney
                         )
@@ -222,27 +178,19 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
+                    isDimmed: group.isHidden,
+                    onSetHidden: { setCategoryGroupHidden(group.id, hidden: $0) },
                     onToggleCollapse: { toggleCollapsed(group.id) }
                 )
                 .textCase(nil)
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button {
-                        setCategoryGroupHidden(group.id, hidden: !group.isHidden)
-                    } label: {
-                        Label(group.isHidden ? "Show" : "Hide",
-                              systemImage: group.isHidden ? "eye" : "eye.slash")
-                    }
-                    .tint(group.isHidden ? .accentColor : .secondary)
-                }
             }
         } else {
-            // The group row lives inside the card (first row, tinted) like
-            // the PWA's table, so its totals share the exact column grid of
-            // the rows below.
+            // Detailed style: header row inside the section with swipe-to-hide
             Section {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
+                    isDimmed: group.isHidden,
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
                     reservesTwoLines: true
@@ -250,13 +198,7 @@ struct BudgetView: View {
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button {
-                        setCategoryGroupHidden(group.id, hidden: !group.isHidden)
-                    } label: {
-                        Label(group.isHidden ? "Show" : "Hide",
-                              systemImage: group.isHidden ? "eye" : "eye.slash")
-                    }
-                    .tint(group.isHidden ? .accentColor : .secondary)
+                    hideGroupButton(group)
                 }
                 if !isCollapsed {
                     ForEach(group.categories) { category in
@@ -264,15 +206,10 @@ struct BudgetView: View {
                             category: category,
                             isHidden: category.hidden,
                             isDimmed: category.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(category.categoryId, hidden: $0)
-                            },
-                            addsGroupBottomPadding:
-                                category.id == group.categories.last?.id,
+                            onSetHidden: { setCategoryHidden(category.categoryId, hidden: $0) },
+                            addsGroupBottomPadding: category.id == group.categories.last?.id,
                             onShowDetails: { selectedCategory = $0 },
                             onEditBudget: { editingCategory = $0 },
-                            // Name shows all time, Spent shows
-                            // the displayed month (GH #56).
                             onShowTransactions: showTransactions,
                             onMoveMoney: moveMoney
                         )
@@ -282,14 +219,13 @@ struct BudgetView: View {
         }
     }
 
-    /// The income group drawn at the bottom of the table, extracted from the
-    /// `List` so the body stays within the compiler's type-check budget.
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
         let group = budgetStore.categoryGroups.first(where: \.isIncome)
         let categories = displayedIncomeCategories(in: budget)
         let name = group?.name ?? categories.first?.groupName ?? "Income"
+
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
@@ -298,9 +234,7 @@ struct BudgetView: View {
                             income: income,
                             isHidden: income.hidden,
                             isDimmed: income.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(income.categoryId, hidden: $0)
-                            },
+                            onSetHidden: { setCategoryHidden(income.categoryId, hidden: $0) },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: false,
                             onShowTransactions: showTransactions
@@ -311,10 +245,10 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
+                    isDimmed: group?.hidden == true,
+                    onSetHidden: group.map { _ in { setCategoryGroupHidden(group!.id, hidden: $0) } },
                     receivedTotal: budget.totalIncome,
-                    onToggleCollapse: {
-                        toggleCollapsed(Self.incomeGroupCollapseID)
-                    }
+                    onToggleCollapse: { toggleCollapsed(Self.incomeGroupCollapseID) }
                 )
                 .textCase(nil)
             }
@@ -323,10 +257,9 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
+                    isDimmed: group?.hidden == true,
                     receivedTotal: budget.totalIncome,
-                    onToggleCollapse: {
-                        toggleCollapsed(Self.incomeGroupCollapseID)
-                    },
+                    onToggleCollapse: { toggleCollapsed(Self.incomeGroupCollapseID) },
                     usesTableNumberFormat: true,
                     reservesTwoLines: true
                 )
@@ -338,9 +271,7 @@ struct BudgetView: View {
                             income: income,
                             isHidden: income.hidden,
                             isDimmed: income.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(income.categoryId, hidden: $0)
-                            },
+                            onSetHidden: { setCategoryHidden(income.categoryId, hidden: $0) },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: true,
                             onShowTransactions: showTransactions
@@ -351,32 +282,24 @@ struct BudgetView: View {
         }
     }
 
-    /// The screen's toolbar, extracted from `body` so the whole screen stays
-    /// within the compiler's type-check budget.
+    // MARK: - Shared Swipe Action (detailed style only)
+
+    @ViewBuilder
+    private func hideGroupButton(_ group: CategoryGroupSection) -> some View {
+        Button {
+            setCategoryGroupHidden(group.id, hidden: !group.isHidden)
+        } label: {
+            Label(group.isHidden ? "Show" : "Hide",
+                  systemImage: group.isHidden ? "eye" : "eye.slash")
+        }
+        .tint(group.isHidden ? .accentColor : .secondary)
+    }
+
+    // MARK: - Toolbar
+
     @ToolbarContentBuilder
     private var budgetToolbar: some ToolbarContent {
-        // Both arrows flank the month in the center, so nothing sits in the
-        // leading "back button" position where the previous-month chevron
-        // used to be mistaken for one (it steps the month, not the
-        // navigation stack).
         ToolbarItem(placement: .principal) {
-            // UIKit centers a title view only while it stays under ~140pt
-            // next to these two trailing buttons; one point over and it
-            // left-aligns the whole stepper against the leading edge instead.
-            // That cliff has been hit twice — GH #234, then again by #319
-            // padding both chevrons out to 44pt wide (44 + 44 + a 78pt
-            // "Aug 2026" = 166). So the width is the budget: the touch target
-            // grows downward to 44pt and stays 30pt wide, giving 138 total.
-            // `.frame(maxWidth: .infinity)` can't buy centering back — the
-            // title view is sized to fit its content, so the frame has no
-            // extra width to center in.
-            //
-            // ponytail: 138 of ~140 is all the headroom there is, and the slot
-            // shrinks as the trailing buttons scale, so raised text sizes still
-            // left-align (measured at XXXL). Anything that needs a bigger
-            // stepper — a third trailing button, unabbreviated months, real
-            // Dynamic Type support — has to leave the bar for a pinned header
-            // row above the summary card, where centering is real layout.
             HStack(spacing: 0) {
                 Button {
                     selectedMonth = Self.shiftMonth(selectedMonth, by: -1)
@@ -399,9 +322,7 @@ struct BudgetView: View {
                 .accessibilityLabel("Next month")
             }
         }
-        // Creation, unlike everything in the options menu, changes the budget
-        // rather than the view of it — so it gets its own button (GH #284).
-        // Nothing to add to until a budget is open.
+
         if budgetStore.currentBudgetMonth != nil {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
@@ -410,8 +331,8 @@ struct BudgetView: View {
                     } label: {
                         Label("New Category", systemImage: "tag")
                     }
-                    // A category needs a group to live in.
                     .disabled(firstSelectableGroupId == nil)
+
                     Button {
                         newBudgetItem = .group
                     } label: {
@@ -425,13 +346,8 @@ struct BudgetView: View {
                 .accessibilityHint("Create a category or category group")
             }
         }
+
         ToolbarItem(placement: .topBarTrailing) {
-            // Every "how should this look" control lives here (GH #157).
-            // Whole-table expand/collapse is a menu rather than a long-press
-            // on the group headers: SwiftUI context menus don't fire inside
-            // the clean style's section headers (GH #130).
-            // The isolated method references can't be inferred as optional
-            // closures under Swift 6, so wrap them.
             let hasBudget = budgetStore.currentBudgetMonth != nil
             BudgetOptionsMenu(
                 expandAllGroups: hasBudget ? { expandAllGroups() } : nil,
@@ -440,16 +356,12 @@ struct BudgetView: View {
         }
     }
 
-    /// The pinned summary plus the scrolling budget table, shown once a
-    /// budget month has loaded. Extracted from `body` so the whole screen
-    /// stays within the compiler's type-check budget.
+    // MARK: - Main Content
+
     @ViewBuilder
     private func loadedBudgetContent(_ budget: BudgetMonth) -> some View {
         VStack(spacing: 0) {
-            // Summary card: the clean style reads as a 2x2 grid of currency
-            // amounts; the detailed style's captioned columns double as the
-            // column headers for the table below. It sits above the List (not
-            // inside it) so it stays pinned while the table scrolls (GH #155).
+            // Summary card
             Group {
                 if budgetStore.budgetDisplayStyle == .clean {
                     CleanBudgetSummary(budget: budget)
@@ -461,8 +373,6 @@ struct BudgetView: View {
                         )
                 } else {
                     TableBudgetSummary(budget: budget)
-                        // Fine-tune the fixed-width columns against the
-                        // amount pills in the rows below.
                         .padding(.leading, 4)
                         .padding(.trailing, 4)
                         .padding(.horizontal, 12)
@@ -473,21 +383,10 @@ struct BudgetView: View {
                         )
                 }
             }
-            // The List below overrides its default margins with 4 pt content
-            // margins; match them so the summary is the same width as the
-            // sections.
             .padding(.horizontal, 4)
             .padding(.top, 8)
-            // A gutter that survives scrolling, unlike the List's top content
-            // margin below. Without it the scrolled rows clip flush against
-            // the capsule — a group header sliced mid-glyph, its tinted
-            // background swallowing the capsule's bottom corners (GH #165).
             .padding(.bottom, 8)
 
-            // The strip filters categories, so it can't express uncategorized
-            // transactions — and the check-in card it replaced held the only
-            // in-app route to that list (otherwise reachable only from a
-            // notification tap).
             if budgetStore.uncategorizedCount > 0 {
                 NavigationLink {
                     UncategorizedTransactionsView()
@@ -503,8 +402,6 @@ struct BudgetView: View {
                     }
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.orange)
-                    // Reads as a full-width row like the List section it used
-                    // to live in (GH #29 / #305), not a stray line of text.
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -519,11 +416,8 @@ struct BudgetView: View {
             }
 
             if budgetStore.showBudgetCheckInStrip {
-                BudgetCheckInStrip(
-                    budget: budget,
-                    selection: $categoryFilter
-                )
-                .padding(.bottom, 8)
+                BudgetCheckInStrip(budget: budget, selection: $categoryFilter)
+                    .padding(.bottom, 8)
             }
 
             List {
@@ -533,9 +427,7 @@ struct BudgetView: View {
                     } description: {
                         Text("Try another category filter.")
                     } actions: {
-                        Button("Show All Categories") {
-                            categoryFilter = .all
-                        }
+                        Button("Show All Categories") { categoryFilter = .all }
                     }
                 }
 
@@ -543,49 +435,16 @@ struct BudgetView: View {
                     groupSection(group)
                 }
 
-                // Income group last, matching the bottom of the web UI's
-                // budget table.
                 if categoryFilter == .all, !displayedIncomeCategories(in: budget).isEmpty {
                     incomeSection(budget)
                 }
             }
-            // Collapse state lives in @AppStorage, and a write to that lands
-            // outside any withAnimation transaction — so the rows have to be
-            // animated from here, off the stored value, rather than at the
-            // call site.
             .animation(AppAnimation.disclosure, value: collapsedGroupsStorage)
-            // The clean style keeps the stock section rhythm; the detailed
-            // table packs its group cards tighter.
-            .listSectionSpacing(
-                budgetStore.budgetDisplayStyle == .clean ? .default : .custom(14)
-            )
-            // Pull-to-refresh belongs to the table alone. Attached to the
-            // container instead, SwiftUI also wires it to the check-in
-            // strip's horizontal ScrollView, so dragging the chips down
-            // fired a sync.
-            .refreshable {
-                await budgetStore.sync()
-            }
+            .listSectionSpacing(budgetStore.budgetDisplayStyle == .clean ? .default : .custom(14))
+            .refreshable { await budgetStore.sync() }
             .contentMargins(.horizontal, 4, for: .scrollContent)
-            // The rest of the gap under the pinned summary — this part
-            // scrolls away with the content, leaving the 8 pt gutter above.
-            // Together they sit a notch wider than the spacing between the
-            // group sections, so the summary reads as its own bar rather than
-            // a first group (GH #165).
-            .contentMargins(
-                .top,
-                budgetStore.budgetDisplayStyle == .clean ? 20 : 16,
-                for: .scrollContent
-            )
-            // Let short rows (group headers) sit below the stock 44 pt
-            // minimum; tap targets stay fine because the whole row is the
-            // button.
+            .contentMargins(.top, budgetStore.budgetDisplayStyle == .clean ? 20 : 16, for: .scrollContent)
             .environment(\.defaultMinListRowHeight, 32)
-            // Rows leaving the table used to be chopped off flat against the
-            // gutter under the summary, a hard grey line across mid-row. Fade
-            // them into it instead. The List's top content margin above is
-            // deeper than this fade, so at rest it covers empty background and
-            // nothing on screen looks washed out.
             .overlay(alignment: .top) {
                 LinearGradient(
                     colors: [
@@ -612,24 +471,17 @@ struct BudgetView: View {
                     }
             )
         }
-        // The budget table is a fixed grid of narrow amount columns;
-        // stretched to iPad width it becomes a category name and its numbers
-        // separated by a foot of nothing.
         .readableWidth()
-        // The pinned summary sits outside the List, so paint the grouped
-        // background behind it to match.
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
-    /// Open the move-money sheet for a tapped balance (GH #128): cover
-    /// overspending when red, move the surplus when green. The month is
-    /// captured alongside so the picker lists its sibling categories.
+
+    // MARK: - Actions
+
     private func moveMoney(_ category: CategoryBudget) {
         guard let budget = budgetStore.currentBudgetMonth else { return }
         transferContext = BudgetTransferContext(category: category, budget: budget)
     }
-    
-    /// The group a new category starts out filed under: the first one the
-    /// table would draw. Nil when the budget has no group to file it in.
+
     private var firstSelectableGroupId: String? {
         let visible = budgetStore.categoryGroups.filter { !$0.hidden }
         return visible.min { $0.sortOrder < $1.sortOrder }?.id
@@ -642,11 +494,7 @@ struct BudgetView: View {
     private func setCategoryHidden(_ id: String, hidden: Bool) {
         Task {
             do {
-                try await budgetStore.setCategoryHidden(
-                    id: id,
-                    hidden: hidden,
-                    month: selectedMonth
-                )
+                try await budgetStore.setCategoryHidden(id: id, hidden: hidden, month: selectedMonth)
             } catch {
                 budgetStore.error = error.localizedDescription
             }
@@ -656,19 +504,13 @@ struct BudgetView: View {
     private func setCategoryGroupHidden(_ id: String, hidden: Bool) {
         Task {
             do {
-                try await budgetStore.setCategoryGroupHidden(
-                    id: id,
-                    hidden: hidden,
-                    month: selectedMonth
-                )
+                try await budgetStore.setCategoryGroupHidden(id: id, hidden: hidden, month: selectedMonth)
             } catch {
                 budgetStore.error = error.localizedDescription
             }
         }
     }
 
-    /// Push the category's transactions: month narrows to one "yyyy-MM",
-    /// nil means all time (GH #56).
     private func showTransactions(_ category: CategoryBudget, month: String?) {
         transactionsDestination = CategoryTransactionsDestination(
             categoryId: category.categoryId,
@@ -685,13 +527,13 @@ struct BudgetView: View {
         )
     }
 
+    // MARK: - Grouped Data
+
     struct CategoryGroupSection {
         let id: String
         let name: String
         let isHidden: Bool
-        /// The rows to draw, after "Hide Spent Categories" filtering.
         let categories: [CategoryBudget]
-        /// Totals over the group's non-hidden category list.
         let totals: CategoryGroupTotals
     }
 
@@ -704,16 +546,10 @@ struct BudgetView: View {
         var sections = byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }
-                // An explicit filter is its own visibility rule: "Not Funded"
-                // must still match zero-available categories even when the
-                // Hide Spent Categories setting would drop them from "All".
                 let base = categoryFilter == .all
                     ? budgetStore.visibleCategoryBudgets(items)
                     : items.filter(categoryFilter.includes)
-                let visible = base
-                    .sorted { $0.categorySortOrder < $1.categorySortOrder }
-                // A group whose rows are all hidden drops out entirely rather
-                // than leaving a header stranded over an empty card.
+                let visible = base.sorted { $0.categorySortOrder < $1.categorySortOrder }
                 guard !visible.isEmpty else { return nil }
                 return (
                     first.groupSortOrder,
@@ -729,13 +565,6 @@ struct BudgetView: View {
                     )
                 )
             }
-        // A group you just made has no categories, so the month's rows above
-        // can't know about it. Draw it anyway — otherwise creating a group
-        // looks like it did nothing (GH #284). Income groups stay out: this
-        // list is the expense table, and income has its own section below,
-        // which likewise only appears once it has categories.
-        // Empty placeholders only belong in the unfiltered table: a filter
-        // that matches nothing should show the empty state, not bare headers.
         sections += budgetStore.categoryGroups
             .filter {
                 categoryFilter == .all && !$0.isIncome
@@ -754,10 +583,7 @@ struct BudgetView: View {
                     )
                 )
             }
-
-        return sections
-            .sorted { $0.0 < $1.0 }
-            .map(\.1)
+        return sections.sorted { $0.0 < $1.0 }.map(\.1)
     }
 
     static func currentMonthString() -> String {
@@ -769,10 +595,8 @@ struct BudgetView: View {
     }
 }
 
-/// A name that always occupies two lines' height, so short and wrapping
-/// names produce equal-height rows and the amount columns line up (GH
-/// #252). A hidden copy reserves the space and the visible copy centers
-/// within it — `reservesSpace` alone pins the text to the top.
+// MARK: - Reusable Views
+
 private struct TwoLineName: View {
     let text: String
     let font: Font
@@ -785,7 +609,6 @@ private struct TwoLineName: View {
                 .lineLimit(2, reservesSpace: true)
                 .minimumScaleFactor(minimumScaleFactor)
                 .hidden()
-
             Text(text)
                 .font(font)
                 .lineLimit(2)
@@ -794,8 +617,6 @@ private struct TwoLineName: View {
     }
 }
 
-/// Status filters stay visible above the category list, so checking the
-/// month never requires opening a menu or scrolling past a large card.
 struct BudgetCheckInStrip: View {
     let budget: BudgetMonth
     @Binding var selection: BudgetCategoryFilter
@@ -838,18 +659,12 @@ struct BudgetCheckInStrip: View {
 
     private func title(for filter: BudgetCategoryFilter) -> String {
         switch filter {
-        case .all:
-            "All"
-        case .needsAttention:
-            "Needs Attention \(count(for: filter))"
-        case .overspent:
-            "\(budget.isTrackingBudget ? "Over Budget" : "Overspent") \(count(for: filter))"
-        case .unassigned:
-            "\(budget.isTrackingBudget ? "No Budget" : "Not Funded") \(count(for: filter))"
-        case .approachingLimit:
-            "\(budget.isTrackingBudget ? "Near Budget" : "Almost Spent") \(count(for: filter))"
-        case .onTrack:
-            "\(budget.isTrackingBudget ? "Within Budget" : "On Track") \(count(for: filter))"
+        case .all: "All"
+        case .needsAttention: "Needs Attention \(count(for: filter))"
+        case .overspent: "\(budget.isTrackingBudget ? "Over Budget" : "Overspent") \(count(for: filter))"
+        case .unassigned: "\(budget.isTrackingBudget ? "No Budget" : "Not Funded") \(count(for: filter))"
+        case .approachingLimit: "\(budget.isTrackingBudget ? "Near Budget" : "Almost Spent") \(count(for: filter))"
+        case .onTrack: "\(budget.isTrackingBudget ? "Within Budget" : "On Track") \(count(for: filter))"
         }
     }
 
@@ -867,17 +682,11 @@ struct CategoryBudgetRow: View {
     var addsGroupBottomPadding = false
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
-    /// Push the category's transactions: month narrows to one "yyyy-MM",
-    /// nil means all time (GH #56).
     var onShowTransactions: (CategoryBudget, String?) -> Void = { _, _ in }
-    /// Open the move-money sheet for this category's balance (GH #128).
     var onMoveMoney: (CategoryBudget) -> Void = { _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
-            // One PWA-style table line: name, then the Budgeted/Spent/Balance
-            // pills in their fixed columns. Each element keeps its own tap
-            // action (our enhancement over the PWA's read-only cells).
             HStack(spacing: BudgetColumn.spacing) {
                 Button {
                     onShowDetails(category)
@@ -916,8 +725,6 @@ struct CategoryBudgetRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Transactions for \(category.categoryName) in \(MonthPicker.title(for: category.month))")
-                // A zero balance has nothing to move and nothing to cover, so
-                // it stays a plain cell.
                 Button {
                     onMoveMoney(category)
                 } label: {
@@ -960,9 +767,6 @@ struct CategoryBudgetRow: View {
     }
 }
 
-/// Clean-style category row, matching the App Store screenshots: name and a
-/// large Available amount up top, the progress bar beneath, then tappable
-/// Budgeted/Spent captions. Same tap actions as the detailed table's cells.
 struct CleanCategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
@@ -971,10 +775,7 @@ struct CleanCategoryBudgetRow: View {
     var onSetHidden: ((Bool) -> Void)?
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
-    /// Push the category's transactions: month narrows to one "yyyy-MM",
-    /// nil means all time (GH #56).
     var onShowTransactions: (CategoryBudget, String?) -> Void = { _, _ in }
-    /// Open the move-money sheet for this category's balance (GH #128).
     var onMoveMoney: (CategoryBudget) -> Void = { _ in }
 
     var body: some View {
@@ -994,8 +795,6 @@ struct CleanCategoryBudgetRow: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Details for \(category.categoryName)")
                 Spacer()
-                // A zero balance has nothing to move and nothing to cover, so
-                // it stays a plain label.
                 Button {
                     onMoveMoney(category)
                 } label: {
@@ -1034,8 +833,6 @@ struct CleanCategoryBudgetRow: View {
                     onShowTransactions(category, category.month)
                 } label: {
                     HStack(spacing: 4) {
-                        // Green + signed so a deposit-only category doesn't
-                        // read as spending (GH #102).
                         Text("Spent: \(budgetStore.displaySpentCaption(category.spent))")
                             .font(.caption)
                             .foregroundStyle(category.spent > 0
@@ -1065,16 +862,10 @@ struct CleanCategoryBudgetRow: View {
     }
 }
 
-/// Whether `month` ("YYYY-MM") is before the current calendar month. The
-/// strings are zero-padded, so a plain lexicographic compare is exact.
 @MainActor private func isPastMonth(_ month: String) -> Bool {
     month < BudgetView.currentMonthString()
 }
 
-/// The tracking-budget result figure for the summary bar: actual savings once
-/// a month is finished, projected savings while it's still current or ahead.
-/// Mirrors the Actual webapp, which flips "Projected savings" to "Saved" when
-/// the month rolls over.
 @MainActor private func trackingSavings(_ budget: BudgetMonth) -> Int {
     isPastMonth(budget.month) ? budget.savedActual : budget.projectedSavings
 }
@@ -1083,9 +874,6 @@ struct CleanCategoryBudgetRow: View {
     isPastMonth(budget.month) ? "Saved" : "Projected"
 }
 
-/// Clean-style summary card: a 2x2 grid whose reading order follows the
-/// money — came in, allocated, went out, left over. Two rows because four
-/// currency amounts don't fit across narrow devices.
 struct CleanBudgetSummary: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let budget: BudgetMonth
@@ -1110,9 +898,6 @@ struct CleanBudgetSummary: View {
                     value: budgetStore.displayBalance(-budget.totalSpent)
                 )
                 Spacer()
-                // Envelope budgets lead with unallocated funds; tracking
-                // budgets report savings instead — actual for a finished month,
-                // projected for the current/future month.
                 if let toBudget = budget.toBudget {
                     SummaryStat(
                         label: "To Budget",
@@ -1135,17 +920,12 @@ struct CleanBudgetSummary: View {
     }
 }
 
-/// PWA-style summary bar: unallocated funds lead, and the three captioned
-/// columns double as the column headers for the table below.
 struct TableBudgetSummary: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let budget: BudgetMonth
 
     var body: some View {
         HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-            // Envelope budgets lead with unallocated funds; tracking
-            // budgets have no to-budget concept, so lead with income
-            // received instead.
             if let toBudget = budget.toBudget {
                 SummaryStat(
                     label: "To Budget",
@@ -1167,9 +947,6 @@ struct TableBudgetSummary: View {
                 label: "Spent",
                 value: budgetStore.displayBudgetCell(budget.totalSpent)
             )
-            // Envelope budgets total the category balances; tracking budgets
-            // report savings instead — actual for a finished month, projected
-            // for the current/future month.
             if budget.toBudget != nil {
                 SummaryColumn(
                     label: "Balance",
@@ -1188,7 +965,6 @@ struct TableBudgetSummary: View {
     }
 }
 
-/// The leading figure in the summary bar (To Budget / Income).
 struct SummaryStat: View {
     let label: String
     let value: String
@@ -1210,8 +986,6 @@ struct SummaryStat: View {
     }
 }
 
-/// One captioned column in the summary bar, sized to line up with the
-/// category pills below it.
 struct SummaryColumn: View {
     let label: String
     let value: String
@@ -1234,7 +1008,6 @@ struct SummaryColumn: View {
     }
 }
 
-/// One amount cell in the budget table, in the PWA's pill style.
 struct BudgetAmountPill: View {
     let text: String
     var color: Color = .primary
@@ -1258,11 +1031,6 @@ struct BudgetAmountPill: View {
     }
 }
 
-/// A `BudgetAmountPill` with a small caption above it, naming the column
-/// ("Budgeted" / "Spent" / "Balance") the same way the pinned summary bar's
-/// columns are captioned. Used by the detailed group header's totals so a
-/// group row reads the same as the summary above it, rather than leaving the
-/// person to cross-reference bare numbers against the summary's labels.
 private struct CaptionedAmountPill: View {
     let label: String
     let text: String
@@ -1282,36 +1050,22 @@ private struct CaptionedAmountPill: View {
     }
 }
 
-/// Group header row: collapse control and group name, plus the group's
-/// Budgeted, Spent and Balance totals in the table's three rightmost
-/// columns, each captioned the same way the pinned summary bar is.
 struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
     let isCollapsed: Bool
-    /// The detailed style totals its columns here; the clean style's header
-    /// is a plain section title above the card, so it leaves this nil.
+    var isDimmed = false
+    var onSetHidden: ((Bool) -> Void)?
     var totals: CategoryGroupTotals?
-    /// Income groups use the same header shell but have one meaningful total:
-    /// money received. It occupies the trailing column where expense groups
-    /// show their balance.
     var receivedTotal: Int? = nil
     let onToggleCollapse: () -> Void
-    /// Detailed tables omit currency symbols from their numeric columns;
-    /// clean headers retain the app-wide currency presentation.
     var usesTableNumberFormat = false
-    /// The detailed style reserves two lines so group rows stay equal-height
-    /// whether names wrap or not (GH #252); the clean style's plain section
-    /// titles keep their natural height.
     var reservesTwoLines = false
 
     var body: some View {
         HStack(spacing: 8) {
             Button(action: onToggleCollapse) {
                 HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-                    // Nested so the chevron centers against the name (which can
-                    // run one or two lines) rather than pinning to the top of
-                    // the row alongside the totals' captions.
                     HStack(spacing: BudgetColumn.spacing) {
                         DisclosureChevron(
                             isExpanded: !isCollapsed,
@@ -1348,8 +1102,6 @@ struct BudgetGroupHeader: View {
                         CaptionedAmountPill(
                             label: "Balance",
                             text: budgetStore.displayBudgetCell(totals.balance),
-                            // Same three-way treatment as the category rows, so a
-                            // group that lands on zero doesn't read as healthy.
                             color: totals.balance < 0
                                 ? .red
                                 : (totals.balance == 0 ? .secondary : .green)
@@ -1368,12 +1120,27 @@ struct BudgetGroupHeader: View {
             .buttonStyle(.plain)
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the group's categories")
+
+            if let onSetHidden {
+                Menu {
+                    Button {
+                        onSetHidden(!isDimmed)
+                    } label: {
+                        Label(
+                            isDimmed ? "Show Group" : "Hide Group",
+                            systemImage: isDimmed ? "eye" : "eye.slash"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .frame(minWidth: 32, minHeight: 44)
+                }
+                .accessibilityLabel("Options for \(name)")
+            }
         }
+        .opacity(isDimmed ? 0.5 : 1)
     }
 
-    /// The pills are decoration to VoiceOver once the button carries its own
-    /// label, so the totals have to be spoken here or they're lost. Currency
-    /// formatting, not the table's symbol-less cells, reads better aloud.
     private var accessibilityLabel: String {
         let state = isCollapsed ? "collapsed" : "expanded"
         if let receivedTotal {
@@ -1406,8 +1173,6 @@ struct BudgetGroupHeader: View {
     }
 }
 
-/// One income category: name and the amount received this month. Tracking
-/// budgets can budget income, so they also get a "Budgeted" caption.
 struct IncomeCategoryRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let income: IncomeCategory
@@ -1475,9 +1240,8 @@ struct IncomeCategoryRow: View {
     }
 }
 
-/// A compact category editor. Amount cells in the budget table keep their
-/// existing actions; tapping the name is reserved for the category's own
-/// metadata and quick-assignment shortcuts.
+// MARK: - Category Detail Sheet
+
 struct CategoryBudgetDetailSheet: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
@@ -1535,36 +1299,33 @@ struct CategoryBudgetDetailSheet: View {
 
                 Section(
                     content: {
-                    // A suggestion overwrites this month's amount, so name the
-                    // month and show what's there now — otherwise the user
-                    // confirms a budget write blind.
-                    LabeledContent(MonthPicker.title(for: category.month)) {
-                        Text(budgetStore.displayBalance(category.budgeted))
-                            .monospacedDigit()
-                    }
-
-                    if quickAssignSuggestions.isEmpty {
-                        Text("No suggestions available")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        ForEach(quickAssignSuggestions) { suggestion in
-                            Button {
-                                Task { await apply(suggestion) }
-                            } label: {
-                                HStack {
-                                    Text(quickAssignTitle(for: suggestion.kind))
-                                        .foregroundStyle(.tint)
-                                    Spacer(minLength: 12)
-                                    Text(budgetStore.displayBalance(suggestion.amount))
-                                        .foregroundStyle(.primary)
-                                        .monospacedDigit()
-                                        .fixedSize(horizontal: true, vertical: false)
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(isApplyingSuggestion)
+                        LabeledContent(MonthPicker.title(for: category.month)) {
+                            Text(budgetStore.displayBalance(category.budgeted))
+                                .monospacedDigit()
                         }
-                    }
+
+                        if quickAssignSuggestions.isEmpty {
+                            Text("No suggestions available")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(quickAssignSuggestions) { suggestion in
+                                Button {
+                                    Task { await apply(suggestion) }
+                                } label: {
+                                    HStack {
+                                        Text(quickAssignTitle(for: suggestion.kind))
+                                            .foregroundStyle(.tint)
+                                        Spacer(minLength: 12)
+                                        Text(budgetStore.displayBalance(suggestion.amount))
+                                            .foregroundStyle(.primary)
+                                            .monospacedDigit()
+                                            .fixedSize(horizontal: true, vertical: false)
+                                    }
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(isApplyingSuggestion)
+                            }
+                        }
                     },
                     header: {
                         Text(isTracking ? "Quick Budget" : "Quick Assign")
@@ -1663,10 +1424,8 @@ struct CategoryBudgetDetailSheet: View {
     }
 }
 
-/// One place for the status color and mode-neutral wording, shared by the
-/// bar, the dot, and the detail sheet — so VoiceOver says the same thing for
-/// the same category everywhere. The detail sheet keeps its own
-/// envelope/tracking titles on top of this.
+// MARK: - Status & Progress Views
+
 extension CategoryProgressState {
     var tint: Color {
         switch self {
@@ -1689,8 +1448,6 @@ extension CategoryProgressState {
     }
 }
 
-/// Spent-vs-available bar for a budget row. Fill and color mirror the row's
-/// Available amount: green while money remains, red once overspent.
 struct CategoryProgressBar: View {
     let fraction: Double
     let state: CategoryProgressState
@@ -1710,16 +1467,12 @@ struct CategoryProgressBar: View {
             }
         }
         .frame(height: 5)
-        // Budgeting a category shrinks its bar as the money lands, so the
-        // edit is visible in the row itself and not only in the pill.
         .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
         .accessibilityLabel("\(state.statusText), spent \(Int((fraction * 100).rounded())) percent")
     }
 }
 
-/// A deliberately quiet status cue for budget rows. The category detail sheet
-/// carries the full plain-language status so the main budget remains scannable.
 struct CompactCategoryStatusDot: View {
     let state: CategoryProgressState
 
@@ -1732,8 +1485,8 @@ struct CompactCategoryStatusDot: View {
     }
 }
 
-/// Edit the budgeted amount for one category-month. Saving writes through
-/// the sync engine (optimistic local-first) and refreshes the month.
+// MARK: - Edit Budget Amount Sheet
+
 struct EditBudgetAmountSheet: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
@@ -1791,7 +1544,6 @@ struct EditBudgetAmountSheet: View {
         errorMessage = nil
         Task {
             do {
-                // An emptied field means "no longer budgeted", i.e. zero.
                 let cents = try BudgetStore.budgetAmountCents(
                     from: amountText.isEmpty ? "0" : amountText,
                     allowNegative: true
@@ -1810,6 +1562,8 @@ struct EditBudgetAmountSheet: View {
     }
 }
 
+// MARK: - Month Picker
+
 struct MonthPicker: View {
     @Binding var selectedMonth: String
 
@@ -1825,13 +1579,9 @@ struct MonthPicker: View {
                 .font(.headline)
                 .lineLimit(1)
         }
-        // The abbreviation is a layout constraint, not what the month is
-        // called — VoiceOver still reads it in full.
         .accessibilityLabel(Self.title(for: selectedMonth))
     }
 
-    /// Next month back through the prior year, newest first, padded with the
-    /// selection itself when swiping has moved outside that window.
     private var monthOptions: [String] {
         let current = BudgetView.currentMonthString()
         var months = (-12...1).map { BudgetView.shiftMonth(current, by: $0) }
@@ -1843,17 +1593,12 @@ struct MonthPicker: View {
     }
 
     nonisolated static func title(for month: String) -> String {
-        guard let date = date(fromMonth: month) else {
-            return month
-        }
+        guard let date = date(fromMonth: month) else { return month }
         return monthTitleFormatter.string(from: date)
     }
 
-    /// `title(for:)` abbreviated to a fixed-ish width for the toolbar stepper.
     nonisolated static func shortTitle(for month: String) -> String {
-        guard let date = date(fromMonth: month) else {
-            return month
-        }
+        guard let date = date(fromMonth: month) else { return month }
         return monthShortTitleFormatter.string(from: date)
     }
 
@@ -1861,9 +1606,7 @@ struct MonthPicker: View {
         let parts = month.split(separator: "-")
         guard parts.count == 2,
               let year = Int(parts[0]),
-              let monthNumber = Int(parts[1]) else {
-            return nil
-        }
+              let monthNumber = Int(parts[1]) else { return nil }
         var components = DateComponents()
         components.year = year
         components.month = monthNumber

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-// MARK: - Formatters
-
+/// Cached formatters for the "yyyy-MM" month keys used by the budget tables
+/// and the month title shown in the toolbar. DateFormatter construction is
+/// expensive, so these are built once rather than per render.
 private let yearMonthFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM"
@@ -14,18 +15,32 @@ private let monthTitleFormatter: DateFormatter = {
     return formatter
 }()
 
+/// Abbreviated variant for the navigation bar's month stepper only. A
+/// centered `.principal` toolbar item is centered in the whole bar, but only
+/// while it clears the trailing buttons — one point wider and UIKit stops
+/// centering and jams it against the leading edge. "September 2026" between
+/// two chevrons is well past that limit, so the bar would centre some months
+/// and left-align others. Every abbreviated month fits, so the stepper holds
+/// still all year (GH #305 review).
 private let monthShortTitleFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "MMM yyyy"
     return formatter
 }()
 
-// MARK: - Shared Column Metrics
-
+/// Shared metrics for the budget table's three numeric columns, so the
+/// summary captions, group totals and category pills line up vertically
+/// like the PWA's table.
 enum BudgetColumn {
     static let width: CGFloat = 70
+    // Tight: every point between the columns comes out of the category
+    // name, which wraps early on a phone ("Caravan Parks 🏕" drops its
+    // emoji to a second line).
     static let spacing: CGFloat = 4
 
+    /// Cell text for the budget table: a plain grouped number without the
+    /// currency symbol, like the PWA's budget table — "USD 1,850.00" in
+    /// every cell would drown the category names on a phone.
     static func text(_ cents: Int, wholeUnits: Bool = false) -> String {
         (Double(cents) / 100.0).formatted(
             .number.precision(.fractionLength(wholeUnits ? 0 : 2)))
@@ -33,16 +48,19 @@ enum BudgetColumn {
 }
 
 private extension BudgetStore {
+    /// Masked variant of `BudgetColumn.text` for the budget table's cells.
+    /// Lives here rather than on the store proper so the table's
+    /// symbol-less number format stays private to this file.
     func displayBudgetCell(_ cents: Int) -> String {
         hideBalances ? Self.hiddenBalanceText : BudgetColumn.text(cents, wholeUnits: hideDecimalPlaces)
     }
 }
 
-// MARK: - BudgetView
-
 struct BudgetView: View {
     nonisolated static let incomeGroupCollapseID = "__income_group__"
 
+    /// IDs controlled by Expand/Collapse All for the budget currently shown.
+    /// Kept pure so the income-group participation has non-UI test coverage.
     nonisolated static func displayedGroupIDs(
         groupIDs: [String],
         hasIncome: Bool
@@ -60,6 +78,8 @@ struct BudgetView: View {
     @State private var transactionsDestination: CategoryTransactionsDestination?
     @State private var newBudgetItem: NewBudgetItem?
     @State private var categoryFilter: BudgetCategoryFilter = .all
+    /// Comma-joined group ids the user has collapsed, PWA-style. Stored as a
+    /// string because @AppStorage can't hold a Set directly.
     @AppStorage("collapsedBudgetGroups") private var collapsedGroupsStorage = ""
 
     private var collapsedGroups: Set<String> {
@@ -74,6 +94,8 @@ struct BudgetView: View {
         collapsedGroupsStorage = groups.sorted().joined(separator: ",")
     }
 
+    // Expand/collapse all touch only the displayed budget's groups; ids
+    // remembered for other budget files stay put (GH #130).
     private func collapseAllGroups() {
         let displayedGroupIDs = Self.displayedGroupIDs(
             groupIDs: groupedCategories.map(\.id),
@@ -118,11 +140,22 @@ struct BudgetView: View {
                 }
             }
             .navigationTitle("Budget")
+            // The summary bar is pinned outside the List (GH #155), so it
+            // can't move with an overscroll the way list content does. A
+            // large title stretches on that overscroll and draws straight
+            // over the card, and collapses on scroll-up, jolting it (GH
+            // #253). Inline keeps the bar a fixed height; the month stepper
+            // below already occupies the centre, and the tab bar says
+            // "Budget" anyway.
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { budgetToolbar }
             .onChange(of: selectedMonth) { _, newMonth in
-                Task { await budgetStore.fetchBudgetMonth(newMonth) }
+                Task {
+                    await budgetStore.fetchBudgetMonth(newMonth)
+                }
             }
+            // Hiding the strip takes its filter with it — otherwise the table
+            // stays filtered with no visible control to clear it.
             .onChange(of: budgetStore.showBudgetCheckInStrip) { _, isShown in
                 if !isShown { categoryFilter = .all }
             }
@@ -137,28 +170,35 @@ struct BudgetView: View {
             }
             .sheet(item: $newBudgetItem) { item in
                 switch item {
-                case .category: NewCategorySheet(groupId: firstSelectableGroupId ?? "")
-                case .group: NewCategoryGroupSheet()
+                case .category:
+                    NewCategorySheet(groupId: firstSelectableGroupId ?? "")
+                case .group:
+                    NewCategoryGroupSheet()
                 }
             }
             .navigationDestination(item: $transactionsDestination) { destination in
                 CategoryTransactionsView(destination: destination)
             }
             .overlay {
-                if budgetStore.isLoading { ProgressView() }
+                if budgetStore.isLoading {
+                    ProgressView()
+                }
             }
         }
         .initialSyncBanner()
     }
 
-    // MARK: - Group Sections
 
+    /// One group's rows, extracted from the `List` so the body stays within
+    /// the compiler's type-check budget.
     @ViewBuilder
     private func groupSection(_ group: CategoryGroupSection) -> some View {
         let isCollapsed = collapsedGroups.contains(group.id)
-
         if budgetStore.budgetDisplayStyle == .clean {
-            // Clean style: section header with the original ellipsis menu
+            // Clean style: the group name sits above the card as a section
+            // header, like the App Store screenshots. The same collapse
+            // control lives there so collapsing behaves identically in both
+            // styles.
             Section {
                 if !isCollapsed {
                     ForEach(group.categories) { category in
@@ -166,9 +206,13 @@ struct BudgetView: View {
                             category: category,
                             isHidden: category.hidden,
                             isDimmed: category.isEffectivelyHidden,
-                            onSetHidden: { setCategoryHidden(category.categoryId, hidden: $0) },
+                            onSetHidden: {
+                                setCategoryHidden(category.categoryId, hidden: $0)
+                            },
                             onShowDetails: { selectedCategory = $0 },
                             onEditBudget: { editingCategory = $0 },
+                            // Name shows all time, Spent shows
+                            // the displayed month (GH #56).
                             onShowTransactions: showTransactions,
                             onMoveMoney: moveMoney
                         )
@@ -178,38 +222,47 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
-                    isDimmed: group.isHidden,
-                    onSetHidden: { setCategoryGroupHidden(group.id, hidden: $0) },
+                    isHidden: group.isHidden,
+                    onSetHidden: {
+                        setCategoryGroupHidden(group.id, hidden: $0)
+                    },
                     onToggleCollapse: { toggleCollapsed(group.id) }
                 )
                 .textCase(nil)
             }
         } else {
-            // Detailed style: header row inside the section with swipe-to-hide
+            // The group row lives inside the card (first row, tinted) like
+            // the PWA's table, so its totals share the exact column grid of
+            // the rows below.
             Section {
                 BudgetGroupHeader(
                     name: group.name,
                     isCollapsed: isCollapsed,
-                    isDimmed: group.isHidden,
+                    isHidden: group.isHidden,
+                    onSetHidden: {
+                        setCategoryGroupHidden(group.id, hidden: $0)
+                    },
                     totals: budgetStore.showGroupTotals ? group.totals : nil,
                     onToggleCollapse: { toggleCollapsed(group.id) },
                     reservesTwoLines: true
                 )
                 .listRowBackground(Color(.tertiarySystemFill))
                 .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    hideGroupButton(group)
-                }
                 if !isCollapsed {
                     ForEach(group.categories) { category in
                         CategoryBudgetRow(
                             category: category,
                             isHidden: category.hidden,
                             isDimmed: category.isEffectivelyHidden,
-                            onSetHidden: { setCategoryHidden(category.categoryId, hidden: $0) },
-                            addsGroupBottomPadding: category.id == group.categories.last?.id,
+                            onSetHidden: {
+                                setCategoryHidden(category.categoryId, hidden: $0)
+                            },
+                            addsGroupBottomPadding:
+                                category.id == group.categories.last?.id,
                             onShowDetails: { selectedCategory = $0 },
                             onEditBudget: { editingCategory = $0 },
+                            // Name shows all time, Spent shows
+                            // the displayed month (GH #56).
                             onShowTransactions: showTransactions,
                             onMoveMoney: moveMoney
                         )
@@ -219,13 +272,14 @@ struct BudgetView: View {
         }
     }
 
+    /// The income group drawn at the bottom of the table, extracted from the
+    /// `List` so the body stays within the compiler's type-check budget.
     @ViewBuilder
     private func incomeSection(_ budget: BudgetMonth) -> some View {
         let isCollapsed = collapsedGroups.contains(Self.incomeGroupCollapseID)
         let group = budgetStore.categoryGroups.first(where: \.isIncome)
         let categories = displayedIncomeCategories(in: budget)
         let name = group?.name ?? categories.first?.groupName ?? "Income"
-
         if budgetStore.budgetDisplayStyle == .clean {
             Section {
                 if !isCollapsed {
@@ -234,7 +288,9 @@ struct BudgetView: View {
                             income: income,
                             isHidden: income.hidden,
                             isDimmed: income.isEffectivelyHidden,
-                            onSetHidden: { setCategoryHidden(income.categoryId, hidden: $0) },
+                            onSetHidden: {
+                                setCategoryHidden(income.categoryId, hidden: $0)
+                            },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: false,
                             onShowTransactions: showTransactions
@@ -245,10 +301,14 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
-                    isDimmed: group?.hidden == true,
-                    onSetHidden: group.map { _ in { setCategoryGroupHidden(group!.id, hidden: $0) } },
+                    isHidden: group?.hidden == true,
+                    onSetHidden: group.map { group in
+                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    },
                     receivedTotal: budget.totalIncome,
-                    onToggleCollapse: { toggleCollapsed(Self.incomeGroupCollapseID) }
+                    onToggleCollapse: {
+                        toggleCollapsed(Self.incomeGroupCollapseID)
+                    }
                 )
                 .textCase(nil)
             }
@@ -257,9 +317,14 @@ struct BudgetView: View {
                 BudgetGroupHeader(
                     name: name,
                     isCollapsed: isCollapsed,
-                    isDimmed: group?.hidden == true,
+                    isHidden: group?.hidden == true,
+                    onSetHidden: group.map { group in
+                        { setCategoryGroupHidden(group.id, hidden: $0) }
+                    },
                     receivedTotal: budget.totalIncome,
-                    onToggleCollapse: { toggleCollapsed(Self.incomeGroupCollapseID) },
+                    onToggleCollapse: {
+                        toggleCollapsed(Self.incomeGroupCollapseID)
+                    },
                     usesTableNumberFormat: true,
                     reservesTwoLines: true
                 )
@@ -271,7 +336,9 @@ struct BudgetView: View {
                             income: income,
                             isHidden: income.hidden,
                             isDimmed: income.isEffectivelyHidden,
-                            onSetHidden: { setCategoryHidden(income.categoryId, hidden: $0) },
+                            onSetHidden: {
+                                setCategoryHidden(income.categoryId, hidden: $0)
+                            },
                             showsBudgeted: budget.toBudget == nil,
                             isDetailed: true,
                             onShowTransactions: showTransactions
@@ -282,24 +349,32 @@ struct BudgetView: View {
         }
     }
 
-    // MARK: - Shared Swipe Action (detailed style only)
-
-    @ViewBuilder
-    private func hideGroupButton(_ group: CategoryGroupSection) -> some View {
-        Button {
-            setCategoryGroupHidden(group.id, hidden: !group.isHidden)
-        } label: {
-            Label(group.isHidden ? "Show" : "Hide",
-                  systemImage: group.isHidden ? "eye" : "eye.slash")
-        }
-        .tint(group.isHidden ? .accentColor : .secondary)
-    }
-
-    // MARK: - Toolbar
-
+    /// The screen's toolbar, extracted from `body` so the whole screen stays
+    /// within the compiler's type-check budget.
     @ToolbarContentBuilder
     private var budgetToolbar: some ToolbarContent {
+        // Both arrows flank the month in the center, so nothing sits in the
+        // leading "back button" position where the previous-month chevron
+        // used to be mistaken for one (it steps the month, not the
+        // navigation stack).
         ToolbarItem(placement: .principal) {
+            // UIKit centers a title view only while it stays under ~140pt
+            // next to these two trailing buttons; one point over and it
+            // left-aligns the whole stepper against the leading edge instead.
+            // That cliff has been hit twice — GH #234, then again by #319
+            // padding both chevrons out to 44pt wide (44 + 44 + a 78pt
+            // "Aug 2026" = 166). So the width is the budget: the touch target
+            // grows downward to 44pt and stays 30pt wide, giving 138 total.
+            // `.frame(maxWidth: .infinity)` can't buy centering back — the
+            // title view is sized to fit its content, so the frame has no
+            // extra width to center in.
+            //
+            // ponytail: 138 of ~140 is all the headroom there is, and the slot
+            // shrinks as the trailing buttons scale, so raised text sizes still
+            // left-align (measured at XXXL). Anything that needs a bigger
+            // stepper — a third trailing button, unabbreviated months, real
+            // Dynamic Type support — has to leave the bar for a pinned header
+            // row above the summary card, where centering is real layout.
             HStack(spacing: 0) {
                 Button {
                     selectedMonth = Self.shiftMonth(selectedMonth, by: -1)
@@ -322,7 +397,9 @@ struct BudgetView: View {
                 .accessibilityLabel("Next month")
             }
         }
-
+        // Creation, unlike everything in the options menu, changes the budget
+        // rather than the view of it — so it gets its own button (GH #284).
+        // Nothing to add to until a budget is open.
         if budgetStore.currentBudgetMonth != nil {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
@@ -331,8 +408,8 @@ struct BudgetView: View {
                     } label: {
                         Label("New Category", systemImage: "tag")
                     }
+                    // A category needs a group to live in.
                     .disabled(firstSelectableGroupId == nil)
-
                     Button {
                         newBudgetItem = .group
                     } label: {
@@ -346,8 +423,13 @@ struct BudgetView: View {
                 .accessibilityHint("Create a category or category group")
             }
         }
-
         ToolbarItem(placement: .topBarTrailing) {
+            // Every "how should this look" control lives here (GH #157).
+            // Whole-table expand/collapse is a menu rather than a long-press
+            // on the group headers: SwiftUI context menus don't fire inside
+            // the clean style's section headers (GH #130).
+            // The isolated method references can't be inferred as optional
+            // closures under Swift 6, so wrap them.
             let hasBudget = budgetStore.currentBudgetMonth != nil
             BudgetOptionsMenu(
                 expandAllGroups: hasBudget ? { expandAllGroups() } : nil,
@@ -356,12 +438,16 @@ struct BudgetView: View {
         }
     }
 
-    // MARK: - Main Content
-
+    /// The pinned summary plus the scrolling budget table, shown once a
+    /// budget month has loaded. Extracted from `body` so the whole screen
+    /// stays within the compiler's type-check budget.
     @ViewBuilder
     private func loadedBudgetContent(_ budget: BudgetMonth) -> some View {
         VStack(spacing: 0) {
-            // Summary card
+            // Summary card: the clean style reads as a 2x2 grid of currency
+            // amounts; the detailed style's captioned columns double as the
+            // column headers for the table below. It sits above the List (not
+            // inside it) so it stays pinned while the table scrolls (GH #155).
             Group {
                 if budgetStore.budgetDisplayStyle == .clean {
                     CleanBudgetSummary(budget: budget)
@@ -373,6 +459,8 @@ struct BudgetView: View {
                         )
                 } else {
                     TableBudgetSummary(budget: budget)
+                        // Fine-tune the fixed-width columns against the
+                        // amount pills in the rows below.
                         .padding(.leading, 4)
                         .padding(.trailing, 4)
                         .padding(.horizontal, 12)
@@ -383,10 +471,21 @@ struct BudgetView: View {
                         )
                 }
             }
+            // The List below overrides its default margins with 4 pt content
+            // margins; match them so the summary is the same width as the
+            // sections.
             .padding(.horizontal, 4)
             .padding(.top, 8)
+            // A gutter that survives scrolling, unlike the List's top content
+            // margin below. Without it the scrolled rows clip flush against
+            // the capsule — a group header sliced mid-glyph, its tinted
+            // background swallowing the capsule's bottom corners (GH #165).
             .padding(.bottom, 8)
 
+            // The strip filters categories, so it can't express uncategorized
+            // transactions — and the check-in card it replaced held the only
+            // in-app route to that list (otherwise reachable only from a
+            // notification tap).
             if budgetStore.uncategorizedCount > 0 {
                 NavigationLink {
                     UncategorizedTransactionsView()
@@ -402,6 +501,8 @@ struct BudgetView: View {
                     }
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.orange)
+                    // Reads as a full-width row like the List section it used
+                    // to live in (GH #29 / #305), not a stray line of text.
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -416,8 +517,11 @@ struct BudgetView: View {
             }
 
             if budgetStore.showBudgetCheckInStrip {
-                BudgetCheckInStrip(budget: budget, selection: $categoryFilter)
-                    .padding(.bottom, 8)
+                BudgetCheckInStrip(
+                    budget: budget,
+                    selection: $categoryFilter
+                )
+                .padding(.bottom, 8)
             }
 
             List {
@@ -427,7 +531,9 @@ struct BudgetView: View {
                     } description: {
                         Text("Try another category filter.")
                     } actions: {
-                        Button("Show All Categories") { categoryFilter = .all }
+                        Button("Show All Categories") {
+                            categoryFilter = .all
+                        }
                     }
                 }
 
@@ -435,16 +541,49 @@ struct BudgetView: View {
                     groupSection(group)
                 }
 
+                // Income group last, matching the bottom of the web UI's
+                // budget table.
                 if categoryFilter == .all, !displayedIncomeCategories(in: budget).isEmpty {
                     incomeSection(budget)
                 }
             }
+            // Collapse state lives in @AppStorage, and a write to that lands
+            // outside any withAnimation transaction — so the rows have to be
+            // animated from here, off the stored value, rather than at the
+            // call site.
             .animation(AppAnimation.disclosure, value: collapsedGroupsStorage)
-            .listSectionSpacing(budgetStore.budgetDisplayStyle == .clean ? .default : .custom(14))
-            .refreshable { await budgetStore.sync() }
+            // The clean style keeps the stock section rhythm; the detailed
+            // table packs its group cards tighter.
+            .listSectionSpacing(
+                budgetStore.budgetDisplayStyle == .clean ? .default : .custom(14)
+            )
+            // Pull-to-refresh belongs to the table alone. Attached to the
+            // container instead, SwiftUI also wires it to the check-in
+            // strip's horizontal ScrollView, so dragging the chips down
+            // fired a sync.
+            .refreshable {
+                await budgetStore.sync()
+            }
             .contentMargins(.horizontal, 4, for: .scrollContent)
-            .contentMargins(.top, budgetStore.budgetDisplayStyle == .clean ? 20 : 16, for: .scrollContent)
+            // The rest of the gap under the pinned summary — this part
+            // scrolls away with the content, leaving the 8 pt gutter above.
+            // Together they sit a notch wider than the spacing between the
+            // group sections, so the summary reads as its own bar rather than
+            // a first group (GH #165).
+            .contentMargins(
+                .top,
+                budgetStore.budgetDisplayStyle == .clean ? 20 : 16,
+                for: .scrollContent
+            )
+            // Let short rows (group headers) sit below the stock 44 pt
+            // minimum; tap targets stay fine because the whole row is the
+            // button.
             .environment(\.defaultMinListRowHeight, 32)
+            // Rows leaving the table used to be chopped off flat against the
+            // gutter under the summary, a hard grey line across mid-row. Fade
+            // them into it instead. The List's top content margin above is
+            // deeper than this fade, so at rest it covers empty background and
+            // nothing on screen looks washed out.
             .overlay(alignment: .top) {
                 LinearGradient(
                     colors: [
@@ -471,17 +610,24 @@ struct BudgetView: View {
                     }
             )
         }
+        // The budget table is a fixed grid of narrow amount columns;
+        // stretched to iPad width it becomes a category name and its numbers
+        // separated by a foot of nothing.
         .readableWidth()
+        // The pinned summary sits outside the List, so paint the grouped
+        // background behind it to match.
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
-
-    // MARK: - Actions
-
+    /// Open the move-money sheet for a tapped balance (GH #128): cover
+    /// overspending when red, move the surplus when green. The month is
+    /// captured alongside so the picker lists its sibling categories.
     private func moveMoney(_ category: CategoryBudget) {
         guard let budget = budgetStore.currentBudgetMonth else { return }
         transferContext = BudgetTransferContext(category: category, budget: budget)
     }
-
+    
+    /// The group a new category starts out filed under: the first one the
+    /// table would draw. Nil when the budget has no group to file it in.
     private var firstSelectableGroupId: String? {
         let visible = budgetStore.categoryGroups.filter { !$0.hidden }
         return visible.min { $0.sortOrder < $1.sortOrder }?.id
@@ -494,7 +640,11 @@ struct BudgetView: View {
     private func setCategoryHidden(_ id: String, hidden: Bool) {
         Task {
             do {
-                try await budgetStore.setCategoryHidden(id: id, hidden: hidden, month: selectedMonth)
+                try await budgetStore.setCategoryHidden(
+                    id: id,
+                    hidden: hidden,
+                    month: selectedMonth
+                )
             } catch {
                 budgetStore.error = error.localizedDescription
             }
@@ -504,13 +654,19 @@ struct BudgetView: View {
     private func setCategoryGroupHidden(_ id: String, hidden: Bool) {
         Task {
             do {
-                try await budgetStore.setCategoryGroupHidden(id: id, hidden: hidden, month: selectedMonth)
+                try await budgetStore.setCategoryGroupHidden(
+                    id: id,
+                    hidden: hidden,
+                    month: selectedMonth
+                )
             } catch {
                 budgetStore.error = error.localizedDescription
             }
         }
     }
 
+    /// Push the category's transactions: month narrows to one "yyyy-MM",
+    /// nil means all time (GH #56).
     private func showTransactions(_ category: CategoryBudget, month: String?) {
         transactionsDestination = CategoryTransactionsDestination(
             categoryId: category.categoryId,
@@ -527,13 +683,13 @@ struct BudgetView: View {
         )
     }
 
-    // MARK: - Grouped Data
-
     struct CategoryGroupSection {
         let id: String
         let name: String
         let isHidden: Bool
+        /// The rows to draw, after "Hide Spent Categories" filtering.
         let categories: [CategoryBudget]
+        /// Totals over the group's non-hidden category list.
         let totals: CategoryGroupTotals
     }
 
@@ -546,10 +702,16 @@ struct BudgetView: View {
         var sections = byGroup
             .compactMap { groupId, items -> (Double, CategoryGroupSection)? in
                 guard let first = items.first else { return nil }
+                // An explicit filter is its own visibility rule: "Not Funded"
+                // must still match zero-available categories even when the
+                // Hide Spent Categories setting would drop them from "All".
                 let base = categoryFilter == .all
                     ? budgetStore.visibleCategoryBudgets(items)
                     : items.filter(categoryFilter.includes)
-                let visible = base.sorted { $0.categorySortOrder < $1.categorySortOrder }
+                let visible = base
+                    .sorted { $0.categorySortOrder < $1.categorySortOrder }
+                // A group whose rows are all hidden drops out entirely rather
+                // than leaving a header stranded over an empty card.
                 guard !visible.isEmpty else { return nil }
                 return (
                     first.groupSortOrder,
@@ -565,6 +727,13 @@ struct BudgetView: View {
                     )
                 )
             }
+        // A group you just made has no categories, so the month's rows above
+        // can't know about it. Draw it anyway — otherwise creating a group
+        // looks like it did nothing (GH #284). Income groups stay out: this
+        // list is the expense table, and income has its own section below,
+        // which likewise only appears once it has categories.
+        // Empty placeholders only belong in the unfiltered table: a filter
+        // that matches nothing should show the empty state, not bare headers.
         sections += budgetStore.categoryGroups
             .filter {
                 categoryFilter == .all && !$0.isIncome
@@ -583,7 +752,10 @@ struct BudgetView: View {
                     )
                 )
             }
-        return sections.sorted { $0.0 < $1.0 }.map(\.1)
+
+        return sections
+            .sorted { $0.0 < $1.0 }
+            .map(\.1)
     }
 
     static func currentMonthString() -> String {
@@ -595,8 +767,10 @@ struct BudgetView: View {
     }
 }
 
-// MARK: - Reusable Views
-
+/// A name that always occupies two lines' height, so short and wrapping
+/// names produce equal-height rows and the amount columns line up (GH
+/// #252). A hidden copy reserves the space and the visible copy centers
+/// within it — `reservesSpace` alone pins the text to the top.
 private struct TwoLineName: View {
     let text: String
     let font: Font
@@ -609,6 +783,7 @@ private struct TwoLineName: View {
                 .lineLimit(2, reservesSpace: true)
                 .minimumScaleFactor(minimumScaleFactor)
                 .hidden()
+
             Text(text)
                 .font(font)
                 .lineLimit(2)
@@ -617,6 +792,8 @@ private struct TwoLineName: View {
     }
 }
 
+/// Status filters stay visible above the category list, so checking the
+/// month never requires opening a menu or scrolling past a large card.
 struct BudgetCheckInStrip: View {
     let budget: BudgetMonth
     @Binding var selection: BudgetCategoryFilter
@@ -659,12 +836,18 @@ struct BudgetCheckInStrip: View {
 
     private func title(for filter: BudgetCategoryFilter) -> String {
         switch filter {
-        case .all: "All"
-        case .needsAttention: "Needs Attention \(count(for: filter))"
-        case .overspent: "\(budget.isTrackingBudget ? "Over Budget" : "Overspent") \(count(for: filter))"
-        case .unassigned: "\(budget.isTrackingBudget ? "No Budget" : "Not Funded") \(count(for: filter))"
-        case .approachingLimit: "\(budget.isTrackingBudget ? "Near Budget" : "Almost Spent") \(count(for: filter))"
-        case .onTrack: "\(budget.isTrackingBudget ? "Within Budget" : "On Track") \(count(for: filter))"
+        case .all:
+            "All"
+        case .needsAttention:
+            "Needs Attention \(count(for: filter))"
+        case .overspent:
+            "\(budget.isTrackingBudget ? "Over Budget" : "Overspent") \(count(for: filter))"
+        case .unassigned:
+            "\(budget.isTrackingBudget ? "No Budget" : "Not Funded") \(count(for: filter))"
+        case .approachingLimit:
+            "\(budget.isTrackingBudget ? "Near Budget" : "Almost Spent") \(count(for: filter))"
+        case .onTrack:
+            "\(budget.isTrackingBudget ? "Within Budget" : "On Track") \(count(for: filter))"
         }
     }
 
@@ -682,11 +865,17 @@ struct CategoryBudgetRow: View {
     var addsGroupBottomPadding = false
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
+    /// Push the category's transactions: month narrows to one "yyyy-MM",
+    /// nil means all time (GH #56).
     var onShowTransactions: (CategoryBudget, String?) -> Void = { _, _ in }
+    /// Open the move-money sheet for this category's balance (GH #128).
     var onMoveMoney: (CategoryBudget) -> Void = { _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
+            // One PWA-style table line: name, then the Budgeted/Spent/Balance
+            // pills in their fixed columns. Each element keeps its own tap
+            // action (our enhancement over the PWA's read-only cells).
             HStack(spacing: BudgetColumn.spacing) {
                 Button {
                     onShowDetails(category)
@@ -725,6 +914,8 @@ struct CategoryBudgetRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Transactions for \(category.categoryName) in \(MonthPicker.title(for: category.month))")
+                // A zero balance has nothing to move and nothing to cover, so
+                // it stays a plain cell.
                 Button {
                     onMoveMoney(category)
                 } label: {
@@ -767,6 +958,9 @@ struct CategoryBudgetRow: View {
     }
 }
 
+/// Clean-style category row, matching the App Store screenshots: name and a
+/// large Available amount up top, the progress bar beneath, then tappable
+/// Budgeted/Spent captions. Same tap actions as the detailed table's cells.
 struct CleanCategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
@@ -775,7 +969,10 @@ struct CleanCategoryBudgetRow: View {
     var onSetHidden: ((Bool) -> Void)?
     var onShowDetails: (CategoryBudget) -> Void = { _ in }
     var onEditBudget: (CategoryBudget) -> Void = { _ in }
+    /// Push the category's transactions: month narrows to one "yyyy-MM",
+    /// nil means all time (GH #56).
     var onShowTransactions: (CategoryBudget, String?) -> Void = { _, _ in }
+    /// Open the move-money sheet for this category's balance (GH #128).
     var onMoveMoney: (CategoryBudget) -> Void = { _ in }
 
     var body: some View {
@@ -795,6 +992,8 @@ struct CleanCategoryBudgetRow: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Details for \(category.categoryName)")
                 Spacer()
+                // A zero balance has nothing to move and nothing to cover, so
+                // it stays a plain label.
                 Button {
                     onMoveMoney(category)
                 } label: {
@@ -833,6 +1032,8 @@ struct CleanCategoryBudgetRow: View {
                     onShowTransactions(category, category.month)
                 } label: {
                     HStack(spacing: 4) {
+                        // Green + signed so a deposit-only category doesn't
+                        // read as spending (GH #102).
                         Text("Spent: \(budgetStore.displaySpentCaption(category.spent))")
                             .font(.caption)
                             .foregroundStyle(category.spent > 0
@@ -862,10 +1063,16 @@ struct CleanCategoryBudgetRow: View {
     }
 }
 
+/// Whether `month` ("YYYY-MM") is before the current calendar month. The
+/// strings are zero-padded, so a plain lexicographic compare is exact.
 @MainActor private func isPastMonth(_ month: String) -> Bool {
     month < BudgetView.currentMonthString()
 }
 
+/// The tracking-budget result figure for the summary bar: actual savings once
+/// a month is finished, projected savings while it's still current or ahead.
+/// Mirrors the Actual webapp, which flips "Projected savings" to "Saved" when
+/// the month rolls over.
 @MainActor private func trackingSavings(_ budget: BudgetMonth) -> Int {
     isPastMonth(budget.month) ? budget.savedActual : budget.projectedSavings
 }
@@ -874,6 +1081,9 @@ struct CleanCategoryBudgetRow: View {
     isPastMonth(budget.month) ? "Saved" : "Projected"
 }
 
+/// Clean-style summary card: a 2x2 grid whose reading order follows the
+/// money — came in, allocated, went out, left over. Two rows because four
+/// currency amounts don't fit across narrow devices.
 struct CleanBudgetSummary: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let budget: BudgetMonth
@@ -898,6 +1108,9 @@ struct CleanBudgetSummary: View {
                     value: budgetStore.displayBalance(-budget.totalSpent)
                 )
                 Spacer()
+                // Envelope budgets lead with unallocated funds; tracking
+                // budgets report savings instead — actual for a finished month,
+                // projected for the current/future month.
                 if let toBudget = budget.toBudget {
                     SummaryStat(
                         label: "To Budget",
@@ -920,12 +1133,17 @@ struct CleanBudgetSummary: View {
     }
 }
 
+/// PWA-style summary bar: unallocated funds lead, and the three captioned
+/// columns double as the column headers for the table below.
 struct TableBudgetSummary: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let budget: BudgetMonth
 
     var body: some View {
         HStack(alignment: .top, spacing: BudgetColumn.spacing) {
+            // Envelope budgets lead with unallocated funds; tracking
+            // budgets have no to-budget concept, so lead with income
+            // received instead.
             if let toBudget = budget.toBudget {
                 SummaryStat(
                     label: "To Budget",
@@ -947,6 +1165,9 @@ struct TableBudgetSummary: View {
                 label: "Spent",
                 value: budgetStore.displayBudgetCell(budget.totalSpent)
             )
+            // Envelope budgets total the category balances; tracking budgets
+            // report savings instead — actual for a finished month, projected
+            // for the current/future month.
             if budget.toBudget != nil {
                 SummaryColumn(
                     label: "Balance",
@@ -965,6 +1186,7 @@ struct TableBudgetSummary: View {
     }
 }
 
+/// The leading figure in the summary bar (To Budget / Income).
 struct SummaryStat: View {
     let label: String
     let value: String
@@ -986,6 +1208,8 @@ struct SummaryStat: View {
     }
 }
 
+/// One captioned column in the summary bar, sized to line up with the
+/// category pills below it.
 struct SummaryColumn: View {
     let label: String
     let value: String
@@ -1008,6 +1232,7 @@ struct SummaryColumn: View {
     }
 }
 
+/// One amount cell in the budget table, in the PWA's pill style.
 struct BudgetAmountPill: View {
     let text: String
     var color: Color = .primary
@@ -1031,6 +1256,11 @@ struct BudgetAmountPill: View {
     }
 }
 
+/// A `BudgetAmountPill` with a small caption above it, naming the column
+/// ("Budgeted" / "Spent" / "Balance") the same way the pinned summary bar's
+/// columns are captioned. Used by the detailed group header's totals so a
+/// group row reads the same as the summary above it, rather than leaving the
+/// person to cross-reference bare numbers against the summary's labels.
 private struct CaptionedAmountPill: View {
     let label: String
     let text: String
@@ -1050,64 +1280,57 @@ private struct CaptionedAmountPill: View {
     }
 }
 
+/// Group header row: collapse control and group name, plus the group's
+/// Budgeted, Spent and Balance totals in the table's three rightmost
+/// columns, each captioned the same way the pinned summary bar is.
+///
+/// Hiding the group uses the same swipe-to-hide gesture as category rows
+/// (`CategoryBudgetRow` / `CleanCategoryBudgetRow`) rather than an inline
+/// "..." menu, so hide behavior is consistent everywhere in the budget
+/// table.
 struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
     let isCollapsed: Bool
-    var isDimmed = false
+    var isHidden = false
     var onSetHidden: ((Bool) -> Void)?
+    /// The detailed style totals its columns here; the clean style's header
+    /// is a plain section title above the card, so it leaves this nil.
     var totals: CategoryGroupTotals?
+    /// Income groups use the same header shell but have one meaningful total:
+    /// money received. It occupies the trailing column where expense groups
+    /// show their balance.
     var receivedTotal: Int? = nil
     let onToggleCollapse: () -> Void
+    /// Detailed tables omit currency symbols from their numeric columns;
+    /// clean headers retain the app-wide currency presentation.
     var usesTableNumberFormat = false
+    /// The detailed style reserves two lines so group rows stay equal-height
+    /// whether names wrap or not (GH #252); the clean style's plain section
+    /// titles keep their natural height.
     var reservesTwoLines = false
 
     var body: some View {
-        HStack(spacing: 8) {
-            Button(action: onToggleCollapse) {
-                HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-                    HStack(spacing: BudgetColumn.spacing) {
-                        DisclosureChevron(
-                            isExpanded: !isCollapsed,
-                            font: .caption2.weight(.semibold)
+        Button(action: onToggleCollapse) {
+            HStack(alignment: .top, spacing: BudgetColumn.spacing) {
+                // Nested so the chevron centers against the name (which can
+                // run one or two lines) rather than pinning to the top of
+                // the row alongside the totals' captions.
+                HStack(spacing: BudgetColumn.spacing) {
+                    DisclosureChevron(
+                        isExpanded: !isCollapsed,
+                        font: .caption2.weight(.semibold)
+                    )
+                    .foregroundStyle(.secondary)
+                    if reservesTwoLines {
+                        TwoLineName(
+                            text: name,
+                            font: .subheadline.weight(.semibold),
+                            minimumScaleFactor: 0.85
                         )
-                        .foregroundStyle(.secondary)
-                        if reservesTwoLines {
-                            TwoLineName(
-                                text: name,
-                                font: .subheadline.weight(.semibold),
-                                minimumScaleFactor: 0.85
-                            )
-                            .foregroundStyle(.primary)
-                        } else {
-                            Text(name)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.85)
-                        }
-                    }
-                    Spacer(minLength: 4)
-                    if let totals {
-                        CaptionedAmountPill(
-                            label: "Budgeted",
-                            text: budgetStore.displayBudgetCell(totals.budgeted),
-                            dimmed: totals.budgeted == 0
-                        )
-                        CaptionedAmountPill(
-                            label: "Spent",
-                            text: budgetStore.displayBudgetCell(totals.spent),
-                            dimmed: totals.spent == 0
-                        )
-                        CaptionedAmountPill(
-                            label: "Balance",
-                            text: budgetStore.displayBudgetCell(totals.balance),
-                            color: totals.balance < 0
-                                ? .red
-                                : (totals.balance == 0 ? .secondary : .green)
-                        )
-                    } else if let receivedTotal {
-                        Text("Received \(receivedText(receivedTotal))")
+                        .foregroundStyle(.primary)
+                    } else {
+                        Text(name)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -1115,32 +1338,56 @@ struct BudgetGroupHeader: View {
                             .frame(maxHeight: .infinity, alignment: .center)
                     }
                 }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityHint("Toggles the group's categories")
-
-            if let onSetHidden {
-                Menu {
-                    Button {
-                        onSetHidden(!isDimmed)
-                    } label: {
-                        Label(
-                            isDimmed ? "Show Group" : "Hide Group",
-                            systemImage: isDimmed ? "eye" : "eye.slash"
-                        )
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .frame(minWidth: 32, minHeight: 44)
+                Spacer(minLength: 4)
+                if let totals {
+                    CaptionedAmountPill(
+                        label: "Budgeted",
+                        text: budgetStore.displayBudgetCell(totals.budgeted),
+                        dimmed: totals.budgeted == 0
+                    )
+                    CaptionedAmountPill(
+                        label: "Spent",
+                        text: budgetStore.displayBudgetCell(totals.spent),
+                        dimmed: totals.spent == 0
+                    )
+                    CaptionedAmountPill(
+                        label: "Balance",
+                        text: budgetStore.displayBudgetCell(totals.balance),
+                        // Same three-way treatment as the category rows, so a
+                        // group that lands on zero doesn't read as healthy.
+                        color: totals.balance < 0
+                            ? .red
+                            : (totals.balance == 0 ? .secondary : .green)
+                    )
+                } else if let receivedTotal {
+                    Text("Received \(receivedText(receivedTotal))")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                 }
-                .accessibilityLabel("Options for \(name)")
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Toggles the group's categories")
+        .opacity(isHidden ? 0.5 : 1)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
             }
         }
-        .opacity(isDimmed ? 0.5 : 1)
     }
 
+    /// The pills are decoration to VoiceOver once the button carries its own
+    /// label, so the totals have to be spoken here or they're lost. Currency
+    /// formatting, not the table's symbol-less cells, reads better aloud.
     private var accessibilityLabel: String {
         let state = isCollapsed ? "collapsed" : "expanded"
         if let receivedTotal {
@@ -1173,6 +1420,8 @@ struct BudgetGroupHeader: View {
     }
 }
 
+/// One income category: name and the amount received this month. Tracking
+/// budgets can budget income, so they also get a "Budgeted" caption.
 struct IncomeCategoryRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let income: IncomeCategory
@@ -1240,8 +1489,9 @@ struct IncomeCategoryRow: View {
     }
 }
 
-// MARK: - Category Detail Sheet
-
+/// A compact category editor. Amount cells in the budget table keep their
+/// existing actions; tapping the name is reserved for the category's own
+/// metadata and quick-assignment shortcuts.
 struct CategoryBudgetDetailSheet: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
@@ -1299,33 +1549,36 @@ struct CategoryBudgetDetailSheet: View {
 
                 Section(
                     content: {
-                        LabeledContent(MonthPicker.title(for: category.month)) {
-                            Text(budgetStore.displayBalance(category.budgeted))
-                                .monospacedDigit()
-                        }
+                    // A suggestion overwrites this month's amount, so name the
+                    // month and show what's there now — otherwise the user
+                    // confirms a budget write blind.
+                    LabeledContent(MonthPicker.title(for: category.month)) {
+                        Text(budgetStore.displayBalance(category.budgeted))
+                            .monospacedDigit()
+                    }
 
-                        if quickAssignSuggestions.isEmpty {
-                            Text("No suggestions available")
-                                .foregroundStyle(.secondary)
-                        } else {
-                            ForEach(quickAssignSuggestions) { suggestion in
-                                Button {
-                                    Task { await apply(suggestion) }
-                                } label: {
-                                    HStack {
-                                        Text(quickAssignTitle(for: suggestion.kind))
-                                            .foregroundStyle(.tint)
-                                        Spacer(minLength: 12)
-                                        Text(budgetStore.displayBalance(suggestion.amount))
-                                            .foregroundStyle(.primary)
-                                            .monospacedDigit()
-                                            .fixedSize(horizontal: true, vertical: false)
-                                    }
+                    if quickAssignSuggestions.isEmpty {
+                        Text("No suggestions available")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(quickAssignSuggestions) { suggestion in
+                            Button {
+                                Task { await apply(suggestion) }
+                            } label: {
+                                HStack {
+                                    Text(quickAssignTitle(for: suggestion.kind))
+                                        .foregroundStyle(.tint)
+                                    Spacer(minLength: 12)
+                                    Text(budgetStore.displayBalance(suggestion.amount))
+                                        .foregroundStyle(.primary)
+                                        .monospacedDigit()
+                                        .fixedSize(horizontal: true, vertical: false)
                                 }
-                                .buttonStyle(.plain)
-                                .disabled(isApplyingSuggestion)
                             }
+                            .buttonStyle(.plain)
+                            .disabled(isApplyingSuggestion)
                         }
+                    }
                     },
                     header: {
                         Text(isTracking ? "Quick Budget" : "Quick Assign")
@@ -1424,8 +1677,10 @@ struct CategoryBudgetDetailSheet: View {
     }
 }
 
-// MARK: - Status & Progress Views
-
+/// One place for the status color and mode-neutral wording, shared by the
+/// bar, the dot, and the detail sheet — so VoiceOver says the same thing for
+/// the same category everywhere. The detail sheet keeps its own
+/// envelope/tracking titles on top of this.
 extension CategoryProgressState {
     var tint: Color {
         switch self {
@@ -1448,6 +1703,8 @@ extension CategoryProgressState {
     }
 }
 
+/// Spent-vs-available bar for a budget row. Fill and color mirror the row's
+/// Available amount: green while money remains, red once overspent.
 struct CategoryProgressBar: View {
     let fraction: Double
     let state: CategoryProgressState
@@ -1467,12 +1724,16 @@ struct CategoryProgressBar: View {
             }
         }
         .frame(height: 5)
+        // Budgeting a category shrinks its bar as the money lands, so the
+        // edit is visible in the row itself and not only in the pill.
         .animation(AppAnimation.amount, value: fraction)
         .accessibilityElement()
         .accessibilityLabel("\(state.statusText), spent \(Int((fraction * 100).rounded())) percent")
     }
 }
 
+/// A deliberately quiet status cue for budget rows. The category detail sheet
+/// carries the full plain-language status so the main budget remains scannable.
 struct CompactCategoryStatusDot: View {
     let state: CategoryProgressState
 
@@ -1485,8 +1746,8 @@ struct CompactCategoryStatusDot: View {
     }
 }
 
-// MARK: - Edit Budget Amount Sheet
-
+/// Edit the budgeted amount for one category-month. Saving writes through
+/// the sync engine (optimistic local-first) and refreshes the month.
 struct EditBudgetAmountSheet: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
@@ -1544,6 +1805,7 @@ struct EditBudgetAmountSheet: View {
         errorMessage = nil
         Task {
             do {
+                // An emptied field means "no longer budgeted", i.e. zero.
                 let cents = try BudgetStore.budgetAmountCents(
                     from: amountText.isEmpty ? "0" : amountText,
                     allowNegative: true
@@ -1562,8 +1824,6 @@ struct EditBudgetAmountSheet: View {
     }
 }
 
-// MARK: - Month Picker
-
 struct MonthPicker: View {
     @Binding var selectedMonth: String
 
@@ -1579,9 +1839,13 @@ struct MonthPicker: View {
                 .font(.headline)
                 .lineLimit(1)
         }
+        // The abbreviation is a layout constraint, not what the month is
+        // called — VoiceOver still reads it in full.
         .accessibilityLabel(Self.title(for: selectedMonth))
     }
 
+    /// Next month back through the prior year, newest first, padded with the
+    /// selection itself when swiping has moved outside that window.
     private var monthOptions: [String] {
         let current = BudgetView.currentMonthString()
         var months = (-12...1).map { BudgetView.shiftMonth(current, by: $0) }
@@ -1593,12 +1857,17 @@ struct MonthPicker: View {
     }
 
     nonisolated static func title(for month: String) -> String {
-        guard let date = date(fromMonth: month) else { return month }
+        guard let date = date(fromMonth: month) else {
+            return month
+        }
         return monthTitleFormatter.string(from: date)
     }
 
+    /// `title(for:)` abbreviated to a fixed-ish width for the toolbar stepper.
     nonisolated static func shortTitle(for month: String) -> String {
-        guard let date = date(fromMonth: month) else { return month }
+        guard let date = date(fromMonth: month) else {
+            return month
+        }
         return monthShortTitleFormatter.string(from: date)
     }
 
@@ -1606,7 +1875,9 @@ struct MonthPicker: View {
         let parts = month.split(separator: "-")
         guard parts.count == 2,
               let year = Int(parts[0]),
-              let monthNumber = Int(parts[1]) else { return nil }
+              let monthNumber = Int(parts[1]) else {
+            return nil
+        }
         var components = DateComponents()
         components.year = year
         components.month = monthNumber

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -76,6 +76,64 @@ final class BudgetGroupCollapseUITests: XCTestCase {
     }
 
     @MainActor
+    func testDetailedGroupSwipeHidesAndShowsExpenseGroup() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "detailed",
+            "-showHiddenCategories", "NO", "-initialTab", "1",
+        ]
+        app.launch()
+
+        let essentials = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Essentials, ")
+        ).firstMatch
+        XCTAssertTrue(essentials.waitForExistence(timeout: 10))
+
+        essentials.swipeLeft()
+        XCTAssertTrue(app.buttons["Hide"].waitForExistence(timeout: 5))
+        app.buttons["Hide"].tap()
+        XCTAssertTrue(essentials.waitForNonExistence(timeout: 5))
+
+        let optionsMenu = app.buttons["Budget options"]
+        optionsMenu.tap()
+        let showHidden = app.buttons["Show Hidden Categories"]
+        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
+        showHidden.tap()
+        XCTAssertTrue(essentials.waitForExistence(timeout: 5))
+
+        essentials.swipeLeft()
+        XCTAssertTrue(app.buttons["Show"].waitForExistence(timeout: 5))
+        app.buttons["Show"].tap()
+
+        optionsMenu.tap()
+        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
+        showHidden.tap()
+        XCTAssertTrue(essentials.waitForExistence(timeout: 5),
+                      "the group should remain visible after hidden categories are turned off")
+    }
+
+    @MainActor
+    func testDetailedIncomeGroupHasNoHideAction() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "detailed", "-initialTab", "1",
+        ]
+        app.launch()
+
+        let income = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Income, ")
+        ).firstMatch
+        for _ in 0..<20 where !income.waitForExistence(timeout: 1) {
+            app.swipeUp(velocity: .slow)
+        }
+        XCTAssertTrue(income.waitForExistence(timeout: 5))
+
+        income.swipeLeft()
+        XCTAssertFalse(app.buttons["Hide"].waitForExistence(timeout: 2),
+                       "the Income group must not offer a hide action")
+    }
+
+    @MainActor
     func testIncomeGroupMatchesCollapseBehaviorInCleanStyle() throws {
         try assertIncomeGroupCollapses(displayStyle: "clean")
     }


### PR DESCRIPTION
Why
The category group header had a three-dot ellipsis menu that was the only way to hide/show groups. This was inconsistent with individual categories, which use swipe-to-hide. The menu also took up visual space and added an extra tap to access the hide option.

What

- Removed the ellipsis menu from detailed view
- Added swipe-to-hide/show actions on expense category groups, matching the existing swipe pattern for individual categories
- Income group remains non-hideable (only individual income categories can be hidden)
- Swipe actions work only in detailed budget display styles
- Group headers show "Hide" with eye.slash icon when visible, "Show" with eye icon when hidden
- Hidden groups display at reduced opacity (50%) for visual feedback

Tested on iphone 17 pro sim