### PR TITLE
Add a dynamic logo for group by date and hide reconciled transactions

### DIFF
--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -349,17 +349,15 @@ struct AccountDetailView: View {
             ToolbarItem(placement: .secondaryAction) {
                 TransactionGroupingToggle()
             }
-           ToolbarItem(placement: .secondaryAction) {
-                Button {
-                    withAnimation { budgetStore.hideClearedTransactions.toggle() }
-                } label: {
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle(isOn: $budgetStore.hideClearedTransactions) {
                     Label(
                         "Hide Cleared Transactions",
                         systemImage: budgetStore.hideClearedTransactions ? "eye.slash" : "eye"
                     )
                 }
             }
-            
+
             ToolbarItem(placement: .secondaryAction) {
                 Button {
                     showingReconcile = true

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -349,9 +349,17 @@ struct AccountDetailView: View {
             ToolbarItem(placement: .secondaryAction) {
                 TransactionGroupingToggle()
             }
-            ToolbarItem(placement: .secondaryAction) {
-                Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
+           ToolbarItem(placement: .secondaryAction) {
+                Button {
+                    withAnimation { budgetStore.hideClearedTransactions.toggle() }
+                } label: {
+                    Label(
+                        "Hide Cleared Transactions",
+                        systemImage: budgetStore.hideClearedTransactions ? "eye.slash" : "eye"
+                    )
+                }
             }
+            
             ToolbarItem(placement: .secondaryAction) {
                 Button {
                     showingReconcile = true

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -247,11 +247,17 @@ struct TransactionPagingSentinel: View {
 struct TransactionGroupingToggle: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
+    private var isGrouped: Bool {
+        budgetStore.transactionDisplayMode == .groupedByDate
+    }
+
     var body: some View {
-        Toggle("Group by Date", isOn: Binding(
-            get: { budgetStore.transactionDisplayMode == .groupedByDate },
+        Toggle(isOn: Binding(
+            get: { isGrouped },
             set: { budgetStore.transactionDisplayMode = $0 ? .groupedByDate : .flat }
-        ))
+        )) {
+            Label("Group by Date", systemImage: isGrouped ? "calendar.badge.checkmark" : "calendar")
+        }
     }
 }
 

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -115,9 +115,7 @@ struct TransactionsListView: View {
                 TransactionGroupingToggle()
             }
             ToolbarItem(placement: .secondaryAction) {
-                Button {
-                    budgetStore.hideClearedTransactions.toggle()
-                } label: {
+                Toggle(isOn: $budgetStore.hideClearedTransactions) {
                     Label(
                         "Hide Cleared Transactions",
                         systemImage: budgetStore.hideClearedTransactions ? "eye.slash" : "eye"
@@ -259,16 +257,15 @@ struct TransactionGroupingToggle: View {
     }
 
     var body: some View {
-        Button {
-            budgetStore.transactionDisplayMode = isGrouped ? .flat : .groupedByDate
-        } label: {
+        Toggle(isOn: Binding(
+            get: { isGrouped },
+            set: { budgetStore.transactionDisplayMode = $0 ? .groupedByDate : .flat }
+        )) {
             Label(
                 "Group by Date",
                 systemImage: isGrouped ? "calendar.badge.checkmark" : "calendar"
             )
         }
-        // Ensure the button looks like a toolbar item, not a plain text button.
-        .buttonStyle(.borderless)
     }
 }
 

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -115,7 +115,14 @@ struct TransactionsListView: View {
                 TransactionGroupingToggle()
             }
             ToolbarItem(placement: .secondaryAction) {
-                Toggle("Hide Cleared Transactions", isOn: $budgetStore.hideClearedTransactions)
+                Button {
+                    budgetStore.hideClearedTransactions.toggle()
+                } label: {
+                    Label(
+                        "Hide Cleared Transactions",
+                        systemImage: budgetStore.hideClearedTransactions ? "eye.slash" : "eye"
+                    )
+                }
             }
         }
         .safeAreaInset(edge: .bottom) {
@@ -252,12 +259,16 @@ struct TransactionGroupingToggle: View {
     }
 
     var body: some View {
-        Toggle(isOn: Binding(
-            get: { isGrouped },
-            set: { budgetStore.transactionDisplayMode = $0 ? .groupedByDate : .flat }
-        )) {
-            Label("Group by Date", systemImage: isGrouped ? "calendar.badge.checkmark" : "calendar")
+        Button {
+            budgetStore.transactionDisplayMode = isGrouped ? .flat : .groupedByDate
+        } label: {
+            Label(
+                "Group by Date",
+                systemImage: isGrouped ? "calendar.badge.checkmark" : "calendar"
+            )
         }
+        // Ensure the button looks like a toolbar item, not a plain text button.
+        .buttonStyle(.borderless)
     }
 }
 

--- a/Actuali/ActualiUITests/TransactionToolbarOptionsUITests.swift
+++ b/Actuali/ActualiUITests/TransactionToolbarOptionsUITests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+final class TransactionToolbarOptionsUITests: XCTestCase {
+
+    @MainActor
+    func testOptionsExposeAndUpdateTheirSelectedState() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData",
+            "-hideClearedTransactions", "NO",
+            "-transactionDisplayMode", "flat",
+        ]
+        app.launch()
+
+        app.tabBars.buttons["Accounts"].tap()
+        let allAccounts = app.staticTexts["All Accounts"].firstMatch
+        XCTAssertTrue(allAccounts.waitForExistence(timeout: 10))
+        allAccounts.tap()
+
+        let moreButton = app.navigationBars.buttons["More"]
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 10))
+        let hideCleared = app.buttons["Hide Cleared Transactions"]
+        let groupByDate = app.buttons["Group by Date"]
+
+        moreButton.tap()
+        XCTAssertTrue(hideCleared.waitForExistence(timeout: 5))
+        XCTAssertFalse(hideCleared.isSelected)
+        XCTAssertFalse(groupByDate.isSelected)
+
+        hideCleared.tap()
+        moreButton.tap()
+        XCTAssertTrue(hideCleared.isSelected)
+        hideCleared.tap()
+
+        moreButton.tap()
+        groupByDate.tap()
+        moreButton.tap()
+        XCTAssertTrue(groupByDate.isSelected)
+        groupByDate.tap()
+    }
+}


### PR DESCRIPTION

## Why

There was no icon for “Group by Date” or “Hide Reconciled Transactions,” which looked a bit weird since the other three items had icons. Whenever either of these two options was enabled, a checkmark would appear, and the menu would get longer because the checkmark wasn’t aligned with the other icons.

## What

Added eyeslash : eye for hide transactions in Account Detail View
Added calendar : calendar-checkmark in Transactions List View

## How it was tested

Iphone 17 pro sim