### PR TITLE
Fix compact group hiding

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -356,6 +356,17 @@ struct BudgetView: View {
             }
         case .compact:
             Section {
+                CompactBudgetGroupHeader(
+                    name: group.name,
+                    isCollapsed: isCollapsed,
+                    isHidden: group.isHidden,
+                    onSetHidden: {
+                        setCategoryGroupHidden(group.id, hidden: $0)
+                    },
+                    totals: budgetStore.showGroupTotals ? group.totals : nil,
+                    showsSpent: budgetStore.showCompactSpentColumn,
+                    onToggleCollapse: { toggleCollapsed(group.id) }
+                )
                 if !isCollapsed {
                     ForEach(group.categories) { category in
                         CompactCategoryBudgetRow(
@@ -375,19 +386,6 @@ struct BudgetView: View {
                         )
                     }
                 }
-            } header: {
-                CompactBudgetGroupHeader(
-                    name: group.name,
-                    isCollapsed: isCollapsed,
-                    isHidden: group.isHidden,
-                    onSetHidden: {
-                        setCategoryGroupHidden(group.id, hidden: $0)
-                    },
-                    totals: budgetStore.showGroupTotals ? group.totals : nil,
-                    showsSpent: budgetStore.showCompactSpentColumn,
-                    onToggleCollapse: { toggleCollapsed(group.id) }
-                )
-                .textCase(nil)
             }
         }
     }
@@ -474,6 +472,19 @@ struct BudgetView: View {
             }
         case .compact:
             Section {
+                CompactIncomeGroupHeader(
+                    name: name,
+                    isCollapsed: isCollapsed,
+                    isHidden: group?.hidden == true,
+                    onSetHidden: onSetHidden,
+                    totalBudgeted: budget.totalBudgetedIncome,
+                    totalReceived: budget.totalIncome,
+                    showsBudgeted: budget.isTrackingBudget,
+                    showsSpent: budgetStore.showCompactSpentColumn,
+                    onToggleCollapse: {
+                        toggleCollapsed(Self.incomeGroupCollapseID)
+                    }
+                )
                 if !isCollapsed {
                     ForEach(categories) { income in
                         CompactIncomeCategoryRow(
@@ -489,21 +500,6 @@ struct BudgetView: View {
                         )
                     }
                 }
-            } header: {
-                CompactIncomeGroupHeader(
-                    name: name,
-                    isCollapsed: isCollapsed,
-                    isHidden: group?.hidden == true,
-                    onSetHidden: onSetHidden,
-                    totalBudgeted: budget.totalBudgetedIncome,
-                    totalReceived: budget.totalIncome,
-                    showsBudgeted: budget.isTrackingBudget,
-                    showsSpent: budgetStore.showCompactSpentColumn,
-                    onToggleCollapse: {
-                        toggleCollapsed(Self.incomeGroupCollapseID)
-                    }
-                )
-                .textCase(nil)
             }
         }
     }

--- a/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
+++ b/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
@@ -208,28 +208,21 @@ struct CompactBudgetGroupHeader: View {
             .accessibilityIdentifier("compactBudgetGroup.\(name)")
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the group's categories")
-
-            if let onSetHidden {
-                Menu {
-                    Button {
-                        onSetHidden(!isHidden)
-                    } label: {
-                        Label(
-                            isHidden ? "Show Group" : "Hide Group",
-                            systemImage: isHidden ? "eye" : "eye.slash"
-                        )
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .frame(minWidth: 32, minHeight: 44)
-                }
-                .accessibilityLabel("Options for \(name)")
-            }
         }
         .foregroundStyle(.primary)
         .background(Color(.secondarySystemBackground))
         .listRowInsets(EdgeInsets())
         .opacity(isHidden ? 0.5 : 1)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
+            }
+        }
     }
 
     private var title: some View {
@@ -540,28 +533,21 @@ struct CompactIncomeGroupHeader: View {
             .accessibilityIdentifier("compactIncomeSection")
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the income categories")
-
-            if let onSetHidden {
-                Menu {
-                    Button {
-                        onSetHidden(!isHidden)
-                    } label: {
-                        Label(
-                            isHidden ? "Show Group" : "Hide Group",
-                            systemImage: isHidden ? "eye" : "eye.slash"
-                        )
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .frame(minWidth: 32, minHeight: 44)
-                }
-                .accessibilityLabel("Options for \(name)")
-            }
         }
         .foregroundStyle(.primary)
         .background(Color(.secondarySystemBackground))
         .listRowInsets(EdgeInsets())
         .opacity(isHidden ? 0.5 : 1)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if let onSetHidden {
+                Button {
+                    onSetHidden(!isHidden)
+                } label: {
+                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+                }
+                .tint(isHidden ? .accentColor : .secondary)
+            }
+        }
     }
 
     private var title: some View {

--- a/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
+++ b/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
@@ -151,64 +151,62 @@ struct CompactBudgetGroupHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            Button(action: onToggleCollapse) {
-                Group {
-                    if dynamicTypeSize.isAccessibilitySize {
-                        VStack(alignment: .leading, spacing: 8) {
-                            title
+        Button(action: onToggleCollapse) {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 8) {
+                        title
+                        ForEach(columnsForLayout, id: \.type) { column in
+                            HStack {
+                                Text(column.type.rawValue)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                CompactAmountText(
+                                    amount: column.amount,
+                                    isBalance: column.type == .balance
+                                )
+                            }
+                        }
+                        .opacity(totals == nil ? 0 : 1)
+                        .accessibilityHidden(totals == nil)
+                    }
+                } else {
+                    HStack(spacing: 0) {
+                        title
+                            .frame(
+                                width: CompactBudgetTableLayout.titleColumnWidth,
+                                alignment: .leading
+                            )
+                        HStack(spacing: CompactBudgetTableLayout.amountColumnSpacing) {
                             ForEach(columnsForLayout, id: \.type) { column in
-                                HStack {
+                                VStack(alignment: .trailing, spacing: 2) {
                                     Text(column.type.rawValue)
-                                        .foregroundStyle(.secondary)
-                                    Spacer()
+                                        .font(.caption2)
+                                        .lineLimit(1)
+                                        .minimumScaleFactor(0.65)
                                     CompactAmountText(
                                         amount: column.amount,
                                         isBalance: column.type == .balance
                                     )
                                 }
+                                .frame(maxWidth: .infinity, alignment: .trailing)
                             }
-                            .opacity(totals == nil ? 0 : 1)
-                            .accessibilityHidden(totals == nil)
                         }
-                    } else {
-                        HStack(spacing: 0) {
-                            title
-                                .frame(
-                                    width: CompactBudgetTableLayout.titleColumnWidth,
-                                    alignment: .leading
-                                )
-                            HStack(spacing: CompactBudgetTableLayout.amountColumnSpacing) {
-                                ForEach(columnsForLayout, id: \.type) { column in
-                                    VStack(alignment: .trailing, spacing: 2) {
-                                        Text(column.type.rawValue)
-                                            .font(.caption2)
-                                            .lineLimit(1)
-                                            .minimumScaleFactor(0.65)
-                                        CompactAmountText(
-                                            amount: column.amount,
-                                            isBalance: column.type == .balance
-                                        )
-                                    }
-                                    .frame(maxWidth: .infinity, alignment: .trailing)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .layoutPriority(1)
-                            .opacity(totals == nil ? 0 : 1)
-                            .accessibilityHidden(totals == nil)
-                        }
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .layoutPriority(1)
+                        .opacity(totals == nil ? 0 : 1)
+                        .accessibilityHidden(totals == nil)
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("compactBudgetGroup.\(name)")
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityHint("Toggles the group's categories")
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("compactBudgetGroup.\(name)")
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Toggles the group's categories")
         .foregroundStyle(.primary)
         .background(Color(.secondarySystemBackground))
         .listRowInsets(EdgeInsets())
@@ -482,58 +480,56 @@ struct CompactIncomeGroupHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            Button(action: onToggleCollapse) {
-                Group {
-                    if dynamicTypeSize.isAccessibilitySize {
-                        VStack(alignment: .leading, spacing: 8) {
-                            title
-                            ForEach(columns, id: \.0) { column, amount in
-                                HStack {
-                                    Text(column.rawValue)
-                                        .foregroundStyle(.secondary)
-                                    Spacer()
-                                    CompactAmountText(amount: amount)
-                                }
+        Button(action: onToggleCollapse) {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 8) {
+                        title
+                        ForEach(columns, id: \.0) { column, amount in
+                            HStack {
+                                Text(column.rawValue)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                CompactAmountText(amount: amount)
                             }
-                        }
-                    } else {
-                        HStack(spacing: 0) {
-                            title
-                                .frame(
-                                    width: CompactBudgetTableLayout.titleColumnWidth,
-                                    alignment: .leading
-                                )
-                            HStack(spacing: CompactBudgetTableLayout.amountColumnSpacing) {
-                                ForEach(Array(layout.incomeColumns.enumerated()), id: \.offset) { _, column in
-                                    Group {
-                                        if let column {
-                                            VStack(alignment: .trailing, spacing: 2) {
-                                                Text(column.rawValue)
-                                                    .font(.caption2)
-                                                CompactAmountText(amount: amount(for: column))
-                                            }
-                                        } else {
-                                            Color.clear
-                                        }
-                                    }
-                                    .frame(maxWidth: .infinity, alignment: .trailing)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .layoutPriority(1)
                         }
                     }
+                } else {
+                    HStack(spacing: 0) {
+                        title
+                            .frame(
+                                width: CompactBudgetTableLayout.titleColumnWidth,
+                                alignment: .leading
+                            )
+                        HStack(spacing: CompactBudgetTableLayout.amountColumnSpacing) {
+                            ForEach(Array(layout.incomeColumns.enumerated()), id: \.offset) { _, column in
+                                Group {
+                                    if let column {
+                                        VStack(alignment: .trailing, spacing: 2) {
+                                            Text(column.rawValue)
+                                                .font(.caption2)
+                                            CompactAmountText(amount: amount(for: column))
+                                        }
+                                    } else {
+                                        Color.clear
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .layoutPriority(1)
+                    }
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("compactIncomeSection")
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityHint("Toggles the income categories")
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("compactIncomeSection")
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Toggles the income categories")
         .foregroundStyle(.primary)
         .background(Color(.secondarySystemBackground))
         .listRowInsets(EdgeInsets())

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -98,8 +98,11 @@ final class BudgetGroupCollapseUITests: XCTestCase {
             NSPredicate(format: "label BEGINSWITH %@", "Essentials, ")
         ).firstMatch
         XCTAssertTrue(essentials.waitForExistence(timeout: 10))
+        if displayStyle == "compact" {
+            XCTAssertFalse(app.buttons["Options for Essentials"].exists)
+        }
 
-        setGroupHidden(true, displayStyle: displayStyle, app: app, group: essentials)
+        setGroupHidden(true, app: app, group: essentials)
         XCTAssertTrue(essentials.waitForNonExistence(timeout: 5))
 
         let optionsMenu = app.buttons["Budget options"]
@@ -109,7 +112,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         showHidden.tap()
         XCTAssertTrue(essentials.waitForExistence(timeout: 5))
 
-        setGroupHidden(false, displayStyle: displayStyle, app: app, group: essentials)
+        setGroupHidden(false, app: app, group: essentials)
 
         optionsMenu.tap()
         XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
@@ -118,19 +121,14 @@ final class BudgetGroupCollapseUITests: XCTestCase {
                       "the group should remain visible after hidden categories are turned off")
     }
 
+    @MainActor
     private func setGroupHidden(
         _ hidden: Bool,
-        displayStyle: String,
         app: XCUIApplication,
         group: XCUIElement
     ) {
-        if displayStyle == "compact" {
-            app.buttons["Options for Essentials"].tap()
-            app.buttons[hidden ? "Hide Group" : "Show Group"].tap()
-        } else {
-            group.swipeLeft()
-            app.buttons[hidden ? "Hide" : "Show"].tap()
-        }
+        group.swipeLeft()
+        app.buttons[hidden ? "Hide" : "Show"].tap()
     }
 
     @MainActor


### PR DESCRIPTION
Compact category-group headers now use the same swipe-to-hide action as Detailed instead of showing the old ellipsis menu. Compact headers are list rows because native SwiftUI section headers do not expose swipe actions reliably.

Tradeoff: compact group headers no longer pin while scrolling. Keeping them pinned would require retaining the obsolete menu/context-menu interaction or replacing the native List behavior; swipe consistency is the requirement of #400.

Verified with:
- `BudgetGroupCollapseUITests` — 8 passed, 0 failed
- `CompactBudgetPresentationTests` — passed after review cleanup
- CI-equivalent unit suite — 1676 passed, 0 failed
- iOS Simulator build — succeeded

Fixes #400