### PR TITLE
FinanceKit Support

### DIFF
--- a/Actuali/Actuali.entitlements
+++ b/Actuali/Actuali.entitlements
@@ -4,12 +4,21 @@
   App entitlements. The app group is how the widget extension reads the
   category-balance snapshot the app writes; the identifier must match
   WidgetSnapshotStore.appGroupID and ActualiWidgets.entitlements.
+
+  FinanceKit (ongoing Wallet access for bank sync) is a managed entitlement:
+  Apple grants it per-app on request, so device builds need a provisioning
+  profile that carries it. Simulator builds and CI are unaffected. The Tier-1
+  Wallet transaction picker works without it.
 -->
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.mfazz.ActualiOS</string>
+	</array>
+	<key>com.apple.developer.financekit</key>
+	<array>
+		<string>financial-data</string>
 	</array>
 </dict>
 </plist>

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Whether this device can serve Wallet (FinanceKit) data, and whether the
+/// person has let Actuali read it.
+enum AppleWalletAvailability: Sendable, Equatable {
+    /// No FinanceKit data on this device — Apple Card, Apple Cash and
+    /// Savings are iPhone-only and currently US-only.
+    case unsupported
+    case notDetermined
+    case denied
+    case authorized
+}
+
+/// A Wallet account (Apple Card, Apple Cash, Savings), reduced to what
+/// linking and syncing need. Framework-free so everything above the thin
+/// FinanceKit bridge stays unit-testable — the same seam as
+/// `WalletImportMapper` (GH #55, Tier 1); this is the Tier-2 automatic sync.
+struct AppleWalletAccount: Identifiable, Sendable, Equatable {
+    /// FinanceKit account UUID, lowercased — stored as `accounts.account_id`.
+    let id: String
+    let name: String
+    /// What FinanceKit reports for the issuing institution ("Apple").
+    let institutionName: String
+    /// Signed like `Transaction.amount`: money owed is negative, so an Apple
+    /// Card balance imports the way a credit card's should.
+    let balanceCents: Int?
+}
+
+/// A Wallet transaction as the bridge hands it over — raw enough that the
+/// normalization into a `BankSyncCandidate` stays testable off-device.
+struct AppleWalletTransaction: Sendable, Equatable {
+    /// FinanceKit transaction UUID, lowercased. The Tier-1 picker import
+    /// stores the same form as `financial_id`, so a transaction someone
+    /// hand-picked earlier is recognised rather than imported twice.
+    let id: String
+    /// Unsigned; `isCredit` carries the direction.
+    let amount: Decimal
+    let isCredit: Bool
+    let merchantName: String?
+    let description: String
+    let status: WalletImportMapper.Status
+    let date: Date
+}
+
+/// The slice of FinanceKit the sync needs. A protocol because the real store
+/// only answers on entitled devices — tests stub it.
+protocol AppleWalletReading: Sendable {
+    func availability() async -> AppleWalletAvailability
+    /// Ask the person for read access. Returns whether it was granted.
+    func requestAccess() async throws -> Bool
+    func accounts() async throws -> [AppleWalletAccount]
+    func transactions(accountId: String) async throws -> [AppleWalletTransaction]
+}
+
+/// Turns Wallet data into the same download shape the SimpleFIN providers
+/// produce, so one import path (`BudgetStore.importBankSync`) serves both.
+struct AppleWalletProvider: Sendable {
+    let store: any AppleWalletReading
+
+    func download(_ targets: [BankSyncTarget]) async throws -> BankSyncDownloadSet {
+        let accounts = try await store.accounts()
+
+        var set = BankSyncDownloadSet()
+        for target in targets {
+            // An account this Wallet doesn't have is left out so the caller
+            // says so — usually a link made from another device's Wallet.
+            guard let account = accounts.first(where: { $0.id == target.externalId })
+            else { continue }
+
+            let transactions = try await store.transactions(accountId: target.externalId)
+            set.byAccount[target.externalId] = BankSyncDownload(
+                candidates: transactions
+                    .compactMap(BankSyncCandidate.init(appleWallet:))
+                    .filter { $0.date >= target.startDay },
+                currentBalanceCents: account.balanceCents
+            )
+        }
+        return set
+    }
+}
+
+extension AppleWalletAccount {
+    /// FinanceKit has no institution id of its own, so the name doubles as
+    /// `banks.bank_id` — the same fallback SimpleFIN orgs without one use.
+    var remoteAccount: BankSyncRemoteAccount {
+        BankSyncRemoteAccount(
+            id: id,
+            name: name,
+            institutionId: institutionName,
+            institutionName: institutionName,
+            balanceCents: balanceCents,
+            source: .financeKit
+        )
+    }
+}

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -24,6 +24,15 @@ struct AppleWalletAccount: Identifiable, Sendable, Equatable {
     /// Signed like `Transaction.amount`: money owed is negative, so an Apple
     /// Card balance imports the way a credit card's should.
     let balanceCents: Int?
+
+    init(id: String, name: String, institutionName: String, balanceCents: Int?) {
+        // Lowercased here, at the one choke point, so the id always matches
+        // the `accounts.account_id` a link wrote regardless of who built it.
+        self.id = id.lowercased()
+        self.name = name
+        self.institutionName = institutionName
+        self.balanceCents = balanceCents
+    }
 }
 
 /// A Wallet transaction as the bridge hands it over — raw enough that the
@@ -40,6 +49,26 @@ struct AppleWalletTransaction: Sendable, Equatable {
     let description: String
     let status: WalletImportMapper.Status
     let date: Date
+
+    init(
+        id: String,
+        amount: Decimal,
+        isCredit: Bool,
+        merchantName: String?,
+        description: String,
+        status: WalletImportMapper.Status,
+        date: Date
+    ) {
+        // Lowercased here, at the one choke point, so `financial_id` dedup
+        // never hinges on which caller remembered to.
+        self.id = id.lowercased()
+        self.amount = amount
+        self.isCredit = isCredit
+        self.merchantName = merchantName
+        self.description = description
+        self.status = status
+        self.date = date
+    }
 }
 
 /// The slice of FinanceKit the sync needs. A protocol because the real store

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -16,7 +16,7 @@ enum AppleWalletAvailability: Sendable, Equatable {
 /// FinanceKit bridge stays unit-testable — the same seam as
 /// `WalletImportMapper` (GH #55, Tier 1); this is the Tier-2 automatic sync.
 struct AppleWalletAccount: Identifiable, Sendable, Equatable {
-    /// FinanceKit account UUID, lowercased — stored as `accounts.account_id`.
+    /// FinanceKit account UUID, lowercased and stored only on this device.
     let id: String
     let name: String
     /// What FinanceKit reports for the issuing institution ("Apple").
@@ -24,15 +24,31 @@ struct AppleWalletAccount: Identifiable, Sendable, Equatable {
     /// Signed like `Transaction.amount`: money owed is negative, so an Apple
     /// Card balance imports the way a credit card's should.
     let balanceCents: Int?
+    /// Available balances already include pending transactions; booked-only
+    /// balances need them folded in before deriving an opening balance.
+    let balanceIncludesPending: Bool
 
-    init(id: String, name: String, institutionName: String, balanceCents: Int?) {
-        // Lowercased here, at the one choke point, so the id always matches
-        // the `accounts.account_id` a link wrote regardless of who built it.
+    init(
+        id: String,
+        name: String,
+        institutionName: String,
+        balanceCents: Int?,
+        balanceIncludesPending: Bool = false
+    ) {
         self.id = id.lowercased()
         self.name = name
         self.institutionName = institutionName
         self.balanceCents = balanceCents
+        self.balanceIncludesPending = balanceIncludesPending
     }
+}
+
+/// A FinanceKit balance reduced to what selecting the latest snapshot needs.
+struct AppleWalletBalance: Sendable, Equatable {
+    let accountId: String
+    let cents: Int
+    let asOfDate: Date
+    let includesPending: Bool
 }
 
 /// A Wallet transaction as the bridge hands it over — raw enough that the
@@ -91,17 +107,21 @@ struct AppleWalletProvider: Sendable {
 
         var set = BankSyncDownloadSet()
         for target in targets {
-            // An account this Wallet doesn't have is left out so the caller
-            // says so — usually a link made from another device's Wallet.
+            // An account this Wallet doesn't have is left out for the caller
+            // to skip as a stale local link.
             guard let account = accounts.first(where: { $0.id == target.externalId })
             else { continue }
 
             let transactions = try await store.transactions(accountId: target.externalId)
+            let candidates = transactions
+                .compactMap(BankSyncCandidate.init(appleWallet:))
+                .filter { $0.date >= target.startDay }
+            let pending = candidates.lazy.filter { !$0.cleared }.reduce(0) { $0 + $1.amount }
             set.byAccount[target.externalId] = BankSyncDownload(
-                candidates: transactions
-                    .compactMap(BankSyncCandidate.init(appleWallet:))
-                    .filter { $0.date >= target.startDay },
-                currentBalanceCents: account.balanceCents
+                candidates: candidates,
+                currentBalanceCents: account.balanceCents.map {
+                    account.balanceIncludesPending ? $0 : $0 + pending
+                }
             )
         }
         return set
@@ -109,8 +129,6 @@ struct AppleWalletProvider: Sendable {
 }
 
 extension AppleWalletAccount {
-    /// FinanceKit has no institution id of its own, so the name doubles as
-    /// `banks.bank_id` — the same fallback SimpleFIN orgs without one use.
     var remoteAccount: BankSyncRemoteAccount {
         BankSyncRemoteAccount(
             id: id,

--- a/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
@@ -1,11 +1,16 @@
 import Foundation
 
 /// The provider an account's transactions are downloaded from. Actual stores
-/// this in `accounts.account_sync_source`; Actuali only speaks SimpleFIN, but
-/// the column is shared with every other client, so a value it doesn't
-/// recognise has to survive a round trip untouched.
+/// this in `accounts.account_sync_source`; Actuali speaks SimpleFIN and
+/// Wallet (FinanceKit), but the column is shared with every other client, so
+/// a value it doesn't recognise has to survive a round trip untouched.
 enum BankSyncSource: String, Sendable, Equatable {
     case simpleFin = "simpleFin"
+    /// Apple Card / Apple Cash / Savings via FinanceKit. Ours alone — no
+    /// upstream client can service it, since the data only exists in this
+    /// device's Wallet. The link still syncs (same columns as any other
+    /// provider), so the web UI shows the account as linked and can unlink it.
+    case financeKit = "financeKit"
 }
 
 /// An account wired up to a bank feed: the budget's account plus the
@@ -23,6 +28,32 @@ struct BankSyncAccount: Sendable, Equatable, Identifiable {
     let closed: Bool
 
     var source: BankSyncSource? { BankSyncSource(rawValue: syncSource) }
+}
+
+/// A provider-side account offered for linking, whichever provider it came
+/// from — what the link flow needs and nothing more.
+struct BankSyncRemoteAccount: Identifiable, Sendable, Equatable {
+    /// The provider's account id — becomes `accounts.account_id`.
+    let id: String
+    let name: String
+    /// The provider's institution id — becomes `banks.bank_id`.
+    let institutionId: String
+    let institutionName: String
+    let balanceCents: Int?
+    let source: BankSyncSource
+}
+
+extension SimpleFINAccount {
+    var remoteAccount: BankSyncRemoteAccount {
+        BankSyncRemoteAccount(
+            id: id,
+            name: name,
+            institutionId: org.bankId ?? org.displayName,
+            institutionName: org.displayName,
+            balanceCents: balanceCents,
+            source: .simpleFin
+        )
+    }
 }
 
 /// Actual's `banks` row: the institution behind one or more linked accounts.

--- a/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncAccount.swift
@@ -1,15 +1,11 @@
 import Foundation
 
-/// The provider an account's transactions are downloaded from. Actual stores
-/// this in `accounts.account_sync_source`; Actuali speaks SimpleFIN and
-/// Wallet (FinanceKit), but the column is shared with every other client, so
-/// a value it doesn't recognise has to survive a round trip untouched.
+/// The provider an account's transactions are downloaded from. Synced links
+/// use `accounts.account_sync_source`; FinanceKit links stay device-local.
 enum BankSyncSource: String, Sendable, Equatable {
     case simpleFin = "simpleFin"
-    /// Apple Card / Apple Cash / Savings via FinanceKit. Ours alone — no
-    /// upstream client can service it, since the data only exists in this
-    /// device's Wallet. The link still syncs (same columns as any other
-    /// provider), so the web UI shows the account as linked and can unlink it.
+    /// Apple Card / Apple Cash / Savings via FinanceKit. Ours alone because
+    /// the identifiers and data only exist in this device's Wallet.
     case financeKit = "financeKit"
 }
 
@@ -19,10 +15,11 @@ struct BankSyncAccount: Sendable, Equatable, Identifiable {
     /// The budget's account id.
     let id: String
     let name: String
-    /// `accounts.account_id` — the id the provider knows the account by.
+    /// The id the provider knows the account by. FinanceKit keeps it locally;
+    /// other providers read it from `accounts.account_id`.
     let externalAccountId: String
-    /// `accounts.account_sync_source`, verbatim. Not every value maps to a
-    /// provider Actuali can sync (see `source`).
+    /// The provider name. Database-backed links preserve
+    /// `accounts.account_sync_source` verbatim; FinanceKit supplies it locally.
     let syncSource: String
     let offBudget: Bool
     let closed: Bool
@@ -33,10 +30,10 @@ struct BankSyncAccount: Sendable, Equatable, Identifiable {
 /// A provider-side account offered for linking, whichever provider it came
 /// from — what the link flow needs and nothing more.
 struct BankSyncRemoteAccount: Identifiable, Sendable, Equatable {
-    /// The provider's account id — becomes `accounts.account_id`.
+    /// The provider's account id.
     let id: String
     let name: String
-    /// The provider's institution id — becomes `banks.bank_id`.
+    /// The provider's institution id.
     let institutionId: String
     let institutionName: String
     let balanceCents: Int?

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -229,6 +229,27 @@ extension BankSyncCandidate {
         )
     }
 
+    /// The same, from a Wallet (FinanceKit) transaction, or nil for rejected
+    /// ones — the money never moved. Payees get the same processor-noise
+    /// cleanup as the Tier-1 picker import, so both routes file "SQ *Coffee"
+    /// under the same payee; the raw description survives in the notes.
+    init?(appleWallet transaction: AppleWalletTransaction) {
+        guard transaction.status != .rejected,
+              let cents = WalletImportMapper.cents(from: transaction.amount) else { return nil }
+        self.init(
+            importedId: transaction.id,
+            date: Transaction.yyyymmdd(from: transaction.date),
+            amount: transaction.isCredit ? cents : -cents,
+            payeeName: Self.payeeName(from: [
+                transaction.merchantName.map(MerchantNormalizer.normalize),
+                MerchantNormalizer.normalize(transaction.description)
+            ]),
+            payeeId: nil,
+            notes: Self.notes(from: transaction.description),
+            cleared: transaction.status == .booked
+        )
+    }
+
     /// The first name with anything in it. Not every bridge fills in a payee,
     /// and importing a nameless one would be worse than reusing the
     /// description.

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -234,19 +234,15 @@ extension BankSyncCandidate {
     /// cleanup as the Tier-1 picker import, so both routes file "SQ *Coffee"
     /// under the same payee; the raw description survives in the notes.
     init?(appleWallet transaction: AppleWalletTransaction) {
-        guard transaction.status != .rejected,
-              let cents = WalletImportMapper.cents(from: transaction.amount) else { return nil }
+        guard let imported = WalletImportMapper.candidate(from: transaction) else { return nil }
         self.init(
-            importedId: transaction.id,
-            date: Transaction.yyyymmdd(from: transaction.date),
-            amount: transaction.isCredit ? cents : -cents,
-            payeeName: Self.payeeName(from: [
-                transaction.merchantName.map(MerchantNormalizer.normalize),
-                MerchantNormalizer.normalize(transaction.description)
-            ]),
+            importedId: imported.id,
+            date: Transaction.yyyymmdd(from: imported.date),
+            amount: imported.amountCents,
+            payeeName: imported.payeeName,
             payeeId: nil,
             notes: Self.notes(from: transaction.description),
-            cleared: transaction.status == .booked
+            cleared: imported.cleared
         )
     }
 

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -37,7 +37,7 @@ struct FinanceKitWalletStore: AppleWalletReading {
         )
         return accounts.map { account in
             AppleWalletAccount(
-                id: account.id.uuidString.lowercased(),
+                id: account.id.uuidString,
                 name: account.displayName,
                 institutionName: account.institutionName,
                 balanceCents: centsByAccount[account.id]
@@ -56,17 +56,7 @@ struct FinanceKitWalletStore: AppleWalletReading {
                 $0.accountID == accountUUID
             })
         )
-        return transactions.map { transaction in
-            AppleWalletTransaction(
-                id: transaction.id.uuidString.lowercased(),
-                amount: transaction.transactionAmount.amount,
-                isCredit: transaction.creditDebitIndicator == .credit,
-                merchantName: transaction.merchantName,
-                description: transaction.transactionDescription,
-                status: Self.status(from: transaction.status),
-                date: transaction.transactionDate
-            )
-        }
+        return transactions.map(AppleWalletTransaction.init)
     }
 
     /// Signed cents from a FinanceKit balance: credit is money there, debit is
@@ -82,9 +72,28 @@ struct FinanceKitWalletStore: AppleWalletReading {
               let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
         return balance.creditDebitIndicator == .credit ? cents : -cents
     }
+}
 
-    private static func status(from status: FinanceKit.TransactionStatus) -> WalletImportMapper.Status {
-        switch status {
+/// The one place FinanceKit's transaction shape is read. Both consumers — the
+/// Tier-1 picker import and bank sync — go through this, so an SDK change
+/// lands in exactly one file.
+extension AppleWalletTransaction {
+    init(_ transaction: FinanceKit.Transaction) {
+        self.init(
+            id: transaction.id.uuidString,
+            amount: transaction.transactionAmount.amount,
+            isCredit: transaction.creditDebitIndicator == .credit,
+            merchantName: transaction.merchantName,
+            description: transaction.transactionDescription,
+            status: WalletImportMapper.Status(transaction.status),
+            date: transaction.transactionDate
+        )
+    }
+}
+
+extension WalletImportMapper.Status {
+    init(_ status: FinanceKit.TransactionStatus) {
+        self = switch status {
         case .authorized: .authorized
         case .memo: .memo
         case .pending: .pending

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -1,0 +1,96 @@
+import FinanceKit
+import Foundation
+
+/// The real FinanceKit-backed `AppleWalletReading`. Deliberately thin — every
+/// mapping decision lives in the framework-free types so it can be tested;
+/// this file only speaks to `FinanceStore`.
+///
+/// Ongoing access needs Apple's managed FinanceKit entitlement
+/// (`com.apple.developer.financekit` in Actuali.entitlements) — unlike the
+/// Tier-1 transaction picker, which works in any build.
+struct FinanceKitWalletStore: AppleWalletReading {
+
+    func availability() async -> AppleWalletAvailability {
+        guard FinanceStore.isDataAvailable(.financialData) else { return .unsupported }
+        // authorizationStatus throws in builds without the FinanceKit
+        // entitlement; treated as not-determined so the setup screen's
+        // connect button is what surfaces the real error.
+        switch try? await FinanceStore.shared.authorizationStatus() {
+        case .authorized: return .authorized
+        case .denied: return .denied
+        default: return .notDetermined
+        }
+    }
+
+    func requestAccess() async throws -> Bool {
+        try await FinanceStore.shared.requestAuthorization() == .authorized
+    }
+
+    func accounts() async throws -> [AppleWalletAccount] {
+        let accounts = try await FinanceStore.shared.accounts(query: AccountQuery())
+        let balances = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery())
+        let centsByAccount = Dictionary(
+            balances.compactMap { balance in
+                Self.cents(from: balance).map { (balance.accountID, $0) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return accounts.map { account in
+            AppleWalletAccount(
+                id: account.id.uuidString.lowercased(),
+                name: account.displayName,
+                institutionName: account.institutionName,
+                balanceCents: centsByAccount[account.id]
+            )
+        }
+    }
+
+    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+        guard let accountUUID = UUID(uuidString: accountId) else { return [] }
+        // ponytail: fetches the account's full history every sync and lets the
+        // caller drop what's outside the window. FinanceKit reads are local, so
+        // this holds up to years of Apple Card history; the upgrade path is a
+        // transactionDate bound in the predicate.
+        let transactions = try await FinanceStore.shared.transactions(
+            query: TransactionQuery(predicate: #Predicate<FinanceKit.Transaction> {
+                $0.accountID == accountUUID
+            })
+        )
+        return transactions.map { transaction in
+            AppleWalletTransaction(
+                id: transaction.id.uuidString.lowercased(),
+                amount: transaction.transactionAmount.amount,
+                isCredit: transaction.creditDebitIndicator == .credit,
+                merchantName: transaction.merchantName,
+                description: transaction.transactionDescription,
+                status: Self.status(from: transaction.status),
+                date: transaction.transactionDate
+            )
+        }
+    }
+
+    /// Signed cents from a FinanceKit balance: credit is money there, debit is
+    /// money owed — which is how an Apple Card's balance comes out negative.
+    private static func cents(from accountBalance: AccountBalance) -> Int? {
+        let balance: Balance? = switch accountBalance.currentBalance {
+        case .booked(let booked): booked
+        case .availableAndBooked(_, let booked): booked
+        case .available(let available): available
+        @unknown default: nil
+        }
+        guard let balance,
+              let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
+        return balance.creditDebitIndicator == .credit ? cents : -cents
+    }
+
+    private static func status(from status: FinanceKit.TransactionStatus) -> WalletImportMapper.Status {
+        switch status {
+        case .authorized: .authorized
+        case .memo: .memo
+        case .pending: .pending
+        case .booked: .booked
+        case .rejected: .rejected
+        @unknown default: .booked
+        }
+    }
+}

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -29,18 +29,15 @@ struct FinanceKitWalletStore: AppleWalletReading {
     func accounts() async throws -> [AppleWalletAccount] {
         let accounts = try await FinanceStore.shared.accounts(query: AccountQuery())
         let balances = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery())
-        let centsByAccount = Dictionary(
-            balances.compactMap { balance in
-                Self.cents(from: balance).map { (balance.accountID, $0) }
-            },
-            uniquingKeysWith: { first, _ in first }
-        )
+        let balancesByAccount = Self.latestBalances(balances.compactMap(Self.balance(from:)))
         return accounts.map { account in
-            AppleWalletAccount(
+            let balance = balancesByAccount[account.id.uuidString.lowercased()]
+            return AppleWalletAccount(
                 id: account.id.uuidString,
                 name: account.displayName,
                 institutionName: account.institutionName,
-                balanceCents: centsByAccount[account.id]
+                balanceCents: balance?.cents,
+                balanceIncludesPending: balance?.includesPending ?? false
             )
         }
     }
@@ -61,16 +58,26 @@ struct FinanceKitWalletStore: AppleWalletReading {
 
     /// Signed cents from a FinanceKit balance: credit is money there, debit is
     /// money owed — which is how an Apple Card's balance comes out negative.
-    private static func cents(from accountBalance: AccountBalance) -> Int? {
-        let balance: Balance? = switch accountBalance.currentBalance {
-        case .booked(let booked): booked
-        case .availableAndBooked(_, let booked): booked
-        case .available(let available): available
+    static func latestBalances(_ balances: [AppleWalletBalance]) -> [String: AppleWalletBalance] {
+        Dictionary(grouping: balances, by: \AppleWalletBalance.accountId)
+            .compactMapValues { $0.max { $0.asOfDate < $1.asOfDate } }
+    }
+
+    private static func balance(from accountBalance: AccountBalance) -> AppleWalletBalance? {
+        let selection: (balance: Balance, includesPending: Bool)? = switch accountBalance.currentBalance {
+        case .available(let available): (available, true)
+        case .booked(let booked): (booked, false)
+        case .availableAndBooked(let available, _): (available, true)
         @unknown default: nil
         }
-        guard let balance,
-              let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
-        return balance.creditDebitIndicator == .credit ? cents : -cents
+        guard let (balance, includesPending) = selection else { return nil }
+        guard let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
+        return AppleWalletBalance(
+            accountId: accountBalance.accountID.uuidString.lowercased(),
+            cents: balance.creditDebitIndicator == .credit ? cents : -cents,
+            asOfDate: balance.asOfDate,
+            includesPending: includesPending
+        )
     }
 }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1076,6 +1076,12 @@ final class BudgetStore: ObservableObject {
         appleWalletStore = store
     }
 
+    /// Test-only: isolate device-local Wallet links from the app's defaults.
+    func configureAppleWalletLinksForTesting(defaults: UserDefaults, budgetId: String) {
+        appleWalletLinkDefaults = defaults
+        _currentBudgetId = Published(initialValue: budgetId)
+    }
+
     /// Test-only: swap in a file manager rooted at a temp directory so
     /// logout()'s full wipe can be exercised without touching the shared
     /// Budgets directory (parallel suites create real budgets there).
@@ -1467,6 +1473,7 @@ final class BudgetStore: ObservableObject {
                 }
                 try? fileManager.deleteBudget(local.id)
                 forgetCachedCurrencyCode(for: local.id)
+                forgetAppleWalletLinks(for: local.id)
             }
 
             // The SimpleFIN access key goes too, for the same reason the
@@ -2402,6 +2409,32 @@ final class BudgetStore: ObservableObject {
     /// out of the way.
     private var appleWalletStore: any AppleWalletReading = FinanceKitWalletStore()
 
+    /// FinanceKit identifiers are meaningful only on this device. Keeping the
+    /// links per budget in UserDefaults prevents unknown provider values from
+    /// reaching Actual's synced `accounts` rows.
+    private var appleWalletLinkDefaults = UserDefaults.standard
+
+    private func appleWalletLinksKey(for budgetId: String) -> String {
+        "appleWalletLinks_\(budgetId)"
+    }
+
+    private var appleWalletLinks: [String: String] {
+        get {
+            guard let budgetId = currentBudgetId else { return [:] }
+            return appleWalletLinkDefaults.dictionary(
+                forKey: appleWalletLinksKey(for: budgetId)
+            ) as? [String: String] ?? [:]
+        }
+        set {
+            guard let budgetId = currentBudgetId else { return }
+            appleWalletLinkDefaults.set(newValue, forKey: appleWalletLinksKey(for: budgetId))
+        }
+    }
+
+    private func forgetAppleWalletLinks(for budgetId: String) {
+        appleWalletLinkDefaults.removeObject(forKey: appleWalletLinksKey(for: budgetId))
+    }
+
     /// Whether Wallet data can be read here, as of the last check. Drives
     /// which of the setup screen's Wallet states shows.
     @Published private(set) var appleWalletAvailability: AppleWalletAvailability = .unsupported
@@ -2562,7 +2595,26 @@ final class BudgetStore: ObservableObject {
             bankSyncAccounts = []
             return
         }
-        bankSyncAccounts = (try? await database.fetchBankSyncAccounts()) ?? []
+        let synced = (try? await database.fetchBankSyncAccounts()) ?? []
+        let walletLinks = appleWalletLinks
+        guard !walletLinks.isEmpty else {
+            bankSyncAccounts = synced
+            return
+        }
+        let syncedById = Dictionary(uniqueKeysWithValues: synced.map { ($0.id, $0) })
+        let budgetAccounts = (try? await database.fetchAccounts()) ?? accounts
+        bankSyncAccounts = budgetAccounts.compactMap { account in
+            if let linked = syncedById[account.id] { return linked }
+            guard let externalId = walletLinks[account.id] else { return nil }
+            return BankSyncAccount(
+                id: account.id,
+                name: account.name,
+                externalAccountId: externalId,
+                syncSource: BankSyncSource.financeKit.rawValue,
+                offBudget: account.offBudget,
+                closed: account.closed
+            )
+        }
     }
 
     /// The bank feed an account is wired up to, if any.
@@ -2571,6 +2623,14 @@ final class BudgetStore: ObservableObject {
     }
 
     func linkBankAccount(accountId: String, to remote: BankSyncRemoteAccount) async throws {
+        if remote.source == .financeKit {
+            guard currentBudgetId != nil else { throw BudgetStoreError.syncNotConfigured }
+            var links = appleWalletLinks
+            links[accountId] = remote.id
+            appleWalletLinks = links
+            await loadBankSyncAccounts()
+            return
+        }
         guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
         try await syncClient.linkAccount(
             accountId: accountId,
@@ -2579,10 +2639,20 @@ final class BudgetStore: ObservableObject {
             institutionId: remote.institutionId,
             institutionName: remote.institutionName
         )
+        var links = appleWalletLinks
+        links.removeValue(forKey: accountId)
+        appleWalletLinks = links
         await refreshDataOnly()
     }
 
     func unlinkBankAccount(accountId: String) async throws {
+        if bankSyncAccount(forAccountId: accountId)?.source == .financeKit {
+            var links = appleWalletLinks
+            links.removeValue(forKey: accountId)
+            appleWalletLinks = links
+            await loadBankSyncAccounts()
+            return
+        }
         guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
         try await syncClient.unlinkAccount(accountId: accountId)
         await refreshDataOnly()
@@ -2613,10 +2683,8 @@ final class BudgetStore: ObservableObject {
 
         var result = BankSyncResult()
 
-        // A Wallet link lives in the budget file, but its data only exists in
-        // the Wallet of the device that made it. Where this device can't
-        // possibly serve it — no FinanceKit data, or never asked — skip
-        // quietly; access someone turned off is theirs to turn back on.
+        // Wallet links and Wallet data both live only on this device. Where
+        // FinanceKit can't serve them, skip quietly unless access was revoked.
         if !walletTargets.isEmpty {
             switch await appleWalletStore.availability() {
             case .authorized:
@@ -2657,15 +2725,17 @@ final class BudgetStore: ObservableObject {
         // that source's problem, not the sync's — its targets fall through the
         // loop below as "failed" while the other source's still import.
         var downloaded = BankSyncDownloadSet()
+        var simpleFinProblems: [String] = []
+        var walletProblems: [String] = []
         if !simpleFinTargets.isEmpty {
             do {
                 let provider = try await makeBankSyncProvider()
                 let set = try await provider.download(downloadTargets(simpleFinTargets))
                 downloaded.byAccount.merge(set.byAccount) { first, _ in first }
-                downloaded.problems += set.problems
+                simpleFinProblems += set.problems
             } catch {
                 guard !walletTargets.isEmpty else { throw error }
-                downloaded.problems.append(error.localizedDescription)
+                simpleFinProblems.append(error.localizedDescription)
             }
         }
         if !walletTargets.isEmpty {
@@ -2673,14 +2743,14 @@ final class BudgetStore: ObservableObject {
                 let set = try await AppleWalletProvider(store: appleWalletStore)
                     .download(downloadTargets(walletTargets))
                 downloaded.byAccount.merge(set.byAccount) { first, _ in first }
-                downloaded.problems += set.problems
+                walletProblems += set.problems
             } catch {
                 guard !simpleFinTargets.isEmpty else { throw error }
-                downloaded.problems.append(error.localizedDescription)
+                walletProblems.append(error.localizedDescription)
             }
         }
 
-        result.problems += downloaded.problems
+        result.problems += simpleFinProblems + walletProblems
         // One rules/context fetch for the whole run, not one per row.
         let prepared = await syncClient.prepareRules()
         let syncedAt = String(Int64(Date().timeIntervalSince1970 * 1000))
@@ -2690,20 +2760,20 @@ final class BudgetStore: ObservableObject {
             guard let download = downloaded.byAccount[target.externalAccountId] else {
                 // A connection-level problem already explains why nothing came
                 // back; don't also tell them to relink an account that's fine.
-                if downloaded.problems.isEmpty {
-                    result.problems.append(target.source == .financeKit
-                        ? "\(target.name): this device's Wallet doesn't have this account — it was probably linked on another device. Unlink it and link it again here."
-                        : "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
+                let sourceHasProblems = target.source == .financeKit
+                    ? !walletProblems.isEmpty
+                    : !simpleFinProblems.isEmpty
+                if target.source == .simpleFin && !sourceHasProblems {
+                    result.problems.append(
+                        "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
                     )
                 }
-                // A Wallet account another device serves fine is only missing
-                // *here*, so this device-relative state must not be stamped
-                // into the synced status columns — it would paint an error
-                // badge on every client over a link that works where it was
-                // made. SimpleFIN is one shared feed, so there it's stamped.
+                // Missing Wallet data is device-local state, so don't stamp it
+                // into synced status columns. SimpleFIN is a shared feed, so
+                // its missing/failed state belongs there.
                 if target.source != .financeKit {
                     statuses.append((target.id, nil,
-                                     downloaded.problems.isEmpty ? "account-missing" : "failed"))
+                                     sourceHasProblems ? "failed" : "account-missing"))
                 }
                 continue
             }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1069,6 +1069,13 @@ final class BudgetStore: ObservableObject {
         simpleFINClient = client
     }
 
+    /// Test-only: swap in a stub Wallet store so the FinanceKit sync path can
+    /// be exercised off-device (the real store only answers on entitled
+    /// iPhones).
+    func setAppleWalletStoreForTesting(_ store: any AppleWalletReading) {
+        appleWalletStore = store
+    }
+
     /// Test-only: swap in a file manager rooted at a temp directory so
     /// logout()'s full wipe can be exercised without touching the shared
     /// Budgets directory (parallel suites create real budgets there).
@@ -2382,12 +2389,42 @@ final class BudgetStore: ObservableObject {
         (try? database?.existingFinancialIds(accountId: accountId)) ?? []
     }
 
-    // MARK: - Bank Sync (SimpleFIN)
+    // MARK: - Bank Sync (SimpleFIN & Apple Wallet)
 
     /// Talks to a SimpleFIN bridge directly, with a key claimed on this
     /// device. Only used when the server has no SimpleFIN of its own — see
     /// `makeBankSyncProvider`.
     private var simpleFINClient = SimpleFINClient()
+
+    /// Reads Wallet (FinanceKit) accounts and transactions. Only answers on
+    /// iPhones with Wallet data and the FinanceKit entitlement; everywhere
+    /// else `availability()` says so and the Wallet half of bank sync stays
+    /// out of the way.
+    private var appleWalletStore: any AppleWalletReading = FinanceKitWalletStore()
+
+    /// Whether Wallet data can be read here, as of the last check. Drives
+    /// which of the setup screen's Wallet states shows.
+    @Published private(set) var appleWalletAvailability: AppleWalletAvailability = .unsupported
+
+    func refreshAppleWalletAvailability() async {
+        appleWalletAvailability = await appleWalletStore.availability()
+    }
+
+    /// Ask the person for read access to Wallet. Returns whether it was
+    /// granted — FinanceKit shows its own consent sheet, so all that's left
+    /// here is remembering the answer.
+    @discardableResult
+    func connectAppleWallet() async throws -> Bool {
+        let granted = try await appleWalletStore.requestAccess()
+        appleWalletAvailability = await appleWalletStore.availability()
+        return granted
+    }
+
+    /// Every Wallet account (Apple Card, Apple Cash, Savings), for the
+    /// linking screen.
+    func fetchAppleWalletAccounts() async throws -> [AppleWalletAccount] {
+        try await appleWalletStore.accounts()
+    }
 
     /// How far back a sync reaches when an account has nothing to anchor to.
     /// 89 days ago through today inclusive is 90 days, the window upstream
@@ -2533,14 +2570,14 @@ final class BudgetStore: ObservableObject {
         bankSyncAccounts.first { $0.id == accountId }
     }
 
-    func linkBankAccount(accountId: String, to remote: SimpleFINAccount) async throws {
+    func linkBankAccount(accountId: String, to remote: BankSyncRemoteAccount) async throws {
         guard let syncClient else { throw BudgetStoreError.syncNotConfigured }
         try await syncClient.linkAccount(
             accountId: accountId,
             externalAccountId: remote.id,
-            source: .simpleFin,
-            institutionId: remote.org.bankId ?? remote.org.displayName,
-            institutionName: remote.org.displayName
+            source: remote.source,
+            institutionId: remote.institutionId,
+            institutionName: remote.institutionName
         )
         await refreshDataOnly()
     }
@@ -2561,16 +2598,37 @@ final class BudgetStore: ObservableObject {
         // and race the first one's writes.
         guard !isBankSyncing else { return BankSyncResult() }
 
-        let targets = bankSyncAccounts.filter {
-            $0.source == .simpleFin && !$0.closed
-                && (accountIds.isEmpty || accountIds.contains($0.id))
+        let linked = bankSyncAccounts.filter {
+            !$0.closed && (accountIds.isEmpty || accountIds.contains($0.id))
         }
-        guard !targets.isEmpty else { return BankSyncResult() }
+        let simpleFinTargets = linked.filter { $0.source == .simpleFin }
+        var walletTargets = linked.filter { $0.source == .financeKit }
+
+        var result = BankSyncResult()
+
+        // A Wallet link lives in the budget file, but its data only exists in
+        // the Wallet of the device that made it. Where this device can't
+        // possibly serve it — no FinanceKit data, or never asked — skip
+        // quietly; access someone turned off is theirs to turn back on.
+        if !walletTargets.isEmpty {
+            switch await appleWalletStore.availability() {
+            case .authorized:
+                break
+            case .denied:
+                result.problems.append(
+                    "Wallet access is turned off. Allow Actuali to read Wallet in Settings, then sync again."
+                )
+                walletTargets = []
+            case .unsupported, .notDetermined:
+                walletTargets = []
+            }
+        }
+
+        let targets = simpleFinTargets + walletTargets
+        guard !targets.isEmpty else { return result }
 
         isBankSyncing = true
         defer { isBankSyncing = false }
-
-        let provider = try await makeBankSyncProvider()
 
         // An account that already has history only needs the window since its
         // earliest transaction; one that has none takes the full lookback.
@@ -2582,16 +2640,43 @@ final class BudgetStore: ObservableObject {
             // mean the same thing here: take the full lookback.
             oldestDates[target.id] = (try? await database.oldestTransactionDate(accountId: target.id)) ?? nil
         }
+        func downloadTargets(_ accounts: [BankSyncAccount]) -> [BankSyncTarget] {
+            accounts.map {
+                BankSyncTarget(
+                    externalId: $0.externalAccountId,
+                    startDay: max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor)
+                )
+            }
+        }
 
-        let downloaded = try await provider.download(targets.map {
-            BankSyncTarget(
-                externalId: $0.externalAccountId,
-                startDay: max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor)
-            )
-        })
+        // Each source downloads on its own; with both in play, one failing is
+        // that source's problem, not the sync's — its targets fall through the
+        // loop below as "failed" while the other source's still import.
+        var downloaded = BankSyncDownloadSet()
+        if !simpleFinTargets.isEmpty {
+            do {
+                let provider = try await makeBankSyncProvider()
+                let set = try await provider.download(downloadTargets(simpleFinTargets))
+                downloaded.byAccount.merge(set.byAccount) { first, _ in first }
+                downloaded.problems += set.problems
+            } catch {
+                guard !walletTargets.isEmpty else { throw error }
+                downloaded.problems.append(error.localizedDescription)
+            }
+        }
+        if !walletTargets.isEmpty {
+            do {
+                let set = try await AppleWalletProvider(store: appleWalletStore)
+                    .download(downloadTargets(walletTargets))
+                downloaded.byAccount.merge(set.byAccount) { first, _ in first }
+                downloaded.problems += set.problems
+            } catch {
+                guard !simpleFinTargets.isEmpty else { throw error }
+                downloaded.problems.append(error.localizedDescription)
+            }
+        }
 
-        var result = BankSyncResult()
-        result.problems = downloaded.problems
+        result.problems += downloaded.problems
         // One rules/context fetch for the whole run, not one per row.
         let prepared = await syncClient.prepareRules()
         let syncedAt = String(Int64(Date().timeIntervalSince1970 * 1000))
@@ -2602,8 +2687,9 @@ final class BudgetStore: ObservableObject {
                 // A connection-level problem already explains why nothing came
                 // back; don't also tell them to relink an account that's fine.
                 if downloaded.problems.isEmpty {
-                    result.problems.append(
-                        "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
+                    result.problems.append(target.source == .financeKit
+                        ? "\(target.name): this device's Wallet doesn't have this account — it was probably linked on another device. Unlink it and link it again here."
+                        : "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
                     )
                     statuses.append((target.id, nil, "account-missing"))
                 } else {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2603,6 +2603,13 @@ final class BudgetStore: ObservableObject {
         }
         let simpleFinTargets = linked.filter { $0.source == .simpleFin }
         var walletTargets = linked.filter { $0.source == .financeKit }
+        guard !(simpleFinTargets.isEmpty && walletTargets.isEmpty) else { return BankSyncResult() }
+
+        // Nothing may suspend between the isBankSyncing guard above and this
+        // write — an await in that window would let a second call slip past
+        // the guard and import everything twice.
+        isBankSyncing = true
+        defer { isBankSyncing = false }
 
         var result = BankSyncResult()
 
@@ -2626,9 +2633,6 @@ final class BudgetStore: ObservableObject {
 
         let targets = simpleFinTargets + walletTargets
         guard !targets.isEmpty else { return result }
-
-        isBankSyncing = true
-        defer { isBankSyncing = false }
 
         // An account that already has history only needs the window since its
         // earliest transaction; one that has none takes the full lookback.
@@ -2691,9 +2695,15 @@ final class BudgetStore: ObservableObject {
                         ? "\(target.name): this device's Wallet doesn't have this account — it was probably linked on another device. Unlink it and link it again here."
                         : "\(target.name): SimpleFIN didn't return this account. Unlink it and link it again."
                     )
-                    statuses.append((target.id, nil, "account-missing"))
-                } else {
-                    statuses.append((target.id, nil, "failed"))
+                }
+                // A Wallet account another device serves fine is only missing
+                // *here*, so this device-relative state must not be stamped
+                // into the synced status columns — it would paint an error
+                // badge on every client over a link that works where it was
+                // made. SimpleFIN is one shared feed, so there it's stamped.
+                if target.source != .financeKit {
+                    statuses.append((target.id, nil,
+                                     downloaded.problems.isEmpty ? "account-missing" : "failed"))
                 }
                 continue
             }

--- a/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
+++ b/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A Wallet (FinanceKit) transaction reduced to the fields Actuali imports.
 /// Framework-independent so mapping and dedup stay unit-testable — the thin
-/// FinanceKit bridge lives in `WalletImportView` (GH #55, Tier 1).
+/// FinanceKit bridge lives in `FinanceKitWalletStore` (GH #55, Tier 1).
 struct WalletImportCandidate: Identifiable, Hashable {
     /// FinanceKit transaction UUID, lowercased — stored as `financial_id`
     /// (Actual's imported_id) for dedup across imports.
@@ -27,34 +27,25 @@ enum WalletImportMapper {
     /// Map one Wallet transaction to an import candidate.
     /// - Returns: `nil` for rejected transactions (the money never moved) and
     ///   for amounts that don't fit integer cents.
-    static func candidate(
-        id: UUID,
-        amount: Decimal,
-        isCredit: Bool,
-        merchantName: String?,
-        transactionDescription: String,
-        status: Status,
-        date: Date
-    ) -> WalletImportCandidate? {
-        guard status != .rejected else { return nil }
-        guard let unsignedCents = cents(from: amount) else { return nil }
+    static func candidate(from transaction: AppleWalletTransaction) -> WalletImportCandidate? {
+        guard transaction.status != .rejected else { return nil }
+        guard let unsignedCents = cents(from: transaction.amount) else { return nil }
 
         // Wallet merchant strings carry the same processor noise as the
         // Shortcuts flow ("SQ *", store numbers) — normalize the same way.
         let rawPayee: String
-        if let merchantName, !merchantName.isEmpty {
+        if let merchantName = transaction.merchantName, !merchantName.isEmpty {
             rawPayee = merchantName
         } else {
-            rawPayee = transactionDescription
+            rawPayee = transaction.description
         }
-        let payee = MerchantNormalizer.normalize(rawPayee)
 
         return WalletImportCandidate(
-            id: id.uuidString.lowercased(),
-            amountCents: isCredit ? unsignedCents : -unsignedCents,
-            payeeName: payee,
-            date: date,
-            cleared: status == .booked
+            id: transaction.id,
+            amountCents: transaction.isCredit ? unsignedCents : -unsignedCents,
+            payeeName: MerchantNormalizer.normalize(rawPayee),
+            date: transaction.date,
+            cleared: transaction.status == .booked
         )
     }
 

--- a/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
+++ b/Actuali/Actuali/Services/WalletImport/WalletImportMapper.swift
@@ -33,17 +33,15 @@ enum WalletImportMapper {
 
         // Wallet merchant strings carry the same processor noise as the
         // Shortcuts flow ("SQ *", store numbers) — normalize the same way.
-        let rawPayee: String
-        if let merchantName = transaction.merchantName, !merchantName.isEmpty {
-            rawPayee = merchantName
-        } else {
-            rawPayee = transaction.description
-        }
+        let payee = [
+            transaction.merchantName.map(MerchantNormalizer.normalize),
+            MerchantNormalizer.normalize(transaction.description)
+        ].compactMap { $0 }.first { !$0.isEmpty } ?? "Unknown"
 
         return WalletImportCandidate(
             id: transaction.id,
             amountCents: transaction.isCredit ? unsignedCents : -unsignedCents,
-            payeeName: MerchantNormalizer.normalize(rawPayee),
+            payeeName: payee,
             date: transaction.date,
             cleared: transaction.status == .booked
         )

--- a/Actuali/Actuali/Views/Accounts/AddAccountView.swift
+++ b/Actuali/Actuali/Views/Accounts/AddAccountView.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 /// Entry point for the Accounts tab's + button. A simple menu of account
 /// creation methods, matching the PWA's own "Add account" popup: a local
-/// (manual) account, or one fed by a bank through SimpleFIN. GoCardless and
-/// the other providers the PWA offers aren't implemented here.
+/// (manual) account, or one fed by a bank through SimpleFIN or Apple Wallet
+/// (FinanceKit). GoCardless and the other providers the PWA offers aren't
+/// implemented here.
 struct AddAccountView: View {
     @Environment(\.dismiss) private var dismiss
 

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 
 private let simpleFINBridgeURL = URL(string: "https://bridge.simplefin.org/")!
 
-/// Set up SimpleFIN and wire its accounts to budget accounts.
+/// Set up bank feeds and wire their accounts to budget accounts.
 ///
-/// Two states. With a connection available — the server's own, or one claimed
-/// on this device — it lists the accounts the bridge serves, each either
-/// linked to a budget account or waiting to be. With neither, it's a paste
-/// field for a setup token. Which connection is in play is worth saying out
-/// loud: only the server's is shared with the web app.
+/// Two providers. Apple Wallet (FinanceKit) shows on devices that have Wallet
+/// data at all: connect once and its accounts are ready to link. SimpleFIN has
+/// two states — with a connection available (the server's own, or one claimed
+/// on this device) it lists the accounts the bridge serves; with neither, it's
+/// a paste field for a setup token. Which SimpleFIN connection is in play is
+/// worth saying out loud: only the server's is shared with the web app.
 struct BankSyncSetupView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
@@ -16,12 +17,18 @@ struct BankSyncSetupView: View {
     @State private var isConnecting = false
     @State private var isLoadingAccounts = false
     @State private var remoteAccounts: [SimpleFINAccount] = []
+    @State private var walletAccounts: [AppleWalletAccount] = []
+    @State private var isConnectingWallet = false
+    @State private var isLoadingWalletAccounts = false
     @State private var errorMessage: String?
-    @State private var linkTarget: SimpleFINAccount?
+    @State private var linkTarget: BankSyncRemoteAccount?
     @State private var showingDisconnectConfirmation = false
 
     var body: some View {
         List {
+            if budgetStore.appleWalletAvailability != .unsupported {
+                walletSection
+            }
             if budgetStore.canSyncBanks {
                 connectedSections
             } else {
@@ -31,8 +38,12 @@ struct BankSyncSetupView: View {
         .navigationTitle("Bank Sync")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            // Which half of this screen applies depends on whether the server
-            // does SimpleFIN itself, so ask before deciding.
+            await budgetStore.refreshAppleWalletAvailability()
+            if budgetStore.appleWalletAvailability == .authorized {
+                await loadWalletAccounts()
+            }
+            // Which half of the SimpleFIN screen applies depends on whether
+            // the server does SimpleFIN itself, so ask before deciding.
             await budgetStore.refreshBankSyncSource()
             if budgetStore.canSyncBanks, remoteAccounts.isEmpty {
                 await loadRemoteAccounts()
@@ -56,6 +67,64 @@ struct BankSyncSetupView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Your accounts stay linked and keep the transactions they've already imported. To sync from this device again you'll need a new setup token.")
+        }
+    }
+
+    // MARK: - Apple Wallet
+
+    @ViewBuilder
+    private var walletSection: some View {
+        Section {
+            switch budgetStore.appleWalletAvailability {
+            case .authorized:
+                if isLoadingWalletAccounts {
+                    HStack {
+                        ProgressView()
+                        Text("Loading accounts…")
+                            .foregroundStyle(.secondary)
+                    }
+                } else if walletAccounts.isEmpty {
+                    Text("No Wallet accounts found on this device.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(walletAccounts) { account in
+                        Button {
+                            linkTarget = account.remoteAccount
+                        } label: {
+                            remoteAccountRow(account.remoteAccount)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            case .denied:
+                Label("Wallet access is turned off", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+            default:
+                Button {
+                    connectWallet()
+                } label: {
+                    if isConnectingWallet {
+                        HStack {
+                            ProgressView()
+                            Text("Connecting…")
+                        }
+                    } else {
+                        Label("Connect Apple Wallet", systemImage: "wallet.pass")
+                    }
+                }
+                .disabled(isConnectingWallet)
+            }
+        } header: {
+            Text("Apple Wallet")
+        } footer: {
+            switch budgetStore.appleWalletAvailability {
+            case .authorized:
+                Text("Tap an account to link it. Apple Card, Apple Cash and Savings transactions are read from this device's Wallet every time you sync, and stored in your budget file like any other transaction.")
+            case .denied:
+                Text("Allow Actuali to read Wallet data in Settings to sync Apple Card, Apple Cash and Savings.")
+            default:
+                Text("Link Apple Card, Apple Cash and Savings so their transactions and balances import automatically when you sync. Apple asks once which data Actuali may read.")
+            }
         }
     }
 
@@ -130,9 +199,9 @@ struct BankSyncSetupView: View {
             } else {
                 ForEach(remoteAccounts) { remote in
                     Button {
-                        linkTarget = remote
+                        linkTarget = remote.remoteAccount
                     } label: {
-                        remoteAccountRow(remote)
+                        remoteAccountRow(remote.remoteAccount)
                     }
                     .buttonStyle(.plain)
                 }
@@ -161,11 +230,11 @@ struct BankSyncSetupView: View {
         }
     }
 
-    private func remoteAccountRow(_ remote: SimpleFINAccount) -> some View {
+    private func remoteAccountRow(_ remote: BankSyncRemoteAccount) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text(remote.name)
-                Text(remote.org.displayName)
+                Text(remote.institutionName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 if let linked = linkedAccountName(for: remote) {
@@ -186,10 +255,10 @@ struct BankSyncSetupView: View {
         }
     }
 
-    /// The budget account a bridge account is already wired to, if any.
-    private func linkedAccountName(for remote: SimpleFINAccount) -> String? {
+    /// The budget account a provider-side account is already wired to, if any.
+    private func linkedAccountName(for remote: BankSyncRemoteAccount) -> String? {
         guard let link = budgetStore.bankSyncAccounts.first(where: {
-            $0.externalAccountId == remote.id && $0.source == .simpleFin
+            $0.externalAccountId == remote.id && $0.syncSource == remote.source.rawValue
         }) else { return nil }
         return link.name
     }
@@ -225,6 +294,32 @@ struct BankSyncSetupView: View {
         }
     }
 
+    private func connectWallet() {
+        isConnectingWallet = true
+        Task {
+            defer { isConnectingWallet = false }
+            do {
+                // A declined consent sheet needs no alert of its own — the
+                // section flips to its denied state, which says what to do.
+                if try await budgetStore.connectAppleWallet() {
+                    await loadWalletAccounts()
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func loadWalletAccounts() async {
+        isLoadingWalletAccounts = true
+        defer { isLoadingWalletAccounts = false }
+        do {
+            walletAccounts = try await budgetStore.fetchAppleWalletAccounts()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     private func disconnect() {
         do {
             try budgetStore.disconnectSimpleFIN()
@@ -235,13 +330,13 @@ struct BankSyncSetupView: View {
     }
 }
 
-/// Pick what a bridge account feeds: an account the budget already has, or a
-/// new one created for it.
+/// Pick what a provider-side account feeds: an account the budget already
+/// has, or a new one created for it.
 struct BankAccountLinkView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
 
-    let remote: SimpleFINAccount
+    let remote: BankSyncRemoteAccount
 
     @State private var newAccountOffBudget = false
     @State private var isWorking = false
@@ -272,7 +367,7 @@ struct BankAccountLinkView: View {
                 } header: {
                     Text("New account")
                 } footer: {
-                    Text("Creates a budget account for \(remote.name) at \(remote.org.displayName) and links it. Its opening balance is worked out on the first sync.")
+                    Text("Creates a budget account for \(remote.name) at \(remote.institutionName) and links it. Its opening balance is worked out on the first sync.")
                 }
 
                 Section("Link to an existing account") {
@@ -319,7 +414,7 @@ struct BankAccountLinkView: View {
 
     private var currentLink: BankSyncAccount? {
         budgetStore.bankSyncAccounts.first {
-            $0.externalAccountId == remote.id && $0.source == .simpleFin
+            $0.externalAccountId == remote.id && $0.syncSource == remote.source.rawValue
         }
     }
 

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -164,7 +164,7 @@ struct TransactionAutomationSettingsView: View {
                 NavigationLink {
                     BankSyncSetupView()
                 } label: {
-                    Label("Bank Sync (SimpleFIN)", systemImage: "building.columns")
+                    Label("Bank Sync (SimpleFIN & Wallet)", systemImage: "building.columns")
                 }
 
                 NavigationLink {

--- a/Actuali/Actuali/Views/Settings/WalletImportView.swift
+++ b/Actuali/Actuali/Views/Settings/WalletImportView.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// FinanceKit transaction picker (GH #55, Tier 1). The picker needs no
 /// FinanceKit entitlement — the user hand-picks transactions and access is
 /// one-time, so this works for any App Store build. Full automatic sync
-/// (Tier 2) needs Apple's managed FinanceKit entitlement and is tracked
-/// separately.
+/// (Tier 2) needs Apple's managed FinanceKit entitlement and lives in bank
+/// sync — see `BankSyncSetupView` and `FinanceKitWalletStore`.
 struct WalletImportView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss

--- a/Actuali/Actuali/Views/Settings/WalletImportView.swift
+++ b/Actuali/Actuali/Views/Settings/WalletImportView.swift
@@ -33,7 +33,9 @@ struct WalletImportView: View {
 
     /// Wallet selection mapped to import candidates, picker order preserved.
     private var candidates: [WalletImportCandidate] {
-        walletSelection.compactMap { Self.candidate(from: $0) }
+        walletSelection.compactMap {
+            WalletImportMapper.candidate(from: AppleWalletTransaction($0))
+        }
     }
 
     private var importableCount: Int {
@@ -198,30 +200,6 @@ struct WalletImportView: View {
         alreadyImportedIds = budgetStore.walletFinancialIds(accountId: accountId)
     }
 
-    /// Bridge FinanceKit's transaction into the framework-free candidate the
-    /// mapper and store work with.
-    private static func candidate(from transaction: FinanceKit.Transaction) -> WalletImportCandidate? {
-        WalletImportMapper.candidate(
-            id: transaction.id,
-            amount: transaction.transactionAmount.amount,
-            isCredit: transaction.creditDebitIndicator == .credit,
-            merchantName: transaction.merchantName,
-            transactionDescription: transaction.transactionDescription,
-            status: Self.status(from: transaction.status),
-            date: transaction.transactionDate
-        )
-    }
-
-    private static func status(from status: FinanceKit.TransactionStatus) -> WalletImportMapper.Status {
-        switch status {
-        case .authorized: .authorized
-        case .memo: .memo
-        case .pending: .pending
-        case .booked: .booked
-        case .rejected: .rejected
-        @unknown default: .booked
-        }
-    }
 }
 
 #Preview {

--- a/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
@@ -97,6 +97,26 @@ struct AppleWalletSyncTests {
         Calendar.current.date(byAdding: .day, value: -days, to: Date())!
     }
 
+    @Test func latestBalanceSnapshotWins() throws {
+        let accountId = Self.cardId
+        let older = AppleWalletBalance(
+            accountId: accountId,
+            cents: -40000,
+            asOfDate: Date(timeIntervalSince1970: 1_000),
+            includesPending: false
+        )
+        let newer = AppleWalletBalance(
+            accountId: accountId,
+            cents: -50000,
+            asOfDate: Date(timeIntervalSince1970: 2_000),
+            includesPending: true
+        )
+
+        let latest = try #require(FinanceKitWalletStore.latestBalances([older, newer])[accountId])
+
+        #expect(latest == newer)
+    }
+
     @Test func downloadCoversOnlyAccountsTheWalletHas() async throws {
         let store = StubWalletStore(
             accountsValue: [AppleWalletAccount(
@@ -111,12 +131,43 @@ struct AppleWalletSyncTests {
             BankSyncTarget(externalId: "not-in-this-wallet", startDay: startDay)
         ])
 
-        // The unknown account is left out entirely, so the caller reports it.
+        // The unknown account is left out entirely for the caller to skip.
         #expect(set.byAccount.count == 1)
         let download = try #require(set.byAccount[Self.cardId])
         #expect(download.candidates.count == 1)
         #expect(download.currentBalanceCents == -50000)
         #expect(download.status == "ok")
+    }
+
+    @Test func bookedBalanceAddsPendingTransactionsButAvailableDoesNot() async throws {
+        let pending = transaction(amount: 12, status: .pending)
+        let bookedStore = StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.cardId,
+                name: "Apple Card",
+                institutionName: "Apple",
+                balanceCents: -50000,
+                balanceIncludesPending: false
+            )],
+            transactionsByAccount: [Self.cardId: [pending]]
+        )
+        let availableStore = StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.cardId,
+                name: "Apple Card",
+                institutionName: "Apple",
+                balanceCents: -51200,
+                balanceIncludesPending: true
+            )],
+            transactionsByAccount: [Self.cardId: [pending]]
+        )
+        let target = BankSyncTarget(externalId: Self.cardId, startDay: 0)
+
+        let booked = try await AppleWalletProvider(store: bookedStore).download([target])
+        let available = try await AppleWalletProvider(store: availableStore).download([target])
+
+        #expect(booked.byAccount[Self.cardId]?.currentBalanceCents == -51200)
+        #expect(available.byAccount[Self.cardId]?.currentBalanceCents == -51200)
     }
 
     /// The store hands over full history; the provider keeps only the sync

--- a/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
@@ -2,19 +2,6 @@ import Foundation
 import Testing
 @testable import Actuali
 
-private struct StubWalletStore: AppleWalletReading {
-    var availabilityValue: AppleWalletAvailability = .authorized
-    var accountsValue: [AppleWalletAccount] = []
-    var transactionsByAccount: [String: [AppleWalletTransaction]] = [:]
-
-    func availability() async -> AppleWalletAvailability { availabilityValue }
-    func requestAccess() async throws -> Bool { availabilityValue == .authorized }
-    func accounts() async throws -> [AppleWalletAccount] { accountsValue }
-    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
-        transactionsByAccount[accountId] ?? []
-    }
-}
-
 struct AppleWalletSyncTests {
 
     private func transaction(
@@ -68,7 +55,7 @@ struct AppleWalletSyncTests {
         let candidate = try #require(BankSyncCandidate(
             appleWallet: transaction(merchantName: "SQ *BLUE BOTTLE #123")
         ))
-        #expect(candidate.payeeName == "BLUE BOTTLE")
+        #expect(candidate.payeeName == "Blue Bottle")
     }
 
     @Test func aMissingMerchantFallsBackToTheDescription() throws {

--- a/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+private struct StubWalletStore: AppleWalletReading {
+    var availabilityValue: AppleWalletAvailability = .authorized
+    var accountsValue: [AppleWalletAccount] = []
+    var transactionsByAccount: [String: [AppleWalletTransaction]] = [:]
+
+    func availability() async -> AppleWalletAvailability { availabilityValue }
+    func requestAccess() async throws -> Bool { availabilityValue == .authorized }
+    func accounts() async throws -> [AppleWalletAccount] { accountsValue }
+    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+        transactionsByAccount[accountId] ?? []
+    }
+}
+
+struct AppleWalletSyncTests {
+
+    private func transaction(
+        id: String = "11111111-1111-1111-1111-111111111111",
+        amount: Decimal = Decimal(string: "33.45")!,
+        isCredit: Bool = false,
+        merchantName: String? = "Blue Bottle",
+        description: String = "BLUE BOTTLE COFFEE",
+        status: WalletImportMapper.Status = .booked,
+        date: Date = Date()
+    ) -> AppleWalletTransaction {
+        AppleWalletTransaction(
+            id: id, amount: amount, isCredit: isCredit, merchantName: merchantName,
+            description: description, status: status, date: date
+        )
+    }
+
+    // MARK: - Candidate mapping
+
+    @Test func aPurchaseBecomesABookedOutflow() throws {
+        let date = Date()
+        let candidate = try #require(BankSyncCandidate(appleWallet: transaction(date: date)))
+
+        #expect(candidate.importedId == "11111111-1111-1111-1111-111111111111")
+        #expect(candidate.amount == -3345)
+        #expect(candidate.date == Transaction.yyyymmdd(from: date))
+        #expect(candidate.payeeName == "Blue Bottle")
+        #expect(candidate.notes == "BLUE BOTTLE COFFEE")
+        #expect(candidate.cleared)
+    }
+
+    @Test func aCreditBecomesAnInflow() throws {
+        let candidate = try #require(BankSyncCandidate(appleWallet: transaction(isCredit: true)))
+        #expect(candidate.amount == 3345)
+    }
+
+    @Test func pendingAndAuthorizedImportUncleared() throws {
+        let pending = try #require(BankSyncCandidate(appleWallet: transaction(status: .pending)))
+        let authorized = try #require(BankSyncCandidate(appleWallet: transaction(status: .authorized)))
+        #expect(!pending.cleared)
+        #expect(!authorized.cleared)
+    }
+
+    @Test func aRejectedTransactionIsDropped() {
+        #expect(BankSyncCandidate(appleWallet: transaction(status: .rejected)) == nil)
+    }
+
+    /// Wallet merchant strings carry the same processor noise as the Tier-1
+    /// picker import; both must file "SQ *X #123" under the same payee.
+    @Test func merchantNoiseIsStrippedLikeThePickerImport() throws {
+        let candidate = try #require(BankSyncCandidate(
+            appleWallet: transaction(merchantName: "SQ *BLUE BOTTLE #123")
+        ))
+        #expect(candidate.payeeName == "BLUE BOTTLE")
+    }
+
+    @Test func aMissingMerchantFallsBackToTheDescription() throws {
+        let candidate = try #require(BankSyncCandidate(
+            appleWallet: transaction(merchantName: nil, description: "Corner Store")
+        ))
+        #expect(candidate.payeeName == "Corner Store")
+    }
+
+    /// Same escaping as every other bank-sync note, so a "#" in a Wallet
+    /// description doesn't silently become a tag.
+    @Test func notesEscapeHashes() throws {
+        let candidate = try #require(BankSyncCandidate(
+            appleWallet: transaction(description: "COFFEE #4")
+        ))
+        #expect(candidate.notes == "COFFEE ##4")
+    }
+
+    @Test func remoteAccountCarriesTheFinanceKitSource() {
+        let account = AppleWalletAccount(
+            id: "22222222-2222-2222-2222-222222222222",
+            name: "Apple Card",
+            institutionName: "Apple",
+            balanceCents: -50000
+        )
+        let remote = account.remoteAccount
+        #expect(remote.source == .financeKit)
+        #expect(remote.id == account.id)
+        #expect(remote.institutionId == "Apple")
+        #expect(remote.institutionName == "Apple")
+        #expect(remote.balanceCents == -50000)
+    }
+
+    // MARK: - Provider
+
+    private static let cardId = "22222222-2222-2222-2222-222222222222"
+
+    private func daysAgo(_ days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -days, to: Date())!
+    }
+
+    @Test func downloadCoversOnlyAccountsTheWalletHas() async throws {
+        let store = StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.cardId, name: "Apple Card", institutionName: "Apple", balanceCents: -50000
+            )],
+            transactionsByAccount: [Self.cardId: [transaction()]]
+        )
+        let startDay = Transaction.yyyymmdd(from: daysAgo(89))
+
+        let set = try await AppleWalletProvider(store: store).download([
+            BankSyncTarget(externalId: Self.cardId, startDay: startDay),
+            BankSyncTarget(externalId: "not-in-this-wallet", startDay: startDay)
+        ])
+
+        // The unknown account is left out entirely, so the caller reports it.
+        #expect(set.byAccount.count == 1)
+        let download = try #require(set.byAccount[Self.cardId])
+        #expect(download.candidates.count == 1)
+        #expect(download.currentBalanceCents == -50000)
+        #expect(download.status == "ok")
+    }
+
+    /// The store hands over full history; the provider keeps only the sync
+    /// window, the same way the SimpleFIN providers do.
+    @Test func downloadDropsTransactionsBeforeTheStartDay() async throws {
+        let store = StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.cardId, name: "Apple Card", institutionName: "Apple", balanceCents: nil
+            )],
+            transactionsByAccount: [Self.cardId: [
+                transaction(id: "11111111-1111-1111-1111-111111111111", date: daysAgo(2)),
+                transaction(id: "33333333-3333-3333-3333-333333333333", date: daysAgo(30))
+            ]]
+        )
+
+        let set = try await AppleWalletProvider(store: store).download([
+            BankSyncTarget(externalId: Self.cardId, startDay: Transaction.yyyymmdd(from: daysAgo(7)))
+        ])
+
+        let download = try #require(set.byAccount[Self.cardId])
+        #expect(download.candidates.map(\.importedId) == ["11111111-1111-1111-1111-111111111111"])
+    }
+}

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+/// A canned Wallet, standing in for FinanceKit off-device.
+private struct StubWalletStore: AppleWalletReading {
+    var availabilityValue: AppleWalletAvailability = .authorized
+    var accountsValue: [AppleWalletAccount] = []
+    var transactionsByAccount: [String: [AppleWalletTransaction]] = [:]
+
+    func availability() async -> AppleWalletAvailability { availabilityValue }
+    func requestAccess() async throws -> Bool { availabilityValue == .authorized }
+    func accounts() async throws -> [AppleWalletAccount] { accountsValue }
+    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+        transactionsByAccount[accountId] ?? []
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct BudgetStoreAppleWalletSyncTests {
+
+    private static let accountId = "acct-card"
+    /// FinanceKit account UUID, lowercased, the way linking stores it.
+    private static let externalAccountId = "22222222-2222-2222-2222-222222222222"
+
+    private static func daysAgo(_ days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -days, to: Date())!
+    }
+
+    private static func expectedDay(_ days: Int) -> Int {
+        Transaction.yyyymmdd(from: daysAgo(days))
+    }
+
+    /// An Apple Card with a booked purchase and a pending one, owing $500.
+    private func appleCard() -> StubWalletStore {
+        StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.externalAccountId, name: "Apple Card",
+                institutionName: "Apple", balanceCents: -50000
+            )],
+            transactionsByAccount: [Self.externalAccountId: [
+                AppleWalletTransaction(
+                    id: "11111111-1111-1111-1111-111111111111",
+                    amount: Decimal(string: "33.45")!, isCredit: false,
+                    merchantName: "Blue Bottle", description: "BLUE BOTTLE COFFEE",
+                    status: .booked, date: Self.daysAgo(5)
+                ),
+                AppleWalletTransaction(
+                    id: "33333333-3333-3333-3333-333333333333",
+                    amount: Decimal(string: "12.00")!, isCredit: false,
+                    merchantName: nil, description: "Corner Store",
+                    status: .pending, date: Self.daysAgo(1)
+                )
+            ]]
+        )
+    }
+
+    private func makeDatabase(linked: Bool = true) throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    type TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    closed INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    account_id TEXT,
+                    account_sync_source TEXT,
+                    bank TEXT,
+                    balance_current INTEGER,
+                    balance_available INTEGER,
+                    balance_limit INTEGER
+                )
+            """)
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    starting_balance_flag INTEGER DEFAULT 0,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    acct TEXT,
+                    category TEXT,
+                    amount INTEGER,
+                    description TEXT,
+                    notes TEXT,
+                    date INTEGER,
+                    imported_description TEXT,
+                    financial_id TEXT,
+                    transferred_id TEXT,
+                    schedule TEXT,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0,
+                    cleared INTEGER DEFAULT 0,
+                    reconciled INTEGER DEFAULT 0,
+                    parent_id TEXT
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE payees (
+                    id TEXT PRIMARY KEY, name TEXT, transfer_acct TEXT, tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: "CREATE TABLE payee_mapping (id TEXT PRIMARY KEY, targetId TEXT)")
+            try db.execute(sql: """
+                CREATE TABLE banks (
+                    id TEXT PRIMARY KEY, bank_id TEXT, name TEXT, tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                )
+                """)
+            if linked {
+                try db.execute(sql: """
+                    INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order,
+                                          account_id, account_sync_source)
+                    VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 1, ?, 'financeKit')
+                    """, arguments: [Self.accountId, Self.externalAccountId])
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
+                    VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 1)
+                    """, arguments: [Self.accountId])
+            }
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(
+        database: BudgetDatabase,
+        walletStore: any AppleWalletReading
+    ) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        store.setAppleWalletStoreForTesting(walletStore)
+        await store.loadBankSyncAccounts()
+        return store
+    }
+
+    private func rows(path: URL, where clause: String = "1=1") throws -> [Row] {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM transactions WHERE \(clause) ORDER BY date, amount")
+        }
+    }
+
+    /// Fetches a single row synchronously so the non-Sendable `Row` never
+    /// crosses an async boundary (see AGENTS.md on GRDB `Row` isolation).
+    private func row(path: URL, sql: String, arguments: StatementArguments = StatementArguments()) throws -> Row? {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Row.fetchOne(db, sql: sql, arguments: arguments)
+        }
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Tests
+
+    @Test func firstSyncImportsTransactionsAndACreditCardOpeningBalance() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        let result = try await store.syncBankAccounts()
+
+        // Two downloads plus the opening balance, which counts as an import
+        // too (upstream folds its id into `added`).
+        #expect(result.added == 3)
+        #expect(result.updated == 0)
+        #expect(result.accountsSynced == 1)
+        #expect(result.problems.isEmpty)
+
+        let imported = try rows(path: url, where: "financial_id IS NOT NULL")
+        #expect(imported.count == 2)
+        #expect(imported[0]["financial_id"] == "11111111-1111-1111-1111-111111111111")
+        #expect(imported[0]["amount"] == -3345)
+        #expect(imported[0]["date"] == Self.expectedDay(5))
+        #expect(imported[0]["cleared"] == 1)
+        #expect(imported[0]["imported_description"] == "Blue Bottle")
+        #expect(imported[0]["notes"] == "BLUE BOTTLE COFFEE")
+        // Pending transactions import uncleared, dated when they happened.
+        #expect(imported[1]["cleared"] == 0)
+        #expect(imported[1]["date"] == Self.expectedDay(1))
+        #expect(imported[1]["imported_description"] == "Corner Store")
+
+        // The card owes $500 now, so what it opened with is that less the
+        // imported history: -50000 - -4545.
+        let opening = try rows(path: url, where: "starting_balance_flag = 1")
+        #expect(opening.count == 1)
+        #expect(opening[0]["amount"] == -45455)
+
+        // The same status columns a SimpleFIN sync stamps for the web UI.
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
+        #expect(account["bank_sync_status"] == "ok")
+    }
+
+    @Test func syncingAgainImportsNothingTwice() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        let first = try await store.syncBankAccounts()
+        let second = try await store.syncBankAccounts()
+
+        #expect(first.added == 3)
+        #expect(second.added == 0)
+        #expect(second.updated == 0)
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+    }
+
+    @Test func linkingWritesTheColumnsTheWebUIReads() async throws {
+        let (database, url) = try makeDatabase(linked: false)
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        let remote = try #require(try await store.fetchAppleWalletAccounts().first)
+
+        try await store.linkBankAccount(accountId: Self.accountId, to: remote.remoteAccount)
+
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
+        #expect(account["account_id"] == Self.externalAccountId)
+        #expect(account["account_sync_source"] == "financeKit")
+        let bankRowId: String? = account["bank"]
+        #expect(bankRowId != nil)
+
+        let bank = try #require(
+            try row(path: url, sql: "SELECT * FROM banks WHERE id = ?", arguments: [bankRowId])
+        )
+        #expect(bank["bank_id"] == "Apple")
+        #expect(bank["name"] == "Apple")
+    }
+
+    /// A Wallet link made on another device (or before an iPad restore) can't
+    /// be serviced where FinanceKit has nothing — that's a quiet skip, not an
+    /// error on every sync.
+    @Test func anUnsupportedDeviceSkipsWalletAccountsQuietly() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        var wallet = appleCard()
+        wallet.availabilityValue = .unsupported
+        let store = try await makeStore(database: database, walletStore: wallet)
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result == BudgetStore.BankSyncResult())
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").isEmpty)
+    }
+
+    /// Access someone turned off is theirs to turn back on — say so.
+    @Test func deniedWalletAccessIsReported() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        var wallet = appleCard()
+        wallet.availabilityValue = .denied
+        let store = try await makeStore(database: database, walletStore: wallet)
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.accountsSynced == 0)
+        #expect(result.problems.count == 1)
+        #expect(result.problems[0].contains("Wallet access"))
+    }
+
+    @Test func anAccountThisWalletDoesntHaveIsReportedNotSilentlySkipped() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        var wallet = appleCard()
+        wallet.accountsValue = []
+        let store = try await makeStore(database: database, walletStore: wallet)
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.accountsSynced == 0)
+        #expect(result.problems.count == 1)
+        #expect(result.problems[0].contains("Apple Card"))
+        #expect(result.problems[0].contains("Wallet"))
+
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
+        )
+        #expect(account["bank_sync_status"] == "account-missing")
+    }
+}

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -3,20 +3,6 @@ import GRDB
 import Testing
 @testable import Actuali
 
-/// A canned Wallet, standing in for FinanceKit off-device.
-private struct StubWalletStore: AppleWalletReading {
-    var availabilityValue: AppleWalletAvailability = .authorized
-    var accountsValue: [AppleWalletAccount] = []
-    var transactionsByAccount: [String: [AppleWalletTransaction]] = [:]
-
-    func availability() async -> AppleWalletAvailability { availabilityValue }
-    func requestAccess() async throws -> Bool { availabilityValue == .authorized }
-    func accounts() async throws -> [AppleWalletAccount] { accountsValue }
-    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
-        transactionsByAccount[accountId] ?? []
-    }
-}
-
 @MainActor
 @Suite(.serialized)
 struct BudgetStoreAppleWalletSyncTests {
@@ -296,9 +282,13 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(result.problems[0].contains("Apple Card"))
         #expect(result.problems[0].contains("Wallet"))
 
+        // Missing-from-Wallet is this device's view, not the account's state:
+        // the same link can be serving fine on the device that made it, so no
+        // failure status may be stamped into the synced columns.
         let account = try #require(
             try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
         )
-        #expect(account["bank_sync_status"] == "account-missing")
+        let status: String? = account["bank_sync_status"]
+        #expect(status == nil)
     }
 }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -43,7 +43,7 @@ struct BudgetStoreAppleWalletSyncTests {
         )
     }
 
-    private func makeDatabase(linked: Bool = true) throws -> (BudgetDatabase, URL) {
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-\(UUID().uuidString).sqlite")
         let queue = try DatabaseQueue(path: tempURL.path)
@@ -109,32 +109,38 @@ struct BudgetStoreAppleWalletSyncTests {
                     value BLOB NOT NULL
                 )
                 """)
-            if linked {
-                try db.execute(sql: """
-                    INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order,
-                                          account_id, account_sync_source)
-                    VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 1, ?, 'financeKit')
-                    """, arguments: [Self.accountId, Self.externalAccountId])
-            } else {
-                try db.execute(sql: """
-                    INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
-                    VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 1)
-                    """, arguments: [Self.accountId])
-            }
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
+                VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 1)
+                """, arguments: [Self.accountId])
         }
         return (try BudgetDatabase(path: tempURL), tempURL)
     }
 
     private func makeStore(
         database: BudgetDatabase,
-        walletStore: any AppleWalletReading
+        walletStore: any AppleWalletReading,
+        linked: Bool = true
     ) async throws -> BudgetStore {
         let store = BudgetStore.previewInstance()
         let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
         store.configureForTesting(database: database, syncClient: syncClient)
+        let defaults = try #require(UserDefaults(suiteName: "BudgetStoreAppleWalletSyncTests"))
+        defaults.removePersistentDomain(forName: "BudgetStoreAppleWalletSyncTests")
+        store.configureAppleWalletLinksForTesting(defaults: defaults, budgetId: "wallet-tests")
         store.setAppleWalletStoreForTesting(walletStore)
-        await store.loadBankSyncAccounts()
+        if linked {
+            let remote = AppleWalletAccount(
+                id: Self.externalAccountId,
+                name: "Apple Card",
+                institutionName: "Apple",
+                balanceCents: nil
+            ).remoteAccount
+            try await store.linkBankAccount(accountId: Self.accountId, to: remote)
+        } else {
+            await store.loadBankSyncAccounts()
+        }
         return store
     }
 
@@ -187,11 +193,11 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(imported[1]["date"] == Self.expectedDay(1))
         #expect(imported[1]["imported_description"] == "Corner Store")
 
-        // The card owes $500 now, so what it opened with is that less the
-        // imported history: -50000 - -4545.
+        // The booked balance excludes the pending $12, so the current balance
+        // is -51200 and the opening balance is -51200 - -4545.
         let opening = try rows(path: url, where: "starting_balance_flag = 1")
         #expect(opening.count == 1)
-        #expect(opening[0]["amount"] == -45455)
+        #expect(opening[0]["amount"] == -46655)
 
         // The same status columns a SimpleFIN sync stamps for the web UI.
         let account = try #require(
@@ -214,10 +220,10 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
     }
 
-    @Test func linkingWritesTheColumnsTheWebUIReads() async throws {
-        let (database, url) = try makeDatabase(linked: false)
+    @Test func linkingStaysDeviceLocal() async throws {
+        let (database, url) = try makeDatabase()
         defer { cleanup(url) }
-        let store = try await makeStore(database: database, walletStore: appleCard())
+        let store = try await makeStore(database: database, walletStore: appleCard(), linked: false)
         let remote = try #require(try await store.fetchAppleWalletAccounts().first)
 
         try await store.linkBankAccount(accountId: Self.accountId, to: remote.remoteAccount)
@@ -225,21 +231,29 @@ struct BudgetStoreAppleWalletSyncTests {
         let account = try #require(
             try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
         )
-        #expect(account["account_id"] == Self.externalAccountId)
-        #expect(account["account_sync_source"] == "financeKit")
+        let externalId: String? = account["account_id"]
+        let source: String? = account["account_sync_source"]
         let bankRowId: String? = account["bank"]
-        #expect(bankRowId != nil)
-
-        let bank = try #require(
-            try row(path: url, sql: "SELECT * FROM banks WHERE id = ?", arguments: [bankRowId])
-        )
-        #expect(bank["bank_id"] == "Apple")
-        #expect(bank["name"] == "Apple")
+        #expect(externalId == nil)
+        #expect(source == nil)
+        #expect(bankRowId == nil)
+        #expect(store.bankSyncAccount(forAccountId: Self.accountId)?.source == .financeKit)
+        #expect(store.bankSyncAccount(forAccountId: Self.accountId)?.externalAccountId
+                == Self.externalAccountId)
     }
 
-    /// A Wallet link made on another device (or before an iPad restore) can't
-    /// be serviced where FinanceKit has nothing — that's a quiet skip, not an
-    /// error on every sync.
+    @Test func unlinkingRemovesTheDeviceLocalLink() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        try await store.unlinkBankAccount(accountId: Self.accountId)
+
+        #expect(store.bankSyncAccount(forAccountId: Self.accountId) == nil)
+    }
+
+    /// A device without FinanceKit can't service its local Wallet link. That
+    /// is a quiet skip, not an error on every sync.
     @Test func anUnsupportedDeviceSkipsWalletAccountsQuietly() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
@@ -268,7 +282,7 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(result.problems[0].contains("Wallet access"))
     }
 
-    @Test func anAccountThisWalletDoesntHaveIsReportedNotSilentlySkipped() async throws {
+    @Test func anAccountThisWalletDoesntHaveIsSkippedQuietly() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         var wallet = appleCard()
@@ -277,14 +291,10 @@ struct BudgetStoreAppleWalletSyncTests {
 
         let result = try await store.syncBankAccounts()
 
-        #expect(result.accountsSynced == 0)
-        #expect(result.problems.count == 1)
-        #expect(result.problems[0].contains("Apple Card"))
-        #expect(result.problems[0].contains("Wallet"))
+        #expect(result == BudgetStore.BankSyncResult())
 
-        // Missing-from-Wallet is this device's view, not the account's state:
-        // the same link can be serving fine on the device that made it, so no
-        // failure status may be stamped into the synced columns.
+        // Missing-from-Wallet is device-local state, so it must not stamp a
+        // failure into the budget's synced status columns.
         let account = try #require(
             try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
         )

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -100,6 +100,31 @@ struct BudgetStoreBankSyncTests {
         """
     }
 
+    private static let walletAccountId = "acct-wallet"
+    private static let walletExternalAccountId = "22222222-2222-2222-2222-222222222222"
+
+    private static func dateDaysAgo(_ days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: -days, to: Date())!
+    }
+
+    /// An Apple Card with one booked purchase, for the mixed-source tests.
+    private func appleCardStub() -> StubWalletStore {
+        StubWalletStore(
+            accountsValue: [AppleWalletAccount(
+                id: Self.walletExternalAccountId, name: "Apple Card",
+                institutionName: "Apple", balanceCents: -50000
+            )],
+            transactionsByAccount: [Self.walletExternalAccountId: [
+                AppleWalletTransaction(
+                    id: "11111111-1111-1111-1111-111111111111",
+                    amount: Decimal(string: "12.00")!, isCredit: false,
+                    merchantName: "Corner Store", description: "CORNER STORE",
+                    status: .booked, date: Self.dateDaysAgo(3)
+                )
+            ]]
+        )
+    }
+
     private func makeDatabase(seedTransactions: Bool = false) throws -> (BudgetDatabase, URL) {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-\(UUID().uuidString).sqlite")
@@ -181,7 +206,11 @@ struct BudgetStoreBankSyncTests {
         return (try BudgetDatabase(path: tempURL), tempURL)
     }
 
-    private func makeStore(database: BudgetDatabase, responseBody: String) async throws -> BudgetStore {
+    private func makeStore(
+        database: BudgetDatabase,
+        responseBody: String,
+        walletStore: (any AppleWalletReading)? = nil
+    ) async throws -> BudgetStore {
         let store = BudgetStore.previewInstance()
         let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
@@ -189,8 +218,26 @@ struct BudgetStoreBankSyncTests {
         store.setSimpleFINClientForTesting(
             SimpleFINClient(session: BridgeTransport.makeSession(body: responseBody))
         )
+        if let walletStore {
+            store.setAppleWalletStoreForTesting(walletStore)
+        }
         await store.loadBankSyncAccounts()
         return store
+    }
+
+    /// Adds a Wallet-linked account alongside the SimpleFIN one the fixture
+    /// always seeds, for the mixed-source tests.
+    private func seedWalletAccount(at url: URL) throws {
+        let queue = try DatabaseQueue(path: url.path)
+        let accountId = Self.walletAccountId
+        let externalId = Self.walletExternalAccountId
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order,
+                                      account_id, account_sync_source)
+                VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 2, ?, 'financeKit')
+                """, arguments: [accountId, externalId])
+        }
     }
 
     private func rows(path: URL, where clause: String = "1=1") throws -> [Row] {
@@ -669,5 +716,88 @@ struct BudgetStoreBankSyncTests {
         #expect(accounts[0].id == "sf-acct-1")
         #expect(accounts[0].org.bankId == "mybank.com")
         #expect(accounts[0].balanceCents == 10000)
+    }
+
+    // MARK: - Mixed sources (SimpleFIN + Apple Wallet)
+
+    @Test func mixedSourcesSyncInOneRun() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try seedWalletAccount(at: url)
+        let store = try await makeStore(
+            database: database,
+            responseBody: accountSet(transactions: """
+                {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+                """),
+            walletStore: appleCardStub()
+        )
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.accountsSynced == 2)
+        #expect(result.problems.isEmpty)
+        #expect(try rows(path: url, where: "financial_id = 'sf-1'").count == 1)
+        let walletRow = try rows(
+            path: url, where: "financial_id = '11111111-1111-1111-1111-111111111111'"
+        )
+        #expect(walletRow.count == 1)
+        #expect(walletRow[0]["acct"] == Self.walletAccountId)
+    }
+
+    /// A broken SimpleFIN setup is that source's problem: the Wallet half of
+    /// the run must still import, with the failure carried in the result.
+    @Test func aSimpleFINFailureDoesntBlockTheWalletImport() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try seedWalletAccount(at: url)
+        let store = try await makeStore(
+            database: database,
+            responseBody: accountSet(transactions: ""),
+            walletStore: appleCardStub()
+        )
+
+        // No device key and no reachable server: the SimpleFIN download can't
+        // even start. With only SimpleFIN linked this throws (see
+        // syncingWithoutAnAccessKeyIsRefused) — with Wallet in the run it
+        // must not.
+        let result = try await withoutStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.accountsSynced == 1)
+        #expect(!result.problems.isEmpty)
+        #expect(try rows(
+            path: url, where: "financial_id = '11111111-1111-1111-1111-111111111111'"
+        ).count == 1)
+    }
+
+    /// And the mirror image: a Wallet read blowing up must not cost the
+    /// SimpleFIN accounts their sync.
+    @Test func aWalletFailureDoesntBlockTheSimpleFINImport() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try seedWalletAccount(at: url)
+        var wallet = appleCardStub()
+        wallet.throwsOnAccounts = true
+        let store = try await makeStore(
+            database: database,
+            responseBody: accountSet(transactions: """
+                {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
+                """),
+            walletStore: wallet
+        )
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.accountsSynced == 1)
+        #expect(!result.problems.isEmpty)
+        #expect(try rows(path: url, where: "financial_id = 'sf-1'").count == 1)
+
+        // The Wallet failure is this device's, so the synced status columns
+        // stay untouched for that account.
+        let walletAccount = try #require(try row(
+            path: url, sql: "SELECT * FROM accounts WHERE id = ?",
+            arguments: [Self.walletAccountId]
+        ))
+        let status: String? = walletAccount["bank_sync_status"]
+        #expect(status == nil)
     }
 }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -215,6 +215,9 @@ struct BudgetStoreBankSyncTests {
         let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
         store.configureForTesting(database: database, syncClient: syncClient)
+        let defaults = try #require(UserDefaults(suiteName: "BudgetStoreBankSyncTests"))
+        defaults.removePersistentDomain(forName: "BudgetStoreBankSyncTests")
+        store.configureAppleWalletLinksForTesting(defaults: defaults, budgetId: "bank-sync-tests")
         store.setSimpleFINClientForTesting(
             SimpleFINClient(session: BridgeTransport.makeSession(body: responseBody))
         )
@@ -222,21 +225,27 @@ struct BudgetStoreBankSyncTests {
             store.setAppleWalletStoreForTesting(walletStore)
         }
         await store.loadBankSyncAccounts()
+        if walletStore != nil {
+            let remote = AppleWalletAccount(
+                id: Self.walletExternalAccountId,
+                name: "Apple Card",
+                institutionName: "Apple",
+                balanceCents: nil
+            ).remoteAccount
+            try await store.linkBankAccount(accountId: Self.walletAccountId, to: remote)
+        }
         return store
     }
 
-    /// Adds a Wallet-linked account alongside the SimpleFIN one the fixture
-    /// always seeds, for the mixed-source tests.
+    /// Adds the account that the mixed-source tests link to Wallet locally.
     private func seedWalletAccount(at url: URL) throws {
         let queue = try DatabaseQueue(path: url.path)
         let accountId = Self.walletAccountId
-        let externalId = Self.walletExternalAccountId
         try queue.write { db in
             try db.execute(sql: """
-                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order,
-                                      account_id, account_sync_source)
-                VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 2, ?, 'financeKit')
-                """, arguments: [accountId, externalId])
+                INSERT INTO accounts (id, name, type, offbudget, closed, tombstone, sort_order)
+                VALUES (?, 'Apple Card', 'credit', 0, 0, 0, 2)
+                """, arguments: [accountId])
         }
     }
 
@@ -799,5 +808,26 @@ struct BudgetStoreBankSyncTests {
         ))
         let status: String? = walletAccount["bank_sync_status"]
         #expect(status == nil)
+    }
+
+    @Test func aWalletFailureDoesntMisclassifyAMissingSimpleFINAccount() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try seedWalletAccount(at: url)
+        var wallet = appleCardStub()
+        wallet.throwsOnAccounts = true
+        let store = try await makeStore(
+            database: database,
+            responseBody: #"{"errors":[],"accounts":[]}"#,
+            walletStore: wallet
+        )
+
+        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+
+        #expect(result.problems.contains { $0.contains("SimpleFIN didn't return this account") })
+        let simpleFinAccount = try #require(try row(
+            path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId]
+        ))
+        #expect(simpleFinAccount["bank_sync_status"] == "account-missing")
     }
 }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -455,7 +455,7 @@ struct BudgetStoreBankSyncTests {
              "name": "Savings", "balance": "0.00"}
             """.utf8))
 
-        try await store.linkBankAccount(accountId: Self.accountId, to: remote)
+        try await store.linkBankAccount(accountId: Self.accountId, to: remote.remoteAccount)
 
         let account = try #require(
             try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])

--- a/Actuali/ActualiTests/Services/BankSync/StubWalletStore.swift
+++ b/Actuali/ActualiTests/Services/BankSync/StubWalletStore.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import Actuali
+
+/// A canned Wallet, standing in for FinanceKit off-device. Shared by the
+/// wallet-sync suites and the mixed-source tests in
+/// `BudgetStoreBankSyncTests`.
+struct StubWalletStore: AppleWalletReading {
+    struct ReadFailed: Error {}
+
+    var availabilityValue: AppleWalletAvailability = .authorized
+    var accountsValue: [AppleWalletAccount] = []
+    var transactionsByAccount: [String: [AppleWalletTransaction]] = [:]
+    /// When set, `accounts()` throws — a Wallet read gone wrong.
+    var throwsOnAccounts = false
+
+    func availability() async -> AppleWalletAvailability { availabilityValue }
+    func requestAccess() async throws -> Bool { availabilityValue == .authorized }
+    func accounts() async throws -> [AppleWalletAccount] {
+        if throwsOnAccounts { throw ReadFailed() }
+        return accountsValue
+    }
+    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+        transactionsByAccount[accountId] ?? []
+    }
+}

--- a/Actuali/ActualiTests/Services/WalletImport/WalletImportMapperTests.swift
+++ b/Actuali/ActualiTests/Services/WalletImport/WalletImportMapperTests.swift
@@ -62,6 +62,12 @@ struct WalletImportMapperTests {
         #expect(mapped.payeeName == "Joes Diner")
     }
 
+    @Test func whitespaceMerchantFallsBackToDescription() throws {
+        let mapped = try #require(candidate(
+            merchantName: "   ", transactionDescription: "JOES DINER"))
+        #expect(mapped.payeeName == "Joes Diner")
+    }
+
     @Test func bookedIsCleared() throws {
         let mapped = try #require(candidate(status: .booked))
         #expect(mapped.cleared)

--- a/Actuali/ActualiTests/Services/WalletImport/WalletImportMapperTests.swift
+++ b/Actuali/ActualiTests/Services/WalletImport/WalletImportMapperTests.swift
@@ -13,15 +13,15 @@ struct WalletImportMapperTests {
         status: WalletImportMapper.Status = .booked,
         date: Date = Date(timeIntervalSince1970: 1_750_000_000)
     ) -> WalletImportCandidate? {
-        WalletImportMapper.candidate(
-            id: id,
+        WalletImportMapper.candidate(from: AppleWalletTransaction(
+            id: id.uuidString,
             amount: amount,
             isCredit: isCredit,
             merchantName: merchantName,
-            transactionDescription: transactionDescription,
+            description: transactionDescription,
             status: status,
             date: date
-        )
+        ))
     }
 
     @Test func debitMapsToNegativeCents() throws {


### PR DESCRIPTION
## Why

Actual supports bank feeds, but Apple Card, Apple Cash and Savings live only in Wallet — until now the only way to get them in was the one-shot FinanceKit picker import (Tier 1). This adds the tracked Tier 2 from #55: link those accounts once and have them sync automatically, like any other bank connection.

## What

- New `financeKit` bank-sync source. Linking writes the same `accounts`/`banks` CRDT columns as SimpleFIN, so the web UI shows the account as linked and can unlink it (it can't download the data — that only exists in the device's Wallet).
- Bank Sync screen gains an **Apple Wallet** section: connect (Apple's consent sheet), list Wallet accounts with balances, tap to link — either to an existing budget account or a newly created one. The link sheet is now provider-neutral (`BankSyncRemoteAccount`).
- Syncing reuses the whole existing pipeline: reconciler matching, opening balance on first sync, payee resolution + rules, `bank_sync_status`/`last_sync` stamping. Pending charges import uncleared and clear when they post. Transaction UUIDs are stored lowercased as `financial_id`, matching the Tier-1 picker, so previously hand-picked transactions aren't duplicated.
- SimpleFIN and Wallet download independently per sync run — one source failing no longer blocks the other. Wallet links this device can't serve (linked on another device, no FinanceKit) skip quietly; denied Wallet access is reported once.
- Adds the `com.apple.developer.financekit` entitlement. It's Apple-managed (granted per app on request); simulator/CI builds are unaffected, but device builds need a provisioning profile carrying it before the feature works.

## How it was tested

- New unit tests: `AppleWalletSyncTests` (candidate mapping — signs, cleared/pending/rejected, merchant normalization, `#` note escaping, window filtering) and `BudgetStoreAppleWalletSyncTests` (link columns, first-sync import + credit-card opening balance, re-sync dedup, unsupported/denied/missing-account paths) against a stubbed `AppleWalletReading` store.
- Updated `BudgetStoreBankSyncTests` for the new `linkBankAccount` signature; the rest of the SimpleFIN suite is unchanged and still covers that path.
- **Not run locally**: this was written in an environment without Xcode, so I could not run `xcodebuild` — relying on CI's iOS 26 + iOS 18 legs for build + test verification.
- End-to-end FinanceKit behavior (consent sheet, real Wallet data) can only be verified on a physical iPhone with the granted entitlement — not yet done.

## Screenshots

<img width="301" alt="Screenshot iPhone 17 Pro 08-29-2026 at 9 18 45 AM" src="https://github.com/user-attachments/assets/10278827-52f0-44ff-82e4-547690188243" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-29-2026 at 9 18 53 AM" src="https://github.com/user-attachments/assets/e96e29ac-1cc4-4c00-a601-6080795a32e8" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-29-2026 at 9 19 01 AM" src="https://github.com/user-attachments/assets/59facc36-b677-4eda-a97e-ba5cea341e44" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-29-2026 at 9 19 08 AM" src="https://github.com/user-attachments/assets/4bc3e5ea-ed78-4d64-8a3f-83388de8b056" />


**The verbiage was created with assistance from AI to provide important detail and clearly define scope**