### PR TITLE
Respect bank sync deleted transaction preference

### DIFF
--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -89,11 +89,17 @@ enum BankSyncReconciler {
         // duplicate it.
         var pending: [(candidate: BankSyncCandidate, match: BankSyncExistingTransaction?, window: [BankSyncExistingTransaction])] = []
         for candidate in candidates {
-            if let match = existing.first(where: {
+            let liveMatch = existing.first(where: {
                 $0.importedId == candidate.importedId
-                    && (!$0.tombstone || !reimportDeleted)
+                    && !$0.tombstone
                     && !matchedIds.contains($0.id)
-            }) {
+            })
+            let deletedMatch = reimportDeleted ? nil : existing.first(where: {
+                $0.importedId == candidate.importedId
+                    && $0.tombstone
+                    && !matchedIds.contains($0.id)
+            })
+            if let match = liveMatch ?? deletedMatch {
                 matchedIds.insert(match.id)
                 pending.append((candidate, match, []))
                 continue

--- a/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
+++ b/Actuali/Actuali/Services/BankSync/BankSyncReconciler.swift
@@ -31,6 +31,7 @@ struct BankSyncExistingTransaction: Sendable, Equatable {
     var notes: String?
     var cleared: Bool
     var reconciled: Bool
+    var tombstone: Bool = false
 }
 
 /// The columns a matched transaction takes from the downloaded one.
@@ -70,7 +71,8 @@ enum BankSyncReconciler {
 
     static func plan(
         candidates: [BankSyncCandidate],
-        existing: [BankSyncExistingTransaction]
+        existing: [BankSyncExistingTransaction],
+        reimportDeleted: Bool = true
     ) -> BankSyncPlan {
         var matchedIds = Set<String>()
         var plan = BankSyncPlan()
@@ -88,7 +90,9 @@ enum BankSyncReconciler {
         var pending: [(candidate: BankSyncCandidate, match: BankSyncExistingTransaction?, window: [BankSyncExistingTransaction])] = []
         for candidate in candidates {
             if let match = existing.first(where: {
-                $0.importedId == candidate.importedId && !matchedIds.contains($0.id)
+                $0.importedId == candidate.importedId
+                    && (!$0.tombstone || !reimportDeleted)
+                    && !matchedIds.contains($0.id)
             }) {
                 matchedIds.insert(match.id)
                 pending.append((candidate, match, []))
@@ -96,7 +100,7 @@ enum BankSyncReconciler {
             }
             let window = existing
                 .compactMap { row -> (row: BankSyncExistingTransaction, distance: Int)? in
-                    guard row.amount == candidate.amount,
+                    guard !row.tombstone, row.amount == candidate.amount,
                           let distance = dayDistance(row.date, candidate.date),
                           distance <= fuzzyMatchDayRadius else { return nil }
                     return (row, distance)
@@ -131,8 +135,9 @@ enum BankSyncReconciler {
                 plan.inserts.append(entry.candidate)
                 continue
             }
-            // Reconciled transactions are locked; upstream leaves them alone.
-            guard !match.reconciled else {
+            // Reconciled and deleted transactions are locked; upstream leaves
+            // both alone. A deleted row only acts as an exact-ID dedupe key.
+            guard !match.reconciled, !match.tombstone else {
                 plan.unchanged += 1
                 continue
             }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3327,10 +3327,13 @@ final class BudgetStore: ObservableObject {
             accountId: target.id,
             from: DayDate(yyyymmdd: earliest)?.adding(days: -radius).yyyymmdd ?? earliest,
             to: DayDate(yyyymmdd: latest)?.adding(days: radius).yyyymmdd ?? latest,
-            includeTombstoned: !reimportDeleted
         )
 
-        let plan = BankSyncReconciler.plan(candidates: candidates, existing: window)
+        let plan = BankSyncReconciler.plan(
+            candidates: candidates,
+            existing: window,
+            reimportDeleted: reimportDeleted
+        )
 
         try await syncClient.applyBankSyncUpdates(plan.updates)
 

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3285,16 +3285,7 @@ final class BudgetStore: ObservableObject {
         // far as the hungriest of them.
         var candidates = download.candidates
 
-        // The opening balance counts as an import too (upstream folds its id
-        // into `added`), so a first sync never reports one fewer than it wrote.
         var added = 0
-        if existingOldestDay == nil {
-            added += try await insertStartingBalance(
-                for: target,
-                currentBalanceCents: download.currentBalanceCents,
-                candidates: candidates
-            ) ? 1 : 0
-        }
         guard let earliest = candidates.map(\.date).min(),
               let latest = candidates.map(\.date).max() else { return (added, 0, []) }
 
@@ -3327,6 +3318,7 @@ final class BudgetStore: ObservableObject {
             accountId: target.id,
             from: DayDate(yyyymmdd: earliest)?.adding(days: -radius).yyyymmdd ?? earliest,
             to: DayDate(yyyymmdd: latest)?.adding(days: radius).yyyymmdd ?? latest,
+            importedIds: Set(candidates.map(\.importedId))
         )
 
         let plan = BankSyncReconciler.plan(
@@ -3334,6 +3326,17 @@ final class BudgetStore: ObservableObject {
             existing: window,
             reimportDeleted: reimportDeleted
         )
+
+        // The opening balance counts as an import too (upstream folds its id
+        // into `added`). Only subtract rows this sync will actually insert.
+        if existingOldestDay == nil {
+            added += try await insertStartingBalance(
+                for: target,
+                currentBalanceCents: download.currentBalanceCents,
+                imported: plan.inserts,
+                startingDay: earliest
+            ) ? 1 : 0
+        }
 
         try await syncClient.applyBankSyncUpdates(plan.updates)
 
@@ -3412,12 +3415,13 @@ final class BudgetStore: ObservableObject {
     private func insertStartingBalance(
         for target: BankSyncAccount,
         currentBalanceCents: Int?,
-        candidates: [BankSyncCandidate]
+        imported: [BankSyncCandidate],
+        startingDay: Int
     ) async throws -> Bool {
         guard let syncClient, let balance = currentBalanceCents else { return false }
         // The balance is as of now, so what the account opened with is what's
         // left once everything about to be imported is taken back off it.
-        let opening = balance - candidates.reduce(0) { $0 + $1.amount }
+        let opening = balance - imported.reduce(0) { $0 + $1.amount }
         guard opening != 0 else { return false }
 
         let payee = try await findOrCreatePayee(name: "Starting Balance")
@@ -3426,7 +3430,7 @@ final class BudgetStore: ObservableObject {
         let transaction = Transaction(
             id: UUID().uuidString,
             accountId: target.id,
-            date: candidates.map(\.date).min() ?? Transaction.yyyymmdd(from: Date()),
+            date: startingDay,
             amount: opening,
             payeeId: payee.id,
             payeeName: payee.name,

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -3317,10 +3317,17 @@ final class BudgetStore: ObservableObject {
         }
 
         let radius = BankSyncReconciler.fuzzyMatchDayRadius
+        // Actual stores this as a synced per-account preference. Its default
+        // is true for backwards compatibility, so an absent preference keeps
+        // the existing reimport behavior.
+        let reimportDeleted = (try await database.fetchPreference(
+            id: "sync-reimport-deleted-\(target.id)"
+        ) ?? "true") == "true"
         let window = try await database.bankSyncWindow(
             accountId: target.id,
             from: DayDate(yyyymmdd: earliest)?.adding(days: -radius).yyyymmdd ?? earliest,
-            to: DayDate(yyyymmdd: latest)?.adding(days: radius).yyyymmdd ?? latest
+            to: DayDate(yyyymmdd: latest)?.adding(days: radius).yyyymmdd ?? latest,
+            includeTombstoned: !reimportDeleted
         )
 
         let plan = BankSyncReconciler.plan(candidates: candidates, existing: window)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2852,23 +2852,32 @@ final class BudgetDatabase: Sendable {
     }
 
     /// The transactions a download could be matching, projected down to the
-    /// columns `BankSyncReconciler` reads. Bounded by date because matching
-    /// only ever looks a week either side of a downloaded transaction.
+    /// columns `BankSyncReconciler` reads. Fuzzy candidates are bounded by
+    /// date; exact provider IDs are included account-wide.
     ///
     /// Split children are excluded: a download matches the parent (which
     /// carries the full amount), never one of its portions. Tombstoned rows
     /// are included so the reconciler can apply the account's
     /// `reimportDeleted` setting: they are usable only as exact-ID dedupe keys.
-    func bankSyncWindow(accountId: String, from: Int, to: Int) async throws -> [BankSyncExistingTransaction] {
+    func bankSyncWindow(
+        accountId: String,
+        from: Int,
+        to: Int,
+        importedIds: Set<String>
+    ) async throws -> [BankSyncExistingTransaction] {
         try await dbQueue.read { db in
+            let placeholders = Array(repeating: "?", count: importedIds.count).joined(separator: ", ")
+            var arguments: [any DatabaseValueConvertible] = [accountId, from, to]
+            arguments.append(contentsOf: importedIds.map { $0 as any DatabaseValueConvertible })
             return try Row.fetchAll(db, sql: """
                 SELECT id, date, amount, description, financial_id, imported_description,
                        notes, cleared, reconciled, tombstone
                 FROM transactions
                 WHERE acct = ?
-                  AND date IS NOT NULL AND date >= ? AND date <= ?
+                  AND ((date IS NOT NULL AND date >= ? AND date <= ?)
+                       OR financial_id IN (\(placeholders)))
                   AND (isChild = 0 OR isChild IS NULL)
-                """, arguments: [accountId, from, to]).map { row in
+                """, arguments: StatementArguments(arguments)).map { row in
                 BankSyncExistingTransaction(
                     id: row["id"],
                     date: row["date"] ?? 0,

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2857,18 +2857,26 @@ final class BudgetDatabase: Sendable {
     ///
     /// Split children are excluded: a download matches the parent (which
     /// carries the full amount), never one of its portions. Tombstoned rows
-    /// are excluded too, so a transaction the person deleted isn't quietly
-    /// resurrected by the next sync — it re-imports as new instead, which is
-    /// the outcome they'd get on the web UI.
-    func bankSyncWindow(accountId: String, from: Int, to: Int) async throws -> [BankSyncExistingTransaction] {
+    /// are included only when the account's `reimportDeleted` setting is
+    /// disabled. In that mode matching the tombstone prevents the downloaded
+    /// transaction from being inserted again while leaving the row deleted.
+    func bankSyncWindow(
+        accountId: String,
+        from: Int,
+        to: Int,
+        includeTombstoned: Bool = false
+    ) async throws -> [BankSyncExistingTransaction] {
         try await dbQueue.read { db in
-            try Row.fetchAll(db, sql: """
+            let tombstoneFilter = includeTombstoned
+                ? ""
+                : "AND (tombstone = 0 OR tombstone IS NULL)"
+            return try Row.fetchAll(db, sql: """
                 SELECT id, date, amount, description, financial_id, imported_description,
                        notes, cleared, reconciled
                 FROM transactions
                 WHERE acct = ?
                   AND date IS NOT NULL AND date >= ? AND date <= ?
-                  AND (tombstone = 0 OR tombstone IS NULL)
+                  \(tombstoneFilter)
                   AND (isChild = 0 OR isChild IS NULL)
                 """, arguments: [accountId, from, to]).map { row in
                 BankSyncExistingTransaction(

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2857,26 +2857,16 @@ final class BudgetDatabase: Sendable {
     ///
     /// Split children are excluded: a download matches the parent (which
     /// carries the full amount), never one of its portions. Tombstoned rows
-    /// are included only when the account's `reimportDeleted` setting is
-    /// disabled. In that mode matching the tombstone prevents the downloaded
-    /// transaction from being inserted again while leaving the row deleted.
-    func bankSyncWindow(
-        accountId: String,
-        from: Int,
-        to: Int,
-        includeTombstoned: Bool = false
-    ) async throws -> [BankSyncExistingTransaction] {
+    /// are included so the reconciler can apply the account's
+    /// `reimportDeleted` setting: they are usable only as exact-ID dedupe keys.
+    func bankSyncWindow(accountId: String, from: Int, to: Int) async throws -> [BankSyncExistingTransaction] {
         try await dbQueue.read { db in
-            let tombstoneFilter = includeTombstoned
-                ? ""
-                : "AND (tombstone = 0 OR tombstone IS NULL)"
             return try Row.fetchAll(db, sql: """
                 SELECT id, date, amount, description, financial_id, imported_description,
-                       notes, cleared, reconciled
+                       notes, cleared, reconciled, tombstone
                 FROM transactions
                 WHERE acct = ?
                   AND date IS NOT NULL AND date >= ? AND date <= ?
-                  \(tombstoneFilter)
                   AND (isChild = 0 OR isChild IS NULL)
                 """, arguments: [accountId, from, to]).map { row in
                 BankSyncExistingTransaction(
@@ -2888,7 +2878,8 @@ final class BudgetDatabase: Sendable {
                     importedPayee: row["imported_description"],
                     notes: row["notes"],
                     cleared: row["cleared"] == 1,
-                    reconciled: row["reconciled"] == 1
+                    reconciled: row["reconciled"] == 1,
+                    tombstone: row["tombstone"] == 1
                 )
             }
         }

--- a/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BankSyncReconcilerTests.swift
@@ -28,11 +28,13 @@ struct BankSyncReconcilerTests {
         importedPayee: String? = nil,
         notes: String? = nil,
         cleared: Bool = false,
-        reconciled: Bool = false
+        reconciled: Bool = false,
+        tombstone: Bool = false
     ) -> BankSyncExistingTransaction {
         BankSyncExistingTransaction(
             id: id, date: date, amount: amount, payeeId: payeeId, importedId: importedId,
-            importedPayee: importedPayee, notes: notes, cleared: cleared, reconciled: reconciled
+            importedPayee: importedPayee, notes: notes, cleared: cleared,
+            reconciled: reconciled, tombstone: tombstone
         )
     }
 
@@ -70,6 +72,20 @@ struct BankSyncReconcilerTests {
         let update = try #require(plan.updates.first)
         #expect(update.existingId == "tx-1")
         #expect(update.cleared)
+    }
+
+    @Test func aLiveIdMatchWinsOverADeletedOne() throws {
+        let plan = BankSyncReconciler.plan(
+            candidates: [candidate(cleared: true)],
+            existing: [
+                existing(id: "tx-deleted", importedId: "sf-1", tombstone: true),
+                existing(id: "tx-live", importedId: "sf-1")
+            ],
+            reimportDeleted: false
+        )
+
+        #expect(try #require(plan.updates.first).existingId == "tx-live")
+        #expect(plan.updates.first?.cleared == true)
     }
 
     /// The id match beats the fuzzy window even when the window has a nearer

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -176,6 +176,7 @@ struct BudgetStoreBankSyncTests {
                 )
                 """)
             try db.execute(sql: "CREATE TABLE payee_mapping (id TEXT PRIMARY KEY, targetId TEXT)")
+            try db.execute(sql: "CREATE TABLE preferences (id TEXT PRIMARY KEY, value TEXT)")
             try db.execute(sql: """
                 CREATE TABLE banks (
                     id TEXT PRIMARY KEY, bank_id TEXT, name TEXT, tombstone INTEGER DEFAULT 0
@@ -344,6 +345,108 @@ struct BudgetStoreBankSyncTests {
         #expect(second.added == 0)
         #expect(second.updated == 0)
         #expect(try rows(path: url, where: "financial_id = 'sf-1'").count == 1)
+    }
+
+    @Test func disabledReimportDeletedTransactionsKeepsDeletedRowsDeleted() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let deletedDay = Self.expectedDay(5)
+        let accountId = Self.accountId
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO transactions
+                    (id, acct, date, amount, imported_description, financial_id,
+                     tombstone, cleared, sort_order)
+                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
+                        1, 1, 1)
+                """, arguments: [accountId, deletedDay])
+            try db.execute(
+                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
+                arguments: ["sync-reimport-deleted-\(accountId)"]
+            )
+        }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-deleted", "posted": \(Self.daysAgo(5)),
+             "amount": "-33.45", "payee": "Deleted Merchant"}
+            """))
+
+        let result = try await store.syncBankAccounts()
+
+        // The opening balance is still created for a new account, but the
+        // deleted bank transaction must not be inserted again.
+        #expect(result.added == 1)
+        #expect(result.updated == 0)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted'").count == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 0").isEmpty)
+        #expect(try row(
+            path: url,
+            sql: "SELECT tombstone FROM transactions WHERE financial_id = 'sf-deleted'"
+        )?["tombstone"] as Int? == 1)
+    }
+
+    @Test func defaultReimportSettingStillReimportsDeletedTransactions() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let accountId = Self.accountId
+        let deletedDay = Self.expectedDay(5)
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO transactions
+                    (id, acct, date, amount, imported_description, financial_id,
+                     tombstone, cleared, sort_order)
+                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
+                        1, 1, 1)
+                """, arguments: [accountId, deletedDay])
+        }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-deleted", "posted": \(Self.daysAgo(5)),
+             "amount": "-33.45", "payee": "Deleted Merchant"}
+            """))
+
+        let result = try await store.syncBankAccounts()
+
+        // An unset preference defaults to Actual's backwards-compatible
+        // behavior: the deleted row is ignored and a new one is imported.
+        #expect(result.added == 2)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted'").count == 2)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 0").count == 1)
+    }
+
+    @Test func disabledReimportMatchesADeletedTransactionWithANewBankId() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let accountId = Self.accountId
+        let deletedDay = Self.expectedDay(5)
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO transactions
+                    (id, acct, date, amount, imported_description, financial_id,
+                     tombstone, cleared, sort_order)
+                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-old-id',
+                        1, 1, 1)
+                """, arguments: [accountId, deletedDay])
+            try db.execute(
+                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
+                arguments: ["sync-reimport-deleted-\(accountId)"]
+            )
+        }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-new-id", "posted": \(Self.daysAgo(5)),
+             "amount": "-33.45", "payee": "Deleted Merchant"}
+            """))
+
+        let result = try await store.syncBankAccounts()
+
+        // The preference also applies when the provider changes the
+        // transaction id: fuzzy matching must find the tombstone rather than
+        // creating a visible duplicate.
+        #expect(result.added == 1)
+        #expect(result.updated == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-new-id'").count == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-new-id' AND tombstone = 0").isEmpty)
     }
 
     /// A transaction entered by hand before the bank posted it should be

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -414,7 +414,7 @@ struct BudgetStoreBankSyncTests {
         #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 0").count == 1)
     }
 
-    @Test func disabledReimportMatchesADeletedTransactionWithANewBankId() async throws {
+    @Test func disabledReimportDoesNotFuzzyMatchADeletedTransactionWithANewBankId() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
         let accountId = Self.accountId
@@ -440,13 +440,45 @@ struct BudgetStoreBankSyncTests {
 
         let result = try await store.syncBankAccounts()
 
-        // The preference also applies when the provider changes the
-        // transaction id: fuzzy matching must find the tombstone rather than
-        // creating a visible duplicate.
-        #expect(result.added == 1)
-        #expect(result.updated == 1)
-        #expect(try rows(path: url, where: "financial_id = 'sf-new-id'").count == 1)
-        #expect(try rows(path: url, where: "financial_id = 'sf-new-id' AND tombstone = 0").isEmpty)
+        // A changed provider id is not proof that this is the deleted
+        // transaction. The tombstone must be excluded from fuzzy matching, so
+        // this download is imported as a new visible transaction.
+        #expect(result.added == 2)
+        #expect(result.updated == 0)
+        #expect(try rows(path: url, where: "financial_id = 'sf-old-id'").count == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-new-id' AND tombstone = 0").count == 1)
+    }
+
+    @Test func disabledReimportDoesNotLetDeletedRowsStealNearbyNewTransactions() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        let accountId = Self.accountId
+        let deletedDay = Self.expectedDay(5)
+        let queue = try DatabaseQueue(path: url.path)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO transactions
+                    (id, acct, date, amount, imported_description, financial_id,
+                     tombstone, cleared, sort_order)
+                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
+                        1, 1, 1)
+                """, arguments: [accountId, deletedDay])
+            try db.execute(
+                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
+                arguments: ["sync-reimport-deleted-\(accountId)"]
+            )
+        }
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-new-charge", "posted": \(Self.daysAgo(8)),
+             "amount": "-33.45", "payee": "New Merchant"}
+            """))
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.added == 2)
+        #expect(result.updated == 0)
+        #expect(try rows(path: url, where: "financial_id = 'sf-new-charge' AND tombstone = 0").count == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 1").count == 1)
     }
 
     /// A transaction entered by hand before the bank posted it should be

--- a/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
+++ b/Actuali/ActualiTests/Services/BankSync/BudgetStoreBankSyncTests.swift
@@ -207,6 +207,31 @@ struct BudgetStoreBankSyncTests {
         return (try BudgetDatabase(path: tempURL), tempURL)
     }
 
+    private func seedDeletedTransaction(
+        at url: URL,
+        importedId: String = "sf-deleted",
+        daysAgo: Int = 5,
+        disableReimport: Bool = true
+    ) async throws {
+        let queue = try DatabaseQueue(path: url.path)
+        let accountId = Self.accountId
+        let date = Self.expectedDay(daysAgo)
+        try await queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO transactions
+                    (id, acct, date, amount, imported_description, financial_id,
+                     tombstone, cleared, sort_order)
+                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', ?, 1, 1, 1)
+                """, arguments: [accountId, date, importedId])
+            if disableReimport {
+                try db.execute(
+                    sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
+                    arguments: ["sync-reimport-deleted-\(accountId)"]
+                )
+            }
+        }
+    }
+
     private func makeStore(
         database: BudgetDatabase,
         responseBody: String,
@@ -350,22 +375,7 @@ struct BudgetStoreBankSyncTests {
     @Test func disabledReimportDeletedTransactionsKeepsDeletedRowsDeleted() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
-        let deletedDay = Self.expectedDay(5)
-        let accountId = Self.accountId
-        let queue = try DatabaseQueue(path: url.path)
-        try await queue.write { db in
-            try db.execute(sql: """
-                INSERT INTO transactions
-                    (id, acct, date, amount, imported_description, financial_id,
-                     tombstone, cleared, sort_order)
-                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
-                        1, 1, 1)
-                """, arguments: [accountId, deletedDay])
-            try db.execute(
-                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
-                arguments: ["sync-reimport-deleted-\(accountId)"]
-            )
-        }
+        try await seedDeletedTransaction(at: url)
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
             {"id": "sf-deleted", "posted": \(Self.daysAgo(5)),
              "amount": "-33.45", "payee": "Deleted Merchant"}
@@ -383,23 +393,16 @@ struct BudgetStoreBankSyncTests {
             path: url,
             sql: "SELECT tombstone FROM transactions WHERE financial_id = 'sf-deleted'"
         )?["tombstone"] as Int? == 1)
+        #expect(try row(
+            path: url,
+            sql: "SELECT amount FROM transactions WHERE starting_balance_flag = 1"
+        )?["amount"] as Int? == 10_000)
     }
 
     @Test func defaultReimportSettingStillReimportsDeletedTransactions() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
-        let accountId = Self.accountId
-        let deletedDay = Self.expectedDay(5)
-        let queue = try DatabaseQueue(path: url.path)
-        try await queue.write { db in
-            try db.execute(sql: """
-                INSERT INTO transactions
-                    (id, acct, date, amount, imported_description, financial_id,
-                     tombstone, cleared, sort_order)
-                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
-                        1, 1, 1)
-                """, arguments: [accountId, deletedDay])
-        }
+        try await seedDeletedTransaction(at: url, disableReimport: false)
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
             {"id": "sf-deleted", "posted": \(Self.daysAgo(5)),
              "amount": "-33.45", "payee": "Deleted Merchant"}
@@ -417,22 +420,7 @@ struct BudgetStoreBankSyncTests {
     @Test func disabledReimportDoesNotFuzzyMatchADeletedTransactionWithANewBankId() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
-        let accountId = Self.accountId
-        let deletedDay = Self.expectedDay(5)
-        let queue = try DatabaseQueue(path: url.path)
-        try await queue.write { db in
-            try db.execute(sql: """
-                INSERT INTO transactions
-                    (id, acct, date, amount, imported_description, financial_id,
-                     tombstone, cleared, sort_order)
-                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-old-id',
-                        1, 1, 1)
-                """, arguments: [accountId, deletedDay])
-            try db.execute(
-                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
-                arguments: ["sync-reimport-deleted-\(accountId)"]
-            )
-        }
+        try await seedDeletedTransaction(at: url, importedId: "sf-old-id")
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
             {"id": "sf-new-id", "posted": \(Self.daysAgo(5)),
              "amount": "-33.45", "payee": "Deleted Merchant"}
@@ -452,22 +440,7 @@ struct BudgetStoreBankSyncTests {
     @Test func disabledReimportDoesNotLetDeletedRowsStealNearbyNewTransactions() async throws {
         let (database, url) = try makeDatabase()
         defer { cleanup(url) }
-        let accountId = Self.accountId
-        let deletedDay = Self.expectedDay(5)
-        let queue = try DatabaseQueue(path: url.path)
-        try await queue.write { db in
-            try db.execute(sql: """
-                INSERT INTO transactions
-                    (id, acct, date, amount, imported_description, financial_id,
-                     tombstone, cleared, sort_order)
-                VALUES ('tx-deleted', ?, ?, -3345, 'Deleted Merchant', 'sf-deleted',
-                        1, 1, 1)
-                """, arguments: [accountId, deletedDay])
-            try db.execute(
-                sql: "INSERT INTO preferences (id, value) VALUES (?, 'false')",
-                arguments: ["sync-reimport-deleted-\(accountId)"]
-            )
-        }
+        try await seedDeletedTransaction(at: url)
         let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
             {"id": "sf-new-charge", "posted": \(Self.daysAgo(8)),
              "amount": "-33.45", "payee": "New Merchant"}
@@ -479,6 +452,22 @@ struct BudgetStoreBankSyncTests {
         #expect(result.updated == 0)
         #expect(try rows(path: url, where: "financial_id = 'sf-new-charge' AND tombstone = 0").count == 1)
         #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 1").count == 1)
+    }
+
+    @Test func disabledReimportMatchesExactIdOutsideTheFuzzyWindow() async throws {
+        let (database, url) = try makeDatabase()
+        defer { cleanup(url) }
+        try await seedDeletedTransaction(at: url, daysAgo: 13)
+        let store = try await makeStore(database: database, responseBody: accountSet(transactions: """
+            {"id": "sf-deleted", "posted": \(Self.daysAgo(5)),
+             "amount": "-33.45", "payee": "Deleted Merchant"}
+            """))
+
+        let result = try await store.syncBankAccounts()
+
+        #expect(result.added == 1) // opening balance only
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted'").count == 1)
+        #expect(try rows(path: url, where: "financial_id = 'sf-deleted' AND tombstone = 0").isEmpty)
     }
 
     /// A transaction entered by hand before the bank posted it should be


### PR DESCRIPTION
## Why

Closes #418. Actuali reimported deleted bank transactions even when the account preference disabled reimporting them.

## What

- Respect the synced per-account `sync-reimport-deleted-<accountId>` preference.
- Include tombstoned rows in the reconciliation input so the reconciler can apply that preference.
- When reimporting is disabled, use a deleted row only for an exact `financial_id` match; exclude it from fuzzy amount/date matching and leave it untouched.
- Added regression coverage for disabled, default/unset, changed-bank-ID, and nearby same-amount scenarios.

This follows Actual Budget’s [`matchTransactions` implementation](https://github.com/actualbudget/actual/blob/master/packages/loot-core/src/server/accounts/sync.ts#L797-L855): it reads `sync-reimport-deleted-<accountId>`, uses the internal transaction view when the preference is false so tombstones can deduplicate exact imported IDs, and uses the normal view otherwise. Actuali mirrors that distinction in `BankSyncReconciler`; its fuzzy window excludes tombstoned rows so an unrelated nearby charge cannot be consumed by a deleted transaction.

## How it was tested

- Bank-sync and reconciler tests pass on the iOS 26.5 simulator.
- The broader non-UI suite has an unrelated existing wallet-import failure: `SQLite error 5: database is locked`.

