### PR TITLE
Fix pasted reconciliation amounts with grouping separators

### DIFF
--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -1151,7 +1151,15 @@ struct AmountInputField: UIViewRepresentable {
                 pendingOperator = nil
             }
 
-            if string.isEmpty {
+            // UIKit delivers a pasted value as one replacement string. Parse
+            // that complete value before feeding characters through the
+            // calculator-mode digit shifter; otherwise a grouping comma is
+            // mistaken for the decimal point ("450,046.23" became "450.04").
+            if string.count > 1,
+               let pastedValue = AmountParser.parse(string),
+               Transaction.cents(fromDollars: pastedValue) != nil {
+                setOperand(to: pastedValue)
+            } else if string.isEmpty {
                 handleBackspace()
             } else {
                 for character in string {

--- a/Actuali/ActualiTests/Views/AmountInputFieldTests.swift
+++ b/Actuali/ActualiTests/Views/AmountInputFieldTests.swift
@@ -76,6 +76,42 @@ struct AmountInputFieldTests {
         #expect(box.value == "12")
     }
 
+    @Test func pastingGroupedDecimalPreservesTheWholeAmount() {
+        let (coordinator, textField, box) = makeField()
+        _ = coordinator.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "450,046.23"
+        )
+
+        #expect(textField.text == "450046.23")
+        #expect(box.value == "450046.23")
+    }
+
+    @Test func pastingAnOversizedNumberFallsBackInsteadOfCrashing() {
+        let (coordinator, textField, box) = makeField()
+        _ = coordinator.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "1,000,000,000,000,000,000,000"
+        )
+
+        #expect(Double(box.value) != nil)
+    }
+
+    @Test func pastingGroupedDecimalInConventionalModeKeepsSignAndCents() {
+        let (coordinator, textField, box) = makeField(
+            allowsNegative: true, conventionalAmountEntry: true
+        )
+        _ = coordinator.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "-450,046.23"
+        )
+
+        #expect(box.value == "-450046.23")
+    }
+
     @Test func conventionalModeKeepsExplicitDecimalEntry() {
         let (coordinator, textField, box) = makeField(conventionalAmountEntry: true)
         type("12.05", into: coordinator, textField)


### PR DESCRIPTION
## Why
Closes #403.

## What
Preserves formatted pasted amounts such as $13,379.70 in the Reconcile Bank Balance field.

## How it was tested
AmountInputFieldTests passed on the iOS 26.5 simulator, including the 450,046.23 regression case.

## Screenshots
Not applicable.