### PR TITLE
Redesign scheduled transaction rows

### DIFF
--- a/Actuali/Actuali/ActualiApp.swift
+++ b/Actuali/Actuali/ActualiApp.swift
@@ -32,7 +32,17 @@ struct ActualiApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            Group {
+                #if DEBUG
+                if CommandLine.arguments.contains("-showScheduleRowFixture") {
+                    ScheduleRowUITestFixture()
+                } else {
+                    ContentView()
+                }
+                #else
+                ContentView()
+                #endif
+            }
                 .environmentObject(budgetStore)
                 .preferredColorScheme(budgetStore.appearanceMode.colorScheme)
                 .task {

--- a/Actuali/Actuali/Views/Schedules/ScheduleStatusBadge.swift
+++ b/Actuali/Actuali/Views/Schedules/ScheduleStatusBadge.swift
@@ -5,8 +5,7 @@ struct ScheduleStatusBadge: View {
     let status: ScheduleStatus
 
     var body: some View {
-        Label(ScheduleDescription.statusLabel(status), systemImage: status.symbolName)
-            .labelStyle(.titleAndIcon)
+        Text(ScheduleDescription.statusLabel(status))
             .font(.caption.weight(.medium))
             .foregroundStyle(status.tint)
             .padding(.horizontal, 8)
@@ -17,17 +16,6 @@ struct ScheduleStatusBadge: View {
 }
 
 extension ScheduleStatus {
-    var symbolName: String {
-        switch self {
-        case .missed: "exclamationmark.circle.fill"
-        case .due: "exclamationmark.triangle.fill"
-        case .upcoming: "calendar"
-        case .paid: "checkmark.circle.fill"
-        case .completed: "star.fill"
-        case .scheduled: "calendar"
-        }
-    }
-
     var tint: Color {
         switch self {
         case .missed: .red

--- a/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
+++ b/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
@@ -235,36 +235,28 @@ struct ScheduleRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
+            HStack(spacing: 8) {
                 Text(title)
                     .font(.body.weight(.medium))
                     .lineLimit(1)
+                ScheduleStatusBadge(status: status)
                 Spacer()
                 Text(amountText)
                     .font(.body)
                     .monospacedDigit()
                     .foregroundStyle(schedule.postAmount > 0 ? Color.green : Color.primary)
             }
-
-            HStack(spacing: 6) {
-                ScheduleStatusBadge(status: status)
-                if schedule.isRecurring {
-                    Image(systemName: "arrow.triangle.2.circlepath")
+            HStack {
+                if let accountName, !accountName.isEmpty {
+                    Text(accountName)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .accessibilityLabel("Recurring")
+                        .lineLimit(1)
                 }
                 Spacer()
                 Text(nextDateText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
-
-            if let subtitle {
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
             }
         }
         .padding(.vertical, 2)
@@ -276,14 +268,6 @@ struct ScheduleRow: View {
         if let name = schedule.name, !name.isEmpty { return name }
         if let payeeName, !payeeName.isEmpty { return payeeName }
         return accountName ?? "Schedule"
-    }
-
-    private var subtitle: String? {
-        var parts: [String] = []
-        // Only repeat the payee when it isn't already doing duty as the title.
-        if let payeeName, !payeeName.isEmpty, title != payeeName { parts.append(payeeName) }
-        if let accountName, !accountName.isEmpty { parts.append(accountName) }
-        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     private var nextDateText: String {
@@ -298,11 +282,14 @@ struct ScheduleRow: View {
         case (.isBetween, .range(let low, let high)):
             let ordered = low <= high ? (low, high) : (high, low)
             return "\(budgetStore.displayBalance(ordered.0)) – \(budgetStore.displayBalance(ordered.1))"
-        case (.isApprox, _):
-            return "~" + budgetStore.displayBalance(schedule.postAmount)
         default:
-            return budgetStore.displayBalance(schedule.postAmount)
+            return Self.formattedAmount(
+                budgetStore.displayBalance(schedule.postAmount), amountOp: schedule.amountOp)
         }
+    }
+
+    nonisolated static func formattedAmount(_ amount: String, amountOp: ScheduleAmountOp) -> String {
+        amountOp == .isApprox ? "~ " + amount : amount
     }
 }
 

--- a/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
+++ b/Actuali/Actuali/Views/Schedules/SchedulesListView.swift
@@ -254,12 +254,20 @@ struct ScheduleRow: View {
                         .lineLimit(1)
                 }
                 Spacer()
+                if schedule.isRecurring {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Recurring")
+                }
                 Text(nextDateText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("scheduleRow.\(schedule.id)")
     }
 
     /// A schedule need not have a name; fall back to the payee, then the
@@ -292,6 +300,28 @@ struct ScheduleRow: View {
         amountOp == .isApprox ? "~ " + amount : amount
     }
 }
+
+#if DEBUG
+struct ScheduleRowUITestFixture: View {
+    private let schedule = ScheduleSummary(
+        id: "fixture", name: "Rent", ruleId: nil,
+        nextDate: DayDate(year: 2026, month: 10, day: 1), nextDateRowId: nil,
+        baseNextDateTs: nil, accountId: nil, payeeId: nil,
+        amount: .fixed(-120_000), amountOp: .isApprox, dateOp: nil,
+        dateCondition: .recurring(RecurConfig(json: [
+            "frequency": "monthly", "start": "2026-09-03",
+        ])!), postsTransaction: false, completed: false,
+        customUpcomingLength: nil, sortOrder: nil, isCustom: false,
+        conditionsJSON: nil, actionsJSON: nil, categoryId: nil)
+
+    var body: some View {
+        ScheduleRow(
+            schedule: schedule, status: .upcoming,
+            accountName: "Checking", payeeName: "Landlord")
+            .padding()
+    }
+}
+#endif
 
 #Preview {
     NavigationStack {

--- a/Actuali/ActualiTests/Views/Schedules/ScheduleRowTests.swift
+++ b/Actuali/ActualiTests/Views/Schedules/ScheduleRowTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Actuali
+
+@Test func approximateScheduleAmountSeparatesTheMarkerFromTheSign() {
+    #expect(ScheduleRow.formattedAmount("-1200.00", amountOp: .isApprox) == "~ -1200.00")
+}

--- a/Actuali/ActualiUITests/ScheduleRowUITests.swift
+++ b/Actuali/ActualiUITests/ScheduleRowUITests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class ScheduleRowUITests: XCTestCase {
+    @MainActor
+    func testRedesignedRowContentsAndRecurrenceAccessibility() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-showScheduleRowFixture"]
+        app.launch()
+
+        let row = app.descendants(matching: .any)["scheduleRow.fixture"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        for text in ["Rent", "Status: Upcoming", "~ -", "1,200.00", "Checking", "Recurring", "Oct", "2026"] {
+            XCTAssertTrue(row.label.contains(text), "row label missing \(text): \(row.label)")
+        }
+    }
+}


### PR DESCRIPTION
Redesigns scheduled transaction rows into two lines: title, status, and amount; then account and date. Approximate amounts now separate the marker from a negative sign, and status pills are text-only to remove excess leading space.

Verified: `xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -derivedDataPath /tmp/actuali-issue405-red.EaGuzd -destination 'platform=iOS Simulator,id=3734574A-55AB-48C8-B395-892C1D46518F' -skip-testing:ActualiUITests` (1,728 passed); simulator build succeeded.

Out of scope: schedule behavior and editing.

Fixes #405