### PR TITLE
Implement uncategorized background view based on style

### DIFF
--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -172,7 +172,7 @@ struct BudgetView: View {
     /// corners since its rows sit edge-to-edge with no rounding.
     private var uncategorizedShape: AnyShape {
         switch budgetStore.budgetDisplayStyle {
-        case .clean: AnyShape(RoundedRectangle(cornerRadius: 20))
+        case .clean: AnyShape(RoundedRectangle(cornerRadius: 24))
         case .detailed: AnyShape(Capsule())
         case .compact: AnyShape(Rectangle())
         }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -167,6 +167,21 @@ struct BudgetView: View {
         budgetStore.budgetDisplayStyle == .compact
     }
 
+    @ViewBuilder
+    private var uncategorizedBackground: some View {
+        switch budgetStore.budgetDisplayStyle {
+        case .clean:
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemGroupedBackground))
+        case .detailed:
+            Capsule()
+                .fill(Color(.secondarySystemGroupedBackground))
+        case .compact:
+            Rectangle()
+                .fill(Color(.secondarySystemGroupedBackground))
+        }
+    }
+    
     var body: some View {
         NavigationStack {
             Group {
@@ -714,10 +729,7 @@ struct BudgetView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(Color(.secondarySystemGroupedBackground))
-                    )
+                    .background(uncategorizedBackground)
                 }
                 .accessibilityIdentifier("budgetUncategorized")
                 .padding(.horizontal, 4)

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -171,7 +171,7 @@ struct BudgetView: View {
     private var uncategorizedBackground: some View {
         switch budgetStore.budgetDisplayStyle {
         case .clean:
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: 20)
                 .fill(Color(.secondarySystemGroupedBackground))
         case .detailed:
             Capsule()

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -167,21 +167,17 @@ struct BudgetView: View {
         budgetStore.budgetDisplayStyle == .compact
     }
 
-    @ViewBuilder
-    private var uncategorizedBackground: some View {
+    /// Shape for the "N uncategorized" link's background, matching the shape
+    /// used elsewhere for each display style. The compact style keeps sharp
+    /// corners since its rows sit edge-to-edge with no rounding.
+    private var uncategorizedShape: AnyShape {
         switch budgetStore.budgetDisplayStyle {
-        case .clean:
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color(.secondarySystemGroupedBackground))
-        case .detailed:
-            Capsule()
-                .fill(Color(.secondarySystemGroupedBackground))
-        case .compact:
-            Rectangle()
-                .fill(Color(.secondarySystemGroupedBackground))
+        case .clean: AnyShape(RoundedRectangle(cornerRadius: 20))
+        case .detailed: AnyShape(Capsule())
+        case .compact: AnyShape(Rectangle())
         }
     }
-    
+
     var body: some View {
         NavigationStack {
             Group {
@@ -729,10 +725,13 @@ struct BudgetView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(uncategorizedBackground)
+                    .background(
+                        Color(isCompact ? .systemBackground : .secondarySystemGroupedBackground),
+                        in: uncategorizedShape
+                    )
                 }
                 .accessibilityIdentifier("budgetUncategorized")
-                .padding(.horizontal, 4)
+                .padding(.horizontal, isCompact ? 0 : 4)
                 .padding(.bottom, 8)
             }
 


### PR DESCRIPTION
## Why

The uncategorized button had a hardcoded corner radius that didn’t visually match the summary card in each budget display style. This made it look inconsistent when switching between Clean, Detailed, and Compact styles.

## What

- Added a computed 'uncategorizedBackground' view builder that returns a style‑appropriate background shape.
- Clean style: 'RoundedRectangle(cornerRadius: 20)'.
- Detailed style: 'Capsule()'. (if we prefer corner radius then I think 32 radius)
- Compact style: 'Rectangle()' (no rounding).
- Replaced the hardcoded background on the uncategorized `NavigationLink` with this new builder.

## How it was tested

Manually verified on an iOS simulator by cycling through all three budget display styles and confirming the uncategorized button’s shape now matches the corresponding summary card.