### PR TITLE
Revert AI review model to Opus 5

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -122,7 +122,7 @@ jobs:
           # code is never on disk. --body-file avoids heredocs/$() in the comment
           # command, which would fail the Bash prefix match and get denied.
           claude_args: |
-            --model claude-fable-5-1
+            --model claude-opus-5
             --allowedTools "Read,Write,Skill,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"
 
       # When the run was triggered by the ai-review label, drop it so a


### PR DESCRIPTION
Every AI Code Review run since the switch to `claude-fable-5-1` (0f036db, 2026-09-04) fails instantly: one turn, zero cost, `is_error: true`. The CI OAuth account does not have access to the Fable tier. Last good run was on `claude-opus-5`, so this puts it back.

Because the workflow runs on `pull_request_target`, the fix only takes effect once merged to main.