### PR TITLE
Add reconciled transaction filter

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -497,6 +497,14 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Whether transaction lists hide transactions locked by reconciliation.
+    /// Persisted to UserDefaults, defaults to off (GH #355).
+    @Published var hideReconciledTransactions: Bool = false {
+        didSet {
+            UserDefaults.standard.set(hideReconciledTransactions, forKey: "hideReconciledTransactions")
+        }
+    }
+
     /// Whether the Accounts list drops its Closed Accounts section, for
     /// budgets that have accumulated closed accounts over the years
     /// (GH #277). Persisted to UserDefaults, defaults to off.
@@ -1201,6 +1209,8 @@ final class BudgetStore: ObservableObject {
             .bool(forKey: "showHiddenCategories"))
         _hideClearedTransactions = Published(initialValue: defaults
             .bool(forKey: "hideClearedTransactions"))
+        _hideReconciledTransactions = Published(initialValue: defaults
+            .bool(forKey: "hideReconciledTransactions"))
         _hideClosedAccounts = Published(initialValue: defaults
             .bool(forKey: "hideClosedAccounts"))
 
@@ -2587,12 +2597,13 @@ final class BudgetStore: ObservableObject {
         limit: Int = BudgetDatabase.transactionPageSize,
         offset: Int = 0,
         search: String? = nil,
-        unclearedOnly: Bool = false
+        unclearedOnly: Bool = false,
+        hideReconciled: Bool = false
     ) async -> [Transaction] {
         do {
             return try await database?.fetchTransactions(
                 accountId: accountId, limit: limit, offset: offset, search: search,
-                unclearedOnly: unclearedOnly
+                unclearedOnly: unclearedOnly, hideReconciled: hideReconciled
             ) ?? []
         } catch is CancellationError {
             // The caller's task was cancelled (e.g. a superseded .task(id:)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -678,15 +678,15 @@ final class BudgetDatabase: Sendable {
     /// account and/or filtered by a free-text search. `search` applies the
     /// TransactionSearchMatcher semantics (payee, category, notes, and
     /// progressive amount matching) in SQL so it covers full history, not
-    /// just the loaded page. `unclearedOnly` drops cleared rows (which
-    /// includes reconciled ones — locking requires cleared first) in SQL for
-    /// the same reason: pages stay full-sized and cover full history.
+    /// just the loaded page. `unclearedOnly` and `hideReconciled` filter in
+    /// SQL for the same reason: pages stay full-sized and cover full history.
     func fetchTransactions(
         accountId: String? = nil,
         limit: Int = BudgetDatabase.transactionPageSize,
         offset: Int = 0,
         search: String? = nil,
-        unclearedOnly: Bool = false
+        unclearedOnly: Bool = false,
+        hideReconciled: Bool = false
     ) async throws -> [Transaction] {
         try await dbQueue.read { db in
             // The list's display payee: own payee first (transfer payees show
@@ -746,6 +746,10 @@ final class BudgetDatabase: Sendable {
 
             if unclearedOnly {
                 sql += " AND (t.cleared = 0 OR t.cleared IS NULL)"
+            }
+
+            if hideReconciled {
+                sql += " AND (t.reconciled = 0 OR t.reconciled IS NULL)"
             }
 
             if let search {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -53,7 +53,8 @@ struct AccountDetailView: View {
         let created = TransactionPager { offset, limit, search in
             await store.fetchTransactions(
                 accountId: accountId, limit: limit, offset: offset, search: search,
-                unclearedOnly: store.hideClearedTransactions
+                unclearedOnly: store.hideClearedTransactions,
+                hideReconciled: store.hideReconciledTransactions
             )
         }
         pager = created
@@ -291,8 +292,10 @@ struct AccountDetailView: View {
                         Text(searchQuery != nil
                             ? "No matching transactions"
                             : budgetStore.hideClearedTransactions
-                                ? "No uncleared transactions"
-                                : "No transactions")
+                            ? "No uncleared transactions"
+                                : budgetStore.hideReconciledTransactions
+                                    ? "No unreconciled transactions"
+                                    : "No transactions")
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -361,6 +364,14 @@ struct AccountDetailView: View {
                     Label(
                         "Hide Cleared Transactions",
                         systemImage: budgetStore.hideClearedTransactions ? "eye.slash" : "eye"
+                    )
+                }
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle(isOn: $budgetStore.hideReconciledTransactions) {
+                    Label(
+                        "Hide Reconciled Transactions",
+                        systemImage: budgetStore.hideReconciledTransactions ? "eye.slash" : "eye"
                     )
                 }
             }
@@ -447,6 +458,9 @@ struct AccountDetailView: View {
         .onChange(of: budgetStore.hideClearedTransactions) {
             // The pager's fetch closure reads the flag, so a reload is all a
             // toggle flip needs.
+            Task { await reload() }
+        }
+        .onChange(of: budgetStore.hideReconciledTransactions) {
             Task { await reload() }
         }
         .onChange(of: budgetStore.creditCardStatementDays[account.id]) {

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -41,7 +41,8 @@ struct TransactionsListView: View {
         let created = TransactionPager { offset, limit, search in
             await store.fetchTransactions(
                 limit: limit, offset: offset, search: search,
-                unclearedOnly: store.hideClearedTransactions
+                unclearedOnly: store.hideClearedTransactions,
+                hideReconciled: store.hideReconciledTransactions
             )
         }
         pager = created
@@ -62,6 +63,12 @@ struct TransactionsListView: View {
                         "No Uncleared Transactions",
                         systemImage: "checkmark.circle",
                         description: Text("Everything is cleared. Turn off Hide Cleared Transactions to see the rest.")
+                    )
+                } else if budgetStore.hideReconciledTransactions {
+                    ContentUnavailableView(
+                        "No Unreconciled Transactions",
+                        systemImage: "lock.fill",
+                        description: Text("Everything is reconciled. Turn off Hide Reconciled Transactions to see the rest.")
                     )
                 } else {
                     ContentUnavailableView(
@@ -136,6 +143,14 @@ struct TransactionsListView: View {
                     )
                 }
             }
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle(isOn: $budgetStore.hideReconciledTransactions) {
+                    Label(
+                        "Hide Reconciled Transactions",
+                        systemImage: budgetStore.hideReconciledTransactions ? "eye.slash" : "eye"
+                    )
+                }
+            }
         }
         .safeAreaInset(edge: .bottom) {
             if isSelecting, let pager {
@@ -166,6 +181,9 @@ struct TransactionsListView: View {
         .onChange(of: budgetStore.hideClearedTransactions) {
             // The pager's fetch closure reads the flag, so a reload is all a
             // toggle flip needs.
+            Task { await reload() }
+        }
+        .onChange(of: budgetStore.hideReconciledTransactions) {
             Task { await reload() }
         }
         .refreshable {

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseHideClearedTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseHideClearedTests.swift
@@ -139,6 +139,24 @@ struct BudgetDatabaseHideClearedTests {
         #expect(all.map(\.id) == ["t-pending", "t-cleared"])
     }
 
+    @Test func hideReconciledDropsOnlyReconciledRows() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedLookups(db)
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, description, amount, date, sort_order, cleared, reconciled) VALUES
+                    ('t-pending',    'acct-1', 'payee-market', -1000, 20260603, 3, 0, 0),
+                    ('t-cleared',    'acct-1', 'payee-market', -2000, 20260602, 2, 1, 0),
+                    ('t-reconciled', 'acct-1', 'payee-market', -3000, 20260601, 1, 1, 1);
+            """)
+        }
+
+        let visible = try await db.fetchTransactions(hideReconciled: true)
+        #expect(visible.map(\.id) == ["t-pending", "t-cleared"])
+    }
+
     @Test func unclearedOnlyComposesWithAccountScopeAndSearch() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }


### PR DESCRIPTION
Adds a persisted Hide Reconciled Transactions toggle beside Hide Cleared Transactions in the account and all-account transaction lists. The shared SQL query excludes reconciled rows before search and pagination, so cleared-but-unreconciled rows remain visible for reconciliation.

Verified with:
- xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination "platform=iOS Simulator,id=BED654F9-9F59-433D-926E-3493EB3BE743" -skip-testing:ActualiUITests (1728 tests in 206 suites)
- xcodebuild -project Actuali/Actuali.xcodeproj -scheme Actuali -sdk iphonesimulator build

Out of scope: category and uncategorized transaction views, which do not expose the existing Hide Cleared Transactions control.

Fixes #355