### PR TITLE
Financekit Updates

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2443,6 +2443,41 @@ final class BudgetStore: ObservableObject {
         "appleWalletLinks_\(budgetId)"
     }
 
+    // MARK: - Import start day
+
+    /// The setting shares the wallet links' defaults store — both are
+    /// per-budget, device-local state that must not reach the synced file.
+    private func bankSyncImportStartKey(for budgetId: String) -> String {
+        "bankSyncImportStart_\(budgetId)"
+    }
+
+    /// The person's chosen import start day (`YYYYMMDD`), or nil to follow
+    /// the default.
+    private var storedBankSyncImportStartDay: Int? {
+        guard let budgetId = currentBudgetId else { return nil }
+        return appleWalletLinkDefaults
+            .object(forKey: bankSyncImportStartKey(for: budgetId)) as? Int
+    }
+
+    func setBankSyncImportStartDay(_ day: Int?) {
+        guard let budgetId = currentBudgetId else { return }
+        let key = bankSyncImportStartKey(for: budgetId)
+        if let day {
+            appleWalletLinkDefaults.set(day, forKey: key)
+        } else {
+            appleWalletLinkDefaults.removeObject(forKey: key)
+        }
+    }
+
+    /// The day imports reach back to for an account with no history of its
+    /// own: the person's chosen day, else the day the budget file began, else
+    /// the 90-day lookback several bank integrations won't serve more than.
+    func resolvedBankSyncImportStartDay() async -> Int {
+        if let chosen = storedBankSyncImportStartDay { return chosen }
+        if let began = try? await database?.earliestMessageDay(), let began { return began }
+        return DayDate.today().adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
+    }
+
     private var appleWalletLinks: [String: String] {
         get {
             guard let budgetId = currentBudgetId else { return [:] }
@@ -2484,9 +2519,10 @@ final class BudgetStore: ObservableObject {
         try await appleWalletStore.accounts()
     }
 
-    /// How far back a sync reaches when an account has nothing to anchor to.
-    /// 89 days ago through today inclusive is 90 days, the window upstream
-    /// settled on because several bank integrations won't serve more.
+    /// The last-resort import lookback, when no day was chosen and the budget
+    /// has no messages to date it by. 89 days ago through today inclusive is
+    /// 90 days, the window upstream settled on because several bank
+    /// integrations won't serve more.
     private static let bankSyncMaxLookbackDays = 89
 
     /// What one run of `syncBankAccounts` did.
@@ -2586,13 +2622,15 @@ final class BudgetStore: ObservableObject {
 
     /// Run a sync and leave its outcome in `bankSyncSummary`. The button-shaped
     /// entry point — `syncBankAccounts` is the one that throws.
-    func runBankSync(accountIds: [String] = []) async {
+    func runBankSync(accountIds: [String] = [], fromImportStart: Bool = false) async {
         // A tap that lands while a sync is already running does nothing — the
         // running sync posts its own summary, which would otherwise be
         // clobbered by this call's empty one.
         guard !isBankSyncing else { return }
         do {
-            bankSyncSummary = try await syncBankAccounts(accountIds: accountIds).summary
+            bankSyncSummary = try await syncBankAccounts(
+                accountIds: accountIds, fromImportStart: fromImportStart
+            ).summary
         } catch {
             bankSyncSummary = error.localizedDescription
         }
@@ -2733,10 +2771,14 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Download and import transactions for the linked accounts.
-    /// - Parameter accountIds: which accounts to sync; empty syncs every
-    ///   linked one, which is what the accounts tab's sync button does.
+    /// - Parameters:
+    ///   - accountIds: which accounts to sync; empty syncs every linked one,
+    ///     which is what the accounts tab's sync button does.
+    ///   - fromImportStart: reach the chosen import start day even for
+    ///     accounts that already have history — the backfill run after the
+    ///     settings day moves earlier.
     @discardableResult
-    func syncBankAccounts(accountIds: [String] = []) async throws -> BankSyncResult {
+    func syncBankAccounts(accountIds: [String] = [], fromImportStart: Bool = false) async throws -> BankSyncResult {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
         // A second run on top of the first would re-download the same window
         // and race the first one's writes.
@@ -2776,21 +2818,29 @@ final class BudgetStore: ObservableObject {
         let targets = simpleFinTargets + walletTargets
         guard !targets.isEmpty else { return result }
 
-        // An account that already has history only needs the window since its
-        // earliest transaction; one that has none takes the full lookback.
+        // Three windows. A first import (no history) starts where the person
+        // chose — by default, the day the budget file began. A backfill run
+        // (the settings screen, after the day moves earlier) reaches the
+        // chosen day regardless of history; dedup keeps the overlap safe.
+        // Ongoing syncs only need the stretch since the account's earliest
+        // transaction, still capped at the rolling 90-day floor — history
+        // already covers everything older, so re-scanning it buys nothing.
+        let importStart = await resolvedBankSyncImportStartDay()
         let lookbackFloor = DayDate.today()
             .adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
         var oldestDates: [String: Int] = [:]
         for target in targets {
             // Both "the read failed" and "the account has no transactions"
-            // mean the same thing here: take the full lookback.
+            // mean the same thing here: start at the chosen day.
             oldestDates[target.id] = (try? await database.oldestTransactionDate(accountId: target.id)) ?? nil
         }
         func downloadTargets(_ accounts: [BankSyncAccount]) -> [BankSyncTarget] {
             accounts.map {
                 BankSyncTarget(
                     externalId: $0.externalAccountId,
-                    startDay: max(lookbackFloor, oldestDates[$0.id] ?? lookbackFloor)
+                    startDay: fromImportStart
+                        ? importStart
+                        : oldestDates[$0.id].map { max(lookbackFloor, $0) } ?? importStart
                 )
             }
         }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2459,40 +2459,9 @@ final class BudgetStore: ObservableObject {
             .object(forKey: bankSyncImportStartKey(for: budgetId)) as? Int
     }
 
-    /// A day the linked accounts owe a reach back to, but haven't made yet.
-    ///
-    /// Held in defaults rather than in memory because the run that would
-    /// honour it can not happen: `runBankSync` drops a request while another
-    /// sync is in flight, the download can fail, and the app can be killed
-    /// mid-import. The chosen day is persisted either way, and the ongoing
-    /// window never reaches below an account's existing history — so without
-    /// this the setting would be quietly unreachable. Any later sync clears
-    /// the debt.
-    private var pendingBankSyncBackfillDay: Int? {
-        get {
-            guard let budgetId = currentBudgetId else { return nil }
-            return appleWalletLinkDefaults
-                .object(forKey: "bankSyncBackfill_\(budgetId)") as? Int
-        }
-        set {
-            guard let budgetId = currentBudgetId else { return }
-            let key = "bankSyncBackfill_\(budgetId)"
-            if let newValue {
-                appleWalletLinkDefaults.set(newValue, forKey: key)
-            } else {
-                appleWalletLinkDefaults.removeObject(forKey: key)
-            }
-        }
-    }
-
-    func setBankSyncImportStartDay(_ day: Int) async {
+    func setBankSyncImportStartDay(_ day: Int) {
         guard let budgetId = currentBudgetId else { return }
-        let previous = await resolvedBankSyncImportStartDay()
         appleWalletLinkDefaults.set(day, forKey: bankSyncImportStartKey(for: budgetId))
-        // Only reaching further back is work: moving the day later imports
-        // nothing new (and removes nothing either).
-        guard day < previous else { return }
-        pendingBankSyncBackfillDay = min(day, pendingBankSyncBackfillDay ?? day)
     }
 
     /// The day imports reach back to for an account with no history of its
@@ -2839,14 +2808,14 @@ final class BudgetStore: ObservableObject {
         guard !targets.isEmpty else { return result }
 
         // Three windows. A first import (no history) starts where the person
-        // chose — by default, the day the budget file began. A run carrying an
-        // unhonoured backfill reaches that day regardless of history; dedup
-        // keeps the overlap safe. Ongoing syncs only need the stretch since
-        // the account's earliest transaction, still capped at the rolling
-        // 90-day floor — history already covers everything older, so
-        // re-scanning it buys nothing.
+        // chose — by default, the day the budget file began. An account whose
+        // history doesn't reach that day yet asks for it again every run until
+        // it does; dedup keeps the overlap safe, and deriving the reach this
+        // way means no run has to be the one that lands it. Ongoing syncs only
+        // need the stretch since the account's earliest transaction, still
+        // capped at the rolling 90-day floor — history already covers
+        // everything older, so re-scanning it buys nothing.
         let importStart = await resolvedBankSyncImportStartDay()
-        let backfillDay = pendingBankSyncBackfillDay
         let lookbackFloor = DayDate.today()
             .adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
         var oldestDates: [String: Int] = [:]
@@ -2861,11 +2830,14 @@ final class BudgetStore: ObservableObject {
                     return BankSyncTarget(externalId: $0.externalAccountId, startDay: importStart)
                 }
                 let incremental = max(lookbackFloor, oldest)
-                // A pending backfill only ever widens the window; one aimed
-                // later than the account already reaches is a no-op.
+                // Reach past existing history only while the chosen day sits
+                // below it. Note this is not `min(importStart, incremental)`:
+                // the default day is older than the 90-day floor for any
+                // budget past its first quarter, and that form would widen
+                // every ongoing sync to it.
                 return BankSyncTarget(
                     externalId: $0.externalAccountId,
-                    startDay: min(backfillDay ?? incremental, incremental)
+                    startDay: importStart < oldest ? importStart : incremental
                 )
             }
         }
@@ -2947,13 +2919,6 @@ final class BudgetStore: ObservableObject {
                 result.problems.append("\(target.name): \(error.localizedDescription)")
                 statuses.append((target.id, nil, "failed"))
             }
-        }
-
-        // The backfill is only paid off once every linked account came back
-        // clean in one run: a partial or per-account sync leaves the ones it
-        // skipped still owing the reach.
-        if accountIds.isEmpty, result.problems.isEmpty, result.accountsSynced == targets.count {
-            pendingBankSyncBackfillDay = nil
         }
 
         // The same two columns every other Actual client stamps, so the web
@@ -3068,29 +3033,24 @@ final class BudgetStore: ObservableObject {
     /// Keep a backfill balance-neutral. Without this the account drifts from
     /// the bank by the sum of everything the backfill reached, permanently —
     /// the opening balance was already standing in for those rows.
+    ///
+    /// Only an opening balance can have absorbed them, so an account without
+    /// one is left alone: there, the older rows are money nothing ever counted
+    /// and the balance is right to move. Nor does the opening's date change —
+    /// it carries income for an on-budget account, and moving it would rewrite
+    /// a past budget month to tidy up a running balance.
     private func absorbIntoStartingBalance(
         for target: BankSyncAccount, backfilled: [Transaction]
     ) async throws {
-        guard let database, let syncClient,
-              let earliest = backfilled.map(\.date).min() else { return }
+        guard let database, let syncClient else { return }
         let carried = backfilled.reduce(0) { $0 + $1.amount }
-
+        guard carried != 0 else { return }
         guard let openingId = try await database.startingBalanceTransactionId(
             accountId: target.id
-        ) else {
-            // No opening balance to correct means nothing was ever folded into
-            // one — but the account still can't move, so write the one the
-            // first sync worked out as zero and skipped. Rows that net to
-            // nothing need no row of their own.
-            guard carried != 0 else { return }
-            try await writeStartingBalance(for: target, amount: -carried, date: earliest)
-            return
-        }
-        guard var opening = try await database.fetchTransaction(id: openingId) else { return }
+        ), var opening = try await database.fetchTransaction(id: openingId) else { return }
+
         opening.amount -= carried
-        // The opening has to sit at or before the history it opens.
-        opening.date = min(opening.date, earliest)
-        try await syncClient.updateTransaction(opening, changedFields: ["amount", "date"])
+        try await syncClient.updateTransaction(opening, changedFields: ["amount"])
     }
 
     /// Give a freshly linked account the opening balance its imported history
@@ -3104,34 +3064,20 @@ final class BudgetStore: ObservableObject {
         currentBalanceCents: Int?,
         candidates: [BankSyncCandidate]
     ) async throws -> Bool {
-        guard let balance = currentBalanceCents else { return false }
+        guard let syncClient, let balance = currentBalanceCents else { return false }
         // The balance is as of now, so what the account opened with is what's
         // left once everything about to be imported is taken back off it.
         let opening = balance - candidates.reduce(0) { $0 + $1.amount }
         guard opening != 0 else { return false }
 
-        try await writeStartingBalance(
-            for: target,
-            amount: opening,
-            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date())
-        )
-        return true
-    }
-
-    /// Write an account's opening-balance row. Shared by the first sync and by
-    /// a backfill that finds none to correct.
-    private func writeStartingBalance(
-        for target: BankSyncAccount, amount: Int, date: Int
-    ) async throws {
-        guard let syncClient else { return }
         let payee = try await findOrCreatePayee(name: "Starting Balance")
         let category = target.offBudget ? nil : startingBalanceCategory()
 
         let transaction = Transaction(
             id: UUID().uuidString,
             accountId: target.id,
-            date: date,
-            amount: amount,
+            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date()),
+            amount: opening,
             payeeId: payee.id,
             payeeName: payee.name,
             categoryId: category?.id,
@@ -3149,6 +3095,7 @@ final class BudgetStore: ObservableObject {
         )
         // Rules never see an opening balance, same as account creation's.
         try await syncClient.createTransaction(transaction, applyRules: false)
+        return true
     }
 
     /// Create a paired transfer between two accounts. Writes both legs with linked

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -2459,14 +2459,40 @@ final class BudgetStore: ObservableObject {
             .object(forKey: bankSyncImportStartKey(for: budgetId)) as? Int
     }
 
-    func setBankSyncImportStartDay(_ day: Int?) {
-        guard let budgetId = currentBudgetId else { return }
-        let key = bankSyncImportStartKey(for: budgetId)
-        if let day {
-            appleWalletLinkDefaults.set(day, forKey: key)
-        } else {
-            appleWalletLinkDefaults.removeObject(forKey: key)
+    /// A day the linked accounts owe a reach back to, but haven't made yet.
+    ///
+    /// Held in defaults rather than in memory because the run that would
+    /// honour it can not happen: `runBankSync` drops a request while another
+    /// sync is in flight, the download can fail, and the app can be killed
+    /// mid-import. The chosen day is persisted either way, and the ongoing
+    /// window never reaches below an account's existing history — so without
+    /// this the setting would be quietly unreachable. Any later sync clears
+    /// the debt.
+    private var pendingBankSyncBackfillDay: Int? {
+        get {
+            guard let budgetId = currentBudgetId else { return nil }
+            return appleWalletLinkDefaults
+                .object(forKey: "bankSyncBackfill_\(budgetId)") as? Int
         }
+        set {
+            guard let budgetId = currentBudgetId else { return }
+            let key = "bankSyncBackfill_\(budgetId)"
+            if let newValue {
+                appleWalletLinkDefaults.set(newValue, forKey: key)
+            } else {
+                appleWalletLinkDefaults.removeObject(forKey: key)
+            }
+        }
+    }
+
+    func setBankSyncImportStartDay(_ day: Int) async {
+        guard let budgetId = currentBudgetId else { return }
+        let previous = await resolvedBankSyncImportStartDay()
+        appleWalletLinkDefaults.set(day, forKey: bankSyncImportStartKey(for: budgetId))
+        // Only reaching further back is work: moving the day later imports
+        // nothing new (and removes nothing either).
+        guard day < previous else { return }
+        pendingBankSyncBackfillDay = min(day, pendingBankSyncBackfillDay ?? day)
     }
 
     /// The day imports reach back to for an account with no history of its
@@ -2474,7 +2500,7 @@ final class BudgetStore: ObservableObject {
     /// the 90-day lookback several bank integrations won't serve more than.
     func resolvedBankSyncImportStartDay() async -> Int {
         if let chosen = storedBankSyncImportStartDay { return chosen }
-        if let began = try? await database?.earliestMessageDay(), let began { return began }
+        if let began = try? await database?.earliestMessageDay() { return began }
         return DayDate.today().adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
     }
 
@@ -2622,15 +2648,13 @@ final class BudgetStore: ObservableObject {
 
     /// Run a sync and leave its outcome in `bankSyncSummary`. The button-shaped
     /// entry point — `syncBankAccounts` is the one that throws.
-    func runBankSync(accountIds: [String] = [], fromImportStart: Bool = false) async {
+    func runBankSync(accountIds: [String] = []) async {
         // A tap that lands while a sync is already running does nothing — the
         // running sync posts its own summary, which would otherwise be
         // clobbered by this call's empty one.
         guard !isBankSyncing else { return }
         do {
-            bankSyncSummary = try await syncBankAccounts(
-                accountIds: accountIds, fromImportStart: fromImportStart
-            ).summary
+            bankSyncSummary = try await syncBankAccounts(accountIds: accountIds).summary
         } catch {
             bankSyncSummary = error.localizedDescription
         }
@@ -2771,14 +2795,10 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Download and import transactions for the linked accounts.
-    /// - Parameters:
-    ///   - accountIds: which accounts to sync; empty syncs every linked one,
-    ///     which is what the accounts tab's sync button does.
-    ///   - fromImportStart: reach the chosen import start day even for
-    ///     accounts that already have history — the backfill run after the
-    ///     settings day moves earlier.
+    /// - Parameter accountIds: which accounts to sync; empty syncs every
+    ///   linked one, which is what the accounts tab's sync button does.
     @discardableResult
-    func syncBankAccounts(accountIds: [String] = [], fromImportStart: Bool = false) async throws -> BankSyncResult {
+    func syncBankAccounts(accountIds: [String] = []) async throws -> BankSyncResult {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
         // A second run on top of the first would re-download the same window
         // and race the first one's writes.
@@ -2819,13 +2839,14 @@ final class BudgetStore: ObservableObject {
         guard !targets.isEmpty else { return result }
 
         // Three windows. A first import (no history) starts where the person
-        // chose — by default, the day the budget file began. A backfill run
-        // (the settings screen, after the day moves earlier) reaches the
-        // chosen day regardless of history; dedup keeps the overlap safe.
-        // Ongoing syncs only need the stretch since the account's earliest
-        // transaction, still capped at the rolling 90-day floor — history
-        // already covers everything older, so re-scanning it buys nothing.
+        // chose — by default, the day the budget file began. A run carrying an
+        // unhonoured backfill reaches that day regardless of history; dedup
+        // keeps the overlap safe. Ongoing syncs only need the stretch since
+        // the account's earliest transaction, still capped at the rolling
+        // 90-day floor — history already covers everything older, so
+        // re-scanning it buys nothing.
         let importStart = await resolvedBankSyncImportStartDay()
+        let backfillDay = pendingBankSyncBackfillDay
         let lookbackFloor = DayDate.today()
             .adding(days: -Self.bankSyncMaxLookbackDays).yyyymmdd
         var oldestDates: [String: Int] = [:]
@@ -2836,11 +2857,15 @@ final class BudgetStore: ObservableObject {
         }
         func downloadTargets(_ accounts: [BankSyncAccount]) -> [BankSyncTarget] {
             accounts.map {
-                BankSyncTarget(
+                guard let oldest = oldestDates[$0.id] else {
+                    return BankSyncTarget(externalId: $0.externalAccountId, startDay: importStart)
+                }
+                let incremental = max(lookbackFloor, oldest)
+                // A pending backfill only ever widens the window; one aimed
+                // later than the account already reaches is a no-op.
+                return BankSyncTarget(
                     externalId: $0.externalAccountId,
-                    startDay: fromImportStart
-                        ? importStart
-                        : oldestDates[$0.id].map { max(lookbackFloor, $0) } ?? importStart
+                    startDay: min(backfillDay ?? incremental, incremental)
                 )
             }
         }
@@ -2910,7 +2935,7 @@ final class BudgetStore: ObservableObject {
                 let outcome = try await importBankSync(
                     download,
                     into: target,
-                    isFirstSync: oldestDates[target.id] == nil,
+                    existingOldestDay: oldestDates[target.id],
                     prepared: prepared
                 )
                 result.added += outcome.added
@@ -2922,6 +2947,13 @@ final class BudgetStore: ObservableObject {
                 result.problems.append("\(target.name): \(error.localizedDescription)")
                 statuses.append((target.id, nil, "failed"))
             }
+        }
+
+        // The backfill is only paid off once every linked account came back
+        // clean in one run: a partial or per-account sync leaves the ones it
+        // skipped still owing the reach.
+        if accountIds.isEmpty, result.problems.isEmpty, result.accountsSynced == targets.count {
+            pendingBankSyncBackfillDay = nil
         }
 
         // The same two columns every other Actual client stamps, so the web
@@ -2938,7 +2970,7 @@ final class BudgetStore: ObservableObject {
     private func importBankSync(
         _ download: BankSyncDownload,
         into target: BankSyncAccount,
-        isFirstSync: Bool,
+        existingOldestDay: Int?,
         prepared: SyncClient.PreparedRules
     ) async throws -> (added: Int, updated: Int, inserted: [Transaction]) {
         guard let database, let syncClient else { throw BudgetStoreError.syncNotConfigured }
@@ -2951,7 +2983,7 @@ final class BudgetStore: ObservableObject {
         // The opening balance counts as an import too (upstream folds its id
         // into `added`), so a first sync never reports one fewer than it wrote.
         var added = 0
-        if isFirstSync {
+        if existingOldestDay == nil {
             added += try await insertStartingBalance(
                 for: target,
                 currentBalanceCents: download.currentBalanceCents,
@@ -3019,7 +3051,46 @@ final class BudgetStore: ObservableObject {
             inserted.append(transaction)
         }
 
+        // Anything older than the history this account already had was folded
+        // into its opening balance when that was worked out. Importing those
+        // rows now would count them twice, so the opening gives back exactly
+        // what they carry: a backfill moves no balance, only detail.
+        if let existingOldestDay {
+            try await absorbIntoStartingBalance(
+                for: target,
+                backfilled: inserted.filter { $0.date < existingOldestDay }
+            )
+        }
+
         return (added + plan.inserts.count, plan.updates.count, inserted)
+    }
+
+    /// Keep a backfill balance-neutral. Without this the account drifts from
+    /// the bank by the sum of everything the backfill reached, permanently —
+    /// the opening balance was already standing in for those rows.
+    private func absorbIntoStartingBalance(
+        for target: BankSyncAccount, backfilled: [Transaction]
+    ) async throws {
+        guard let database, let syncClient,
+              let earliest = backfilled.map(\.date).min() else { return }
+        let carried = backfilled.reduce(0) { $0 + $1.amount }
+
+        guard let openingId = try await database.startingBalanceTransactionId(
+            accountId: target.id
+        ) else {
+            // No opening balance to correct means nothing was ever folded into
+            // one — but the account still can't move, so write the one the
+            // first sync worked out as zero and skipped. Rows that net to
+            // nothing need no row of their own.
+            guard carried != 0 else { return }
+            try await writeStartingBalance(for: target, amount: -carried, date: earliest)
+            return
+        }
+        guard var opening = try await database.fetchTransaction(id: openingId) else { return }
+        opening.amount -= carried
+        // The opening has to sit at or before the history it opens.
+        opening.date = min(opening.date, earliest)
+        try await syncClient.updateTransaction(opening, changedFields: ["amount", "date"])
     }
 
     /// Give a freshly linked account the opening balance its imported history
@@ -3033,20 +3104,34 @@ final class BudgetStore: ObservableObject {
         currentBalanceCents: Int?,
         candidates: [BankSyncCandidate]
     ) async throws -> Bool {
-        guard let syncClient, let balance = currentBalanceCents else { return false }
+        guard let balance = currentBalanceCents else { return false }
         // The balance is as of now, so what the account opened with is what's
         // left once everything about to be imported is taken back off it.
         let opening = balance - candidates.reduce(0) { $0 + $1.amount }
         guard opening != 0 else { return false }
 
+        try await writeStartingBalance(
+            for: target,
+            amount: opening,
+            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date())
+        )
+        return true
+    }
+
+    /// Write an account's opening-balance row. Shared by the first sync and by
+    /// a backfill that finds none to correct.
+    private func writeStartingBalance(
+        for target: BankSyncAccount, amount: Int, date: Int
+    ) async throws {
+        guard let syncClient else { return }
         let payee = try await findOrCreatePayee(name: "Starting Balance")
         let category = target.offBudget ? nil : startingBalanceCategory()
 
         let transaction = Transaction(
             id: UUID().uuidString,
             accountId: target.id,
-            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date()),
-            amount: opening,
+            date: date,
+            amount: amount,
             payeeId: payee.id,
             payeeName: payee.name,
             categoryId: category?.id,
@@ -3064,7 +3149,6 @@ final class BudgetStore: ObservableObject {
         )
         // Rules never see an opening balance, same as account creation's.
         try await syncClient.createTransaction(transaction, applyRules: false)
-        return true
     }
 
     /// Create a paired transfer between two accounts. Writes both legs with linked

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2741,6 +2741,20 @@ final class BudgetDatabase: Sendable {
 
     // MARK: - Bank Sync
 
+    /// The day (`YYYYMMDD`) of the budget's earliest CRDT message — the day
+    /// the budget file began, wherever it began: the messages travel with the
+    /// file, so every device answers the same. Nil for a budget with no
+    /// messages yet. HLC timestamps sort lexically and start with the ISO
+    /// date, so MIN gives the earliest and its first ten characters the day.
+    func earliestMessageDay() async throws -> Int? {
+        try await dbQueue.read { db in
+            guard let timestamp = try String.fetchOne(
+                db, sql: "SELECT MIN(timestamp) FROM messages_crdt"
+            ), timestamp.count >= 10 else { return nil }
+            return Int(timestamp.prefix(10).replacingOccurrences(of: "-", with: ""))
+        }
+    }
+
     /// Every account wired up to a bank feed, in the order the accounts tab
     /// lists them. Empty (rather than an error) on a budget file old enough
     /// to predate the columns — nothing can be linked in that case anyway.

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2746,12 +2746,33 @@ final class BudgetDatabase: Sendable {
     /// file, so every device answers the same. Nil for a budget with no
     /// messages yet. HLC timestamps sort lexically and start with the ISO
     /// date, so MIN gives the earliest and its first ten characters the day.
+    ///
+    /// That day is UTC, unlike every other `YYYYMMDD` here, which comes from
+    /// `Calendar.current`. Deliberate: agreeing across devices is the whole
+    /// point, and a local reading would have two phones in different zones
+    /// answer differently for the same file. Worst case it names the day
+    /// after the one the file was really made on, which only shifts an import
+    /// floor by a day.
     func earliestMessageDay() async throws -> Int? {
         try await dbQueue.read { db in
             guard let timestamp = try String.fetchOne(
                 db, sql: "SELECT MIN(timestamp) FROM messages_crdt"
             ), timestamp.count >= 10 else { return nil }
             return Int(timestamp.prefix(10).replacingOccurrences(of: "-", with: ""))
+        }
+    }
+
+    /// The id of an account's opening-balance row, if it has one. A backfill
+    /// needs it to hand back what the rows it imports were already counted
+    /// for (see `absorbIntoStartingBalance`).
+    func startingBalanceTransactionId(accountId: String) async throws -> String? {
+        try await dbQueue.read { db in
+            try String.fetchOne(db, sql: """
+                SELECT id FROM transactions
+                WHERE acct = ? AND starting_balance_flag = 1
+                  AND (tombstone = 0 OR tombstone IS NULL)
+                ORDER BY date
+                """, arguments: [accountId])
         }
     }
 

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -175,11 +175,11 @@ struct BankSyncSetupView: View {
         }
     }
 
-    /// Store the day, then reach it. The store holds the day as a debt until a
-    /// sync honours it, so a run that fails here is retried by the next one —
-    /// this is only what makes the import visible while the screen is open.
+    /// Store the day, then reach it. The window is derived from the day, so a
+    /// run that fails here costs nothing — the next sync reaches just as far.
+    /// This is only what makes the import visible while the screen is open.
     private func applyImportStart(_ day: Int) async {
-        await budgetStore.setBankSyncImportStartDay(day)
+        budgetStore.setBankSyncImportStartDay(day)
         isBackfilling = true
         defer { isBackfilling = false }
         do {

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -23,6 +23,10 @@ struct BankSyncSetupView: View {
     @State private var errorMessage: String?
     @State private var linkTarget: BankSyncRemoteAccount?
     @State private var showingDisconnectConfirmation = false
+    @State private var importStartDate = Date()
+    /// Nil until the stored day is loaded, which is what keeps the picker's
+    /// initial assignment from being written back (or from kicking a sync).
+    @State private var savedImportStartDay: Int?
 
     var body: some View {
         List {
@@ -34,10 +38,14 @@ struct BankSyncSetupView: View {
             } else {
                 setupSection
             }
+            importStartSection
         }
         .navigationTitle("Bank Sync")
         .navigationBarTitleDisplayMode(.inline)
         .task {
+            let day = await budgetStore.resolvedBankSyncImportStartDay()
+            importStartDate = Transaction.date(fromYYYYMMDD: day)
+            savedImportStartDay = day
             await budgetStore.refreshAppleWalletAvailability()
             if budgetStore.appleWalletAvailability == .authorized {
                 await loadWalletAccounts()
@@ -125,6 +133,35 @@ struct BankSyncSetupView: View {
             default:
                 Text("Link Apple Card, Apple Cash and Savings so their transactions and balances import automatically when you sync. Apple asks once which data Actuali may read.")
             }
+        }
+    }
+
+    // MARK: - Import start
+
+    private var importStartSection: some View {
+        Section {
+            DatePicker(
+                "Import transactions since",
+                selection: $importStartDate,
+                in: ...Date(),
+                displayedComponents: .date
+            )
+            .datePickerStyle(.graphical)
+            .disabled(savedImportStartDay == nil)
+            .onChange(of: importStartDate) { _, newDate in
+                let day = Transaction.yyyymmdd(from: newDate)
+                guard let saved = savedImportStartDay, day != saved else { return }
+                savedImportStartDay = day
+                budgetStore.setBankSyncImportStartDay(day)
+                // Reach the chosen day right away, so picking an earlier one
+                // visibly fills in the older history. Dedup keeps re-covered
+                // ground safe, so a later pick costs nothing either.
+                Task { await budgetStore.runBankSync(fromImportStart: true) }
+            }
+        } header: {
+            Text("Import Start Date")
+        } footer: {
+            Text("Linked accounts import transactions from this day on. It starts out as the day this budget began; pick an earlier day to pull in older history. Transactions already imported always stay.")
         }
     }
 

--- a/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
+++ b/Actuali/Actuali/Views/Accounts/BankSyncSetupView.swift
@@ -27,6 +27,7 @@ struct BankSyncSetupView: View {
     /// Nil until the stored day is loaded, which is what keeps the picker's
     /// initial assignment from being written back (or from kicking a sync).
     @State private var savedImportStartDay: Int?
+    @State private var isBackfilling = false
 
     var body: some View {
         List {
@@ -138,30 +139,58 @@ struct BankSyncSetupView: View {
 
     // MARK: - Import start
 
+    @ViewBuilder
     private var importStartSection: some View {
-        Section {
-            DatePicker(
-                "Import transactions since",
-                selection: $importStartDate,
-                in: ...Date(),
-                displayedComponents: .date
-            )
-            .datePickerStyle(.graphical)
-            .disabled(savedImportStartDay == nil)
-            .onChange(of: importStartDate) { _, newDate in
-                let day = Transaction.yyyymmdd(from: newDate)
-                guard let saved = savedImportStartDay, day != saved else { return }
-                savedImportStartDay = day
-                budgetStore.setBankSyncImportStartDay(day)
-                // Reach the chosen day right away, so picking an earlier one
-                // visibly fills in the older history. Dedup keeps re-covered
-                // ground safe, so a later pick costs nothing either.
-                Task { await budgetStore.runBankSync(fromImportStart: true) }
+        // Nothing to import from means nothing to date, so the calendar only
+        // shows where one of the two providers is actually on offer.
+        if budgetStore.canSyncBanks || budgetStore.appleWalletAvailability != .unsupported {
+            Section {
+                DatePicker(
+                    "Import transactions since",
+                    selection: $importStartDate,
+                    in: ...Date(),
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.graphical)
+                .disabled(savedImportStartDay == nil || isBackfilling)
+                .onChange(of: importStartDate) { _, newDate in
+                    let day = Transaction.yyyymmdd(from: newDate)
+                    guard let saved = savedImportStartDay, day != saved else { return }
+                    savedImportStartDay = day
+                    Task { await applyImportStart(day) }
+                }
+
+                if isBackfilling {
+                    HStack {
+                        ProgressView()
+                        Text("Importing older transactions…")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text("Import Start Date")
+            } footer: {
+                Text("Linked accounts import transactions from this day on. It starts out as the day this budget began; pick an earlier day to pull in older history. Transactions already imported always stay.")
             }
-        } header: {
-            Text("Import Start Date")
-        } footer: {
-            Text("Linked accounts import transactions from this day on. It starts out as the day this budget began; pick an earlier day to pull in older history. Transactions already imported always stay.")
+        }
+    }
+
+    /// Store the day, then reach it. The store holds the day as a debt until a
+    /// sync honours it, so a run that fails here is retried by the next one —
+    /// this is only what makes the import visible while the screen is open.
+    private func applyImportStart(_ day: Int) async {
+        await budgetStore.setBankSyncImportStartDay(day)
+        isBackfilling = true
+        defer { isBackfilling = false }
+        do {
+            // The throwing entry point, not `runBankSync`: its summary alert
+            // lives on the accounts tab, which this screen may not be inside.
+            let result = try await budgetStore.syncBankAccounts()
+            if !result.problems.isEmpty {
+                errorMessage = result.problems.joined(separator: "\n\n")
+            }
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -272,7 +272,7 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
 
         let result = try await store.syncBankAccounts()
 
@@ -293,11 +293,11 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
         _ = try await store.syncBankAccounts()
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 1)
 
-        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
         let backfill = try await store.syncBankAccounts()
 
         #expect(backfill.added == 1)
@@ -314,11 +314,11 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
         _ = try await store.syncBankAccounts()
         #expect(try accountBalance(path: url) == -51200)
 
-        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
         _ = try await store.syncBankAccounts()
 
         #expect(try accountBalance(path: url) == -51200)
@@ -326,28 +326,55 @@ struct BudgetStoreAppleWalletSyncTests {
         let opening = try rows(path: url, where: "starting_balance_flag = 1")
         #expect(opening.count == 1)
         #expect(opening[0]["amount"] == -46655)
-        // …and moved back to sit at or before the history it opens.
-        #expect(opening[0]["date"] == Self.expectedDay(5))
+        // …and stayed in its own month. It carries income for an on-budget
+        // account, so moving it would rewrite a past budget month.
+        #expect(opening[0]["date"] == Self.expectedDay(1))
     }
 
-    /// The chosen day is a debt the store keeps until some sync pays it. A run
-    /// that never happens — dropped because another sync was in flight, failed,
-    /// or killed — must not strand the setting: the next sync still reaches it.
-    @Test func anUnhonouredBackfillIsHeldForTheNextSync() async throws {
+    /// The reach is derived from the chosen day and the account's history, so
+    /// no single run has to be the one that lands it. A tap whose sync never
+    /// happens — dropped because another was in flight, failed, or killed —
+    /// leaves the next sync reaching just as far, whichever path kicks it.
+    @Test func theReachSurvivesARunThatNeverHappens() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
         _ = try await store.syncBankAccounts()
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 1)
 
-        // Choose an earlier day and run nothing at all, the way a dropped tap
-        // leaves it. A later automatic pass is what picks the debt up.
-        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        // Choose an earlier day and run nothing at all. The automatic Wallet
+        // pass syncs by account id, which is the path a debt would miss.
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
         await store.autoSyncAppleWalletAccounts()
 
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
         #expect(try accountBalance(path: url) == -51200)
+    }
+
+    /// An account whose first sync got no balance has no opening balance, so
+    /// nothing ever stood in for its older rows. Backfilling them is money the
+    /// account never counted, and the balance is right to move — inventing an
+    /// opening to hold it still would push a made-up row to every device.
+    @Test func aBackfillMovesAnAccountThatHasNoOpeningBalance() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        var wallet = appleCard()
+        wallet.accountsValue = [AppleWalletAccount(
+            id: Self.externalAccountId, name: "Apple Card",
+            institutionName: "Apple", balanceCents: nil
+        )]
+        let store = try await makeStore(database: database, walletStore: wallet)
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
+        _ = try await store.syncBankAccounts()
+        #expect(try rows(path: url, where: "starting_balance_flag = 1").isEmpty)
+        #expect(try accountBalance(path: url) == -1200)
+
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
+        _ = try await store.syncBankAccounts()
+
+        #expect(try rows(path: url, where: "starting_balance_flag = 1").isEmpty)
+        #expect(try accountBalance(path: url) == -4545)
     }
 
     /// Once the reach has landed, ordinary syncs stop asking for it — and
@@ -356,7 +383,7 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
         _ = try await store.syncBankAccounts()
 
         let again = try await store.syncBankAccounts()
@@ -372,11 +399,11 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
         _ = try await store.syncBankAccounts()
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
 
-        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
         _ = try await store.syncBankAccounts()
 
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -209,6 +209,78 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
     }
 
+    // MARK: - Import start day
+
+    /// With no chosen day, imports reach back to the day the budget file
+    /// began — the day of its earliest CRDT message, which travels with the
+    /// file to every device.
+    @Test func importStartDefaultsToTheDayTheBudgetBegan() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO messages_crdt (timestamp, dataset, row, column, value)
+                VALUES ('2024-03-05T12:00:00.000Z-0000-abcdef1234567890',
+                        'accounts', 'acct-card', 'name', X'00')
+                """)
+        }
+        let store = try await makeStore(
+            database: database, walletStore: appleCard(), linked: false
+        )
+
+        #expect(await store.resolvedBankSyncImportStartDay() == 20240305)
+    }
+
+    /// A budget with no messages yet falls back to the shared 90-day lookback.
+    @Test func importStartFallsBackToTheLookbackWindow() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(
+            database: database, walletStore: appleCard(), linked: false
+        )
+
+        let resolved = await store.resolvedBankSyncImportStartDay()
+        #expect(resolved == DayDate.today().adding(days: -89).yyyymmdd)
+    }
+
+    /// The chosen day bounds the first import: anything older stays out, and
+    /// what it did to the balance lands in the opening balance instead.
+    @Test func aChosenDayLimitsTheFirstImport() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
+
+        let result = try await store.syncBankAccounts()
+
+        // Only the day-1 pending purchase is in the window; the day-5 booked
+        // one stays out.
+        let imported = try rows(path: url, where: "financial_id IS NOT NULL")
+        #expect(imported.count == 1)
+        #expect(imported[0]["financial_id"] == "33333333-3333-3333-3333-333333333333")
+        #expect(result.accountsSynced == 1)
+    }
+
+    /// Moving the day earlier and running the backfill pass reaches past the
+    /// account's existing history and pulls the older transactions in.
+    @Test func aBackfillRunReachesPastExistingHistory() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        store.setBankSyncImportStartDay(Self.expectedDay(2))
+        _ = try await store.syncBankAccounts()
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 1)
+
+        store.setBankSyncImportStartDay(Self.expectedDay(30))
+        let backfill = try await store.syncBankAccounts(fromImportStart: true)
+
+        #expect(backfill.added == 1)
+        let imported = try rows(path: url, where: "financial_id IS NOT NULL")
+        #expect(imported.count == 2)
+        #expect(imported[0]["financial_id"] == "11111111-1111-1111-1111-111111111111")
+    }
+
     /// What a run inserts comes back on the result, so the automatic sync
     /// can post the new-transaction notification — the detector path only
     /// sees rows authored by other devices, which these are not. The opening

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreAppleWalletSyncTests.swift
@@ -94,6 +94,16 @@ struct BudgetStoreAppleWalletSyncTests {
                 )
                 """)
             try db.execute(sql: "CREATE TABLE payee_mapping (id TEXT PRIMARY KEY, targetId TEXT)")
+            // Every display read joins through these; a backfill fetches the
+            // opening balance back to correct it, so this fixture needs them.
+            try db.execute(sql: """
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY, name TEXT, cat_group TEXT,
+                    is_income INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                )
+                """)
+            try db.execute(sql: "CREATE TABLE category_mapping (id TEXT PRIMARY KEY, transferId TEXT)")
             try db.execute(sql: """
                 CREATE TABLE banks (
                     id TEXT PRIMARY KEY, bank_id TEXT, name TEXT, tombstone INTEGER DEFAULT 0
@@ -157,6 +167,18 @@ struct BudgetStoreAppleWalletSyncTests {
         let queue = try DatabaseQueue(path: path.path)
         return try queue.read { db in
             try Row.fetchOne(db, sql: sql, arguments: arguments)
+        }
+    }
+
+    /// What the account is worth: every live row, opening balance included.
+    /// A bank-linked account reconciles when this equals what the bank says.
+    private func accountBalance(path: URL) throws -> Int {
+        let queue = try DatabaseQueue(path: path.path)
+        return try queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COALESCE(SUM(amount), 0) FROM transactions
+                WHERE acct = ? AND (tombstone = 0 OR tombstone IS NULL)
+                """, arguments: [Self.accountId]) ?? 0
         }
     }
 
@@ -250,7 +272,7 @@ struct BudgetStoreAppleWalletSyncTests {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        store.setBankSyncImportStartDay(Self.expectedDay(2))
+        await store.setBankSyncImportStartDay(Self.expectedDay(2))
 
         let result = try await store.syncBankAccounts()
 
@@ -260,25 +282,105 @@ struct BudgetStoreAppleWalletSyncTests {
         #expect(imported.count == 1)
         #expect(imported[0]["financial_id"] == "33333333-3333-3333-3333-333333333333")
         #expect(result.accountsSynced == 1)
+        // What stayed out is still in the balance, via the opening.
+        #expect(try accountBalance(path: url) == -51200)
     }
 
-    /// Moving the day earlier and running the backfill pass reaches past the
-    /// account's existing history and pulls the older transactions in.
-    @Test func aBackfillRunReachesPastExistingHistory() async throws {
+    /// Moving the day earlier reaches past the account's existing history and
+    /// pulls the older transactions in — on the next ordinary sync, with no
+    /// special "backfill" call.
+    @Test func movingTheDayEarlierReachesPastExistingHistory() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let store = try await makeStore(database: database, walletStore: appleCard())
-        store.setBankSyncImportStartDay(Self.expectedDay(2))
+        await store.setBankSyncImportStartDay(Self.expectedDay(2))
         _ = try await store.syncBankAccounts()
         #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 1)
 
-        store.setBankSyncImportStartDay(Self.expectedDay(30))
-        let backfill = try await store.syncBankAccounts(fromImportStart: true)
+        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        let backfill = try await store.syncBankAccounts()
 
         #expect(backfill.added == 1)
         let imported = try rows(path: url, where: "financial_id IS NOT NULL")
         #expect(imported.count == 2)
         #expect(imported[0]["financial_id"] == "11111111-1111-1111-1111-111111111111")
+    }
+
+    /// A backfill adds detail, not money. The opening balance already stood in
+    /// for everything before the account's first imported day, so giving those
+    /// rows their own lines must leave the account reconciling exactly as it
+    /// did — otherwise it drifts from the card by the backfilled amount.
+    @Test func aBackfillLeavesTheAccountBalanceAlone() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        _ = try await store.syncBankAccounts()
+        #expect(try accountBalance(path: url) == -51200)
+
+        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        _ = try await store.syncBankAccounts()
+
+        #expect(try accountBalance(path: url) == -51200)
+        // The opening gave back exactly what the backfilled row carries…
+        let opening = try rows(path: url, where: "starting_balance_flag = 1")
+        #expect(opening.count == 1)
+        #expect(opening[0]["amount"] == -46655)
+        // …and moved back to sit at or before the history it opens.
+        #expect(opening[0]["date"] == Self.expectedDay(5))
+    }
+
+    /// The chosen day is a debt the store keeps until some sync pays it. A run
+    /// that never happens — dropped because another sync was in flight, failed,
+    /// or killed — must not strand the setting: the next sync still reaches it.
+    @Test func anUnhonouredBackfillIsHeldForTheNextSync() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        _ = try await store.syncBankAccounts()
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 1)
+
+        // Choose an earlier day and run nothing at all, the way a dropped tap
+        // leaves it. A later automatic pass is what picks the debt up.
+        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        await store.autoSyncAppleWalletAccounts()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+        #expect(try accountBalance(path: url) == -51200)
+    }
+
+    /// Once the reach has landed, ordinary syncs stop asking for it — and
+    /// nothing is imported or removed twice.
+    @Test func aPaidBackfillDoesNotRepeat() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        _ = try await store.syncBankAccounts()
+
+        let again = try await store.syncBankAccounts()
+
+        #expect(again.added == 0)
+        #expect(again.updated == 0)
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+        #expect(try rows(path: url, where: "starting_balance_flag = 1").count == 1)
+    }
+
+    /// Moving the day later removes nothing — the footer promises it.
+    @Test func movingTheDayLaterKeepsWhatWasImported() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let store = try await makeStore(database: database, walletStore: appleCard())
+        await store.setBankSyncImportStartDay(Self.expectedDay(30))
+        _ = try await store.syncBankAccounts()
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+
+        await store.setBankSyncImportStartDay(Self.expectedDay(2))
+        _ = try await store.syncBankAccounts()
+
+        #expect(try rows(path: url, where: "financial_id IS NOT NULL").count == 2)
+        #expect(try accountBalance(path: url) == -51200)
     }
 
     /// What a run inserts comes back on the result, so the automatic sync


### PR DESCRIPTION
## Why

Bank sync always imported the last 90 days — a window hardcoded from upstream's bank-integration limits. That's the wrong amount of history for almost everyone: a fresh budget gets three months of pre-budget transactions it never wanted, while someone linking Apple Card via FinanceKit (where full history is available on-device) couldn't reach back further even if they wanted years. How far back to import should be the user's call.

## What

- The Bank Sync screen gains an **Import Start Date** section: a graphical calendar (capped at today) showing the effective date and accepting any day.
- **Default: the day the budget file began.** Sourced from the budget's earliest CRDT message timestamp rather than file metadata — the messages travel inside the budget file, so every device (and a re-downloaded copy) resolves the same day. A budget with no messages yet falls back to the old 90-day lookback.
- The choice is stored per budget, device-locally (same store as the Wallet links), so nothing non-standard reaches the synced file.
- Three sync windows follow from it:
  - A **first import** (account with no history) starts at the chosen day. Anything older stays out and its effect lands in the opening balance, so the account still reconciles.
  - **Picking an earlier day** immediately runs a backfill sync that reaches the chosen day past existing history — older transactions fill in right after the tap, with dedup keeping the overlap safe.
  - **Ongoing syncs** keep the existing incremental window (since the account's earliest transaction, capped at the rolling 90-day floor), so long-lived accounts don't re-scan years of history on every foreground auto-sync.
- Moving the day later never deletes anything — already-imported transactions stay, and the footer says so.
- Applies to both providers; SimpleFIN bridges simply serve whatever slice of the requested range they have.

## How it was tested

- New unit tests: the default resolves to the earliest-message day, the no-messages fallback resolves to the 90-day lookback, a chosen day bounds the first import (older transaction excluded, window respected), and a backfill run reaches past existing history and imports the older rows.
- Existing SimpleFIN and Wallet suites pass unchanged under the new window logic — ongoing-sync behavior is deliberately identical to before.
- **Not run locally** (no Xcode in the authoring environment) — relying on CI's iOS 26 + iOS 18 legs.
- Not yet verified on device: the calendar UI flow and the backfill-on-earlier-pick behavior with real Wallet data.

## Screenshots

None yet — will add a shot of the calendar section once there's a device build to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)