### PR TITLE
Delete budget

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1461,10 +1461,7 @@ final class BudgetStore: ObservableObject {
         // "vnode unlinked" hazard downloadBudget also guards against), and a
         // live sync client would let the next foreground refresh republish
         // the wiped budget's data from that orphaned connection.
-        syncStateCancellable?.cancel()
-        syncStateCancellable = nil
-        syncClient = nil
-        database = nil
+        closeCurrentBudget()
 
         if clearLocalData {
             // Wipe every locally-synced budget's database and metadata from
@@ -1494,13 +1491,22 @@ final class BudgetStore: ObservableObject {
         // Re-probe on the next connection in case the server URL changes.
         availableLoginMethods = []
         ownerExists = true
-        
+    }
+
+    /// Close whatever budget is open and return to the "select a budget" empty
+    /// state, leaving the server session alone. Tears down the database and
+    /// sync client first (see logout's vnode-unlink comment) and then clears
+    /// everything loaded in memory, so nothing from the old budget lingers in
+    /// the UI. The dataVersion bump makes views that cache their own fetches
+    /// drop them.
+    private func closeCurrentBudget() {
+        syncStateCancellable?.cancel()
+        syncStateCancellable = nil
+        syncClient = nil
+        database = nil
+
         backups = []
         syncDetachedByRestore = false
-
-        // Clear everything currently loaded in memory too, so nothing from
-        // the old budget lingers in the UI post-disconnect. The dataVersion
-        // bump makes views that cache their own fetches drop them.
         currentBudgetId = nil
         requestedBudgetMonth = nil
         currentBudgetMonth = nil
@@ -1517,6 +1523,47 @@ final class BudgetStore: ObservableObject {
         isInitialSyncing = false
         dataVersion += 1
         clearWidgetSnapshot()
+    }
+
+    // MARK: - Budget Deletion
+
+    /// Delete a budget's local copy — database, metadata, and backups — and
+    /// any device-side state for it, leaving the server file untouched so it
+    /// can be downloaded again. Deleting the currently open budget closes it
+    /// and returns the app to the "select a budget" empty state.
+    func removeLocalBudget(cloudFileId: String) {
+        guard let local = fileManager.listLocalBudgets().first(
+            where: { $0.cloudFileId == cloudFileId }
+        ) else { return }
+
+        // Close before deleting files — same vnode-unlink hazard as logout.
+        if local.id == currentBudgetId {
+            closeCurrentBudget()
+        }
+
+        // The derived encryption key must not outlive the files it unlocks.
+        try? EncryptionKeyManager.remove(fileId: cloudFileId)
+        try? fileManager.deleteBudget(local.id)
+        forgetCachedCurrencyCode(for: local.id)
+        forgetAppleWalletLinks(for: local.id)
+    }
+
+    /// Delete a budget's file on the Actual server — for every client — then
+    /// remove this device's copy and its list row. Returns nil on success, or
+    /// a user-facing message so the confirmation sheet can stay open (see
+    /// `error`: form-local failures stay in the presenting view).
+    func deleteServerBudget(_ remoteBudget: RemoteBudget) async -> String? {
+        do {
+            try await serverClient.deleteFile(fileId: remoteBudget.id)
+        } catch ActualServerError.fileNotFound {
+            // Already gone on the server (deleted from another client) —
+            // finish the local half below so the stale row heals.
+        } catch {
+            return error.localizedDescription
+        }
+        removeLocalBudget(cloudFileId: remoteBudget.id)
+        remoteBudgets.removeAll { $0.id == remoteBudget.id }
+        return nil
     }
 
     /// Load the auth token, migrating from UserDefaults to Keychain on first run.

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -1531,18 +1531,26 @@ final class BudgetStore: ObservableObject {
     /// any device-side state for it, leaving the server file untouched so it
     /// can be downloaded again. Deleting the currently open budget closes it
     /// and returns the app to the "select a budget" empty state.
-    func removeLocalBudget(cloudFileId: String) {
+    func removeLocalBudget(cloudFileId: String) async {
+        // The derived encryption key must not outlive the budget — removed
+        // even without a local directory (a failed download can leave a key
+        // behind with nothing to unlock).
+        try? EncryptionKeyManager.remove(fileId: cloudFileId)
+
         guard let local = fileManager.listLocalBudgets().first(
             where: { $0.cloudFileId == cloudFileId }
         ) else { return }
 
-        // Close before deleting files — same vnode-unlink hazard as logout.
         if local.id == currentBudgetId {
+            // Best-effort push of unsynced local edits before the database
+            // holding them is destroyed; offline they're still lost, which the
+            // confirmation dialog warns about. Only the open budget has a live
+            // sync client — a closed budget's pending messages can't be sent.
+            await flushPendingSync()
+            // Close before deleting files — same vnode-unlink hazard as logout.
             closeCurrentBudget()
         }
 
-        // The derived encryption key must not outlive the files it unlocks.
-        try? EncryptionKeyManager.remove(fileId: cloudFileId)
         try? fileManager.deleteBudget(local.id)
         forgetCachedCurrencyCode(for: local.id)
         forgetAppleWalletLinks(for: local.id)
@@ -1561,7 +1569,7 @@ final class BudgetStore: ObservableObject {
         } catch {
             return error.localizedDescription
         }
-        removeLocalBudget(cloudFileId: remoteBudget.id)
+        await removeLocalBudget(cloudFileId: remoteBudget.id)
         remoteBudgets.removeAll { $0.id == remoteBudget.id }
         return nil
     }

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -815,6 +815,37 @@ actor ActualServerClient {
         return fileInfo
     }
 
+    /// `POST /sync/delete-user-file` — marks the file deleted on the server for
+    /// every client. Mirrors upstream's `removeFile` (cloud-storage.ts), which
+    /// sends the token in the body; the header is our usual transport for it.
+    func deleteFile(fileId: String) async throws {
+        guard let serverURL else { throw ActualServerError.invalidURL }
+        guard let token else { throw ActualServerError.unauthorized }
+
+        let url = serverURL.appendingPathComponent("/sync/delete-user-file")
+        var request = makeRequest(url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-ACTUAL-TOKEN")
+        request.httpBody = try JSONEncoder().encode(["token": token, "fileId": fileId])
+
+        let (data, response) = try await send(request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ActualServerError.invalidResponse
+        }
+        if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
+        // The server answers an unknown fileId with 400 (its own FIXME says it
+        // should be 404), so treat both as "no such file".
+        if httpResponse.statusCode == 400 || httpResponse.statusCode == 404 {
+            throw ActualServerError.fileNotFound
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw ActualServerError.httpError(
+                statusCode: httpResponse.statusCode, message: String(data: data, encoding: .utf8)
+            )
+        }
+    }
+
     func getKeyInfo(fileId: String) async throws -> ServerKeyInfo {
         guard let serverURL else { throw ActualServerError.invalidURL }
         guard let token else { throw ActualServerError.unauthorized }

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -833,12 +833,17 @@ actor ActualServerClient {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ActualServerError.invalidResponse
         }
-        if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
-        // The server answers an unknown fileId with 400 (its own FIXME says it
-        // should be 404), so treat both as "no such file".
-        if httpResponse.statusCode == 400 || httpResponse.statusCode == 404 {
-            throw ActualServerError.fileNotFound
+        // Callers treat .fileNotFound as "already deleted" and destroy the
+        // local copy, so nothing that isn't the Actual server's own answer may
+        // map to it: an auth proxy's login page is named as such, and 404 —
+        // which the server never sends for a missing file (it answers 400, its
+        // own FIXME notwithstanding) — stays a plain HTTP error, since it
+        // usually means a proxy or a stripped route.
+        if looksLikeAuthProxy(httpResponse, data: data) {
+            throw ActualServerError.authProxyBlocked
         }
+        if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
+        if httpResponse.statusCode == 400 { throw ActualServerError.fileNotFound }
         guard httpResponse.statusCode == 200 else {
             throw ActualServerError.httpError(
                 statusCode: httpResponse.statusCode, message: String(data: data, encoding: .utf8)

--- a/Actuali/Actuali/Services/Network/ActualServerClient.swift
+++ b/Actuali/Actuali/Services/Network/ActualServerClient.swift
@@ -843,7 +843,9 @@ actor ActualServerClient {
             throw ActualServerError.authProxyBlocked
         }
         if httpResponse.statusCode == 403 { throw ActualServerError.unauthorized }
-        if httpResponse.statusCode == 400 { throw ActualServerError.fileNotFound }
+        if httpResponse.statusCode == 400, data == Data("file-not-found".utf8) {
+            throw ActualServerError.fileNotFound
+        }
         guard httpResponse.statusCode == 200 else {
             throw ActualServerError.httpError(
                 statusCode: httpResponse.statusCode, message: String(data: data, encoding: .utf8)

--- a/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
@@ -275,19 +275,17 @@ private struct BudgetSelectionSettingsSection: View {
 
     /// The open budget's server fileId — currentBudgetId is the internal id,
     /// so map through the local metadata.
-    private var currentCloudFileId: String? {
+    private func currentCloudFileId(in locals: [BudgetMetadata]) -> String? {
         guard let budgetId = budgetStore.currentBudgetId else { return nil }
-        return BudgetFileManager.shared.listLocalBudgets()
-            .first { $0.id == budgetId }?.cloudFileId
+        return locals.first { $0.id == budgetId }?.cloudFileId
     }
 
     /// The open budget when the server list doesn't include it (still loading,
     /// or the file was deleted from another client). It keeps a row so the
     /// selection stays visible and the local copy stays removable.
-    private var unlistedCurrentBudget: BudgetStore.RemoteBudget? {
+    private func unlistedCurrentBudget(in locals: [BudgetMetadata]) -> BudgetStore.RemoteBudget? {
         guard let budgetId = budgetStore.currentBudgetId,
-              let metadata = BudgetFileManager.shared.listLocalBudgets()
-                  .first(where: { $0.id == budgetId }),
+              let metadata = locals.first(where: { $0.id == budgetId }),
               let fileId = metadata.cloudFileId,
               !budgetStore.remoteBudgets.contains(where: { $0.id == fileId })
         else { return nil }
@@ -299,32 +297,17 @@ private struct BudgetSelectionSettingsSection: View {
         )
     }
 
-    private func hasLocalCopy(_ budget: BudgetStore.RemoteBudget) -> Bool {
-        BudgetFileManager.shared.listLocalBudgets().contains { $0.cloudFileId == budget.id }
-    }
-
     var body: some View {
+        // One directory read per render; every row check below shares it.
+        let localBudgets = BudgetFileManager.shared.listLocalBudgets()
+
         Section {
             ForEach(budgetStore.remoteBudgets) { budget in
-                budgetRow(budget)
+                budgetRow(budget, locals: localBudgets)
             }
 
-            if let unlisted = unlistedCurrentBudget {
-                HStack {
-                    if unlisted.isEncrypted {
-                        Image(systemName: "lock.fill").foregroundStyle(.secondary)
-                    }
-                    Text(unlisted.name)
-                    Spacer()
-                    Image(systemName: "checkmark")
-                        .foregroundStyle(.tint)
-                        .accessibilityLabel("Selected")
-                }
-                .contextMenu {
-                    Button("Remove from This Device", systemImage: "iphone.slash") {
-                        budgetToRemoveLocally = unlisted
-                    }
-                }
+            if let unlisted = unlistedCurrentBudget(in: localBudgets) {
+                budgetRow(unlisted, locals: localBudgets)
             }
 
             if budgetStore.remoteBudgets.isEmpty && !budgetStore.isLoading {
@@ -375,11 +358,11 @@ private struct BudgetSelectionSettingsSection: View {
             presenting: budgetToRemoveLocally
         ) { budget in
             Button("Remove from This Device", role: .destructive) {
-                budgetStore.removeLocalBudget(cloudFileId: budget.id)
+                Task { await budgetStore.removeLocalBudget(cloudFileId: budget.id) }
             }
             Button("Cancel", role: .cancel) {}
         } message: { budget in
-            Text("Removes “\(budget.name)” from this device, including its local backups. The budget stays on your server and can be downloaded again.")
+            Text("Removes “\(budget.name)” from this device, including its local backups. Any changes that haven't synced to the server yet will be lost. The budget stays on your server and can be downloaded again.")
         }
         .task {
             await budgetStore.fetchRemoteBudgets()
@@ -387,8 +370,11 @@ private struct BudgetSelectionSettingsSection: View {
         }
     }
 
-    private func budgetRow(_ budget: BudgetStore.RemoteBudget) -> some View {
-        Button {
+    private func budgetRow(
+        _ budget: BudgetStore.RemoteBudget, locals: [BudgetMetadata]
+    ) -> some View {
+        let hasLocalCopy = locals.contains { $0.cloudFileId == budget.id }
+        return Button {
             openBudget(budget)
         } label: {
             HStack {
@@ -399,7 +385,7 @@ private struct BudgetSelectionSettingsSection: View {
                 Spacer()
                 if budgetStore.downloadingBudgetId == budget.id {
                     ProgressView()
-                } else if budget.id == currentCloudFileId {
+                } else if budget.id == currentCloudFileId(in: locals) {
                     Image(systemName: "checkmark")
                         .foregroundStyle(.tint)
                         .accessibilityLabel("Selected")
@@ -414,7 +400,7 @@ private struct BudgetSelectionSettingsSection: View {
                 budgetToDeleteFromServer = budget
             }
             .tint(.red)
-            if hasLocalCopy(budget) {
+            if hasLocalCopy {
                 Button("Remove", systemImage: "iphone.slash") {
                     budgetToRemoveLocally = budget
                 }
@@ -422,7 +408,7 @@ private struct BudgetSelectionSettingsSection: View {
             }
         }
         .contextMenu {
-            if hasLocalCopy(budget) {
+            if hasLocalCopy {
                 Button("Remove from This Device", systemImage: "iphone.slash") {
                     budgetToRemoveLocally = budget
                 }

--- a/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/ConnectionDataSettingsView.swift
@@ -270,67 +270,61 @@ private struct BudgetSelectionSettingsSection: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @State private var budgetToUnlock: BudgetStore.RemoteBudget?
     @State private var showingBudgetSelectPrompt = false
+    @State private var budgetToRemoveLocally: BudgetStore.RemoteBudget?
+    @State private var budgetToDeleteFromServer: BudgetStore.RemoteBudget?
 
-    private var selection: Binding<String?> {
-        Binding(
-            get: {
-                // The picker matches on the server fileId, but currentBudgetId
-                // is the internal id — map through the local metadata.
-                guard let budgetId = budgetStore.currentBudgetId,
-                      let metadata = BudgetFileManager.shared.listLocalBudgets().first(
-                        where: { $0.id == budgetId }
-                      ) else {
-                    return nil
-                }
-                return metadata.cloudFileId
-            },
-            set: { newId in
-                if let id = newId,
-                   let budget = budgetStore.remoteBudgets.first(where: { $0.id == id }) {
-                    Task { await budgetStore.downloadBudget(budget) }
-                }
-            }
+    /// The open budget's server fileId — currentBudgetId is the internal id,
+    /// so map through the local metadata.
+    private var currentCloudFileId: String? {
+        guard let budgetId = budgetStore.currentBudgetId else { return nil }
+        return BudgetFileManager.shared.listLocalBudgets()
+            .first { $0.id == budgetId }?.cloudFileId
+    }
+
+    /// The open budget when the server list doesn't include it (still loading,
+    /// or the file was deleted from another client). It keeps a row so the
+    /// selection stays visible and the local copy stays removable.
+    private var unlistedCurrentBudget: BudgetStore.RemoteBudget? {
+        guard let budgetId = budgetStore.currentBudgetId,
+              let metadata = BudgetFileManager.shared.listLocalBudgets()
+                  .first(where: { $0.id == budgetId }),
+              let fileId = metadata.cloudFileId,
+              !budgetStore.remoteBudgets.contains(where: { $0.id == fileId })
+        else { return nil }
+        return BudgetStore.RemoteBudget(
+            id: fileId,
+            name: metadata.budgetName ?? "Unknown",
+            groupId: metadata.groupId,
+            isEncrypted: metadata.encryptKeyId != nil
         )
+    }
+
+    private func hasLocalCopy(_ budget: BudgetStore.RemoteBudget) -> Bool {
+        BudgetFileManager.shared.listLocalBudgets().contains { $0.cloudFileId == budget.id }
     }
 
     var body: some View {
         Section {
-            Picker("Budget", selection: selection) {
-                // Placeholder until a budget is chosen — deliberately
-                // not offered again afterwards, so "None" can't be
-                // (re)selected.
-                if selection.wrappedValue == nil {
-                    Text("Select a Budget").tag(nil as String?)
-                }
-                // Render a placeholder tag for the current cloudFileId
-                // when remoteBudgets hasn't loaded yet (or doesn't
-                // include it), so SwiftUI can match the selection
-                // and we don't get an "invalid selection" warning.
-                if let currentId = selection.wrappedValue,
-                   !budgetStore.remoteBudgets.contains(where: { $0.id == currentId }) {
-                    Text(budgetStore.remoteBudgets.isEmpty ? "Loading…" : "Unknown")
-                        .tag(currentId as String?)
-                }
-                ForEach(budgetStore.remoteBudgets.filter { !$0.isEncrypted }) { budget in
-                    Text(budget.name).tag(budget.id as String?)
-                }
+            ForEach(budgetStore.remoteBudgets) { budget in
+                budgetRow(budget)
             }
-            .disabled(budgetStore.downloadingBudgetId != nil)
 
-            ForEach(budgetStore.remoteBudgets.filter(\.isEncrypted)) { budget in
-                Button {
-                    openBudget(budget)
-                } label: {
-                    HStack {
+            if let unlisted = unlistedCurrentBudget {
+                HStack {
+                    if unlisted.isEncrypted {
                         Image(systemName: "lock.fill").foregroundStyle(.secondary)
-                        Text(budget.name)
-                        Spacer()
-                        if budgetStore.downloadingBudgetId == budget.id {
-                            ProgressView()
-                        }
+                    }
+                    Text(unlisted.name)
+                    Spacer()
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                        .accessibilityLabel("Selected")
+                }
+                .contextMenu {
+                    Button("Remove from This Device", systemImage: "iphone.slash") {
+                        budgetToRemoveLocally = unlisted
                     }
                 }
-                .disabled(budgetStore.downloadingBudgetId != nil)
             }
 
             if budgetStore.remoteBudgets.isEmpty && !budgetStore.isLoading {
@@ -345,12 +339,17 @@ private struct BudgetSelectionSettingsSection: View {
                 if budgetStore.remoteBudgets.isEmpty && !budgetStore.isLoading {
                     Text("No budgets were found on your server. Create one in Actual Budget, then tap Refresh Budgets.")
                 } else {
-                    Text("Select a budget to load it onto this device. The app stays empty until one is chosen.")
+                    Text("Select a budget to load it onto this device. The app stays empty until one is chosen.\n\nTouch and hold a budget for options to remove it from this device or delete it from the server.")
                 }
+            } else if !budgetStore.remoteBudgets.isEmpty {
+                Text("Touch and hold a budget for options to remove it from this device or delete it from the server.")
             }
         }
         .sheet(item: $budgetToUnlock) { budget in
             EncryptionPasswordSheet(budget: budget, budgetStore: budgetStore)
+        }
+        .sheet(item: $budgetToDeleteFromServer) { budget in
+            DeleteServerBudgetSheet(budget: budget, budgetStore: budgetStore)
         }
         .confirmationDialog(
             "Select a Budget",
@@ -366,9 +365,71 @@ private struct BudgetSelectionSettingsSection: View {
         } message: {
             Text("You're connected! Choose which budget to load onto this device.")
         }
+        .confirmationDialog(
+            "Remove from this device?",
+            isPresented: Binding(
+                get: { budgetToRemoveLocally != nil },
+                set: { if !$0 { budgetToRemoveLocally = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: budgetToRemoveLocally
+        ) { budget in
+            Button("Remove from This Device", role: .destructive) {
+                budgetStore.removeLocalBudget(cloudFileId: budget.id)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { budget in
+            Text("Removes “\(budget.name)” from this device, including its local backups. The budget stays on your server and can be downloaded again.")
+        }
         .task {
             await budgetStore.fetchRemoteBudgets()
             promptBudgetSelectionIfNeeded()
+        }
+    }
+
+    private func budgetRow(_ budget: BudgetStore.RemoteBudget) -> some View {
+        Button {
+            openBudget(budget)
+        } label: {
+            HStack {
+                if budget.isEncrypted {
+                    Image(systemName: "lock.fill").foregroundStyle(.secondary)
+                }
+                Text(budget.name)
+                Spacer()
+                if budgetStore.downloadingBudgetId == budget.id {
+                    ProgressView()
+                } else if budget.id == currentCloudFileId {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                        .accessibilityLabel("Selected")
+                }
+            }
+        }
+        .disabled(budgetStore.downloadingBudgetId != nil)
+        // No .destructive role on the swipe buttons: that animates the row
+        // away on tap, before the confirmation has run.
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button("Delete", systemImage: "trash") {
+                budgetToDeleteFromServer = budget
+            }
+            .tint(.red)
+            if hasLocalCopy(budget) {
+                Button("Remove", systemImage: "iphone.slash") {
+                    budgetToRemoveLocally = budget
+                }
+                .tint(.orange)
+            }
+        }
+        .contextMenu {
+            if hasLocalCopy(budget) {
+                Button("Remove from This Device", systemImage: "iphone.slash") {
+                    budgetToRemoveLocally = budget
+                }
+            }
+            Button("Delete from Server…", systemImage: "trash", role: .destructive) {
+                budgetToDeleteFromServer = budget
+            }
         }
     }
 
@@ -385,6 +446,68 @@ private struct BudgetSelectionSettingsSection: View {
     private func promptBudgetSelectionIfNeeded() {
         if budgetStore.currentBudgetId == nil && !budgetStore.remoteBudgets.isEmpty {
             showingBudgetSelectPrompt = true
+        }
+    }
+}
+
+/// Retype-to-confirm sheet for the irreversible half of budget deletion.
+/// A sheet rather than an alert so the Delete button can stay disabled until
+/// the typed name matches (mirrors EncryptionPasswordSheet).
+private struct DeleteServerBudgetSheet: View {
+    let budget: BudgetStore.RemoteBudget
+    @ObservedObject var budgetStore: BudgetStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var typedName = ""
+    @State private var errorText: String?
+    @State private var isWorking = false
+
+    private var nameMatches: Bool {
+        typedName.trimmingCharacters(in: .whitespacesAndNewlines) == budget.name
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Budget name", text: $typedName)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .disabled(isWorking)
+                } header: {
+                    Text("Delete from Server")
+                } footer: {
+                    Text("This permanently deletes “\(budget.name)” from your Actual server for every device that uses it, along with this device's copy and its local backups. This cannot be undone.\n\nType the budget's name to confirm.")
+                }
+
+                if let errorText {
+                    Text(errorText).foregroundStyle(.red).font(.callout)
+                }
+            }
+            .navigationTitle("Delete Budget")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.disabled(isWorking)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Delete", role: .destructive) { Task { await deleteBudget() } }
+                        .disabled(!nameMatches || isWorking)
+                }
+            }
+            .interactiveDismissDisabled(isWorking)
+        }
+    }
+
+    private func deleteBudget() async {
+        isWorking = true
+        errorText = nil
+        let failure = await budgetStore.deleteServerBudget(budget)
+        isWorking = false
+        if let failure {
+            errorText = failure
+        } else {
+            dismiss()
         }
     }
 }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
@@ -21,7 +21,8 @@ private final class DeleteBudgetTransport: URLProtocol {
             headerFields: ["Content-Type": "application/json"]
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Data(#"{"status":"ok"}"#.utf8))
+        let body = Self.status == 400 ? "file-not-found" : #"{"status":"ok"}"#
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
         client?.urlProtocolDidFinishLoading(self)
     }
 

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
@@ -1,0 +1,240 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Answers /sync/delete-user-file with a preset status so deleteServerBudget's
+/// orchestration (server call, then local cleanup) can run offline.
+private final class DeleteBudgetTransport: URLProtocol {
+    nonisolated(unsafe) static var status = 200
+    nonisolated(unsafe) static var requestedPaths: [String] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestedPaths.append(request.url?.path ?? "")
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"status":"ok"}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Coverage for the two budget-deletion scopes (GH #390): "remove from this
+/// device" deletes the local directory and device-side state while leaving the
+/// server file alone, and "delete from server" additionally soft-deletes the
+/// server file. Deleting the open budget must close it and return the app to
+/// the "select a budget" empty state instead of leaving a dangling session.
+@MainActor
+@Suite(.serialized)
+struct BudgetStoreDeleteBudgetTests {
+
+    /// Store + file manager rooted in a unique temp directory, so parallel
+    /// suites that create real budgets in the shared directory stay unaffected.
+    private func makeIsolatedStore() throws -> (BudgetStore, BudgetFileManager) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("delete-budget-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let manager = BudgetFileManager(rootDirectoryForTesting: root)
+        let store = BudgetStore.previewInstance()
+        store.setFileManagerForTesting(manager)
+        return (store, manager)
+    }
+
+    /// On-disk budget with the metadata.json that listLocalBudgets() keys on,
+    /// plus a backup archive to prove directory removal takes backups/ along.
+    private func seedBudget(
+        id: String,
+        cloudFileId: String,
+        encryptKeyId: String? = nil,
+        in manager: BudgetFileManager
+    ) throws {
+        let dir = manager.budgetDirectory(for: id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("stub".utf8).write(to: manager.databasePath(for: id))
+        try Data("backup".utf8).write(to: manager.backupPath(for: id, name: "2026-01-01_00-00-00.zip"))
+        let metadata = BudgetMetadata(
+            id: id,
+            budgetName: "Test Budget",
+            cloudFileId: cloudFileId,
+            groupId: nil,
+            resetClock: nil,
+            lastUploaded: nil,
+            encryptKeyId: encryptKeyId
+        )
+        try JSONEncoder().encode(metadata).write(to: manager.metadataPath(for: id))
+    }
+
+    private func makeOpenDatabase() throws -> BudgetDatabase {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("delete-budget-db-\(UUID().uuidString).sqlite")
+        return try BudgetDatabase(path: url)
+    }
+
+    private func makeStubbedServerClient(status: Int = 200) async throws -> ActualServerClient {
+        DeleteBudgetTransport.status = status
+        DeleteBudgetTransport.requestedPaths = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DeleteBudgetTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: configuration))
+        try await client.configure(serverURL: "https://budget.example.com")
+        await client.setToken("test-token")
+        return client
+    }
+
+    // MARK: - Remove from this device
+
+    @Test func removesOnlyTheTargetedBudgetIncludingBackups() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        try seedBudget(id: "budget-b", cloudFileId: "file-b", in: manager)
+
+        store.removeLocalBudget(cloudFileId: "file-a")
+
+        #expect(!manager.budgetExists("budget-a"))
+        #expect(!FileManager.default.fileExists(atPath: manager.budgetDirectory(for: "budget-a").path))
+        // The neighbor is untouched, backups included.
+        #expect(manager.budgetExists("budget-b"))
+        #expect(FileManager.default.fileExists(
+            atPath: manager.backupPath(for: "budget-b", name: "2026-01-01_00-00-00.zip").path
+        ))
+    }
+
+    @Test func removingTheOpenBudgetClosesItAndReturnsToEmptyState() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        store.currentBudgetId = "budget-a"
+        store.configureForTesting(
+            database: try makeOpenDatabase(),
+            syncClient: SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        )
+        store.accounts = [
+            Account(id: "a1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 100)
+        ]
+
+        store.removeLocalBudget(cloudFileId: "file-a")
+
+        #expect(store.currentBudgetId == nil)
+        #expect(store.databaseForLogger == nil)
+        #expect(store.accounts.isEmpty)
+        #expect(!manager.budgetExists("budget-a"))
+    }
+
+    @Test func removingAnotherBudgetLeavesTheOpenOneAlone() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        try seedBudget(id: "budget-b", cloudFileId: "file-b", in: manager)
+        store.currentBudgetId = "budget-a"
+        store.configureForTesting(
+            database: try makeOpenDatabase(),
+            syncClient: SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        )
+
+        store.removeLocalBudget(cloudFileId: "file-b")
+
+        #expect(store.currentBudgetId == "budget-a")
+        #expect(store.databaseForLogger != nil)
+        #expect(manager.budgetExists("budget-a"))
+        #expect(!manager.budgetExists("budget-b"))
+    }
+
+    /// The derived encryption key must not outlive the files it unlocks.
+    @Test func removalDeletesTheBudgetsEncryptionKey() throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        let fileId = "cloud-file-\(UUID().uuidString)"
+        try seedBudget(id: "budget-enc", cloudFileId: fileId, encryptKeyId: "key-1", in: manager)
+        try EncryptionKeyManager.store(
+            LoadedKey(keyId: "key-1", key: SymmetricKey(size: .bits256)),
+            fileId: fileId
+        )
+        defer { try? EncryptionKeyManager.remove(fileId: fileId) }
+
+        store.removeLocalBudget(cloudFileId: fileId)
+
+        #expect(EncryptionKeyManager.load(fileId: fileId) == nil)
+    }
+
+    // MARK: - Delete from server
+
+    @Test func serverDeleteRemovesTheFileTheLocalCopyAndTheListRow() async throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        store.setServerClientForTesting(try await makeStubbedServerClient())
+        let remote = BudgetStore.RemoteBudget(
+            id: "file-a", name: "Test Budget", groupId: nil, isEncrypted: false
+        )
+        store.remoteBudgets = [
+            remote,
+            BudgetStore.RemoteBudget(id: "file-b", name: "Other", groupId: nil, isEncrypted: false),
+        ]
+
+        let failure = await store.deleteServerBudget(remote)
+
+        #expect(failure == nil)
+        #expect(DeleteBudgetTransport.requestedPaths == ["/sync/delete-user-file"])
+        #expect(!manager.budgetExists("budget-a"))
+        #expect(store.remoteBudgets.map(\.id) == ["file-b"])
+    }
+
+    /// A file already deleted from another client answers file-not-found; the
+    /// local half still runs so the stale row heals instead of erroring.
+    @Test func serverDeleteTreatsFileNotFoundAsSuccess() async throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        store.setServerClientForTesting(try await makeStubbedServerClient(status: 400))
+        let remote = BudgetStore.RemoteBudget(
+            id: "file-a", name: "Test Budget", groupId: nil, isEncrypted: false
+        )
+        store.remoteBudgets = [remote]
+
+        let failure = await store.deleteServerBudget(remote)
+
+        #expect(failure == nil)
+        #expect(!manager.budgetExists("budget-a"))
+        #expect(store.remoteBudgets.isEmpty)
+    }
+
+    /// Any other server failure aborts the whole delete: the local copy and
+    /// backups must survive until the server file is actually gone.
+    @Test func serverFailureKeepsTheLocalCopyAndBackups() async throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, manager) = try makeIsolatedStore()
+        try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
+        store.setServerClientForTesting(try await makeStubbedServerClient(status: 500))
+        let remote = BudgetStore.RemoteBudget(
+            id: "file-a", name: "Test Budget", groupId: nil, isEncrypted: false
+        )
+        store.remoteBudgets = [remote]
+
+        let failure = await store.deleteServerBudget(remote)
+
+        #expect(failure != nil)
+        #expect(manager.budgetExists("budget-a"))
+        #expect(FileManager.default.fileExists(
+            atPath: manager.backupPath(for: "budget-a", name: "2026-01-01_00-00-00.zip").path
+        ))
+        #expect(store.remoteBudgets.map(\.id) == ["file-a"])
+    }
+}

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDeleteBudgetTests.swift
@@ -92,14 +92,14 @@ struct BudgetStoreDeleteBudgetTests {
 
     // MARK: - Remove from this device
 
-    @Test func removesOnlyTheTargetedBudgetIncludingBackups() throws {
+    @Test func removesOnlyTheTargetedBudgetIncludingBackups() async throws {
         let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
         defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
         let (store, manager) = try makeIsolatedStore()
         try seedBudget(id: "budget-a", cloudFileId: "file-a", in: manager)
         try seedBudget(id: "budget-b", cloudFileId: "file-b", in: manager)
 
-        store.removeLocalBudget(cloudFileId: "file-a")
+        await store.removeLocalBudget(cloudFileId: "file-a")
 
         #expect(!manager.budgetExists("budget-a"))
         #expect(!FileManager.default.fileExists(atPath: manager.budgetDirectory(for: "budget-a").path))
@@ -110,7 +110,7 @@ struct BudgetStoreDeleteBudgetTests {
         ))
     }
 
-    @Test func removingTheOpenBudgetClosesItAndReturnsToEmptyState() throws {
+    @Test func removingTheOpenBudgetClosesItAndReturnsToEmptyState() async throws {
         let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
         defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
         let (store, manager) = try makeIsolatedStore()
@@ -125,7 +125,7 @@ struct BudgetStoreDeleteBudgetTests {
                     offBudget: false, closed: false, sortOrder: 0, balance: 100)
         ]
 
-        store.removeLocalBudget(cloudFileId: "file-a")
+        await store.removeLocalBudget(cloudFileId: "file-a")
 
         #expect(store.currentBudgetId == nil)
         #expect(store.databaseForLogger == nil)
@@ -133,7 +133,7 @@ struct BudgetStoreDeleteBudgetTests {
         #expect(!manager.budgetExists("budget-a"))
     }
 
-    @Test func removingAnotherBudgetLeavesTheOpenOneAlone() throws {
+    @Test func removingAnotherBudgetLeavesTheOpenOneAlone() async throws {
         let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
         defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
         let (store, manager) = try makeIsolatedStore()
@@ -145,7 +145,7 @@ struct BudgetStoreDeleteBudgetTests {
             syncClient: SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
         )
 
-        store.removeLocalBudget(cloudFileId: "file-b")
+        await store.removeLocalBudget(cloudFileId: "file-b")
 
         #expect(store.currentBudgetId == "budget-a")
         #expect(store.databaseForLogger != nil)
@@ -154,7 +154,7 @@ struct BudgetStoreDeleteBudgetTests {
     }
 
     /// The derived encryption key must not outlive the files it unlocks.
-    @Test func removalDeletesTheBudgetsEncryptionKey() throws {
+    @Test func removalDeletesTheBudgetsEncryptionKey() async throws {
         let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
         defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
         let (store, manager) = try makeIsolatedStore()
@@ -166,7 +166,25 @@ struct BudgetStoreDeleteBudgetTests {
         )
         defer { try? EncryptionKeyManager.remove(fileId: fileId) }
 
-        store.removeLocalBudget(cloudFileId: fileId)
+        await store.removeLocalBudget(cloudFileId: fileId)
+
+        #expect(EncryptionKeyManager.load(fileId: fileId) == nil)
+    }
+
+    /// A failed download can leave a derived key with no budget directory;
+    /// deletion must still clear it rather than bailing on the missing copy.
+    @Test func removalDeletesTheKeyEvenWithoutALocalCopy() async throws {
+        let saved = UserDefaults.standard.string(forKey: "currentBudgetId")
+        defer { UserDefaults.standard.set(saved, forKey: "currentBudgetId") }
+        let (store, _) = try makeIsolatedStore()
+        let fileId = "cloud-file-\(UUID().uuidString)"
+        try EncryptionKeyManager.store(
+            LoadedKey(keyId: "key-1", key: SymmetricKey(size: .bits256)),
+            fileId: fileId
+        )
+        defer { try? EncryptionKeyManager.remove(fileId: fileId) }
+
+        await store.removeLocalBudget(cloudFileId: fileId)
 
         #expect(EncryptionKeyManager.load(fileId: fileId) == nil)
     }

--- a/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
+++ b/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import Actuali
+
+/// Captures delete-user-file requests and answers with a preset status, so the
+/// client's request shape and error mapping can be pinned down offline.
+private final class DeleteFileTransport: URLProtocol {
+    nonisolated(unsafe) static var capturedRequests: [URLRequest] = []
+    nonisolated(unsafe) static var capturedBodies: [Data] = []
+    nonisolated(unsafe) static var status = 200
+    nonisolated(unsafe) static var responseBody = Data(#"{"status":"ok"}"#.utf8)
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequests.append(request)
+        Self.capturedBodies.append(Self.readBody(request))
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseBody)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    /// URLSession hands POST bodies to URLProtocol as a stream, not httpBody.
+    private static func readBody(_ request: URLRequest) -> Data {
+        guard let stream = request.httpBodyStream else { return request.httpBody ?? Data() }
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        let bufferSize = 16 * 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            body.append(buffer, count: read)
+        }
+        return body
+    }
+}
+
+@Suite(.serialized)
+struct ActualServerClientDeleteFileTests {
+    private func makeClient(status: Int = 200) async throws -> ActualServerClient {
+        DeleteFileTransport.capturedRequests = []
+        DeleteFileTransport.capturedBodies = []
+        DeleteFileTransport.status = status
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DeleteFileTransport.self]
+        let client = ActualServerClient(session: URLSession(configuration: configuration))
+        try await client.configure(serverURL: "https://budget.example.com")
+        await client.setToken("test-token")
+        return client
+    }
+
+    /// Upstream's removeFile POSTs `{token, fileId}` to /delete-user-file
+    /// (cloud-storage.ts); the header carries the token like our other routes.
+    @Test func postsTokenAndFileIdToDeleteUserFile() async throws {
+        let client = try await makeClient()
+
+        try await client.deleteFile(fileId: "file-123")
+
+        let request = try #require(DeleteFileTransport.capturedRequests.first)
+        #expect(request.url?.path == "/sync/delete-user-file")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "X-ACTUAL-TOKEN") == "test-token")
+        let body = try JSONDecoder().decode(
+            [String: String].self,
+            from: try #require(DeleteFileTransport.capturedBodies.first)
+        )
+        #expect(body == ["token": "test-token", "fileId": "file-123"])
+    }
+
+    @Test func requiresAToken() async throws {
+        let client = try await makeClient()
+        await client.setToken(nil)
+
+        await #expect(throws: ActualServerError.self) {
+            try await client.deleteFile(fileId: "file-123")
+        }
+        #expect(DeleteFileTransport.capturedRequests.isEmpty)
+    }
+
+    @Test func mapsForbiddenToUnauthorized() async throws {
+        let client = try await makeClient(status: 403)
+
+        do {
+            try await client.deleteFile(fileId: "file-123")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .unauthorized = error else {
+                Issue.record("Expected .unauthorized, got \(error)")
+                return
+            }
+        }
+    }
+
+    /// The server answers an unknown fileId with 400 file-not-found (its own
+    /// FIXME says it should be 404), so both map to `.fileNotFound`.
+    @Test func mapsBadRequestToFileNotFound() async throws {
+        for status in [400, 404] {
+            let client = try await makeClient(status: status)
+            do {
+                try await client.deleteFile(fileId: "file-123")
+                Issue.record("Expected deleteFile to throw for \(status)")
+            } catch let error as ActualServerError {
+                guard case .fileNotFound = error else {
+                    Issue.record("Expected .fileNotFound for \(status), got \(error)")
+                    return
+                }
+            }
+        }
+    }
+
+    @Test func surfacesOtherServerFailuresAsHTTPErrors() async throws {
+        let client = try await makeClient(status: 500)
+
+        do {
+            try await client.deleteFile(fileId: "file-123")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .httpError(let statusCode, _) = error else {
+                Issue.record("Expected .httpError, got \(error)")
+                return
+            }
+            #expect(statusCode == 500)
+        }
+    }
+}

--- a/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
+++ b/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
@@ -9,6 +9,7 @@ private final class DeleteFileTransport: URLProtocol {
     nonisolated(unsafe) static var capturedBodies: [Data] = []
     nonisolated(unsafe) static var status = 200
     nonisolated(unsafe) static var responseBody = Data(#"{"status":"ok"}"#.utf8)
+    nonisolated(unsafe) static var responseContentType = "application/json"
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -21,7 +22,7 @@ private final class DeleteFileTransport: URLProtocol {
             url: request.url!,
             statusCode: Self.status,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"]
+            headerFields: ["Content-Type": Self.responseContentType]
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Self.responseBody)
@@ -50,10 +51,16 @@ private final class DeleteFileTransport: URLProtocol {
 
 @Suite(.serialized)
 struct ActualServerClientDeleteFileTests {
-    private func makeClient(status: Int = 200) async throws -> ActualServerClient {
+    private func makeClient(
+        status: Int = 200,
+        responseBody: String = #"{"status":"ok"}"#,
+        responseContentType: String = "application/json"
+    ) async throws -> ActualServerClient {
         DeleteFileTransport.capturedRequests = []
         DeleteFileTransport.capturedBodies = []
         DeleteFileTransport.status = status
+        DeleteFileTransport.responseBody = Data(responseBody.utf8)
+        DeleteFileTransport.responseContentType = responseContentType
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DeleteFileTransport.self]
         let client = ActualServerClient(session: URLSession(configuration: configuration))
@@ -105,18 +112,52 @@ struct ActualServerClientDeleteFileTests {
     }
 
     /// The server answers an unknown fileId with 400 file-not-found (its own
-    /// FIXME says it should be 404), so both map to `.fileNotFound`.
+    /// FIXME says it should be 404).
     @Test func mapsBadRequestToFileNotFound() async throws {
-        for status in [400, 404] {
-            let client = try await makeClient(status: status)
-            do {
-                try await client.deleteFile(fileId: "file-123")
-                Issue.record("Expected deleteFile to throw for \(status)")
-            } catch let error as ActualServerError {
-                guard case .fileNotFound = error else {
-                    Issue.record("Expected .fileNotFound for \(status), got \(error)")
-                    return
-                }
+        let client = try await makeClient(status: 400)
+        do {
+            try await client.deleteFile(fileId: "file-123")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .fileNotFound = error else {
+                Issue.record("Expected .fileNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    /// The Actual server never answers a missing file with 404 — that status
+    /// means a proxy or a stripped route. It must NOT map to .fileNotFound,
+    /// which callers treat as "already deleted" before destroying local data.
+    @Test func keeps404AsAPlainHTTPError() async throws {
+        let client = try await makeClient(status: 404)
+        do {
+            try await client.deleteFile(fileId: "file-123")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .httpError(let statusCode, _) = error else {
+                Issue.record("Expected .httpError, got \(error)")
+                return
+            }
+            #expect(statusCode == 404)
+        }
+    }
+
+    /// An auth proxy's HTML login page is named as such rather than surfacing
+    /// as a decode failure — or worse, a status that callers act on.
+    @Test func namesAnAuthProxyAnswer() async throws {
+        let client = try await makeClient(
+            status: 200,
+            responseBody: "<html><body>Sign in</body></html>",
+            responseContentType: "text/html"
+        )
+        do {
+            try await client.deleteFile(fileId: "file-123")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .authProxyBlocked = error else {
+                Issue.record("Expected .authProxyBlocked, got \(error)")
+                return
             }
         }
     }

--- a/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
+++ b/Actuali/ActualiTests/Services/Network/ActualServerClientDeleteFileTests.swift
@@ -114,7 +114,7 @@ struct ActualServerClientDeleteFileTests {
     /// The server answers an unknown fileId with 400 file-not-found (its own
     /// FIXME says it should be 404).
     @Test func mapsBadRequestToFileNotFound() async throws {
-        let client = try await makeClient(status: 400)
+        let client = try await makeClient(status: 400, responseBody: "file-not-found")
         do {
             try await client.deleteFile(fileId: "file-123")
             Issue.record("Expected deleteFile to throw")
@@ -123,6 +123,20 @@ struct ActualServerClientDeleteFileTests {
                 Issue.record("Expected .fileNotFound, got \(error)")
                 return
             }
+        }
+    }
+
+    @Test func keepsOtherBadRequestsAsHTTPErrors() async throws {
+        let client = try await makeClient(status: 400, responseBody: "invalid fileId")
+        do {
+            try await client.deleteFile(fileId: "budget@2026")
+            Issue.record("Expected deleteFile to throw")
+        } catch let error as ActualServerError {
+            guard case .httpError(let statusCode, _) = error else {
+                Issue.record("Expected .httpError, got \(error)")
+                return
+            }
+            #expect(statusCode == 400)
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing! Keep it short — a couple of sentences per section is plenty. -->

## Why

Actuali can open and sync budget files but has no way to get rid of one — deleting a budget meant leaving the app for Actual's web or desktop client, and there was no way to drop just the local copy short of Disconnect wiping everything. Closes [MattFaz/actuali#390](https://github.com/MattFaz/actuali/issues/390).

## What

- Budget Selection is now a unified list of rows (the Picker is gone; encrypted budgets were already rows) with a checkmark on the open budget. Each row gets swipe actions and a context menu with two scopes:
  - **Remove from This Device** — deletes the local directory (database, metadata, backups) and device-side state (encryption key, cached currency, Wallet links), leaving the server file untouched for re-download. Guarded by a confirmation dialog. Only offered when a local copy exists.
  - **Delete from Server** — `POST /sync/delete-user-file` (matching upstream's `removeFile` in `cloud-storage.ts`), then the same local cleanup. Guarded by a retype-the-budget-name sheet; Delete stays disabled until the name matches. A 400/404 ("file not found") answer is treated as already-deleted so stale rows heal; any other failure aborts, keeping the local copy and backups until the server file is actually gone.
- Deleting the currently open budget closes it and returns the app to the "select a budget" empty state (via `closeCurrentBudget()`, factored out of `logout()` — same teardown ordering, database closed before files are touched).
- The open budget keeps a list row even when the server listing doesn't include it (still loading, or deleted from another client), so it stays visible and removable.

## How it was tested

- New unit tests: `ActualServerClientDeleteFileTests` (request shape — path, method, token header/body — and 403/400/404/500 error mapping via a stub transport) and `BudgetStoreDeleteBudgetTests` (targeted removal leaves neighboring budgets and their backups alone, removing the open budget closes it and clears published state, encryption-key cleanup, and the three server-delete outcomes: success, file-not-found heals, other failures keep local data). Both follow the existing `URLProtocol`-stub and isolated-`BudgetFileManager` patterns.
- Existing `BudgetStoreLogoutTests` cover the `logout()` refactor unchanged.

## Screenshots

<img width="301" alt="Screenshot iPhone 17 Pro 08-31-2026 at 3 38 33 PM" src="https://github.com/user-attachments/assets/bfbea25f-ab24-40a3-8c62-b5697a39d69e" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-31-2026 at 3 38 43 PM" src="https://github.com/user-attachments/assets/b5d399bf-36b2-4fbc-bd24-ea3ae813106c" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-31-2026 at 3 38 57 PM" src="https://github.com/user-attachments/assets/fea86a34-4dbe-481f-8969-3a9cd8d27d9d" />
<img width="301" alt="Screenshot iPhone 17 Pro 08-31-2026 at 3 39 04 PM" src="https://github.com/user-attachments/assets/1df5b210-8280-4f9a-861d-85976606cc23" />

