### PR TITLE
Rollover spending

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -115,6 +115,12 @@ struct CategoryBudget: Identifiable, Hashable {
     /// progress is measured against the balance rather than this month's
     /// budgeted amount, mirroring the web's BalanceWithCarryover.
     var longGoal = false
+    
+    /// The row's `carryover` flag ("Rollover overspending" in the web's
+    /// balance menu): a negative balance rolls into next month instead of
+    /// being absorbed by To Budget (envelope) or dropped (tracking). Distinct
+    /// from `carryover`, which is the amount that actually rolled in.
+    var carryoverEnabled = false
 
     var isEffectivelyHidden: Bool { hidden || groupHidden }
 

--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -115,7 +115,7 @@ struct CategoryBudget: Identifiable, Hashable {
     /// progress is measured against the balance rather than this month's
     /// budgeted amount, mirroring the web's BalanceWithCarryover.
     var longGoal = false
-    
+
     /// The row's `carryover` flag ("Rollover overspending" in the web's
     /// balance menu): a negative balance rolls into next month instead of
     /// being absorbed by To Budget (envelope) or dropped (tracking). Distinct

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -5179,6 +5179,30 @@ return transaction.id
         try await syncClient.setBudgetAmount(month: month, categoryId: categoryId, amount: amountCents)
         await fetchBudgetMonth(month)
     }
+    
+    /// Turn "rollover overspending" on or off for a category (GH #372), then
+    /// refetch the month so the published flag and Available recompute.
+    /// Mirrors the web's balance menu: the flag is written from this month
+    /// through the last month the web would have created, so both clients
+    /// agree on which rows carry it.
+    func setBudgetCarryover(month: String, categoryId: String, enabled: Bool) async throws {
+        guard let syncClient else {
+            throw BudgetStoreError.syncNotConfigured
+        }
+        try await syncClient.setBudgetCarryover(
+            months: Self.carryoverMonths(from: month), categoryId: categoryId, flag: enabled)
+        await fetchBudgetMonth(month)
+    }
+
+    /// The months upstream `setCategoryCarryover` flags: `month` through the
+    /// latest month in the web's sheet, which `createAllBudgets` extends to
+    /// twelve months past today (`getBudgetRange`). A month already beyond
+    /// that gets flagged alone. Pure, so it stays callable off the main actor.
+    nonisolated static func carryoverMonths(from month: String, now: Date = Date()) -> [String] {
+        let latest = BudgetMonthMath.addMonths(BudgetMonthMath.currentMonth(now), 12)
+        let count = max(BudgetMonthMath.differenceInCalendarMonths(latest, month), 0)
+        return (0...count).map { BudgetMonthMath.addMonths(month, $0) }
+    }
 
     /// Move budgeted funds between categories (GH #128), nil meaning the
     /// month's "To Budget" pool on that side. Writes through the sync engine

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -5179,18 +5179,18 @@ return transaction.id
         try await syncClient.setBudgetAmount(month: month, categoryId: categoryId, amount: amountCents)
         await fetchBudgetMonth(month)
     }
-    
+
     /// Turn "rollover overspending" on or off for a category (GH #372), then
     /// refetch the month so the published flag and Available recompute.
     /// Mirrors the web's balance menu: the flag is written from this month
     /// through the last month the web would have created, so both clients
-    /// agree on which rows carry it.
-    func setBudgetCarryover(month: String, categoryId: String, enabled: Bool) async throws {
+    /// agree on which rows carry it. `now` pins the range's end for tests.
+    func setBudgetCarryover(month: String, categoryId: String, enabled: Bool, now: Date = Date()) async throws {
         guard let syncClient else {
             throw BudgetStoreError.syncNotConfigured
         }
         try await syncClient.setBudgetCarryover(
-            months: Self.carryoverMonths(from: month), categoryId: categoryId, flag: enabled)
+            months: Self.carryoverMonths(from: month, now: now), categoryId: categoryId, flag: enabled)
         await fetchBudgetMonth(month)
     }
 

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -1700,7 +1700,8 @@ final class BudgetDatabase: Sendable {
                     hidden: cat.hidden == 1,
                     groupHidden: group.hidden == 1,
                     goal: targetBudgets[cat.id]?.goal,
-                    longGoal: targetBudgets[cat.id]?.longGoal == 1
+                    longGoal: targetBudgets[cat.id]?.longGoal == 1,
+                    carryoverEnabled: targetBudgets[cat.id]?.flag == true
                 )
             }
 

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -990,7 +990,7 @@ actor SyncClient {
         // 4. Push to the server in the background
         scheduleAutomaticSync()
     }
-    
+
     /// Set a category's carryover ("rollover overspending") flag on every
     /// month in `months`, optimistic local-first. Mirrors upstream
     /// setCategoryCarryover / setCarryover (loot-core budget/actions.ts):

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -990,6 +990,51 @@ actor SyncClient {
         // 4. Push to the server in the background
         scheduleAutomaticSync()
     }
+    
+    /// Set a category's carryover ("rollover overspending") flag on every
+    /// month in `months`, optimistic local-first. Mirrors upstream
+    /// setCategoryCarryover / setCarryover (loot-core budget/actions.ts):
+    /// each month reuses its existing (month, category) row or creates the
+    /// {YYYYMM}-{categoryId} one, and the flag lands as 1/0. All months go
+    /// out in one message batch, like upstream's batchMessages.
+    func setBudgetCarryover(months: [String], categoryId: String, flag: Bool) async throws {
+        guard let database else { throw SyncError.notConfigured }
+
+        logger.debug("setBudgetCarryover() - months: \(months.count, privacy: .public), category: \(categoryId, privacy: .private), flag: \(flag, privacy: .public)")
+
+        // 1. Generate CRDT messages for every month (before any DB write, so
+        //    an HLC failure leaves nothing stranded)
+        var messages: [CRDTMessage] = []
+        for month in months {
+            guard let cell = try database.budgetCell(month: month, categoryId: categoryId) else {
+                throw SyncError.budgetTableMissing
+            }
+            var fields: [(column: String, value: (any Sendable)?)] = []
+            if !cell.exists {
+                fields.append(("month", cell.monthInt))
+                fields.append(("category", categoryId))
+            }
+            fields.append(("carryover", flag ? 1 : 0))
+            messages += try await messageGenerator.messages(dataset: cell.table, row: cell.rowId, fields: fields)
+        }
+        logger.debug("Generated \(messages.count, privacy: .public) CRDT messages")
+
+        // 2. Apply locally (optimistic) through the same LWW upsert incoming
+        //    messages use, so a local edit and the identical edit arriving
+        //    from another device converge byte-for-byte.
+        try database.applyMessages(messages)
+
+        // 3. Store messages and update merkle
+        for msg in try database.insertMessages(messages) {
+            merkle = merkle.inserting(msg.timestamp)
+        }
+        merkle = merkle.pruned()
+        try saveClock()
+        logger.debug("Messages stored, merkle updated (hash: \(self.merkle.root.hash, privacy: .public))")
+
+        // 4. Push to the server in the background
+        scheduleAutomaticSync()
+    }
 
     /// Store parsed goal templates into `categories.goal_def` (optimistic
     /// local-first). Mirrors upstream `storeTemplates` (goal-template.ts): the

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1860,13 +1860,16 @@ struct CategoryBudgetDetailSheet: View {
                 if budgetStore.goalTemplatesEnabled {
                     goalSection
                 }
-                
+
                 Section {
                     // The binding, not onChange, kicks off the write: a failed
                     // save reverts the state directly, which must not re-save.
+                    // The guard covers a second tap landing before .disabled
+                    // re-renders, so two writes can't race for the same rows.
                     Toggle("Rollover Overspending", isOn: Binding(
                         get: { rolloverEnabled },
                         set: { enabled in
+                            guard !isSavingRollover else { return }
                             rolloverEnabled = enabled
                             Task { await saveRollover(enabled) }
                         }
@@ -1877,7 +1880,6 @@ struct CategoryBudgetDetailSheet: View {
                         ? "Carry this category's balance into next month. Applies from \(MonthPicker.title(for: category.month)) onward."
                         : "Carry overspending into next month instead of taking it from To Budget. Applies from \(MonthPicker.title(for: category.month)) onward.")
                 }
-
 
                 Section(
                     content: {
@@ -2065,7 +2067,7 @@ struct CategoryBudgetDetailSheet: View {
             isApplyingSuggestion = false
         }
     }
-    
+
     /// Writes immediately, like the web's balance menu — a rollover change
     /// is a budget edit, not part of the name draft the Save button commits.
     private func saveRollover(_ enabled: Bool) async {
@@ -2083,7 +2085,6 @@ struct CategoryBudgetDetailSheet: View {
         }
         isSavingRollover = false
     }
-
 
     private func saveName() async {
         guard trimmedName != category.categoryName else {

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1895,6 +1895,7 @@ struct CategoryBudgetDetailSheet: View {
                         get: { rolloverEnabled },
                         set: { enabled in
                             guard !isSavingRollover else { return }
+                            isSavingRollover = true
                             rolloverEnabled = enabled
                             Task { await saveRollover(enabled) }
                         }
@@ -2096,7 +2097,6 @@ struct CategoryBudgetDetailSheet: View {
     /// Writes immediately, like the web's balance menu — a rollover change
     /// is a budget edit, not part of the name draft the Save button commits.
     private func saveRollover(_ enabled: Bool) async {
-        isSavingRollover = true
         errorMessage = nil
         do {
             try await budgetStore.setBudgetCarryover(

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1135,9 +1135,7 @@ struct CategoryBudgetRow: View {
                 } label: {
                     BudgetAmountPill(
                         text: budgetStore.displayBudgetCell(category.available),
-                        color: balanceColor(
-                            category, goalsEnabled: budgetStore.goalTemplatesEnabled,
-                            zero: .secondary)
+                        color: balanceTint
                     )
                 }
                 .buttonStyle(.borderless)
@@ -1145,6 +1143,7 @@ struct CategoryBudgetRow: View {
                 .accessibilityLabel(category.isOverspent
                     ? "Cover overspending for \(category.categoryName)"
                     : "Move money from \(category.categoryName)")
+                .rolloverIndicator(category.carryoverEnabled, color: balanceTint)
             }
             if budgetStore.showBudgetProgressBars, category.showsProgressBar {
                 CategoryProgressBar(
@@ -1180,6 +1179,10 @@ struct CategoryBudgetRow: View {
             onShowTransactions: onShowTransactions,
             onMoveMoney: onMoveMoney
         ))
+    }
+
+    private var balanceTint: Color {
+        balanceColor(category, goalsEnabled: budgetStore.goalTemplatesEnabled, zero: .secondary)
     }
 }
 
@@ -1223,15 +1226,14 @@ struct CleanCategoryBudgetRow: View {
                     onMoveMoney(category)
                 } label: {
                     Text(budgetStore.displayBalance(category.available))
-                        .foregroundColor(balanceColor(
-                            category, goalsEnabled: budgetStore.goalTemplatesEnabled,
-                            zero: .green))
+                        .foregroundColor(balanceTint)
                 }
                 .buttonStyle(.borderless)
                 .disabled(category.available == 0)
                 .accessibilityLabel(category.isOverspent
                     ? "Cover overspending for \(category.categoryName)"
                     : "Move money from \(category.categoryName)")
+                .rolloverIndicator(category.carryoverEnabled, color: balanceTint)
             }
             if budgetStore.showBudgetProgressBars, category.showsProgressBar {
                 CategoryProgressBar(
@@ -1297,6 +1299,10 @@ struct CleanCategoryBudgetRow: View {
             onMoveMoney: onMoveMoney
         ))
     }
+
+    private var balanceTint: Color {
+        balanceColor(category, goalsEnabled: budgetStore.goalTemplatesEnabled, zero: .green)
+    }
 }
 
 /// Shared long-press/right-click menu for all category row styles — the same
@@ -1352,6 +1358,25 @@ func balanceColor(_ category: CategoryBudget, goalsEnabled: Bool, zero: Color) -
         return category.isGoalUnderfunded ? .orange : .green
     }
     return category.available == 0 ? zero : .green
+}
+
+extension View {
+    /// The web's CarryoverIndicator: a small arrow just past the balance's
+    /// trailing edge, in the balance's color, when the category's overspending
+    /// rolls into next month (GH #372). An overlay rather than a sibling so
+    /// amounts stay column-aligned whether or not a row rolls over.
+    func rolloverIndicator(_ shown: Bool, color: Color) -> some View {
+        overlay(alignment: .trailing) {
+            if shown {
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 7, weight: .heavy))
+                    .foregroundStyle(color)
+                    .offset(x: 10)
+                    .accessibilityHidden(true)
+            }
+        }
+        .accessibilityHint(shown ? "Overspending rolls over to next month" : "")
+    }
 }
 
 /// Whether `month` ("YYYY-MM") is before the current calendar month. The

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -1806,7 +1806,9 @@ struct CategoryBudgetDetailSheet: View {
     @State private var editingNote = false
     @State private var note: EntityNote = .unsupported
     @State private var history: [CategoryBudget] = []
+    @State private var rolloverEnabled: Bool
     @State private var isSavingName = false
+    @State private var isSavingRollover = false
     @State private var isApplyingSuggestion = false
     @State private var isApplyingTemplate = false
     @State private var editingAutomations = false
@@ -1815,6 +1817,7 @@ struct CategoryBudgetDetailSheet: View {
     init(category: CategoryBudget) {
         self.category = category
         _name = State(initialValue: category.categoryName)
+        _rolloverEnabled = State(initialValue: category.carryoverEnabled)
     }
 
     private var isTracking: Bool {
@@ -1857,6 +1860,24 @@ struct CategoryBudgetDetailSheet: View {
                 if budgetStore.goalTemplatesEnabled {
                     goalSection
                 }
+                
+                Section {
+                    // The binding, not onChange, kicks off the write: a failed
+                    // save reverts the state directly, which must not re-save.
+                    Toggle("Rollover Overspending", isOn: Binding(
+                        get: { rolloverEnabled },
+                        set: { enabled in
+                            rolloverEnabled = enabled
+                            Task { await saveRollover(enabled) }
+                        }
+                    ))
+                    .disabled(isSavingRollover)
+                } footer: {
+                    Text(isTracking
+                        ? "Carry this category's balance into next month. Applies from \(MonthPicker.title(for: category.month)) onward."
+                        : "Carry overspending into next month instead of taking it from To Budget. Applies from \(MonthPicker.title(for: category.month)) onward.")
+                }
+
 
                 Section(
                     content: {
@@ -2044,6 +2065,25 @@ struct CategoryBudgetDetailSheet: View {
             isApplyingSuggestion = false
         }
     }
+    
+    /// Writes immediately, like the web's balance menu — a rollover change
+    /// is a budget edit, not part of the name draft the Save button commits.
+    private func saveRollover(_ enabled: Bool) async {
+        isSavingRollover = true
+        errorMessage = nil
+        do {
+            try await budgetStore.setBudgetCarryover(
+                month: category.month,
+                categoryId: category.categoryId,
+                enabled: enabled
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+            rolloverEnabled = !enabled
+        }
+        isSavingRollover = false
+    }
+
 
     private func saveName() async {
         guard trimmedName != category.categoryName else {

--- a/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
+++ b/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
@@ -344,6 +344,7 @@ struct CompactCategoryBudgetRow: View {
                 .buttonStyle(.borderless)
                 .disabled(category.available == 0)
                 .accessibilityLabel(balanceActionLabel)
+                .rolloverIndicator(category.carryoverEnabled, color: categoryBalanceColor)
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
             .layoutPriority(1)
@@ -379,6 +380,7 @@ struct CompactCategoryBudgetRow: View {
             .buttonStyle(.plain)
             .disabled(category.available == 0)
             .accessibilityLabel(balanceActionLabel)
+            .rolloverIndicator(category.carryoverEnabled, color: categoryBalanceColor)
         }
     }
 

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSetBudgetCarryoverTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSetBudgetCarryoverTests.swift
@@ -133,7 +133,8 @@ struct BudgetStoreSetBudgetCarryoverTests {
         let store = try await makeStore(database: database)
         let queue = try DatabaseQueue(path: path.path)
 
-        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: true)
+        let now = date(2026, 9, 15)
+        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: true, now: now)
 
         let rows = try await queue.read { db in
             try Row.fetchAll(db, sql: "SELECT * FROM zero_budgets ORDER BY month").map {
@@ -141,12 +142,13 @@ struct BudgetStoreSetBudgetCarryoverTests {
             }
         }
         // Existing row reused (amount untouched), and one row per month
-        // through the end of the sheet — the same rows the web would write.
+        // through twelve months past "today" — the same rows the web writes.
         let july = try #require(rows.first)
         #expect(july.id == "other-client-row")
         #expect(july.amount == 1000)
         #expect(july.carryover == 1)
-        #expect(rows.count == BudgetStore.carryoverMonths(from: "2026-07").count)
+        #expect(rows.count == 15) // 2026-07 through 2027-09
+        #expect(rows.last?.month == 202709)
         #expect(rows.dropFirst().allSatisfy { $0.carryover == 1 })
         #expect(rows.dropFirst().first?.id == "202608-cat-groceries")
 
@@ -161,7 +163,7 @@ struct BudgetStoreSetBudgetCarryoverTests {
         let august = try await database.fetchBudgetMonth(month: "2026-08")
         #expect(august.categoryBudgets.first { $0.categoryId == "cat-groceries" }?.available == -2000)
 
-        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: false)
+        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: false, now: now)
 
         let flags = try await queue.read { db in
             try Int.fetchAll(db, sql: "SELECT carryover FROM zero_budgets")

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSetBudgetCarryoverTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSetBudgetCarryoverTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import GRDB
+import Testing
+@testable import Actuali
+
+@MainActor
+struct BudgetStoreSetBudgetCarryoverTests {
+
+    /// Full schema fetchBudgetMonth needs (matches BudgetStoreSetBudgetAmountTests)
+    /// plus messages_crdt for the sync write path.
+    private func makeDatabase() throws -> (BudgetDatabase, URL) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: tempURL.path)
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transactions (
+                    id TEXT PRIMARY KEY,
+                    acct TEXT,
+                    category TEXT,
+                    description TEXT,
+                    amount INTEGER,
+                    date INTEGER,
+                    transferred_id TEXT,
+                    parent_id TEXT,
+                    isParent INTEGER DEFAULT 0,
+                    isChild INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE categories (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    cat_group TEXT,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_groups (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    is_income INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    hidden INTEGER DEFAULT 0,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE category_mapping (
+                    id TEXT PRIMARY KEY,
+                    transferId TEXT
+                );
+
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    offbudget INTEGER DEFAULT 0,
+                    sort_order REAL,
+                    tombstone INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE zero_budgets (
+                    id TEXT PRIMARY KEY,
+                    month INTEGER,
+                    category TEXT,
+                    amount INTEGER DEFAULT 0,
+                    carryover INTEGER DEFAULT 0
+                );
+
+                CREATE TABLE messages_crdt (
+                    id INTEGER PRIMARY KEY,
+                    timestamp TEXT NOT NULL UNIQUE,
+                    dataset TEXT NOT NULL,
+                    row TEXT NOT NULL,
+                    column TEXT NOT NULL,
+                    value BLOB NOT NULL
+                );
+
+                INSERT INTO category_groups (id, name) VALUES ('grp-1', 'Daily');
+                INSERT INTO categories (id, name, cat_group) VALUES ('cat-groceries', 'Groceries', 'grp-1');
+                INSERT INTO category_mapping (id, transferId) VALUES ('cat-groceries', 'cat-groceries');
+                INSERT INTO accounts (id, name, offbudget) VALUES ('acct-1', 'Checking', 0);
+
+                -- A row another client wrote under its own id: the flag must
+                -- land on it rather than fork a second row for the same cell.
+                INSERT INTO zero_budgets (id, month, category, amount)
+                    VALUES ('other-client-row', 202607, 'cat-groceries', 1000);
+                -- Overspend July by 2000 so the flag has something to roll.
+                INSERT INTO transactions (id, acct, category, amount, date)
+                    VALUES ('txn-1', 'acct-1', 'cat-groceries', -3000, 20260710);
+            """)
+        }
+        return (try BudgetDatabase(path: tempURL), tempURL)
+    }
+
+    private func makeStore(database: BudgetDatabase) async throws -> BudgetStore {
+        let store = BudgetStore.previewInstance()
+        let syncClient = SyncClient(serverClient: ActualServerClient(), nodeId: "89e0e8e90b203f9e")
+        try await syncClient.configure(database: database, fileId: "test-file", groupId: "test-group")
+        store.configureForTesting(database: database, syncClient: syncClient)
+        return store
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        Calendar.current.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    // MARK: - Month range (pure, mirrors upstream getAllMonths)
+
+    @Test func carryoverMonthsRunThroughTwelveMonthsPastToday() {
+        let months = BudgetStore.carryoverMonths(from: "2026-07", now: date(2026, 9, 15))
+        #expect(months.first == "2026-07")
+        #expect(months.last == "2027-09")
+        #expect(months.count == 15)
+    }
+
+    @Test func carryoverMonthsBeyondTheSheetIsJustThatMonth() {
+        let months = BudgetStore.carryoverMonths(from: "2028-01", now: date(2026, 9, 15))
+        #expect(months == ["2028-01"])
+    }
+
+    // MARK: - End-to-end save
+
+    @Test func togglingRolloverFlagsEveryMonthAndCarriesOverspending() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        let queue = try DatabaseQueue(path: path.path)
+
+        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: true)
+
+        let rows = try await queue.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM zero_budgets ORDER BY month").map {
+                BudgetRow(id: $0["id"], month: $0["month"], amount: $0["amount"], carryover: $0["carryover"])
+            }
+        }
+        // Existing row reused (amount untouched), and one row per month
+        // through the end of the sheet — the same rows the web would write.
+        let july = try #require(rows.first)
+        #expect(july.id == "other-client-row")
+        #expect(july.amount == 1000)
+        #expect(july.carryover == 1)
+        #expect(rows.count == BudgetStore.carryoverMonths(from: "2026-07").count)
+        #expect(rows.dropFirst().allSatisfy { $0.carryover == 1 })
+        #expect(rows.dropFirst().first?.id == "202608-cat-groceries")
+
+        // The published month reflects the flag without a manual refresh...
+        let month = try #require(store.currentBudgetMonth)
+        #expect(month.month == "2026-07")
+        let groceries = try #require(month.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(groceries.carryoverEnabled)
+        #expect(groceries.available == -2000)
+
+        // ...and the overspend now rolls into August instead of being absorbed.
+        let august = try await database.fetchBudgetMonth(month: "2026-08")
+        #expect(august.categoryBudgets.first { $0.categoryId == "cat-groceries" }?.available == -2000)
+
+        try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-groceries", enabled: false)
+
+        let flags = try await queue.read { db in
+            try Int.fetchAll(db, sql: "SELECT carryover FROM zero_budgets")
+        }
+        #expect(flags.allSatisfy { $0 == 0 })
+        let refreshed = try #require(store.currentBudgetMonth?.categoryBudgets.first { $0.categoryId == "cat-groceries" })
+        #expect(!refreshed.carryoverEnabled)
+        let augustOff = try await database.fetchBudgetMonth(month: "2026-08")
+        #expect(augustOff.categoryBudgets.first { $0.categoryId == "cat-groceries" }?.available == 0)
+    }
+
+    @Test func withoutSyncClientThrowsSyncNotConfigured() async throws {
+        let store = BudgetStore.previewInstance()
+
+        await #expect(throws: BudgetStoreError.syncNotConfigured) {
+            try await store.setBudgetCarryover(month: "2026-07", categoryId: "cat-1", enabled: true)
+        }
+    }
+}
+
+/// Sendable snapshot of a zero_budgets row, extracted inside the GRDB read
+/// closure so no non-Sendable `Row` crosses the async boundary.
+private struct BudgetRow: Sendable {
+    let id: String
+    let month: Int
+    let amount: Int
+    let carryover: Int
+}


### PR DESCRIPTION
## Why

Actual lets you roll a category's overspending into the next month instead of pulling it from To Budget, which is handy for things like work or travel expenses awaiting reimbursement. Actuali had no way to flip that flag, so it meant a trip back to the web app. Closes #372.

## What

- The category detail sheet (tap a category, or the hamburger on a row) now has a **Rollover Overspending** toggle, with a footer explaining what it does in envelope vs tracking terms. It saves immediately, like the web's balance menu, and reverts itself with an error if the write fails.
- The flag is written through the sync engine, mirroring upstream `setCategoryCarryover` / `setCarryover` (loot-core `budget/actions.ts`): reuse the existing `(month, category)` row or create the `{YYYYMM}-{categoryId}` one, write `carryover` as 1/0, and batch every month into one message set.
- Month range matches the web too: the chosen month through twelve months past today (upstream `getAllMonths` over the sheet that `getBudgetRange` creates), so both clients agree on which rows carry the flag. A month already past that range is flagged alone.
- `CategoryBudget` exposes the row's flag as `carryoverEnabled`, read from the existing budget walk, so the sheet shows the current state.

## How it was tested

- New `BudgetStoreSetBudgetCarryoverTests`: month-range math, an end-to-end toggle that reuses a row written under a foreign id, flags every month through the end of the range, republishes the month, and actually rolls a July overspend into August (then clears it all on disable), plus the no-sync-client error path.
- Full unit suite (`-skip-testing:ActualiUITests`) passed in CI on both the iOS 18 and iOS 26 simulators.

## Screenshots

<img width="301" alt="Screenshot iPhone 17 Pro 09-02-2026 at 9 12 46 AM" src="https://github.com/user-attachments/assets/329e2b9a-a165-4c6c-801e-2b605c64d9dd" />
