### PR TITLE
Fix flaky CI tests

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1069,6 +1069,11 @@ final class BudgetStore: ObservableObject {
         simpleFINClient = client
     }
 
+    /// Test-only: avoid sharing the app's Keychain credential across parallel suites.
+    func setSimpleFINAccessKeyForTesting(_ accessKey: SimpleFINAccessKey?) {
+        simpleFINAccessKeyProvider = { accessKey }
+    }
+
     /// Test-only: swap in a stub Wallet store so the FinanceKit sync path can
     /// be exercised off-device (the real store only answers on entitled
     /// iPhones).
@@ -2402,6 +2407,7 @@ final class BudgetStore: ObservableObject {
     /// device. Only used when the server has no SimpleFIN of its own — see
     /// `makeBankSyncProvider`.
     private var simpleFINClient = SimpleFINClient()
+    private var simpleFINAccessKeyProvider = { SimpleFINCredentials.accessKey }
 
     /// Reads Wallet (FinanceKit) accounts and transactions. Only answers on
     /// iPhones with Wallet data and the FinanceKit entitlement; everywhere
@@ -2527,7 +2533,7 @@ final class BudgetStore: ObservableObject {
     /// needs a second setup token, and a link made here is one the server can
     /// actually service.
     private func makeBankSyncProvider() async throws -> any BankSyncProvider {
-        let deviceKey = SimpleFINCredentials.accessKey
+        let deviceKey = simpleFINAccessKeyProvider()
         do {
             // nil means the route isn't served here — an older server, or a
             // proxy that strips it. Not a failure, just not an option.

--- a/Actuali/Actuali/Services/DemoDataSeeder.swift
+++ b/Actuali/Actuali/Services/DemoDataSeeder.swift
@@ -14,7 +14,7 @@ enum DemoDataSeeder {
     /// Overwrites any existing demo budget. Does NOT connect to a server or
     /// start sync. `tracking` seeds a tracking (`reflect_budgets`) budget rather
     /// than the default envelope (`zero_budgets`) one.
-    static func seed(tracking: Bool = false) throws {
+    static func seed(tracking: Bool = false, now: Date = Date()) throws {
         let fileManager = BudgetFileManager.shared
         let budgetDir = fileManager.budgetDirectory(for: budgetId)
 
@@ -43,7 +43,7 @@ enum DemoDataSeeder {
 
         try dbQueue.write { db in
             try createSchema(db, tracking: tracking)
-            try insertSeedData(db, tracking: tracking)
+            try insertSeedData(db, tracking: tracking, now: now)
         }
 
         logger.info("Demo data seeded successfully at \(dbPath.path, privacy: .public)")
@@ -233,9 +233,8 @@ enum DemoDataSeeder {
 
     // MARK: - Seed Data
 
-    private static func insertSeedData(_ db: Database, tracking: Bool) throws {
+    private static func insertSeedData(_ db: Database, tracking: Bool, now: Date) throws {
         let cal = Calendar(identifier: .gregorian)
-        let now = Date()
         let comps = cal.dateComponents([.year, .month, .day], from: now)
         let year = comps.year ?? 2026
         let month = comps.month ?? 1
@@ -438,6 +437,8 @@ enum DemoDataSeeder {
             // Off-budget: monthly brokerage contribution
             (vanguardPayeeId, nil, vanguardId, 2, 50_000),
         ]
+        let pendingDayByAccount = Dictionary(grouping: monthly.filter { $0.day <= today }, by: \.account)
+            .mapValues { $0.map(\.day).max() ?? 1 }
 
         for monthsAgo in stride(from: historyMonths, through: 0, by: -1) {
             // Deterministic per-month wiggle so months aren't identical.
@@ -454,8 +455,8 @@ enum DemoDataSeeder {
                 } else {
                     varied = item.amount
                 }
-                // Older transactions are reconciled/cleared; the newest are still pending.
-                let cleared = !(monthsAgo == 0 && item.day > max(today - 3, 0))
+                // Older transactions are cleared; each account's newest are still pending.
+                let cleared = monthsAgo != 0 || item.day < pendingDayByAccount[item.account, default: item.day]
                 transactions.append((item.payee, item.category, varied,
                                      ymd(monthsAgo: monthsAgo, day: item.day),
                                      item.account, cleared, false))

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -209,7 +209,8 @@ struct BudgetStoreBankSyncTests {
     private func makeStore(
         database: BudgetDatabase,
         responseBody: String,
-        walletStore: (any AppleWalletReading)? = nil
+        walletStore: (any AppleWalletReading)? = nil,
+        hasAccessKey: Bool = true
     ) async throws -> BudgetStore {
         let store = BudgetStore.previewInstance()
         let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
@@ -221,6 +222,9 @@ struct BudgetStoreBankSyncTests {
         store.setSimpleFINClientForTesting(
             SimpleFINClient(session: BridgeTransport.makeSession(body: responseBody))
         )
+        store.setSimpleFINAccessKeyForTesting(hasAccessKey
+            ? try SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
+            : nil)
         if let walletStore {
             store.setAppleWalletStoreForTesting(walletStore)
         }
@@ -265,34 +269,6 @@ struct BudgetStoreBankSyncTests {
         }
     }
 
-    private func withStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
-        // Put back whatever the app container's Keychain held before, so a key
-        // someone genuinely configured in this simulator survives a test run.
-        let previous = SimpleFINCredentials.accessKey
-        try SimpleFINCredentials.save(
-            SimpleFINAccessKey.parse("https://demo:demo@bridge.example.com/simplefin")
-        )
-        defer {
-            if let previous {
-                try? SimpleFINCredentials.save(previous)
-            } else {
-                try? SimpleFINCredentials.clear()
-            }
-        }
-        return try await body()
-    }
-
-    /// The inverse: run with no key stored, putting back whatever was there.
-    @discardableResult
-    private func withoutStoredAccessKey<T>(_ body: () async throws -> T) async throws -> T {
-        let previous = SimpleFINCredentials.accessKey
-        try? SimpleFINCredentials.clear()
-        defer {
-            if let previous { try? SimpleFINCredentials.save(previous) }
-        }
-        return try await body()
-    }
-
     private func cleanup(_ url: URL) {
         try? FileManager.default.removeItem(at: url)
     }
@@ -321,9 +297,7 @@ struct BudgetStoreBankSyncTests {
              "amount": "-12.00", "description": "Corner Store"}
             """))
 
-        let result = try await withStoredAccessKey {
-            try await store.syncBankAccounts()
-        }
+        let result = try await store.syncBankAccounts()
 
         // Two downloads plus the opening balance, which counts as an import
         // too (upstream folds its id into `added`).
@@ -363,8 +337,8 @@ struct BudgetStoreBankSyncTests {
             """)
         let store = try await makeStore(database: database, responseBody: body)
 
-        let first = try await withStoredAccessKey { try await store.syncBankAccounts() }
-        let second = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let first = try await store.syncBankAccounts()
+        let second = try await store.syncBankAccounts()
 
         #expect(first.added == 2)  // the download and the opening balance
         #expect(second.added == 0)
@@ -381,7 +355,7 @@ struct BudgetStoreBankSyncTests {
             {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
             """))
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.added == 0)
         #expect(result.updated == 1)
@@ -420,7 +394,7 @@ struct BudgetStoreBankSyncTests {
             {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "BLUE BOTTLE"}
             """))
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.added == 0)
         #expect(result.updated == 1)
@@ -436,7 +410,7 @@ struct BudgetStoreBankSyncTests {
             {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
             """))
 
-        _ = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        _ = try await store.syncBankAccounts()
 
         let queue = try DatabaseQueue(path: url.path)
         let financialIdMessages = try await queue.read { db in
@@ -453,10 +427,9 @@ struct BudgetStoreBankSyncTests {
         defer { cleanup(url) }
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: ""))
 
-        try await withoutStoredAccessKey {
-            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-                _ = try await store.syncBankAccounts()
-            }
+        store.setSimpleFINAccessKeyForTesting(nil)
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
         }
     }
 
@@ -467,7 +440,7 @@ struct BudgetStoreBankSyncTests {
             database: database, responseBody: #"{"errors": [], "accounts": []}"#
         )
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.accountsSynced == 0)
         #expect(result.problems.count == 1)
@@ -486,7 +459,7 @@ struct BudgetStoreBankSyncTests {
         """
         let store = try await makeStore(database: database, responseBody: body)
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         // The bridge's errors aren't keyed by account, so they're paired up by
         // the institution they name — which is what lets the account carry the
@@ -560,7 +533,7 @@ struct BudgetStoreBankSyncTests {
             {"id": "sf-1", "posted": \(Self.daysAgo(5)), "amount": "-33.45", "payee": "Blue Bottle"}
             """))
 
-        _ = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        _ = try await store.syncBankAccounts()
 
         let account = try #require(
             try row(path: url, sql: "SELECT * FROM accounts WHERE id = ?", arguments: [Self.accountId])
@@ -583,6 +556,7 @@ struct BudgetStoreBankSyncTests {
         bodies: [String: String]
     ) async throws -> BudgetStore {
         let store = BudgetStore.previewInstance()
+        store.setSimpleFINAccessKeyForTesting(nil)
         let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
         store.configureForTesting(database: database, syncClient: syncClient)
@@ -641,10 +615,8 @@ struct BudgetStoreBankSyncTests {
             "/simplefin/status": #"{"status":"ok","data":{"configured":false}}"#
         ])
 
-        try await withoutStoredAccessKey {
-            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-                _ = try await store.syncBankAccounts()
-            }
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
         }
         #expect(!store.serverProvidesBankSync)
     }
@@ -656,10 +628,8 @@ struct BudgetStoreBankSyncTests {
         defer { cleanup(url) }
         let store = try await makeServerStore(database: database, bodies: [:])
 
-        try await withoutStoredAccessKey {
-            await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
-                _ = try await store.syncBankAccounts()
-            }
+        await #expect(throws: BudgetStoreError.bankSyncNotConfigured) {
+            _ = try await store.syncBankAccounts()
         }
     }
 
@@ -741,7 +711,7 @@ struct BudgetStoreBankSyncTests {
             walletStore: appleCardStub()
         )
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.accountsSynced == 2)
         #expect(result.problems.isEmpty)
@@ -762,14 +732,15 @@ struct BudgetStoreBankSyncTests {
         let store = try await makeStore(
             database: database,
             responseBody: accountSet(transactions: ""),
-            walletStore: appleCardStub()
+            walletStore: appleCardStub(),
+            hasAccessKey: false
         )
 
         // No device key and no reachable server: the SimpleFIN download can't
         // even start. With only SimpleFIN linked this throws (see
         // syncingWithoutAnAccessKeyIsRefused) — with Wallet in the run it
         // must not.
-        let result = try await withoutStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.accountsSynced == 1)
         #expect(!result.problems.isEmpty)
@@ -794,7 +765,7 @@ struct BudgetStoreBankSyncTests {
             walletStore: wallet
         )
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.accountsSynced == 1)
         #expect(!result.problems.isEmpty)
@@ -822,7 +793,7 @@ struct BudgetStoreBankSyncTests {
             walletStore: wallet
         )
 
-        let result = try await withStoredAccessKey { try await store.syncBankAccounts() }
+        let result = try await store.syncBankAccounts()
 
         #expect(result.problems.contains { $0.contains("SimpleFIN didn't return this account") })
         let simpleFinAccount = try #require(try row(

--- a/Actuali/ActualiTests/Services/DemoDataSeederTests.swift
+++ b/Actuali/ActualiTests/Services/DemoDataSeederTests.swift
@@ -11,8 +11,8 @@ import Testing
 @MainActor
 struct DemoDataSeederTests {
 
-    private func seedAndOpen(tracking: Bool = false) throws -> BudgetDatabase {
-        try DemoDataSeeder.seed(tracking: tracking)
+    private func seedAndOpen(tracking: Bool = false, now: Date = Date()) throws -> BudgetDatabase {
+        try DemoDataSeeder.seed(tracking: tracking, now: now)
         let dbPath = BudgetFileManager.shared.databasePath(for: DemoDataSeeder.budgetId)
         return try BudgetDatabase(path: dbPath)
     }
@@ -44,6 +44,18 @@ struct DemoDataSeederTests {
         let month = try await database.fetchBudgetMonth(month: currentMonth)
 
         #expect(month.toBudget != nil)
+    }
+
+    @Test func newestCheckingTransactionsStayUnclearedAtMonthEnd() async throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let august31 = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 31, hour: 12)))
+        let database = try seedAndOpen(now: august31)
+        let checking = try #require(try await database.fetchAccounts().first { $0.name == "Chase Checking" })
+        let newest = try #require(try await database.fetchTransactions()
+            .filter { $0.accountId == checking.id }
+            .max { $0.date < $1.date })
+
+        #expect(!newest.cleared)
     }
 
     // Two pages so the demo exercises the dashboard switcher (GH #120);

--- a/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
+++ b/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
@@ -83,7 +83,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
 
         app.tabBars.buttons["Budget"].tap()
         let headerWithTotals = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH 'Essentials, expanded, spent '")
+            NSPredicate(format: "label BEGINSWITH 'Essentials, expanded, budgeted '")
         ).firstMatch
         XCTAssertTrue(
             headerWithTotals.waitForExistence(timeout: 10),


### PR DESCRIPTION
Fixes CI failures by:
- keeping each demo account’s newest transactions uncleared at month end
- matching the group header’s current accessibility label
- isolating SimpleFIN access keys per BudgetStore test so parallel logout tests cannot clear them

Tested:
- full iOS 26 unit suite: 1,482 tests
- bank sync and logout race stress run: 175 tests across five iterations
- affected Budget View Settings and Reconciliation UI tests