### PR TITLE
Fix Age of Money same-day ordering

### DIFF
--- a/Actuali/Actuali/Services/Reports/Engines/AgeOfMoneyEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/AgeOfMoneyEngine.swift
@@ -60,7 +60,12 @@ enum AgeOfMoneyEngine {
             }
             .sorted { lhs, rhs in
                 if lhs.date != rhs.date { return lhs.date < rhs.date }
-                return (lhs.sortOrder ?? 0, lhs.id) < (rhs.sortOrder ?? 0, rhs.id)
+                switch (lhs.sortOrder, rhs.sortOrder) {
+                case let (left?, right?) where left != right: return left > right
+                case (_?, nil): return true
+                case (nil, _?): return false
+                default: return lhs.id < rhs.id
+                }
             }
 
         // FIFO drain (upstream calculateAgeOfMoney).

--- a/Actuali/ActualiTests/Services/Reports/AgeOfMoneyEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/AgeOfMoneyEngineTests.swift
@@ -86,6 +86,25 @@ struct AgeOfMoneyEngineTests {
         #expect(data.currentAge == 38)
     }
 
+    @Test func sameDayExpensesKeepUpstreamDescendingSortOrder() {
+        // v_transactions orders same-day rows by sort_order DESC and the
+        // upstream date-only stable sort preserves that order. Reversing it
+        // changes which of the last ten ages is retained.
+        var txs = [
+            tx("i1", date: 20260101, amount: 50),
+            tx("i2", date: 20260201, amount: 110)
+        ]
+        for index in 1...11 {
+            txs.append(tx("e\(index)", date: 20260301, amount: index == 1 ? -60 : -10))
+            txs[txs.count - 1].sortOrder = Double(index)
+        }
+
+        let data = AgeOfMoneyEngine.compute(
+            meta: meta(start: "2026-03", end: "2026-03", mode: .static),
+            transactions: txs, today: today, context: .empty)
+        #expect(data.currentAge == 40)
+    }
+
     @Test func trendComparesLastTwoGraphPoints() {
         // Ages fall over months → declining trend (diff < -2).
         // e1 (Mar 1) ages from i1 (2025-01-01) → 424; the Mar point (424) is

--- a/Actuali/ActualiTests/Services/Reports/AgeOfMoneyEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/AgeOfMoneyEngineTests.swift
@@ -105,6 +105,24 @@ struct AgeOfMoneyEngineTests {
         #expect(data.currentAge == 40)
     }
 
+    @Test func sameDayNilSortOrderDrainsLast() {
+        // SQLite puts NULL last under sort_order DESC. A missing sort order
+        // must therefore drain after a same-day row with a real sort order.
+        var txs = [
+            tx("i1", date: 20260101, amount: 100),
+            tx("i2", date: 20260201, amount: 100),
+            tx("no-order", date: 20260301, amount: -150),
+            tx("ordered", date: 20260301, amount: -50)
+        ]
+        txs[3].sortOrder = 5
+
+        let data = AgeOfMoneyEngine.compute(
+            meta: meta(start: "2026-03", end: "2026-03", mode: .static),
+            transactions: txs, today: today, context: .empty)
+        #expect(data.currentAge == 44)
+        #expect(data.insufficientData == false)
+    }
+
     @Test func trendComparesLastTwoGraphPoints() {
         // Ages fall over months → declining trend (diff < -2).
         // e1 (Mar 1) ages from i1 (2025-01-01) → 424; the Mar point (424) is


### PR DESCRIPTION
## What changed

Match Actual's stable same-day transaction ordering by sorting `sortOrder` descending, with the same nil and ID tie-break behavior. Add a regression test covering the rolling last-ten age calculation.

## Why

The iOS engine sorted same-day rows ascending, which could assign different income buckets to expenses and show a different Age of Money than the web app.

## Verification

- `xcodebuild test ... -skip-testing:ActualiUITests` on iOS 18.5 simulator — **TEST SUCCEEDED**
- `xcodebuild test ... -only-testing:ActualiTests/AgeOfMoneyEngineTests` — 13 tests passed
- `xcodebuild build ... -sdk iphonesimulator` — **BUILD SUCCEEDED**
- No standalone lint/typecheck command is configured; the native build completed successfully.

Fixes #395