### PR TITLE
FinanceKit Updates

### DIFF
--- a/Actuali/Actuali/Services/BackgroundRefresh.swift
+++ b/Actuali/Actuali/Services/BackgroundRefresh.swift
@@ -109,12 +109,7 @@ enum BackgroundRefresh {
 
     @MainActor
     private static func defaultSync() async -> Bool {
-        let store = BudgetStore.shared
-        let synced = await store.syncInBackground()
-        if synced {
-            await store.notifyAboutSyncedTransactions()
-        }
-        return synced
+        await BudgetStore.shared.syncInBackground()
     }
 }
 

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -46,7 +46,7 @@ struct AppleWalletAccount: Identifiable, Sendable, Equatable {
 /// A FinanceKit balance reduced to what selecting the latest snapshot needs.
 struct AppleWalletBalance: Sendable, Equatable {
     let accountId: String
-    let cents: Int
+    let cents: Int?
     let asOfDate: Date
     let includesPending: Bool
 }

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -139,4 +139,13 @@ extension AppleWalletAccount {
             source: .financeKit
         )
     }
+
+    /// A credit card's *available* number is its remaining credit, not a
+    /// balance: what's owed is that less the limit — negative like any credit
+    /// card balance, positive when overpaid. With no known limit there's no
+    /// way to say what's owed; better no balance than the remaining credit
+    /// imported as one.
+    static func owedBalance(fromRemainingCredit remainingCents: Int, creditLimitCents: Int?) -> Int? {
+        creditLimitCents.map { remainingCents - $0 }
+    }
 }

--- a/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
+++ b/Actuali/Actuali/Services/BankSync/AppleWalletSync.swift
@@ -94,7 +94,10 @@ protocol AppleWalletReading: Sendable {
     /// Ask the person for read access. Returns whether it was granted.
     func requestAccess() async throws -> Bool
     func accounts() async throws -> [AppleWalletAccount]
-    func transactions(accountId: String) async throws -> [AppleWalletTransaction]
+    /// Transactions on or after `sinceDay` (`YYYYMMDD`). A store may return
+    /// more — the caller drops anything before the day — but shouldn't return
+    /// meaningfully less-bounded history than asked for.
+    func transactions(accountId: String, sinceDay: Int) async throws -> [AppleWalletTransaction]
 }
 
 /// Turns Wallet data into the same download shape the SimpleFIN providers
@@ -112,7 +115,9 @@ struct AppleWalletProvider: Sendable {
             guard let account = accounts.first(where: { $0.id == target.externalId })
             else { continue }
 
-            let transactions = try await store.transactions(accountId: target.externalId)
+            let transactions = try await store.transactions(
+                accountId: target.externalId, sinceDay: target.startDay
+            )
             let candidates = transactions
                 .compactMap(BankSyncCandidate.init(appleWallet:))
                 .filter { $0.date >= target.startDay }

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -29,9 +29,13 @@ struct FinanceKitWalletStore: AppleWalletReading {
     func accounts() async throws -> [AppleWalletAccount] {
         let accounts = try await FinanceStore.shared.accounts(query: AccountQuery())
         let balances = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery())
-        let balancesByAccount = Self.latestBalances(balances.compactMap(Self.balance(from:)))
         return accounts.map { account in
-            let balance = balancesByAccount[account.id.uuidString.lowercased()]
+            // Which of a snapshot's numbers is the balance depends on the
+            // account it belongs to, so snapshots are mapped per account.
+            let snapshots = balances
+                .filter { $0.accountID == account.id }
+                .compactMap { Self.balance(from: $0, for: account) }
+            let balance = Self.latestBalances(snapshots)[account.id.uuidString.lowercased()]
             return AppleWalletAccount(
                 id: account.id.uuidString,
                 name: account.displayName,
@@ -56,28 +60,57 @@ struct FinanceKitWalletStore: AppleWalletReading {
         return transactions.map(AppleWalletTransaction.init)
     }
 
-    /// Signed cents from a FinanceKit balance: credit is money there, debit is
-    /// money owed — which is how an Apple Card's balance comes out negative.
     static func latestBalances(_ balances: [AppleWalletBalance]) -> [String: AppleWalletBalance] {
         Dictionary(grouping: balances, by: \AppleWalletBalance.accountId)
             .compactMapValues { $0.max { $0.asOfDate < $1.asOfDate } }
     }
 
-    private static func balance(from accountBalance: AccountBalance) -> AppleWalletBalance? {
-        let selection: (balance: Balance, includesPending: Bool)? = switch accountBalance.currentBalance {
-        case .available(let available): (available, true)
-        case .booked(let booked): (booked, false)
-        case .availableAndBooked(let available, _): (available, true)
+    /// One snapshot's balance, picked per account kind. Booked is what's
+    /// there or owed; available includes pending — but on a credit card the
+    /// available number is the *remaining credit*, not a balance at all, so
+    /// there the booked number wins and an available-only snapshot has to be
+    /// resolved against the card's limit (Apple Card reports only that shape).
+    private static func balance(
+        from accountBalance: AccountBalance,
+        for account: FinanceKit.Account
+    ) -> AppleWalletBalance? {
+        let isLiability = account.liabilityAccount != nil
+        let selection: (balance: Balance, includesPending: Bool, isRemainingCredit: Bool)?
+        selection = switch accountBalance.currentBalance {
+        case .booked(let booked): (booked, false, false)
+        case .availableAndBooked(let available, let booked):
+            isLiability ? (booked, false, false) : (available, true, false)
+        case .available(let available): (available, true, isLiability)
         @unknown default: nil
         }
-        guard let (balance, includesPending) = selection else { return nil }
-        guard let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
+        guard let (balance, includesPending, isRemainingCredit) = selection,
+              let signed = signedCents(balance) else { return nil }
+
+        // Remaining credit moves the moment a charge authorizes, so a balance
+        // derived from it already includes pending.
+        let cents = isRemainingCredit
+            ? AppleWalletAccount.owedBalance(
+                fromRemainingCredit: signed,
+                creditLimitCents: account.liabilityAccount?.creditInformation.creditLimit
+                    .flatMap { WalletImportMapper.cents(from: $0.amount) }
+            )
+            : signed
+        guard let cents else { return nil }
+
         return AppleWalletBalance(
             accountId: accountBalance.accountID.uuidString.lowercased(),
-            cents: balance.creditDebitIndicator == .credit ? cents : -cents,
+            cents: cents,
             asOfDate: balance.asOfDate,
             includesPending: includesPending
         )
+    }
+
+    /// Signed cents from one FinanceKit balance: credit is money there, debit
+    /// is money owed — which is how an Apple Card's booked balance comes out
+    /// negative.
+    private static func signedCents(_ balance: Balance) -> Int? {
+        guard let cents = WalletImportMapper.cents(from: balance.amount.amount) else { return nil }
+        return balance.creditDebitIndicator == .credit ? cents : -cents
     }
 }
 

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -46,18 +46,28 @@ struct FinanceKitWalletStore: AppleWalletReading {
         }
     }
 
-    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+    func transactions(accountId: String, sinceDay: Int) async throws -> [AppleWalletTransaction] {
         guard let accountUUID = UUID(uuidString: accountId) else { return [] }
-        // ponytail: fetches the account's full history every sync and lets the
-        // caller drop what's outside the window. FinanceKit reads are local, so
-        // this holds up to years of Apple Card history; the upgrade path is a
-        // transactionDate bound in the predicate.
-        let transactions = try await FinanceStore.shared.transactions(
-            query: TransactionQuery(predicate: #Predicate<FinanceKit.Transaction> {
-                $0.accountID == accountUUID
-            })
-        )
-        return transactions.map(AppleWalletTransaction.init)
+        // Only the sync window: an Apple Card can carry years of history, and
+        // this read now runs on every foregrounding. The provider still drops
+        // anything the local-midnight boundary lets through early.
+        let start = Transaction.date(fromYYYYMMDD: sinceDay)
+        do {
+            return try await FinanceStore.shared.transactions(
+                query: TransactionQuery(predicate: #Predicate<FinanceKit.Transaction> {
+                    $0.accountID == accountUUID && $0.transactionDate >= start
+                })
+            ).map(AppleWalletTransaction.init)
+        } catch {
+            // If FinanceKit won't evaluate the date bound, full history still
+            // syncs correctly — it's only more work. A genuinely failing read
+            // fails here too, so nothing real is swallowed.
+            return try await FinanceStore.shared.transactions(
+                query: TransactionQuery(predicate: #Predicate<FinanceKit.Transaction> {
+                    $0.accountID == accountUUID
+                })
+            ).map(AppleWalletTransaction.init)
+        }
     }
 
     static func latestBalances(_ balances: [AppleWalletBalance]) -> [String: AppleWalletBalance] {

--- a/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
+++ b/Actuali/Actuali/Services/BankSync/FinanceKitWalletStore.swift
@@ -28,22 +28,35 @@ struct FinanceKitWalletStore: AppleWalletReading {
 
     func accounts() async throws -> [AppleWalletAccount] {
         let accounts = try await FinanceStore.shared.accounts(query: AccountQuery())
-        let balances = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery())
-        return accounts.map { account in
-            // Which of a snapshot's numbers is the balance depends on the
-            // account it belongs to, so snapshots are mapped per account.
-            let snapshots = balances
-                .filter { $0.accountID == account.id }
-                .compactMap { Self.balance(from: $0, for: account) }
-            let balance = Self.latestBalances(snapshots)[account.id.uuidString.lowercased()]
-            return AppleWalletAccount(
+        var result: [AppleWalletAccount] = []
+        for account in accounts {
+            let accountId = account.id
+            let available = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery(
+                sortDescriptors: [SortDescriptor(\AccountBalance.available?.asOfDate, order: .reverse)],
+                predicate: #Predicate<AccountBalance> {
+                    $0.accountID == accountId && $0.available != nil
+                },
+                limit: 1
+            ))
+            let booked = try await FinanceStore.shared.accountBalances(query: AccountBalanceQuery(
+                sortDescriptors: [SortDescriptor(\AccountBalance.booked?.asOfDate, order: .reverse)],
+                predicate: #Predicate<AccountBalance> {
+                    $0.accountID == accountId && $0.booked != nil
+                },
+                limit: 1
+            ))
+            let balance = Self.latestBalance((available + booked).compactMap {
+                Self.balance(from: $0, for: account)
+            })
+            result.append(AppleWalletAccount(
                 id: account.id.uuidString,
                 name: account.displayName,
                 institutionName: account.institutionName,
                 balanceCents: balance?.cents,
                 balanceIncludesPending: balance?.includesPending ?? false
-            )
+            ))
         }
+        return result
     }
 
     func transactions(accountId: String, sinceDay: Int) async throws -> [AppleWalletTransaction] {
@@ -70,9 +83,8 @@ struct FinanceKitWalletStore: AppleWalletReading {
         }
     }
 
-    static func latestBalances(_ balances: [AppleWalletBalance]) -> [String: AppleWalletBalance] {
-        Dictionary(grouping: balances, by: \AppleWalletBalance.accountId)
-            .compactMapValues { $0.max { $0.asOfDate < $1.asOfDate } }
+    static func latestBalance(_ balances: [AppleWalletBalance]) -> AppleWalletBalance? {
+        balances.max { $0.asOfDate < $1.asOfDate }
     }
 
     /// One snapshot's balance, picked per account kind. Booked is what's
@@ -93,19 +105,19 @@ struct FinanceKitWalletStore: AppleWalletReading {
         case .available(let available): (available, true, isLiability)
         @unknown default: nil
         }
-        guard let (balance, includesPending, isRemainingCredit) = selection,
-              let signed = signedCents(balance) else { return nil }
+        guard let (balance, includesPending, isRemainingCredit) = selection else { return nil }
 
         // Remaining credit moves the moment a charge authorizes, so a balance
         // derived from it already includes pending.
         let cents = isRemainingCredit
-            ? AppleWalletAccount.owedBalance(
-                fromRemainingCredit: signed,
+            ? signedCents(balance).flatMap {
+                AppleWalletAccount.owedBalance(
+                fromRemainingCredit: $0,
                 creditLimitCents: account.liabilityAccount?.creditInformation.creditLimit
                     .flatMap { WalletImportMapper.cents(from: $0.amount) }
-            )
-            : signed
-        guard let cents else { return nil }
+                )
+            }
+            : signedCents(balance)
 
         return AppleWalletBalance(
             accountId: accountBalance.accountID.uuidString.lowercased(),

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1793,11 +1793,6 @@ final class BudgetStore: ObservableObject {
         }
 
         isLoading = false
-
-        // A budget that just opened imports its Wallet feeds straight away.
-        // Launch is a foreground moment `syncOnForeground` usually races past
-        // while this load is still running, so it can't be left to that hook.
-        Task { await autoSyncAppleWalletAccounts() }
     }
 
     /// Seed `payeeLocationWritesEnabled` from the last cached answer for the
@@ -2663,33 +2658,22 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Import new Wallet transactions without a button press. Runs where a
-    /// refresh already happens — budget load, foregrounding, pull-to-refresh —
+    /// refresh already happens — foregrounding, pull-to-refresh, background —
     /// and only for FinanceKit accounts: their reads are local and free, while
     /// SimpleFIN downloads stay behind an explicit sync. Quiet on purpose: no
     /// summary alert for a sync nobody asked for, and a device that can't
     /// serve the feed skips; a manual sync still reports problems.
-    func autoSyncAppleWalletAccounts() async {
+    @discardableResult
+    func autoSyncAppleWalletAccounts() async -> [Transaction] {
         let walletIds = bankSyncAccounts
             .filter { $0.source == .financeKit && !$0.closed }
             .map(\.id)
-        guard !walletIds.isEmpty else { return }
-        guard await appleWalletStore.availability() == .authorized else { return }
+        guard !walletIds.isEmpty else { return [] }
+        guard await appleWalletStore.availability() == .authorized else { return [] }
         guard let result = try? await syncBankAccounts(accountIds: walletIds),
-              !result.importedTransactions.isEmpty else { return }
+              !result.importedTransactions.isEmpty else { return [] }
 
-        // The same summary notification a server sync posts — an import
-        // nobody triggered is exactly when a banner earns its place. The
-        // detector path can't see these rows (they're authored by this
-        // device), so they're handed over directly. Opt-in and permission
-        // are enforced inside the notifier.
-        let accountNames = accounts.reduce(into: [String: String]()) { $0[$1.id] = $1.name }
-        await NewTransactionNotifier.notify(
-            about: result.importedTransactions,
-            currencyCode: currencyCode,
-            narrowSymbol: useNarrowCurrencySymbol,
-            accountNames: accountNames,
-            offBudgetAccountIds: offBudgetAccountIds
-        )
+        return result.importedTransactions
     }
 
     func linkBankAccount(accountId: String, to remote: BankSyncRemoteAccount) async throws {
@@ -4352,9 +4336,9 @@ final class BudgetStore: ObservableObject {
             lastSyncTime = Date()
             logger.debug("sync() completed, refreshing data...")
             await refreshDataOnly()
-            await notifyAboutSyncedTransactions()
             // Pull-to-refresh doubles as the Wallet feed's refresh.
-            await autoSyncAppleWalletAccounts()
+            let walletTransactions = await autoSyncAppleWalletAccounts()
+            await notifyAboutSyncedTransactions(additional: walletTransactions)
         }
         await work.value
     }
@@ -4403,10 +4387,10 @@ final class BudgetStore: ObservableObject {
         // an occurrence another client already covered.
         if success { await postDueSchedulesIfNeeded() }
         await refreshDataOnly()
-        await notifyAboutSyncedTransactions()
         // Coming to the foreground is when Wallet has new purchases to hand
         // over, so the feeds import here without anyone pressing sync.
-        await autoSyncAppleWalletAccounts()
+        let walletTransactions = await autoSyncAppleWalletAccounts()
+        await notifyAboutSyncedTransactions(additional: walletTransactions)
     }
 
     /// Headless sync for background refresh. On a cold background launch the
@@ -4425,7 +4409,8 @@ final class BudgetStore: ObservableObject {
         await refreshDataOnly()
         // Wallet feeds import in the same background window, so a purchase
         // reaches the budget — and can notify — without the app being opened.
-        await autoSyncAppleWalletAccounts()
+        let walletTransactions = await autoSyncAppleWalletAccounts()
+        await notifyAboutSyncedTransactions(additional: walletTransactions)
         return true
     }
 
@@ -4437,14 +4422,18 @@ final class BudgetStore: ObservableObject {
         return (try? await database.fetchTransaction(id: id)) ?? nil
     }
 
-    /// Detect transactions that arrived via the sync just completed and post
-    /// the summary notification for them. Shared by the foreground and
+    /// Detect transactions that arrived via the sync just completed, combine
+    /// them with any locally imported Wallet rows, and post one summary
+    /// notification. Shared by the foreground and
     /// background sync paths so behavior is uniform: a foreground sync posts
     /// the same notification a background refresh would (NotificationRouter's
     /// willPresent shows it as a banner in-app) instead of silently consuming
     /// it. Opt-in and permission are enforced inside NewTransactionNotifier.
-    func notifyAboutSyncedTransactions() async {
-        let fresh = await detectNewTransactionsForNotification()
+    func notifyAboutSyncedTransactions(additional: [Transaction] = []) async {
+        await notifyAboutTransactions(await detectNewTransactionsForNotification() + additional)
+    }
+
+    private func notifyAboutTransactions(_ fresh: [Transaction]) async {
         // The sync that just ran refreshed the accounts cache, so names are
         // current even on a cold background launch.
         let accountNames = accounts.reduce(into: [String: String]()) {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2479,6 +2479,11 @@ final class BudgetStore: ObservableObject {
         var accountsSynced = 0
         var added = 0
         var updated = 0
+        /// The rows this run inserted (opening balances excluded), so the
+        /// automatic Wallet sync can post the new-transaction notification —
+        /// the detector behind `notifyAboutSyncedTransactions` only sees rows
+        /// authored by *other* devices, which imports made here are not.
+        var importedTransactions: [Transaction] = []
         /// Anything worth telling the person about: a bank connection that
         /// needs re-authenticating, an account SimpleFIN no longer knows.
         /// A run can succeed for some accounts and report problems for others.
@@ -2605,7 +2610,32 @@ final class BudgetStore: ObservableObject {
             bankSyncAccounts = []
             return
         }
-        let synced = (try? await database.fetchBankSyncAccounts()) ?? []
+        var synced = (try? await database.fetchBankSyncAccounts()) ?? []
+
+        // Early builds wrote financeKit links into the synced columns, where
+        // the ids mean nothing to any other device and today's unlink path
+        // can no longer reach them. Adopt each into the device-local store
+        // first, then clear the columns the way any unlink would. Idempotent:
+        // once cleared, there are no strays left to find.
+        let strays = synced.filter { $0.source == .financeKit }
+        if !strays.isEmpty, currentBudgetId != nil {
+            var links = appleWalletLinks
+            for stray in strays where links[stray.id] == nil {
+                links[stray.id] = stray.externalAccountId
+            }
+            appleWalletLinks = links
+            if let syncClient {
+                for stray in strays {
+                    try? await syncClient.unlinkAccount(accountId: stray.id)
+                }
+                synced = (try? await database.fetchBankSyncAccounts()) ?? []
+            } else {
+                // No sync client yet (restored budget): serve the link from
+                // the local store now, leave the columns for a later load.
+                synced.removeAll { $0.source == .financeKit }
+            }
+        }
+
         let walletLinks = appleWalletLinks
         guard !walletLinks.isEmpty else {
             bankSyncAccounts = synced
@@ -2644,7 +2674,22 @@ final class BudgetStore: ObservableObject {
             .map(\.id)
         guard !walletIds.isEmpty else { return }
         guard await appleWalletStore.availability() == .authorized else { return }
-        _ = try? await syncBankAccounts(accountIds: walletIds)
+        guard let result = try? await syncBankAccounts(accountIds: walletIds),
+              !result.importedTransactions.isEmpty else { return }
+
+        // The same summary notification a server sync posts — an import
+        // nobody triggered is exactly when a banner earns its place. The
+        // detector path can't see these rows (they're authored by this
+        // device), so they're handed over directly. Opt-in and permission
+        // are enforced inside the notifier.
+        let accountNames = accounts.reduce(into: [String: String]()) { $0[$1.id] = $1.name }
+        await NewTransactionNotifier.notify(
+            about: result.importedTransactions,
+            currencyCode: currencyCode,
+            narrowSymbol: useNarrowCurrencySymbol,
+            accountNames: accountNames,
+            offBudgetAccountIds: offBudgetAccountIds
+        )
     }
 
     func linkBankAccount(accountId: String, to remote: BankSyncRemoteAccount) async throws {
@@ -2816,6 +2861,7 @@ final class BudgetStore: ObservableObject {
                 )
                 result.added += outcome.added
                 result.updated += outcome.updated
+                result.importedTransactions += outcome.inserted
                 result.accountsSynced += 1
                 statuses.append((target.id, syncedAt, download.status))
             } catch {
@@ -2840,7 +2886,7 @@ final class BudgetStore: ObservableObject {
         into target: BankSyncAccount,
         isFirstSync: Bool,
         prepared: SyncClient.PreparedRules
-    ) async throws -> (added: Int, updated: Int) {
+    ) async throws -> (added: Int, updated: Int, inserted: [Transaction]) {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
 
         // The provider already dropped anything older than this account's own
@@ -2859,7 +2905,7 @@ final class BudgetStore: ObservableObject {
             ) ? 1 : 0
         }
         guard let earliest = candidates.map(\.date).min(),
-              let latest = candidates.map(\.date).max() else { return (added, 0) }
+              let latest = candidates.map(\.date).max() else { return (added, 0, []) }
 
         // Resolve payees by name without creating any: the payee pass compares
         // ids, and a name the budget doesn't have yet can't match anything.
@@ -2892,6 +2938,7 @@ final class BudgetStore: ObservableObject {
 
         // Oldest first: sort_order is stamped at insert, so inserting in date
         // order leaves the newest transaction at the top of the account.
+        var inserted: [Transaction] = []
         for candidate in plan.inserts.sorted(by: { $0.date < $1.date }) {
             let payeeId = try await resolvePayeeId(name: candidate.payeeName, editing: nil)
             let transaction = Transaction(
@@ -2915,9 +2962,10 @@ final class BudgetStore: ObservableObject {
                 financialId: candidate.importedId
             )
             try await syncClient.createTransaction(transaction, prepared: prepared)
+            inserted.append(transaction)
         }
 
-        return (added + plan.inserts.count, plan.updates.count)
+        return (added + plan.inserts.count, plan.updates.count, inserted)
     }
 
     /// Give a freshly linked account the opening balance its imported history
@@ -4375,6 +4423,9 @@ final class BudgetStore: ObservableObject {
         await client.automaticSync()
         lastSyncTime = Date()
         await refreshDataOnly()
+        // Wallet feeds import in the same background window, so a purchase
+        // reaches the budget — and can notify — without the app being opened.
+        await autoSyncAppleWalletAccounts()
         return true
     }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1723,6 +1723,11 @@ final class BudgetStore: ObservableObject {
             dataVersion += 1
             publishWidgetSnapshot()
 
+            // Linked feeds drive the sync buttons in the accounts UI. Without
+            // this, a fresh launch hides them until something else happens to
+            // refresh the data.
+            await loadBankSyncAccounts()
+
             // Get file metadata for groupId
             // Note: budgetId is the internal ID (from metadata.json), but remoteBudgets uses server fileId
             // So we need to load the local metadata to get the cloudFileId for lookup
@@ -1788,6 +1793,11 @@ final class BudgetStore: ObservableObject {
         }
 
         isLoading = false
+
+        // A budget that just opened imports its Wallet feeds straight away.
+        // Launch is a foreground moment `syncOnForeground` usually races past
+        // while this load is still running, so it can't be left to that hook.
+        Task { await autoSyncAppleWalletAccounts() }
     }
 
     /// Seed `payeeLocationWritesEnabled` from the last cached answer for the
@@ -2620,6 +2630,21 @@ final class BudgetStore: ObservableObject {
     /// The bank feed an account is wired up to, if any.
     func bankSyncAccount(forAccountId accountId: String) -> BankSyncAccount? {
         bankSyncAccounts.first { $0.id == accountId }
+    }
+
+    /// Import new Wallet transactions without a button press. Runs where a
+    /// refresh already happens — budget load, foregrounding, pull-to-refresh —
+    /// and only for FinanceKit accounts: their reads are local and free, while
+    /// SimpleFIN downloads stay behind an explicit sync. Quiet on purpose: no
+    /// summary alert for a sync nobody asked for, and a device that can't
+    /// serve the feed skips; a manual sync still reports problems.
+    func autoSyncAppleWalletAccounts() async {
+        let walletIds = bankSyncAccounts
+            .filter { $0.source == .financeKit && !$0.closed }
+            .map(\.id)
+        guard !walletIds.isEmpty else { return }
+        guard await appleWalletStore.availability() == .authorized else { return }
+        _ = try? await syncBankAccounts(accountIds: walletIds)
     }
 
     func linkBankAccount(accountId: String, to remote: BankSyncRemoteAccount) async throws {
@@ -4280,6 +4305,8 @@ final class BudgetStore: ObservableObject {
             logger.debug("sync() completed, refreshing data...")
             await refreshDataOnly()
             await notifyAboutSyncedTransactions()
+            // Pull-to-refresh doubles as the Wallet feed's refresh.
+            await autoSyncAppleWalletAccounts()
         }
         await work.value
     }
@@ -4329,6 +4356,9 @@ final class BudgetStore: ObservableObject {
         if success { await postDueSchedulesIfNeeded() }
         await refreshDataOnly()
         await notifyAboutSyncedTransactions()
+        // Coming to the foreground is when Wallet has new purchases to hand
+        // over, so the feeds import here without anyone pressing sync.
+        await autoSyncAppleWalletAccounts()
     }
 
     /// Headless sync for background refresh. On a cold background launch the

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -119,7 +119,7 @@ struct BankSyncSetupView: View {
         } footer: {
             switch budgetStore.appleWalletAvailability {
             case .authorized:
-                Text("Tap an account to link it. Apple Card, Apple Cash and Savings transactions are read from this device's Wallet every time you sync, and stored in your budget file like any other transaction.")
+                Text("Tap an account to link it. Apple Card, Apple Cash and Savings transactions import automatically when you open the app or pull to refresh — read from this device's Wallet and stored in your budget file like any other transaction.")
             case .denied:
                 Text("Allow Actuali to read Wallet data in Settings to sync Apple Card, Apple Cash and Savings.")
             default:

--- a/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
@@ -138,9 +138,29 @@ struct AppleWalletSyncTests {
             includesPending: true
         )
 
-        let latest = try #require(FinanceKitWalletStore.latestBalances([older, newer])[accountId])
+        let latest = try #require(FinanceKitWalletStore.latestBalance([older, newer]))
 
         #expect(latest == newer)
+    }
+
+    @Test func newestBalanceWithoutAnAmountDoesNotFallBackToAnOlderSnapshot() throws {
+        let older = AppleWalletBalance(
+            accountId: Self.cardId,
+            cents: -50000,
+            asOfDate: Date(timeIntervalSince1970: 1_000),
+            includesPending: false
+        )
+        let newer = AppleWalletBalance(
+            accountId: Self.cardId,
+            cents: nil,
+            asOfDate: Date(timeIntervalSince1970: 2_000),
+            includesPending: true
+        )
+
+        let latest = try #require(FinanceKitWalletStore.latestBalance([older, newer]))
+
+        #expect(latest == newer)
+        #expect(latest.cents == nil)
     }
 
     @Test func downloadCoversOnlyAccountsTheWalletHas() async throws {

--- a/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/AppleWalletSyncTests.swift
@@ -97,6 +97,32 @@ struct AppleWalletSyncTests {
         Calendar.current.date(byAdding: .day, value: -days, to: Date())!
     }
 
+    // MARK: - Apple Card remaining credit
+
+    /// Apple Card reports its balance as an available-only snapshot, and that
+    /// number is the *remaining credit*: with a $5,000 limit and $3,500 left
+    /// to spend, the card owes $1,500.
+    @Test func whatsOwedIsRemainingCreditLessTheLimit() {
+        #expect(AppleWalletAccount.owedBalance(
+            fromRemainingCredit: 350_000, creditLimitCents: 500_000
+        ) == -150_000)
+    }
+
+    /// An overpaid card has more to spend than its limit — a positive balance.
+    @Test func anOverpaidCardComesOutPositive() {
+        #expect(AppleWalletAccount.owedBalance(
+            fromRemainingCredit: 510_000, creditLimitCents: 500_000
+        ) == 10_000)
+    }
+
+    /// With no known limit there's no way to work out what's owed; no balance
+    /// beats importing the remaining credit as if it were one.
+    @Test func aCardWithoutAKnownLimitGetsNoBalance() {
+        #expect(AppleWalletAccount.owedBalance(
+            fromRemainingCredit: 350_000, creditLimitCents: nil
+        ) == nil)
+    }
+
     @Test func latestBalanceSnapshotWins() throws {
         let accountId = Self.cardId
         let older = AppleWalletBalance(

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -166,6 +166,34 @@ struct BudgetStoreAppleWalletSyncTests {
 
     // MARK: - Tests
 
+    /// Budget load, foregrounding and pull-to-refresh import Wallet feeds
+    /// without a button press — and without popping the sync summary alert.
+    @Test func autoSyncImportsQuietly() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        await store.autoSyncAppleWalletAccounts()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+        #expect(store.bankSyncSummary == nil)
+    }
+
+    /// A device that can't serve the feed skips the automatic pass entirely —
+    /// no import, and no alert nobody asked for.
+    @Test func autoSyncStaysQuietWhenWalletCantAnswer() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        var wallet = appleCard()
+        wallet.availabilityValue = .denied
+        let store = try await makeStore(database: database, walletStore: wallet)
+
+        await store.autoSyncAppleWalletAccounts()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").isEmpty)
+        #expect(store.bankSyncSummary == nil)
+    }
+
     @Test func firstSyncImportsTransactionsAndACreditCardOpeningBalance() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -179,6 +179,64 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(store.bankSyncSummary == nil)
     }
 
+    /// What a run inserts comes back on the result, so the automatic sync
+    /// can post the new-transaction notification — the detector path only
+    /// sees rows authored by other devices, which these are not. The opening
+    /// balance stays out; nobody needs a banner for it.
+    @Test func theResultCarriesInsertedRowsForNotification() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        let result = try await store.syncBankAccounts()
+        #expect(result.importedTransactions.count == 2)
+        #expect(result.importedTransactions.allSatisfy { $0.accountId == Self.accountId })
+
+        let second = try await store.syncBankAccounts()
+        #expect(second.importedTransactions.isEmpty)
+    }
+
+    /// Early builds wrote financeKit links into the synced columns. Loading
+    /// adopts them into the device-local store and clears the columns like an
+    /// unlink would — the link itself must survive the move.
+    @Test func strayColumnLinksMigrateToTheDeviceLocalStore() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let queue = try DatabaseQueue(path: url.path)
+        let accountId = Self.accountId
+        let externalId = Self.externalAccountId
+        try await queue.write { db in
+            try db.execute(sql: """
+                UPDATE accounts
+                SET account_id = ?, account_sync_source = 'financeKit', bank = 'bank-1'
+                WHERE id = ?
+                """, arguments: [externalId, accountId])
+        }
+        let store = try await makeStore(
+            database: database, walletStore: appleCard(), linked: false
+        )
+
+        // The link survives, served from the device-local store…
+        let link = try #require(store.bankSyncAccount(forAccountId: accountId))
+        #expect(link.source == .financeKit)
+        #expect(link.externalAccountId == externalId)
+
+        // …the synced columns are cleared the way any unlink clears them…
+        let account = try #require(
+            try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [accountId])
+        )
+        let source: String? = account["account_sync_source"]
+        let externalColumn: String? = account["account_id"]
+        let bank: String? = account["bank"]
+        #expect(source == nil)
+        #expect(externalColumn == nil)
+        #expect(bank == nil)
+
+        // …and the account still syncs.
+        let result = try await store.syncBankAccounts()
+        #expect(result.accountsSynced == 1)
+    }
+
     /// A device that can't serve the feed skips the automatic pass entirely —
     /// no import, and no alert nobody asked for.
     @Test func autoSyncStaysQuietWhenWalletCantAnswer() async throws {

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -179,6 +179,36 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(store.bankSyncSummary == nil)
     }
 
+    @Test func pullToRefreshImportsWalletTransactions() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        await store.sync()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+    }
+
+    @Test func foregroundSyncImportsWalletTransactions() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        await store.syncOnForeground()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+    }
+
+    @Test func backgroundSyncImportsWalletTransactions() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+
+        #expect(await store.syncInBackground())
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+    }
+
     /// What a run inserts comes back on the result, so the automatic sync
     /// can post the new-transaction notification — the detector path only
     /// sees rows authored by other devices, which these are not. The opening

--- a/Actuali/ActualiTests/Services/BankSync/StubWalletStore.swift
+++ b/Actuali/ActualiTests/Services/BankSync/StubWalletStore.swift
@@ -19,7 +19,9 @@ struct StubWalletStore: AppleWalletReading {
         if throwsOnAccounts { throw ReadFailed() }
         return accountsValue
     }
-    func transactions(accountId: String) async throws -> [AppleWalletTransaction] {
+    // sinceDay is deliberately ignored: the provider must hold its own window
+    // filter even when a store over-serves, which these tests exercise.
+    func transactions(accountId: String, sinceDay: Int) async throws -> [AppleWalletTransaction] {
         transactionsByAccount[accountId] ?? []
     }
 }


### PR DESCRIPTION
## Why

Device testing of the FinanceKit feed surfaced two bugs and a gap: Apple Card imported its *remaining credit* as its balance, there was no visible way to sync or import Wallet transactions after launching the app, and imports only ever happened while the app was open. Follow-up work rounds the feed out: background imports with notifications, migration for links written by early builds, and window-bounded FinanceKit reads.

## What

- **Apple Card balance fix** — FinanceKit's *available* balance is the actual money for asset accounts (Apple Cash, Savings) but the remaining credit for Apple Card, which reports only that shape. Balance snapshot selection is now per account kind: liability accounts take the booked number when present, and an available-only snapshot resolves to *available − credit limit* (negative like any card balance, positive when overpaid, pending-inclusive). With no known limit the card gets no balance rather than a wrong one, which also skips the opening-balance transaction.
- **Sync entry points actually appear** — `loadLocalBudget` never populated `bankSyncAccounts`, and both sync buttons are gated on it, so a fresh launch had no way to import until some later refresh. The initial load now loads linked feeds.
- **Automatic Wallet imports** — Wallet feeds import with no button press on budget load, app foregrounding, pull-to-refresh, and now background refresh (BGTaskScheduler), so a purchase reaches the budget without opening the app. FinanceKit reads are local and free; SimpleFIN stays behind its explicit sync button. The automatic pass is quiet — no summary alert — and background/auto imports post the same new-transaction notification a server sync does (the existing detector only sees rows authored by other devices, so the sync result now carries its inserted rows and hands them to the notifier directly; opt-in and permission stay enforced there).
- **Stray-link migration** — early builds wrote `financeKit` into the synced `account_sync_source` columns, where the ids mean nothing to other devices and the current unlink path can't reach them. Loading adopts any stray into the device-local link store and clears the columns like an unlink; idempotent, and the link keeps working through the move.
- **Windowed fetches** — FinanceKit transaction queries are bounded to the sync window instead of pulling full card history on every pass. If FinanceKit won't evaluate the date bound, the bridge falls back to the unbounded query (worst case is the old behavior, never a missed import), and the provider keeps its own window filter either way.

## How it was tested

- New unit tests: Apple Card remaining-credit derivation (owed / overpaid / unknown-limit), auto-sync importing quietly and skipping when Wallet can't answer, the sync result carrying inserted rows (empty on re-sync, opening balance excluded), and the stray-link migration round-trip (link survives, columns cleared, account still syncs).
- Existing Wallet and SimpleFIN suites updated for the windowed-fetch signature; the shared stub deliberately over-serves so the provider's own window filter stays exercised.
- **Not run locally** (no Xcode in the authoring environment) — relying on CI's iOS 26 + iOS 18 legs.
- Verified on device by the author: Apple Cash/Savings balances correct, Apple Card previously showed remaining credit (the bug this fixes). Still to confirm on device: the corrected card balance, background imports, and notification delivery — background timing is at iOS's discretion.

## Screenshots

None — behavior changes only render meaningfully on a physical iPhone with Wallet data and the FinanceKit entitlement.

**The verbiage was created with assistance from AI to provide important detail and clearly define scope**