### PR TITLE
Support fixed day-of-month credit card payment due dates (#381)

### DIFF
--- a/Actuali/Actuali/Localizable.xcstrings
+++ b/Actuali/Actuali/Localizable.xcstrings
@@ -45528,6 +45528,61 @@
         }
       }
     },
+    "Days After": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Days After" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Jours après" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Días después" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Dias após" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Tage danach" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Giorni dopo" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Dagen na" } }
+      }
+    },
+    "Day of Month": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Day of Month" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Jour du mois" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Día del mes" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Dia do mês" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Tag des Monats" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Giorno del mese" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Dag van de maand" } }
+      }
+    },
+    "Payment Due": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Payment Due" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échéance de paiement" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Fecha de vencimiento" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Vencimento" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Fälligkeit" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Scadenza del pagamento" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Vervaldatum" } }
+      }
+    },
+    "Payment Due Day": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Payment Due Day" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Jour d’échéance" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Día de vencimiento" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Dia de vencimento" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Fälligkeitstag" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Giorno di scadenza" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Vervaldag" } }
+      }
+    },
+    "The payment due date is either a set number of days after the statement closes, or a fixed day of the month. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip.": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The payment due date is either a set number of days after the statement closes, or a fixed day of the month. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La date d’échéance du paiement correspond soit à un nombre défini de jours après la clôture du relevé, soit à un jour fixe du mois. Elle est définie par votre émetteur — consultez un relevé récent, car elle varie selon la carte et le pays.\n\nUne limite de crédit affiche le crédit disponible sur le compte. Laissez ce champ vide pour ne pas l’afficher." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La fecha de vencimiento del pago es un número establecido de días después del cierre del extracto o un día fijo del mes. La establece su emisor; consulte un extracto reciente, ya que varía según la tarjeta y el país.\n\nUn límite de crédito muestra el crédito disponible en la cuenta. Déjelo vacío para omitirlo." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A data de vencimento é um número definido de dias após o fechamento da fatura ou um dia fixo do mês. A administradora a define — consulte uma fatura recente, pois ela varia conforme o cartão e o país.\n\nUm limite de crédito mostra o crédito disponível na conta. Deixe em branco para não exibi-lo." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Der Zahlungstermin ist entweder eine feste Anzahl von Tagen nach dem Abschluss der Abrechnung oder ein fester Kalendertag im Monat. Er wird von Ihrem Kartenanbieter festgelegt – prüfen Sie eine aktuelle Abrechnung, da er je nach Karte und Land variiert.\n\nEin Kreditlimit zeigt den verfügbaren Kredit des Kontos an. Lassen Sie das Feld leer, um es nicht anzuzeigen." } },
+        "it": { "stringUnit": { "state": "translated", "value": "La data di scadenza del pagamento è un numero prestabilito di giorni dopo la chiusura dell’estratto conto oppure un giorno fisso del mese. È stabilita dall’emittente: consulta un estratto conto recente, perché varia in base alla carta e al Paese.\n\nUn limite di credito mostra il credito disponibile sul conto. Lascia vuoto per non mostrarlo." } },
+        "nl": { "stringUnit": { "state": "translated", "value": "De betaaldatum is een vast aantal dagen na het sluiten van het afschrift, of een vaste dag van de maand. Uw uitgever bepaalt deze datum — controleer een recent afschrift, want deze verschilt per kaart en land.\n\nEen kredietlimiet toont het beschikbare krediet op de rekening. Laat dit leeg om het niet weer te geven." } }
+      }
+    },
     "Payment Due After": {
       "localizations": {
         "en": {

--- a/Actuali/Actuali/Models/CreditCardConfig.swift
+++ b/Actuali/Actuali/Models/CreditCardConfig.swift
@@ -5,7 +5,8 @@ import Foundation
 struct CreditCardConfig: Codable, Equatable, Hashable, Sendable {
     var statementDay: Int
     var dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays
-    var limit: Int?
+    var dueDay: Int? = nil
+    var limit: Int? = nil
 }
 
 extension CreditCardConfig {
@@ -13,6 +14,14 @@ extension CreditCardConfig {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         statementDay = try container.decode(Int.self, forKey: .statementDay)
         dueOffsetDays = try container.decodeIfPresent(Int.self, forKey: .dueOffsetDays) ?? CreditCardCycle.defaultDueOffsetDays
+        dueDay = try container.decodeIfPresent(Int.self, forKey: .dueDay)
         limit = try container.decodeIfPresent(Int.self, forKey: .limit)
+    }
+
+    var paymentDue: CreditCardCycle.PaymentDue {
+        if let dueDay {
+            return .dayOfMonth(dueDay)
+        }
+        return .daysAfter(dueOffsetDays)
     }
 }

--- a/Actuali/Actuali/Models/CreditCardConfig.swift
+++ b/Actuali/Actuali/Models/CreditCardConfig.swift
@@ -15,6 +15,9 @@ extension CreditCardConfig {
         statementDay = try container.decode(Int.self, forKey: .statementDay)
         dueOffsetDays = try container.decodeIfPresent(Int.self, forKey: .dueOffsetDays) ?? CreditCardCycle.defaultDueOffsetDays
         dueDay = try container.decodeIfPresent(Int.self, forKey: .dueDay)
+        if let dueDay, !(1...31).contains(dueDay) {
+            throw DecodingError.dataCorruptedError(forKey: .dueDay, in: container, debugDescription: "dueDay must be between 1 and 31")
+        }
         limit = try container.decodeIfPresent(Int.self, forKey: .limit)
     }
 

--- a/Actuali/Actuali/Models/CreditCardCycle.swift
+++ b/Actuali/Actuali/Models/CreditCardCycle.swift
@@ -26,14 +26,6 @@ struct CreditCardCycle: Equatable, Hashable {
         }
     }
 
-    /// Fixed day of the month if configured, otherwise nil.
-    var dueDay: Int? {
-        switch paymentDue {
-        case .daysAfter: return nil
-        case .dayOfMonth(let day): return day
-        }
-    }
-
     /// Applied to cards configured before the offset became per-card.
     static let defaultDueOffsetDays = 15
 
@@ -44,11 +36,6 @@ struct CreditCardCycle: Equatable, Hashable {
     init(statementDay: Int, paymentDue: PaymentDue = .daysAfter(Self.defaultDueOffsetDays)) {
         self.statementDay = statementDay
         self.paymentDue = paymentDue
-    }
-
-    /// Backward-compatible initializer for callers and tests passing `dueOffsetDays`.
-    init(statementDay: Int, dueOffsetDays: Int) {
-        self.init(statementDay: statementDay, paymentDue: .daysAfter(dueOffsetDays))
     }
 
     /// Clamps statement day to the given month's actual length.
@@ -113,17 +100,11 @@ struct CreditCardCycle: Equatable, Hashable {
         // payment covers the cycle now running.
         var due = dueDate(forStatement: cycleRange(for: today).end)
         var statement = previousStatementDate(for: today)
-        // A statement can only be pending while its due date is within
-        // the due window of today. For day-of-month, the payment window spans
-        // at most one cycle, so 2 iterations bounds the walk.
-        let maxIterations: Int
-        switch paymentDue {
-        case .daysAfter(let days):
-            maxIterations = days / 28 + 1
-        case .dayOfMonth:
-            maxIterations = 2
-        }
-        for _ in 0...maxIterations {
+        // A statement can only be pending while its due date is within the due
+        // window of today, which spans at most one cycle per whole month of
+        // offset. A fixed day of the month never exceeds one cycle, and the 15
+        // this returns for that rule already bounds the walk.
+        for _ in 0...(dueOffsetDays / 28 + 1) {
             let statementDue = dueDate(forStatement: statement)
             guard today <= statementDue else { break }
             due = statementDue

--- a/Actuali/Actuali/Models/CreditCardCycle.swift
+++ b/Actuali/Actuali/Models/CreditCardCycle.swift
@@ -4,14 +4,35 @@ import Foundation
 /// Stored per-budget in UserDefaults (lazy / lightweight: `[accountId: statementDay]`
 /// plus `[accountId: dueOffsetDays]`).
 struct CreditCardCycle: Equatable, Hashable {
+    /// How the payment due date is calculated: either relative to statement closing,
+    /// or a fixed calendar day of the month.
+    enum PaymentDue: Equatable, Hashable, Sendable {
+        case daysAfter(Int)
+        case dayOfMonth(Int)
+    }
+
     /// Day of the month the statement closes (1...31).
     let statementDay: Int
 
-    /// Days between the statement closing and the payment due date. The
-    /// interest-free period is set by the issuer, not the network — US cards
-    /// cluster around 21-25 days while Australian ones commonly run 25 or 45 —
-    /// so it is configured per card rather than assumed.
-    let dueOffsetDays: Int
+    /// Payment due rule for this card.
+    let paymentDue: PaymentDue
+
+    /// Days between statement closing and payment due date when using relative offset,
+    /// or `defaultDueOffsetDays` when using a fixed day of the month.
+    var dueOffsetDays: Int {
+        switch paymentDue {
+        case .daysAfter(let days): return days
+        case .dayOfMonth: return Self.defaultDueOffsetDays
+        }
+    }
+
+    /// Fixed day of the month if configured, otherwise nil.
+    var dueDay: Int? {
+        switch paymentDue {
+        case .daysAfter: return nil
+        case .dayOfMonth(let day): return day
+        }
+    }
 
     /// Applied to cards configured before the offset became per-card.
     static let defaultDueOffsetDays = 15
@@ -20,9 +41,14 @@ struct CreditCardCycle: Equatable, Hashable {
     /// in `upcomingDueDate`.
     static let maxDueOffsetDays = 60
 
-    init(statementDay: Int, dueOffsetDays: Int = Self.defaultDueOffsetDays) {
+    init(statementDay: Int, paymentDue: PaymentDue = .daysAfter(Self.defaultDueOffsetDays)) {
         self.statementDay = statementDay
-        self.dueOffsetDays = dueOffsetDays
+        self.paymentDue = paymentDue
+    }
+
+    /// Backward-compatible initializer for callers and tests passing `dueOffsetDays`.
+    init(statementDay: Int, dueOffsetDays: Int) {
+        self.init(statementDay: statementDay, paymentDue: .daysAfter(dueOffsetDays))
     }
 
     /// Clamps statement day to the given month's actual length.
@@ -61,6 +87,20 @@ struct CreditCardCycle: Equatable, Hashable {
         cycleRange(for: today).start.adding(days: -1)
     }
 
+    /// Calculates the payment due date corresponding to a given statement closing date.
+    func dueDate(forStatement statement: DayDate) -> DayDate {
+        switch paymentDue {
+        case .daysAfter(let days):
+            return statement.adding(days: days)
+        case .dayOfMonth(let day):
+            // If dueDay > statementDay: payment is due in the same month as statement closing (e.g. 5th -> 25th).
+            // If dueDay <= statementDay: payment is due in the following month (e.g. 15th -> 1st).
+            let month = (day > statementDay) ? statement : statement.adding(months: 1)
+            let clamped = min(day, DayDate.lastDay(year: month.year, month: month.month))
+            return DayDate(year: month.year, month: month.month, day: clamped)
+        }
+    }
+
     /// Next upcoming payment due date.
     ///
     /// Statements close monthly but the due offset can run longer than a cycle
@@ -71,13 +111,20 @@ struct CreditCardCycle: Equatable, Hashable {
     func upcomingDueDate(for today: DayDate = .today()) -> DayDate {
         // Fallback: everything already closed is paid or past due, so the next
         // payment covers the cycle now running.
-        var due = cycleRange(for: today).end.adding(days: dueOffsetDays)
+        var due = dueDate(forStatement: cycleRange(for: today).end)
         var statement = previousStatementDate(for: today)
         // A statement can only be pending while its due date is within
-        // `dueOffsetDays` of today, which spans at most one cycle per whole
-        // month of offset — the extra step is the one that ends the walk.
-        for _ in 0...(dueOffsetDays / 28 + 1) {
-            let statementDue = statement.adding(days: dueOffsetDays)
+        // the due window of today. For day-of-month, the payment window spans
+        // at most one cycle, so 2 iterations bounds the walk.
+        let maxIterations: Int
+        switch paymentDue {
+        case .daysAfter(let days):
+            maxIterations = days / 28 + 1
+        case .dayOfMonth:
+            maxIterations = 2
+        }
+        for _ in 0...maxIterations {
+            let statementDue = dueDate(forStatement: statement)
             guard today <= statementDue else { break }
             due = statementDue
             statement = previousStatementDate(for: statement)

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -714,6 +714,11 @@ final class BudgetStore: ObservableObject {
         creditCardConfigs.mapValues(\.dueOffsetDays)
     }
 
+    /// Mappings from accountId -> day of the month payment is due, if configured.
+    var creditCardDueDays: [String: Int] {
+        creditCardConfigs.compactMapValues(\.dueDay)
+    }
+
     /// Mappings from accountId -> credit limit in cents (positive). Optional per
     /// card: without one there is no available-credit figure to show.
     var creditCardLimits: [String: Int] {
@@ -734,13 +739,18 @@ final class BudgetStore: ObservableObject {
     func setCreditCard(
         accountId: String,
         statementDay: Int?,
-        dueOffsetDays: Int = CreditCardCycle.defaultDueOffsetDays,
+        paymentDue: CreditCardCycle.PaymentDue = .daysAfter(CreditCardCycle.defaultDueOffsetDays),
         limit: Int?
     ) async {
         guard currentBudgetId != nil else { return }
         let previous = creditCardConfigs[accountId]
         let config: CreditCardConfig? = statementDay.map {
-            CreditCardConfig(statementDay: $0, dueOffsetDays: dueOffsetDays, limit: limit)
+            switch paymentDue {
+            case .daysAfter(let days):
+                return CreditCardConfig(statementDay: $0, dueOffsetDays: days, dueDay: nil, limit: limit)
+            case .dayOfMonth(let day):
+                return CreditCardConfig(statementDay: $0, dueOffsetDays: CreditCardCycle.defaultDueOffsetDays, dueDay: day, limit: limit)
+            }
         }
         creditCardConfigs[accountId] = config
         guard let syncClient else {
@@ -756,11 +766,26 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    /// Backward-compatible overload for callers passing `dueOffsetDays`.
+    func setCreditCard(
+        accountId: String,
+        statementDay: Int?,
+        dueOffsetDays: Int,
+        limit: Int?
+    ) async {
+        await setCreditCard(
+            accountId: accountId,
+            statementDay: statementDay,
+            paymentDue: .daysAfter(dueOffsetDays),
+            limit: limit
+        )
+    }
+
     func creditCardCycle(for accountId: String) -> CreditCardCycle? {
-        guard let day = creditCardStatementDays[accountId] else { return nil }
+        guard let config = creditCardConfigs[accountId] else { return nil }
         return CreditCardCycle(
-            statementDay: day,
-            dueOffsetDays: creditCardDueOffsets[accountId] ?? CreditCardCycle.defaultDueOffsetDays
+            statementDay: config.statementDay,
+            paymentDue: config.paymentDue
         )
     }
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -714,11 +714,6 @@ final class BudgetStore: ObservableObject {
         creditCardConfigs.mapValues(\.dueOffsetDays)
     }
 
-    /// Mappings from accountId -> day of the month payment is due, if configured.
-    var creditCardDueDays: [String: Int] {
-        creditCardConfigs.compactMapValues(\.dueDay)
-    }
-
     /// Mappings from accountId -> credit limit in cents (positive). Optional per
     /// card: without one there is no available-credit figure to show.
     var creditCardLimits: [String: Int] {
@@ -749,7 +744,12 @@ final class BudgetStore: ObservableObject {
             case .daysAfter(let days):
                 return CreditCardConfig(statementDay: $0, dueOffsetDays: days, dueDay: nil, limit: limit)
             case .dayOfMonth(let day):
-                return CreditCardConfig(statementDay: $0, dueOffsetDays: CreditCardCycle.defaultDueOffsetDays, dueDay: day, limit: limit)
+                // Older builds ignore `dueDay` and fall back to `dueOffsetDays`.
+                // Store the real gap so they stay close to the correct date.
+                let cycle = CreditCardCycle(statementDay: $0, paymentDue: .dayOfMonth(day))
+                let statement = cycle.previousStatementDate()
+                let offset = max(1, statement.days(until: cycle.dueDate(forStatement: statement)))
+                return CreditCardConfig(statementDay: $0, dueOffsetDays: offset, dueDay: day, limit: limit)
             }
         }
         creditCardConfigs[accountId] = config
@@ -764,21 +764,6 @@ final class BudgetStore: ObservableObject {
             creditCardConfigs[accountId] = previous
             self.error = error.localizedDescription
         }
-    }
-
-    /// Backward-compatible overload for callers passing `dueOffsetDays`.
-    func setCreditCard(
-        accountId: String,
-        statementDay: Int?,
-        dueOffsetDays: Int,
-        limit: Int?
-    ) async {
-        await setCreditCard(
-            accountId: accountId,
-            statementDay: statementDay,
-            paymentDue: .daysAfter(dueOffsetDays),
-            limit: limit
-        )
     }
 
     func creditCardCycle(for accountId: String) -> CreditCardCycle? {

--- a/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
@@ -4,9 +4,15 @@ import SwiftUI
 struct CreditCardsSettingsView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.locale) private var locale
-    enum DueDateMode: String, CaseIterable {
-        case daysAfter = "Days After"
-        case dayOfMonth = "Day of Month"
+    enum DueDateMode: CaseIterable, Hashable {
+        case daysAfter, dayOfMonth
+
+        var title: String {
+            switch self {
+            case .daysAfter: String(localized: "Days After")
+            case .dayOfMonth: String(localized: "Day of Month")
+            }
+        }
     }
     @State private var showingAddSheet = false
     @State private var editingAccountId: String?
@@ -168,22 +174,22 @@ struct CreditCardsSettingsView: View {
                         }
                     }
 
-                    Picker("Payment Due", selection: $selectedDueMode) {
+                    Picker(String(localized: "Payment Due"), selection: $selectedDueMode) {
                         ForEach(DueDateMode.allCases, id: \.self) { mode in
-                            Text(mode.rawValue).tag(mode)
+                            Text(mode.title).tag(mode)
                         }
                     }
                     .pickerStyle(.segmented)
 
                     if selectedDueMode == .daysAfter {
-                        Picker("Payment Due After", selection: $selectedDueOffset) {
+                        Picker(String(localized: "Payment Due After"), selection: $selectedDueOffset) {
                             ForEach(1...CreditCardCycle.maxDueOffsetDays, id: \.self) { days in
-                                Text(days == 1 ? "1 day" : "\(days) days").tag(days)
+                                Text(days == 1 ? String(localized: "1 Day") : String(format: String(localized: "%lld days"), Int64(days))).tag(days)
                             }
                         }
                     } else {
-                            Picker("Payment Due Day", selection: $selectedDueDay) {
-                                ForEach(1...31, id: \.self) { day in
+                        Picker(String(localized: "Payment Due Day"), selection: $selectedDueDay) {
+                            ForEach(1...31, id: \.self) { day in
                                 Text(ScheduleDescription.ordinal(day, locale: locale)).tag(day)
                             }
                         }
@@ -201,7 +207,7 @@ struct CreditCardsSettingsView: View {
                 } header: {
                     Text(String(localized: "Card Details"))
                 } footer: {
-                    Text("The payment due date is either a set number of days after the statement closes, or a fixed day of the month. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip.")
+                    Text(String(localized: "The payment due date is either a set number of days after the statement closes, or a fixed day of the month. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip."))
                 }
 
                 if isEditing {

--- a/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/CreditCardsSettingsView.swift
@@ -4,11 +4,17 @@ import SwiftUI
 struct CreditCardsSettingsView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.locale) private var locale
+    enum DueDateMode: String, CaseIterable {
+        case daysAfter = "Days After"
+        case dayOfMonth = "Day of Month"
+    }
     @State private var showingAddSheet = false
     @State private var editingAccountId: String?
     @State private var selectedAccountId = ""
     @State private var selectedStatementDay = 15
+    @State private var selectedDueMode: DueDateMode = .daysAfter
     @State private var selectedDueOffset = CreditCardCycle.defaultDueOffsetDays
+    @State private var selectedDueDay = 1
     /// Dot-decimal amount as typed, the format `AmountInputField` binds to.
     /// Empty means "no limit set".
     @State private var selectedLimitText = ""
@@ -62,7 +68,16 @@ struct CreditCardsSettingsView: View {
                         Button {
                             selectedAccountId = item.account.id
                             selectedStatementDay = item.cycle.statementDay
-                            selectedDueOffset = item.cycle.dueOffsetDays
+                            switch item.cycle.paymentDue {
+                            case .daysAfter(let days):
+                                selectedDueMode = .daysAfter
+                                selectedDueOffset = days
+                                selectedDueDay = 1
+                            case .dayOfMonth(let day):
+                                selectedDueMode = .dayOfMonth
+                                selectedDueDay = day
+                                selectedDueOffset = CreditCardCycle.defaultDueOffsetDays
+                            }
                             selectedLimitText = limitText(for: item.account.id)
                             editingAccountId = item.account.id
                         } label: {
@@ -106,7 +121,9 @@ struct CreditCardsSettingsView: View {
                             selectedAccountId = first.id
                         }
                         selectedStatementDay = 15
+                        selectedDueMode = .daysAfter
                         selectedDueOffset = CreditCardCycle.defaultDueOffsetDays
+                        selectedDueDay = 1
                         selectedLimitText = ""
                         showingAddSheet = true
                     } label: {
@@ -151,9 +168,24 @@ struct CreditCardsSettingsView: View {
                         }
                     }
 
-                    Picker(String(localized: "Payment Due After"), selection: $selectedDueOffset) {
-                        ForEach(1...CreditCardCycle.maxDueOffsetDays, id: \.self) { days in
-                            Text(days == 1 ? String(localized: "1 Day") : String(format: String(localized: "%lld days"), Int64(days))).tag(days)
+                    Picker("Payment Due", selection: $selectedDueMode) {
+                        ForEach(DueDateMode.allCases, id: \.self) { mode in
+                            Text(mode.rawValue).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    if selectedDueMode == .daysAfter {
+                        Picker("Payment Due After", selection: $selectedDueOffset) {
+                            ForEach(1...CreditCardCycle.maxDueOffsetDays, id: \.self) { days in
+                                Text(days == 1 ? "1 day" : "\(days) days").tag(days)
+                            }
+                        }
+                    } else {
+                            Picker("Payment Due Day", selection: $selectedDueDay) {
+                                ForEach(1...31, id: \.self) { day in
+                                Text(ScheduleDescription.ordinal(day, locale: locale)).tag(day)
+                            }
                         }
                     }
 
@@ -169,7 +201,7 @@ struct CreditCardsSettingsView: View {
                 } header: {
                     Text(String(localized: "Card Details"))
                 } footer: {
-                    Text(String(localized: "The payment due date is the statement closing date plus this many days. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip."))
+                    Text("The payment due date is either a set number of days after the statement closes, or a fixed day of the month. Your issuer sets it — check a recent statement, as it varies by card and country.\n\nA credit limit shows available credit on the account. Leave it empty to skip.")
                 }
 
                 if isEditing {
@@ -199,10 +231,13 @@ struct CreditCardsSettingsView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(String(localized: "Save")) {
                         Task {
+                            let paymentDue: CreditCardCycle.PaymentDue = (selectedDueMode == .dayOfMonth)
+                                ? .dayOfMonth(selectedDueDay)
+                                : .daysAfter(selectedDueOffset)
                             await budgetStore.setCreditCard(
                                 accountId: selectedAccountId,
                                 statementDay: selectedStatementDay,
-                                dueOffsetDays: selectedDueOffset,
+                                paymentDue: paymentDue,
                                 limit: enteredLimitCents
                             )
                         }

--- a/Actuali/ActualiTests/Models/CreditCardConfigTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardConfigTests.swift
@@ -30,6 +30,25 @@ struct CreditCardConfigTests {
         let decoded = try JSONDecoder().decode(CreditCardConfig.self, from: data)
         #expect(decoded.statementDay == 15)
         #expect(decoded.dueOffsetDays == CreditCardCycle.defaultDueOffsetDays)
+        #expect(decoded.dueDay == nil)
+        #expect(decoded.paymentDue == .daysAfter(CreditCardCycle.defaultDueOffsetDays))
+        #expect(decoded.limit == nil)
+    }
+
+    @Test func encodesAndDecodesJSONWithDueDay() throws {
+        let config = CreditCardConfig(
+            statementDay: 15,
+            dueOffsetDays: CreditCardCycle.defaultDueOffsetDays,
+            dueDay: 1,
+            limit: nil
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CreditCardConfig.self, from: data)
+
+        #expect(decoded.statementDay == 15)
+        #expect(decoded.dueDay == 1)
+        #expect(decoded.paymentDue == .dayOfMonth(1))
         #expect(decoded.limit == nil)
     }
 }

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -208,10 +208,10 @@ struct CreditCardCycleTests {
 
     @Test func dueSummaryWithDueDayReadsAccurately() {
         let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
-        // Feb 15 statement -> due Mar 1, 2026
         #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 3, day: 1)) == "Due today")
         #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 28)) == "Due tomorrow")
-        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due 1 Mar 2026 (9d)")
+        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 20)).hasPrefix("Due "))
+        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 20)).hasSuffix("(9d)"))
         #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due in 9d")
     }
 

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -161,6 +161,60 @@ struct CreditCardCycleTests {
         #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due in 10d")
     }
 
+    @Test func upcomingDueDateWhenDueDayIsNextMonth() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        // Today is Feb 20, 2026: Feb 15 statement closed, due on Mar 1, 2026
+        let today = DayDate(year: 2026, month: 2, day: 20)
+        let due = cycle.upcomingDueDate(for: today)
+
+        #expect(due == DayDate(year: 2026, month: 3, day: 1))
+        #expect(cycle.daysUntilDue(for: today) == 9)
+    }
+
+    @Test func upcomingDueDateWhenDueDayIsSameMonth() {
+        let cycle = CreditCardCycle(statementDay: 5, paymentDue: .dayOfMonth(25))
+        // Today is Jan 10, 2026: Jan 5 statement closed, due on Jan 25, 2026
+        let today = DayDate(year: 2026, month: 1, day: 10)
+        let due = cycle.upcomingDueDate(for: today)
+
+        #expect(due == DayDate(year: 2026, month: 1, day: 25))
+        #expect(cycle.daysUntilDue(for: today) == 15)
+    }
+
+    @Test func upcomingDueDateRollsToCurrentCycleWhenPastPreviousDueDay() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        // Today is Mar 2, 2026: Feb 15 statement was due Mar 1 (passed),
+        // so next due is Mar 15 statement due Apr 1
+        let today = DayDate(year: 2026, month: 3, day: 2)
+        let due = cycle.upcomingDueDate(for: today)
+
+        #expect(due == DayDate(year: 2026, month: 4, day: 1))
+        #expect(cycle.daysUntilDue(for: today) == 30)
+    }
+
+    @Test func upcomingDueDateClampsForShorterMonthsWithDueDay() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(31))
+        // Feb 15, 2026 statement -> due on Feb 28 (clamped to month end)
+        let today = DayDate(year: 2026, month: 2, day: 20)
+        #expect(cycle.upcomingDueDate(for: today) == DayDate(year: 2026, month: 2, day: 28))
+    }
+
+    @Test func upcomingDueDateRollsOverYearEndWithDueDay() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        // Today is Dec 20, 2026: Dec 15 statement closed, due on Jan 1, 2027
+        let today = DayDate(year: 2026, month: 12, day: 20)
+        #expect(cycle.upcomingDueDate(for: today) == DayDate(year: 2027, month: 1, day: 1))
+    }
+
+    @Test func dueSummaryWithDueDayReadsAccurately() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        // Feb 15 statement -> due Mar 1, 2026
+        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 3, day: 1)) == "Due today")
+        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 28)) == "Due tomorrow")
+        #expect(cycle.dueSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due 1 Mar 2026 (9d)")
+        #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due in 9d")
+    }
+
     // MARK: - Store Persistence
 
     /// Points the store at throwaway budget ids and configures test database and sync client.
@@ -214,6 +268,20 @@ struct CreditCardCycleTests {
             // by a later card on the same account.
             await store.setCreditCard(accountId: "acct_anz", statementDay: nil, limit: nil)
             #expect(store.creditCardDueOffsets["acct_anz"] == nil)
+        }
+    }
+
+    @Test func dueDayPersistsAndClearsWithTheCard() async throws {
+        try await withStore { store in
+            await store.setCreditCard(accountId: "acct_alipay", statementDay: 15, paymentDue: .dayOfMonth(1), limit: nil)
+
+            #expect(store.creditCardDueDays["acct_alipay"] == 1)
+            #expect(store.creditCardCycle(for: "acct_alipay")?.paymentDue == .dayOfMonth(1))
+            #expect(store.creditCardCycle(for: "acct_alipay")?.dueDay == 1)
+
+            await store.setCreditCard(accountId: "acct_alipay", statementDay: nil, limit: nil)
+            #expect(store.creditCardDueDays["acct_alipay"] == nil)
+            #expect(store.creditCardCycle(for: "acct_alipay") == nil)
         }
     }
 

--- a/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
+++ b/Actuali/ActualiTests/Models/CreditCardCycleTests.swift
@@ -106,7 +106,7 @@ struct CreditCardCycleTests {
     }
 
     @Test func upcomingDueDateHonoursALongerPerCardOffset() {
-        let cycle = CreditCardCycle(statementDay: 15, dueOffsetDays: 25)
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .daysAfter(25))
         // Today is Feb 20, 2026: Feb 15 statement + 25 days = Mar 12.
         let today = DayDate(year: 2026, month: 2, day: 20)
 
@@ -118,7 +118,7 @@ struct CreditCardCycleTests {
     /// next payment belongs to the *older* one. Returning the most recent
     /// statement's due date would skip a payment the user still owes.
     @Test func upcomingDueDatePicksTheEarliestStatementStillAwaitingPayment() {
-        let cycle = CreditCardCycle(statementDay: 15, dueOffsetDays: 45)
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .daysAfter(45))
         let today = DayDate(year: 2026, month: 2, day: 20)
 
         // Jan 15 statement -> due Mar 1; Feb 15 statement -> due Apr 1.
@@ -127,7 +127,7 @@ struct CreditCardCycleTests {
     }
 
     @Test func upcomingDueDateAdvancesOnceTheEarliestPendingDuePasses() {
-        let cycle = CreditCardCycle(statementDay: 15, dueOffsetDays: 45)
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .daysAfter(45))
         // Mar 2 is one day past the Jan 15 statement's Mar 1 due date, so the
         // Feb 15 statement's Apr 1 due date is now the next one.
         let today = DayDate(year: 2026, month: 3, day: 2)
@@ -136,7 +136,7 @@ struct CreditCardCycleTests {
     }
 
     @Test func upcomingDueDateTerminatesAtTheWidestOffset() {
-        let cycle = CreditCardCycle(statementDay: 15, dueOffsetDays: CreditCardCycle.maxDueOffsetDays)
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .daysAfter(CreditCardCycle.maxDueOffsetDays))
         let today = DayDate(year: 2026, month: 2, day: 20)
         // Dec 15 statement + 60 days = Feb 13 (passed), so Jan 15 + 60 is next.
         #expect(cycle.upcomingDueDate(for: today) == DayDate(year: 2026, month: 3, day: 16))
@@ -159,6 +159,20 @@ struct CreditCardCycleTests {
         #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 3, day: 2)) == "Due today")
         #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 3, day: 1)) == "Due tomorrow")
         #expect(cycle.dueShortSummary(for: DayDate(year: 2026, month: 2, day: 20)) == "Due in 10d")
+    }
+
+    @Test func dueDayEqualToStatementDayFallsInTheNextMonth() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(15))
+        // Jan 15 statement closes, payment is due Feb 15.
+        #expect(cycle.dueDate(forStatement: DayDate(year: 2026, month: 1, day: 15))
+            == DayDate(year: 2026, month: 2, day: 15))
+        #expect(cycle.upcomingDueDate(for: DayDate(year: 2026, month: 1, day: 20))
+            == DayDate(year: 2026, month: 2, day: 15))
+    }
+
+    @Test func dueOffsetDaysForDayOfMonthFallsBackToDefault() {
+        let cycle = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        #expect(cycle.dueOffsetDays == CreditCardCycle.defaultDueOffsetDays)
     }
 
     @Test func upcomingDueDateWhenDueDayIsNextMonth() {
@@ -259,7 +273,7 @@ struct CreditCardCycleTests {
 
     @Test func dueOffsetPersistsAndClearsWithTheCard() async throws {
         try await withStore { store in
-            await store.setCreditCard(accountId: "acct_anz", statementDay: 20, dueOffsetDays: 45, limit: nil)
+            await store.setCreditCard(accountId: "acct_anz", statementDay: 20, paymentDue: .daysAfter(45), limit: nil)
 
             #expect(store.creditCardDueOffsets["acct_anz"] == 45)
             #expect(store.creditCardCycle(for: "acct_anz")?.dueOffsetDays == 45)
@@ -275,12 +289,9 @@ struct CreditCardCycleTests {
         try await withStore { store in
             await store.setCreditCard(accountId: "acct_alipay", statementDay: 15, paymentDue: .dayOfMonth(1), limit: nil)
 
-            #expect(store.creditCardDueDays["acct_alipay"] == 1)
             #expect(store.creditCardCycle(for: "acct_alipay")?.paymentDue == .dayOfMonth(1))
-            #expect(store.creditCardCycle(for: "acct_alipay")?.dueDay == 1)
 
             await store.setCreditCard(accountId: "acct_alipay", statementDay: nil, limit: nil)
-            #expect(store.creditCardDueDays["acct_alipay"] == nil)
             #expect(store.creditCardCycle(for: "acct_alipay") == nil)
         }
     }
@@ -299,7 +310,7 @@ struct CreditCardCycleTests {
 
     @Test func cardConfigIsScopedToTheBudgetThatSetIt() async throws {
         try await withStore(budgetIds: ["budget-a", "budget-b"]) { store in
-            await store.setCreditCard(accountId: "acct_chase", statementDay: 18, dueOffsetDays: 25, limit: nil)
+            await store.setCreditCard(accountId: "acct_chase", statementDay: 18, paymentDue: .daysAfter(25), limit: nil)
 
             store.currentBudgetId = "budget-b"
             #expect(store.creditCardStatementDays.isEmpty)
@@ -358,7 +369,7 @@ struct CreditCardCycleTests {
                 account(id: "acct_closed", name: "Closed Card", closed: true),
                 account(id: "acct_untracked", name: "Everyday Checking", type: .checking),
             ]
-            await store.setCreditCard(accountId: "acct_open", statementDay: 15, dueOffsetDays: 25, limit: nil)
+            await store.setCreditCard(accountId: "acct_open", statementDay: 15, paymentDue: .daysAfter(25), limit: nil)
             await store.setCreditCard(accountId: "acct_closed", statementDay: 20, limit: nil)
             await store.setCreditCard(accountId: "acct_deleted", statementDay: 25, limit: nil)
 

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditCardTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditCardTests.swift
@@ -128,7 +128,7 @@ struct BudgetStoreCreditCardTests {
         store.currentBudgetId = "test-budget"
         store.configureForTesting(database: database, syncClient: syncClient)
 
-        await store.setCreditCard(accountId: "acct_chase", statementDay: 18, dueOffsetDays: 25, limit: 500_000)
+        await store.setCreditCard(accountId: "acct_chase", statementDay: 18, paymentDue: .daysAfter(25), limit: 500_000)
 
         #expect(store.creditCardStatementDays["acct_chase"] == 18)
         #expect(store.creditCardDueOffsets["acct_chase"] == 25)

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditLimitTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreCreditLimitTests.swift
@@ -86,7 +86,7 @@ struct BudgetStoreCreditLimitTests {
             #expect(store.creditCardLimits["acct_card"] == nil)
 
             // ...while setting a limit updates the stored config.
-            await store.setCreditCard(accountId: "acct_card", statementDay: 3, dueOffsetDays: 25, limit: 1_000_000)
+            await store.setCreditCard(accountId: "acct_card", statementDay: 3, paymentDue: .daysAfter(25), limit: 1_000_000)
             #expect(store.creditCardLimits["acct_card"] == 1_000_000)
         }
     }

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseCreditCardTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseCreditCardTests.swift
@@ -85,6 +85,11 @@ struct BudgetDatabaseCreditCardTests {
                 sql: "INSERT INTO preferences (id, value) VALUES (?, ?)",
                 arguments: ["actuali:credit_card:acct_corrupt", "{invalid_json}"]
             )
+            // Synced preferences are external input; reject impossible fixed due days.
+            try conn.execute(
+                sql: "INSERT INTO preferences (id, value) VALUES (?, ?)",
+                arguments: ["actuali:credit_card:acct_invalid_due_day", #"{"statementDay":15,"dueDay":0}"#]
+            )
         }
 
         let configs = try await db.fetchCreditCardConfigs()

--- a/Actuali/ActualiTests/Views/CreditCardsSettingsViewTests.swift
+++ b/Actuali/ActualiTests/Views/CreditCardsSettingsViewTests.swift
@@ -31,6 +31,20 @@ struct CreditCardsSettingsViewTests {
         #expect(sorted.map(\.account.name) == ["Zeta", "Alpha"])
     }
 
+    @Test func sortsWithMixOfOffsetAndDayOfMonth() {
+        let today = DayDate(year: 2026, month: 2, day: 20)
+        // Statement day 15, due 1st of month: Feb 15 statement is due Mar 1 (9 days out)
+        let dayOfMonthCard = CreditCardCycle(statementDay: 15, paymentDue: .dayOfMonth(1))
+        // Statement day 15, default 15-day offset: Feb 15 statement is due Mar 2 (10 days out)
+        let offsetCard = CreditCardCycle(statementDay: 15, paymentDue: .daysAfter(15))
+
+        let sorted = CreditCardsSettingsView.sortedCards(
+            [(account: account("Offset"), cycle: offsetCard), (account: account("DayOfMonth"), cycle: dayOfMonthCard)],
+            today: today
+        )
+        #expect(sorted.map(\.account.name) == ["DayOfMonth", "Offset"])
+    }
+
     /// `daysUntilDue` clamps at 0, so past-due cards all tie there. Without the
     /// name tie-break the surviving order comes from a Dictionary, which Swift
     /// reseeds every launch.


### PR DESCRIPTION
## Why

Closes #381

Credit card payment due dates could previously only be configured as a relative number of days after the statement closes. Many card issuers and fintech services (e.g. Alipay Huabei, European/Asian banks) fix repayment on a specific calendar day of the month (e.g. 1st, 25th). Because month lengths vary, fixed day offsets caused the due date to drift across months.

## What

- **Explicit `PaymentDue` enum**: Added `PaymentDue.daysAfter(Int)` and `PaymentDue.dayOfMonth(Int)` to `CreditCardCycle` (defaulting to `.daysAfter(15)`).
- **Calendar day due date calculations**: Correctly computes repayment date for same-month (`dueDay > statementDay`) and next-month (`dueDay <= statementDay`) cycles, with month-end clamping (e.g. 31st clamped to Feb 28) and year-end rollover.
- **Synced persistence**: Added optional `dueDay: Int?` to `CreditCardConfig`. Existing cards continue decoding as `.daysAfter(dueOffsetDays)` with full backward compatibility.
- **Settings UI**: Added a segmented control in the Add/Edit Credit Card sheet allowing users to toggle between **Days After** (1...60 days) and **Day of Month** (1st...31st).

## How it was tested

- **`CreditCardCycleTests`**: Added unit tests covering same-month due dates, next-month due dates, cycle advancement when a due date passes, short month clamping, year-end rollovers, summary text formatting, and store persistence roundtrips.
- **`CreditCardConfigTests`**: Added tests for JSON encoding and decoding with and without `dueDay`.
- **`CreditCardsSettingsViewTests`**: Added test for sorting cards with a mix of relative offset and day-of-month configurations.
