### PR TITLE
Reports update

### DIFF
--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2327,7 +2327,7 @@ final class BudgetDatabase: Sendable {
                 "graph_type", "date_range", "date_static", "start_date",
                 "end_date", "include_current", "show_empty", "show_offbudget",
                 "show_hidden", "show_uncategorized", "sort_by", "conditions",
-                "conditions_op"
+                "conditions_op", "show_trend_lines", "trim_intervals"
             ]
             let select = wanted
                 .map { existing.contains($0) ? $0 : "NULL AS \($0)" }
@@ -2361,6 +2361,8 @@ final class BudgetDatabase: Sendable {
                     showHidden: (row["show_hidden"] as Int? ?? 0) != 0,
                     showUncategorized: (row["show_uncategorized"] as Int? ?? 0) != 0,
                     sortBy: row["sort_by"] ?? "desc",
+                    showTrendLines: (row["show_trend_lines"] as Int? ?? 0) != 0,
+                    trimIntervals: (row["trim_intervals"] as Int? ?? 0) != 0,
                     conditions: conditions,
                     conditionsOp: row["conditions_op"] ?? "and"
                 )

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2179,10 +2179,14 @@ final class BudgetDatabase: Sendable {
             let rows = try Row.fetchAll(db, sql: """
                 SELECT
                     t.id, t.isParent, t.isChild, t.acct, t.category, t.amount,
-                    t.description, t.notes, t.date, t.imported_description,
+                    t.notes, t.date, t.imported_description,
                     t.schedule,
                     t.transferred_id, t.cleared, t.reconciled, t.sort_order,
                     t.tombstone, t.parent_id,
+                    -- Merged payees keep their old id on the row; Actual's
+                    -- transaction view resolves it through payee_mapping, so
+                    -- reports group and filter by the surviving payee.
+                    COALESCE(pm.targetId, t.description) AS payee_id,
                     COALESCE(pa.name, p.name) as payee_name,
                     p.transfer_acct as transfer_acct,
                     c.name as category_name
@@ -2212,7 +2216,7 @@ final class BudgetDatabase: Sendable {
                     accountId: row["acct"] ?? "",
                     date: row["date"] ?? 0,
                     amount: row["amount"] ?? 0,
-                    payeeId: row["description"],
+                    payeeId: row["payee_id"],
                     payeeName: row["payee_name"],
                     categoryId: row["category"],
                     categoryName: row["category_name"],

--- a/Actuali/Actuali/Services/Reports/CustomReportConfig.swift
+++ b/Actuali/Actuali/Services/Reports/CustomReportConfig.swift
@@ -22,6 +22,8 @@ struct CustomReportConfig: Equatable {
     var showHidden: Bool
     var showUncategorized: Bool
     var sortBy: String        // "desc" | "asc" | "name" | "budget"
+    var showTrendLines: Bool   // LineGraph only (upstream show_trend_lines)
+    var trimIntervals: Bool    // drop empty leading/trailing intervals (upstream trim_intervals)
     var conditions: [WidgetRuleCondition]?
     var conditionsOp: String?
 }

--- a/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
@@ -11,20 +11,30 @@ struct CustomReportData: Equatable {
         var values: [[Double]]        // [series][interval], currency units
     }
     struct TableRow: Equatable { var name: String; var totalUnits: Double }
+    /// One donut wedge. `group` indexes `Kind.donut`'s `groups` ring for the
+    /// two-ring Category+Group layout; nil on a single-ring donut.
+    struct Slice: Equatable { var label: String; var valueUnits: Double; var group: Int? }
+    /// Least-squares trend through one line series, as its values at the
+    /// first and last interval.
+    struct Trend: Equatable { var startUnits: Double; var endUnits: Double }
 
     enum Kind: Equatable {
         case bars([Bar], signed: Bool)   // signed → color bars by sign (Net)
         case stacked(Stacked)
+        case lines(Stacked, trends: [Trend])   // trends empty unless showTrendLines
+        case area([Bar])                       // one point per interval
+        case donut(slices: [Slice], groups: [Bar])   // groups empty → single ring
         case table([TableRow])
         case unsupported(String)
     }
     var kind: Kind
 }
 
-/// Port of the webapp's custom-spreadsheet.ts for the option subset Actuali
-/// renders. Everything computes from the shared reports transaction array;
-/// configs outside the supported matrix return `.unsupported` naming the
-/// offending option so the card can explain itself.
+/// Port of the webapp's custom-spreadsheet.ts for the option matrix the web
+/// UI can save. Everything computes from the shared reports transaction
+/// array (or, for the Budgeted balance type, from budget cells); configs
+/// outside the matrix return `.unsupported` naming the offending option so
+/// the card can explain itself.
 enum CustomReportEngine {
 
     /// Row keys for the synthetic rows upstream appends after the real
@@ -41,6 +51,32 @@ enum CustomReportEngine {
         var groups: [CategoryGroup]      // in budget sort order
         var offBudgetAccountIds: Set<String>
         var firstDayOfWeekIdx: Int
+        var payees: [Payee] = []                              // groupBy Payee, store order
+        var accounts: [Account] = []                          // groupBy Account, store order
+        var budgetEntries: [BudgetAnalysisBudgetEntry] = []   // balanceType Budgeted
+    }
+
+    /// Assets/debts sums for one row or bucket (upstream QueryDataEntity split).
+    private struct Cell {
+        var assets = 0
+        var debts = 0
+
+        mutating func add(_ amount: Int) {
+            if amount > 0 { assets += amount } else { debts += amount }
+        }
+
+        static func + (lhs: Cell, rhs: Cell) -> Cell {
+            Cell(assets: lhs.assets + rhs.assets, debts: lhs.debts + rhs.debts)
+        }
+    }
+
+    /// One named row (category, group, payee, account) after bucketing.
+    private struct Row {
+        let key: String
+        let name: String
+        let cell: Cell            // whole-range aggregate
+        var perBucket: [Double]   // metric per interval, currency units
+        let total: Double         // metric over the aggregate, not Σ perBucket
     }
 
     static func compute(
@@ -58,19 +94,21 @@ enum CustomReportEngine {
                                     rangeLabel: config.dateStatic ? "" : (config.dateRange ?? "All time"),
                                     kind: .unsupported(""))
 
-        // Supported-matrix guard: name the first offending option.
+        // Supported-matrix guard (upstream ReportOptions.ts): name the first
+        // offending option.
         for (value, supported, label) in [
             (config.mode, ["total", "time"], "mode"),
-            (config.groupBy, ["Category", "Group", "Interval"], "group by"),
-            (config.balanceType, ["Payment", "Deposit", "Net"], "balance type"),
+            (config.groupBy, ["Category", "Group", "CategoryGroup", "Payee", "Account", "Interval"], "group by"),
+            (config.balanceType, ["Payment", "Deposit", "Net", "Net Payment", "Net Deposit", "Budgeted"], "balance type"),
             (config.interval, ["Daily", "Weekly", "Monthly", "Yearly"], "interval"),
-            (config.graphType, ["BarGraph", "StackedBarGraph", "TableGraph"], "graph"),
+            (config.graphType, ["BarGraph", "StackedBarGraph", "LineGraph", "AreaGraph", "DonutGraph", "TableGraph"], "graph"),
         ] where !supported.contains(value) {
             data.kind = .unsupported("\(value) \(label) isn't supported yet")
             return data
         }
 
-        // Date range from actual history.
+        // Date range from actual history (also for Budgeted, as upstream's
+        // card does).
         let live = transactions.filter { !$0.tombstone }
         let earliest = live.map(\.date).min().map(dateFrom)
         let latest = live.map(\.date).max().map(dateFrom)
@@ -85,12 +123,22 @@ enum CustomReportEngine {
         let categoriesById = Dictionary(uniqueKeysWithValues: reportContext.categories.map { ($0.id, $0) })
         let groupsById = Dictionary(uniqueKeysWithValues: reportContext.groups.map { ($0.id, $0) })
 
+        // Dataset: transactions in range, or budget cells for Budgeted
+        // (upstream fetchSpreadsheetQueryData). Budget cells only honour
+        // category conditions (budgetDataQuery.filterCategoriesByConditions).
+        let budgeted = config.balanceType == "Budgeted"
+        let source = budgeted
+            ? budgetRows(reportContext, startYMD: startYMD, endYMD: endYMD)
+            : live.filter { $0.date >= startYMD && $0.date <= endYMD }
+        let conditions = budgeted
+            ? config.conditions?.filter { ["category", "category_group"].contains($0.field) }
+            : config.conditions
+
         // Filter (upstream: conditions, then filterHiddenItems) — single pass.
         // Category resolves through the lookup, mirroring upstream's query
         // join: a dangling categoryId behaves exactly like no category.
-        let pool = live.filter { tx in
-            guard tx.date >= startYMD && tx.date <= endYMD else { return false }
-            guard ConditionsFilter.matches(transaction: tx, conditions: config.conditions,
+        let pool = source.filter { tx in
+            guard ConditionsFilter.matches(transaction: tx, conditions: conditions,
                                            op: config.conditionsOp, context: filterContext)
             else { return false }
             let category = tx.categoryId.flatMap { categoriesById[$0] }
@@ -110,12 +158,11 @@ enum CustomReportEngine {
                                       firstDayOfWeekIdx: reportContext.firstDayOfWeekIdx)
         let bucketIndex = Dictionary(uniqueKeysWithValues:
             buckets.enumerated().map { ($0.element.key, $0.offset) })
-        let labels = buckets.map(\.label)
+        var labels = buckets.map(\.label)
 
-        // Accumulate assets/debts per (group, bucket). Group key "" = whole row
-        // (groupBy Interval).
-        struct Cell { var assets = 0; var debts = 0 }
-        var cells: [String: [Int: Cell]] = [:]   // groupKey -> bucketIdx -> sums
+        // Accumulate assets/debts per (row, bucket). Row key "" = whole
+        // dataset (groupBy Interval).
+        var cells: [String: [Int: Cell]] = [:]   // rowKey -> bucketIdx -> sums
         for tx in pool {
             let key = bucketKey(forYMD: tx.date, interval: config.interval,
                                 firstDayOfWeekIdx: reportContext.firstDayOfWeekIdx)
@@ -125,89 +172,241 @@ enum CustomReportEngine {
             // off-budget txs (even categorized ones) to "Off budget", then
             // uncategorized transfers to "Transfers", the rest to
             // "Uncategorized". Group mode folds all three into one group.
+            // Payee/Account have no synthetic rows: a tx with no payee
+            // matches nothing (upstream `payee === item.id`).
             let category = tx.categoryId.flatMap { categoriesById[$0] }
             let offBudget = reportContext.offBudgetAccountIds.contains(tx.accountId)
-            let groupKey: String
+            let rowKey: String
             switch config.groupBy {
-            case "Category":
-                if let category, !offBudget { groupKey = category.id }
-                else if offBudget { groupKey = Synthetic.offBudget }
-                else if tx.transferAcct != nil { groupKey = Synthetic.transfer }
-                else { groupKey = Synthetic.uncategorized }
+            case "Category", "CategoryGroup":
+                if let category, !offBudget { rowKey = category.id }
+                else if offBudget { rowKey = Synthetic.offBudget }
+                else if tx.transferAcct != nil { rowKey = Synthetic.transfer }
+                else { rowKey = Synthetic.uncategorized }
             case "Group":
-                if let category, !offBudget { groupKey = category.groupId }
-                else { groupKey = Synthetic.uncategorized }
-            default: groupKey = ""   // Interval
+                if let category, !offBudget { rowKey = category.groupId }
+                else { rowKey = Synthetic.uncategorized }
+            case "Payee":
+                guard let payee = tx.payeeId else { continue }
+                rowKey = payee
+            case "Account":
+                rowKey = tx.accountId
+            default: rowKey = ""   // Interval
             }
-            var cell = cells[groupKey, default: [:]][idx, default: Cell()]
-            if tx.amount > 0 { cell.assets += tx.amount } else { cell.debts += tx.amount }
-            cells[groupKey, default: [:]][idx] = cell
+            cells[rowKey, default: [:]][idx, default: Cell()].add(tx.amount)
         }
 
-        func value(_ cell: Cell) -> Double {
-            switch config.balanceType {
-            case "Payment": return Double(-cell.debts) / 100    // |debts|
-            case "Deposit": return Double(cell.assets) / 100
-            default:        return Double(cell.assets + cell.debts) / 100  // Net, signed
-            }
+        let value = { (cell: Cell) in metric(cell, balanceType: config.balanceType) }
+        func bucketCells(_ rowKey: String) -> [Cell] {
+            (0..<buckets.count).map { cells[rowKey]?[$0] ?? Cell() }
         }
+        let signed = ["Net", "Budgeted"].contains(config.balanceType)
 
         // groupBy Interval → one row per bucket (web renders intervalData here).
         if config.groupBy == "Interval" {
-            let row = cells[""] ?? [:]
-            let values = labels.indices.map { row[$0].map(value) ?? 0 }
-            if config.graphType == "TableGraph" {
+            var values = bucketCells("").map(value)
+            if config.trimIntervals {
+                let range = trimmedRange([values])
+                labels = Array(labels[range])
+                values = Array(values[range])
+            }
+            switch config.graphType {
+            case "TableGraph":
                 data.kind = .table(zip(labels, values).map { .init(name: $0, totalUnits: $1) })
-            } else {
+            case "AreaGraph":
+                data.kind = .area(zip(labels, values).map { .init(label: $0, valueUnits: $1) })
+            default:
                 data.kind = .bars(zip(labels, values).map { .init(label: $0, valueUnits: $1) },
-                                  signed: config.balanceType == "Net")
+                                  signed: signed)
             }
             return data
         }
 
-        // Named groups in budget order. Upstream (ReportOptions.categoryLists)
+        // Named rows in store order. Upstream (ReportOptions.categoryLists)
         // always appends the synthetic rows; when their txs are filtered out
         // they total zero and fall to the showEmpty filter like any other row.
-        let orderedGroups: [(key: String, name: String)]
-        if config.groupBy == "Category" {
-            orderedGroups = reportContext.categories.map { ($0.id, $0.name) } + [
+        let orderedRows: [(key: String, name: String)]
+        switch config.groupBy {
+        case "Group":
+            orderedRows = reportContext.groups.map { ($0.id, $0.name) }
+                + [(Synthetic.uncategorized, "Uncategorized & Off budget")]
+        case "Payee":
+            // Transfer payees carry no name of their own; upstream's v_payees
+            // shows the linked account.
+            let accountNames = Dictionary(reportContext.accounts.map { ($0.id, $0.name) },
+                                          uniquingKeysWith: { first, _ in first })
+            orderedRows = reportContext.payees.map { payee in
+                (payee.id, payee.transferAccountId.flatMap { accountNames[$0] } ?? payee.name)
+            }
+        case "Account":
+            orderedRows = reportContext.accounts.map { ($0.id, $0.name) }
+        default:   // Category, CategoryGroup
+            orderedRows = reportContext.categories.map { ($0.id, $0.name) } + [
                 (Synthetic.uncategorized, "Uncategorized"),
                 (Synthetic.offBudget, "Off budget"),
                 (Synthetic.transfer, "Transfers"),
             ]
-        } else {
-            orderedGroups = reportContext.groups.map { ($0.id, $0.name) }
-                + [(Synthetic.uncategorized, "Uncategorized & Off budget")]
         }
 
-        struct GroupTotal { let key: String; let name: String; let total: Double; let perBucket: [Double] }
-        var totals: [GroupTotal] = orderedGroups.map { group in
-            let row = cells[group.key] ?? [:]
-            let perBucket = (0..<buckets.count).map { row[$0].map(value) ?? 0 }
-            return GroupTotal(key: group.key, name: group.name,
-                              total: perBucket.reduce(0, +), perBucket: perBucket)
+        var rows: [Row] = orderedRows.map { row in
+            let perBucket = bucketCells(row.key)
+            let cell = perBucket.reduce(Cell(), +)
+            return Row(key: row.key, name: row.name, cell: cell,
+                       perBucket: perBucket.map(value), total: value(cell))
         }
+        // Upstream filterEmptyRows: Net/Budgeted keep any row with activity;
+        // the rest keep rows whose metric is non-zero. For Net Payment /
+        // Net Deposit that is the row's whole-range net, so a row that is
+        // negative in one month but positive overall hides under Net Payment.
         if !config.showEmpty {
-            totals = totals.filter { $0.total != 0 || $0.perBucket.contains { $0 != 0 } }
+            rows = rows.filter { signed ? ($0.cell.assets != 0 || $0.cell.debts != 0) : $0.total != 0 }
         }
-        switch config.sortBy {
-        case "asc":  totals.sort { abs($0.total) < abs($1.total) }
-        case "name": totals.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-        case "budget": break                       // keep budget order
-        default:     totals.sort { abs($0.total) > abs($1.total) }  // desc
+        // Upstream trimIntervals.ts: span from the first to the last interval
+        // where any surviving row, or the overall total, is non-zero.
+        if config.trimIntervals {
+            let overall = (0..<buckets.count).map { i in
+                value(cells.values.reduce(Cell()) { $0 + ($1[i] ?? Cell()) })
+            }
+            let range = trimmedRange(rows.map(\.perBucket) + [overall])
+            labels = Array(labels[range])
+            for i in rows.indices { rows[i].perBucket = Array(rows[i].perBucket[range]) }
         }
+        rows = sorted(rows, by: config.sortBy, total: \.total, name: \.name)
 
-        if config.graphType == "TableGraph" {
-            data.kind = .table(totals.map { .init(name: $0.name, totalUnits: $0.total) })
-        } else if config.mode == "time" {
-            data.kind = .stacked(.init(intervalLabels: labels,
-                                       seriesNames: totals.map(\.name),
-                                       values: totals.map(\.perBucket)))
-        } else {
-            data.kind = .bars(totals.map { .init(label: $0.name, valueUnits: $0.total) },
-                              signed: config.balanceType == "Net")
+        switch config.graphType {
+        case "TableGraph":
+            data.kind = .table(rows.map { .init(name: $0.name, totalUnits: $0.total) })
+        case "StackedBarGraph":
+            data.kind = .stacked(series(rows, labels: labels))
+        case "LineGraph":
+            let s = series(rows, labels: labels)
+            data.kind = .lines(s, trends: config.showTrendLines ? s.values.compactMap(trend) : [])
+        case "DonutGraph" where config.groupBy == "CategoryGroup":
+            data.kind = twoRingDonut(rows, context: reportContext,
+                                     categoriesById: categoriesById, sortBy: config.sortBy)
+        case "DonutGraph":
+            // A wedge can't have a negative angle; upstream disables Net here,
+            // so every allowed metric is already non-negative.
+            data.kind = .donut(slices: rows.filter { $0.total > 0 }
+                                   .map { .init(label: $0.name, valueUnits: $0.total, group: nil) },
+                               groups: [])
+        default:
+            data.kind = .bars(rows.map { .init(label: $0.name, valueUnits: $0.total) }, signed: signed)
         }
         return data
+    }
+
+    // MARK: - Metric
+
+    /// Upstream balanceTypeMap: Payment = |debts|, Deposit = assets,
+    /// Net Payment = |net| when negative, Net Deposit = net when positive,
+    /// Net and Budgeted = signed net (totalBudgeted mirrors totalTotals; only
+    /// the dataset differs).
+    private static func metric(_ cell: Cell, balanceType: String) -> Double {
+        let net = cell.assets + cell.debts
+        switch balanceType {
+        case "Payment":     return Double(-cell.debts) / 100
+        case "Deposit":     return Double(cell.assets) / 100
+        case "Net Payment": return net < 0 ? Double(-net) / 100 : 0
+        case "Net Deposit": return net > 0 ? Double(net) / 100 : 0
+        default:            return Double(net) / 100
+        }
+    }
+
+    /// Upstream sortData.ts sorts by the signed metric (its debts reversal is
+    /// already baked in because Payment is stored positive here).
+    private static func sorted<T>(
+        _ items: [T], by sortBy: String,
+        total: KeyPath<T, Double>, name: KeyPath<T, String>
+    ) -> [T] {
+        switch sortBy {
+        case "asc":  return items.sorted { $0[keyPath: total] < $1[keyPath: total] }
+        case "name": return items.sorted {
+            $0[keyPath: name].localizedCaseInsensitiveCompare($1[keyPath: name]) == .orderedAscending
+        }
+        case "budget": return items                 // keep store order
+        default:     return items.sorted { $0[keyPath: total] > $1[keyPath: total] }  // desc
+        }
+    }
+
+    private static func series(_ rows: [Row], labels: [String]) -> CustomReportData.Stacked {
+        .init(intervalLabels: labels, seriesNames: rows.map(\.name), values: rows.map(\.perBucket))
+    }
+
+    /// First…last interval where any series is non-zero; empty when none is.
+    private static func trimmedRange(_ series: [[Double]]) -> Range<Int> {
+        let count = series.first?.count ?? 0
+        let nonEmpty = (0..<count).map { i in series.contains { $0[i] != 0 } }
+        guard let first = nonEmpty.firstIndex(of: true),
+              let last = nonEmpty.lastIndex(of: true) else { return 0..<0 }
+        return first..<(last + 1)
+    }
+
+    /// Least-squares line through the series (upstream computeTrendLines.ts)
+    /// over x = 0…n-1. Needs two points.
+    static func trend(_ ys: [Double]) -> CustomReportData.Trend? {
+        guard ys.count >= 2 else { return nil }
+        let n = Double(ys.count)
+        let sumX = n * (n - 1) / 2
+        let sumX2 = (n - 1) * n * (2 * n - 1) / 6
+        let sumY = ys.reduce(0, +)
+        let sumXY = ys.enumerated().reduce(0.0) { $0 + Double($1.offset) * $1.element }
+        let slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
+        let intercept = (sumY - slope * sumX) / n
+        return .init(startUnits: intercept, endUnits: intercept + slope * (n - 1))
+    }
+
+    // MARK: - Budgeted dataset
+
+    /// Upstream budgetDataQuery.fetchBudgetData: one row per month in range
+    /// per non-income category with a non-zero budget, keyed to the month.
+    /// Emitted as synthetic transactions so the same bucketing and row
+    /// filters apply.
+    private static func budgetRows(_ context: ReportContext, startYMD: Int, endYMD: Int) -> [Transaction] {
+        let income = Set(context.categories.filter(\.isIncome).map(\.id))
+        return context.budgetEntries.compactMap { entry in
+            guard entry.amountCents != 0, !income.contains(entry.categoryId),
+                  (startYMD / 100...endYMD / 100).contains(entry.month) else { return nil }
+            // ponytail: cells sit on the 1st, so Daily/Weekly intervals show a
+            // month's budget on its first day where upstream shows nothing.
+            return Transaction(
+                id: "\(entry.month)-\(entry.categoryId)", accountId: "",
+                date: entry.month * 100 + 1, amount: entry.amountCents,
+                payeeId: nil, payeeName: nil, categoryId: entry.categoryId, categoryName: nil,
+                notes: nil, cleared: true, reconciled: false, transferId: nil,
+                isParent: false, parentId: nil, tombstone: false,
+                sortOrder: nil, importedPayee: nil)
+        }
+    }
+
+    // MARK: - Two-ring donut (groupBy CategoryGroup)
+
+    /// Upstream grouped-spreadsheet.ts + DonutGraph.tsx adjustedGroupData:
+    /// the inner ring is the category groups in store order (the synthetic
+    /// rows form "Uncategorized & Off budget"), each group's value being the
+    /// sum of its visible categories so the rings line up; zero groups drop
+    /// out, and groups and their categories sort by the same rule.
+    private static func twoRingDonut(
+        _ rows: [Row], context: ReportContext,
+        categoriesById: [String: Category], sortBy: String
+    ) -> CustomReportData.Kind {
+        struct Group { let name: String; let total: Double; let members: [Row] }
+        let order = context.groups.map { ($0.id, $0.name) }
+            + [(Synthetic.uncategorized, "Uncategorized & Off budget")]
+        var groups: [Group] = order.compactMap { entry -> Group? in
+            let (id, name) = entry
+            let members = sorted(
+                rows.filter { $0.total > 0 && (categoriesById[$0.key]?.groupId ?? Synthetic.uncategorized) == id },
+                by: sortBy, total: \.total, name: \.name)
+            guard !members.isEmpty else { return nil }
+            return Group(name: name, total: members.map(\.total).reduce(0, +), members: members)
+        }
+        groups = sorted(groups, by: sortBy, total: \.total, name: \.name)
+        return .donut(
+            slices: groups.enumerated().flatMap { gi, group in
+                group.members.map { .init(label: $0.name, valueUnits: $0.total, group: gi) }
+            },
+            groups: groups.map { .init(label: $0.name, valueUnits: $0.total) })
     }
 
     // MARK: - Interval bucketing

--- a/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
@@ -215,6 +215,12 @@ enum CustomReportEngine {
                 data.kind = .table(zip(labels, values).map { .init(name: $0, totalUnits: $1) })
             case "AreaGraph":
                 data.kind = .area(zip(labels, values).map { .init(label: $0, valueUnits: $1) })
+            case "DonutGraph":
+                // Upstream allows Interval on a total-mode donut: one wedge
+                // per interval, and a wedge can't have a non-positive angle.
+                data.kind = .donut(slices: zip(labels, values).filter { $0.1 > 0 }
+                                       .map { .init(label: $0, valueUnits: $1, group: nil) },
+                                   groups: [])
             default:
                 data.kind = .bars(zip(labels, values).map { .init(label: $0, valueUnits: $1) },
                                   signed: signed)
@@ -366,7 +372,7 @@ enum CustomReportEngine {
         let income = Set(context.categories.filter(\.isIncome).map(\.id))
         return context.budgetEntries.compactMap { entry in
             guard entry.amountCents != 0, !income.contains(entry.categoryId),
-                  (startYMD / 100...endYMD / 100).contains(entry.month) else { return nil }
+                  entry.month >= startYMD / 100, entry.month <= endYMD / 100 else { return nil }
             // ponytail: cells sit on the 1st, so Daily/Weekly intervals show a
             // month's budget on its first day where upstream shows nothing.
             return Transaction(

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -103,6 +103,9 @@ struct DashboardView: View {
             switch $0 {
             case .budgetAnalysis, .sankey, .balanceForecast: return true
             case .spending(_, let meta): return meta?.mode == .budget
+            // Budgeted custom reports read budget cells instead of transactions.
+            case .customReport(_, let meta):
+                return (meta?.id).flatMap { customReportConfigs[$0] }?.balanceType == "Budgeted"
             default: return false
             }
         }
@@ -204,7 +207,10 @@ struct DashboardView: View {
                         categories: budgetStore.categoryGroups.flatMap(\.categories),
                         groups: budgetStore.categoryGroups,
                         offBudgetAccountIds: Set(budgetStore.accounts.filter(\.offBudget).map(\.id)),
-                        firstDayOfWeekIdx: firstDayOfWeekIdx
+                        firstDayOfWeekIdx: firstDayOfWeekIdx,
+                        payees: budgetStore.payees,
+                        accounts: budgetStore.accounts,
+                        budgetEntries: reportBudgets.entries
                     ),
                     filterContext: conditionsContext,
                     today: Date()

--- a/Actuali/Actuali/Views/Reports/Widgets/CustomReportWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/CustomReportWidgetView.swift
@@ -5,6 +5,13 @@ struct CustomReportWidgetView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     let data: CustomReportData
 
+    /// Fixed cycle standing in for upstream's qualitative colour scale. Only
+    /// the donut assigns colours itself: a category can share a name with its
+    /// group, and `foregroundStyle(by:)` would merge the two.
+    private static let palette: [Color] = [
+        .blue, .green, .orange, .purple, .pink, .teal, .indigo, .yellow, .mint, .cyan, .brown, .red
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
@@ -39,23 +46,14 @@ struct CustomReportWidgetView: View {
                         : Color.accentColor)
                 }
                 .frame(height: 180)
-                // Financial chart axes otherwise reveal the underlying totals.
-                .chartYAxis(budgetStore.hideBalances ? .hidden : .automatic)
-                .accessibilityHidden(budgetStore.hideBalances)
+                .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
             }
 
         case .stacked(let stacked):
             if stacked.seriesNames.isEmpty {
                 emptyText
             } else {
-                // Flatten to (interval, series, value) points for Charts.
-                let points = stacked.seriesNames.enumerated().flatMap { s, name in
-                    stacked.intervalLabels.enumerated().map { i, label in
-                        StackPoint(interval: label, series: name,
-                                   value: stacked.values[s][i])
-                    }
-                }
-                Chart(points) { point in
+                Chart(points(stacked)) { point in
                     BarMark(
                         x: .value("Interval", point.interval),
                         y: .value("Amount", point.value)
@@ -64,9 +62,77 @@ struct CustomReportWidgetView: View {
                 }
                 .chartLegend(.visible)
                 .frame(height: 200)
-                // Financial chart axes otherwise reveal the underlying totals.
-                .chartYAxis(budgetStore.hideBalances ? .hidden : .automatic)
-                .accessibilityHidden(budgetStore.hideBalances)
+                .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
+            }
+
+        case .lines(let stacked, let trends):
+            if stacked.seriesNames.isEmpty {
+                emptyText
+            } else {
+                Chart {
+                    ForEach(points(stacked)) { point in
+                        LineMark(
+                            x: .value("Interval", point.interval),
+                            y: .value("Amount", point.value),
+                            series: .value("Series", point.series)
+                        )
+                        .foregroundStyle(by: .value("Group", point.series))
+                        PointMark(
+                            x: .value("Interval", point.interval),
+                            y: .value("Amount", point.value)
+                        )
+                        .foregroundStyle(by: .value("Group", point.series))
+                        .symbolSize(16)
+                    }
+                    // Upstream draws each series' least-squares trend as a
+                    // dashed line in the series colour, from the first to the
+                    // last interval.
+                    ForEach(trendPoints(stacked, trends: trends)) { point in
+                        LineMark(
+                            x: .value("Interval", point.interval),
+                            y: .value("Amount", point.value),
+                            series: .value("Series", "trend:" + point.series)
+                        )
+                        .foregroundStyle(by: .value("Group", point.series))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                    }
+                }
+                .chartLegend(.visible)
+                .frame(height: 200)
+                .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
+            }
+
+        case .area(let bars):
+            if bars.count < 2 {
+                emptyText
+            } else {
+                Chart(Array(bars.enumerated()), id: \.offset) { _, bar in
+                    AreaMark(
+                        x: .value("Interval", bar.label),
+                        y: .value("Amount", bar.valueUnits)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(.linearGradient(
+                        colors: [Color.accentColor.opacity(0.6), Color.accentColor.opacity(0.1)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ))
+                    LineMark(
+                        x: .value("Interval", bar.label),
+                        y: .value("Amount", bar.valueUnits)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(Color.accentColor)
+                }
+                .frame(height: 180)
+                .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
+            }
+
+        case .donut(let slices, let groups):
+            if slices.isEmpty {
+                emptyText
+            } else {
+                donut(slices: slices, groups: groups)
             }
 
         case .table(let rows):
@@ -78,7 +144,7 @@ struct CustomReportWidgetView: View {
                         HStack {
                             Text(row.name).font(.subheadline)
                             Spacer()
-                            Text(budgetStore.displayBalance(Int((row.totalUnits * 100).rounded())))
+                            Text(budgetStore.displayBalance(cents(row.totalUnits)))
                                 .font(.subheadline)
                                 .monospacedDigit()
                         }
@@ -94,6 +160,93 @@ struct CustomReportWidgetView: View {
         }
     }
 
+    // MARK: - Donut
+
+    /// Two rings are two overlaid charts rather than two mark sets in one:
+    /// every SectorMark in a chart shares one angular stack, so a second ring
+    /// inside the same chart would only get half the circle.
+    private func donut(slices: [CustomReportData.Slice], groups: [CustomReportData.Bar]) -> some View {
+        let colors = sliceColors(slices, groups: groups)
+        return VStack(alignment: .leading, spacing: 8) {
+            ZStack {
+                if !groups.isEmpty {
+                    Chart(Array(groups.enumerated()), id: \.offset) { i, group in
+                        SectorMark(
+                            angle: .value("Amount", group.valueUnits),
+                            innerRadius: .ratio(0.45),
+                            outerRadius: .ratio(0.65),
+                            angularInset: 1
+                        )
+                        .foregroundStyle(Self.palette[i % Self.palette.count])
+                    }
+                }
+                Chart(Array(slices.enumerated()), id: \.offset) { i, slice in
+                    SectorMark(
+                        angle: .value("Amount", slice.valueUnits),
+                        innerRadius: .ratio(groups.isEmpty ? 0.6 : 0.68),
+                        angularInset: 1
+                    )
+                    .foregroundStyle(colors[i])
+                }
+            }
+            .frame(height: 180)
+            // Wedge sizes alone don't give the totals away, but the legend
+            // below does, so it goes through displayBalance like everything else.
+            .accessibilityHidden(budgetStore.hideBalances)
+
+            VStack(alignment: .leading, spacing: 4) {
+                if groups.isEmpty {
+                    ForEach(Array(slices.enumerated()), id: \.offset) { i, slice in
+                        legendRow(color: colors[i], label: slice.label, units: slice.valueUnits)
+                    }
+                } else {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { gi, group in
+                        legendRow(color: Self.palette[gi % Self.palette.count],
+                                  label: group.label, units: group.valueUnits)
+                        ForEach(Array(slices.enumerated()).filter { $0.element.group == gi },
+                                id: \.offset) { i, slice in
+                            legendRow(color: colors[i], label: slice.label,
+                                      units: slice.valueUnits, indent: 14)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Single ring: palette by position. Two rings: each category takes its
+    /// group's colour lightened by position within the group, as upstream's
+    /// DonutGraph buildColorMap does (0.15 … 0.65 toward white).
+    private func sliceColors(_ slices: [CustomReportData.Slice], groups: [CustomReportData.Bar]) -> [Color] {
+        guard !groups.isEmpty else {
+            return slices.indices.map { Self.palette[$0 % Self.palette.count] }
+        }
+        var positionInGroup: [Int: Int] = [:]
+        let groupSizes = Dictionary(grouping: slices.compactMap(\.group), by: { $0 }).mapValues(\.count)
+        return slices.map { slice in
+            let gi = slice.group ?? 0
+            let k = positionInGroup[gi, default: 0]
+            positionInGroup[gi] = k + 1
+            let shade = 0.15 + Double(k) / Double(max(groupSizes[gi] ?? 1, 1)) * 0.5
+            return Self.palette[gi % Self.palette.count].mix(with: .white, by: shade)
+        }
+    }
+
+    private func legendRow(color: Color, label: String, units: Double, indent: CGFloat = 0) -> some View {
+        HStack(spacing: 6) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(label).font(.caption).lineLimit(1)
+            Spacer()
+            Text(budgetStore.displayBalance(cents(units)))
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+        .padding(.leading, indent)
+    }
+
+    // MARK: - Helpers
+
     private var emptyText: some View {
         Text("No data in range")
             .font(.subheadline)
@@ -101,10 +254,41 @@ struct CustomReportWidgetView: View {
             .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
     }
 
+    private func cents(_ units: Double) -> Int {
+        Int((units * 100).rounded())
+    }
+
+    /// Flatten to (interval, series, value) points for Charts.
+    private func points(_ stacked: CustomReportData.Stacked) -> [StackPoint] {
+        stacked.seriesNames.enumerated().flatMap { s, name in
+            stacked.intervalLabels.enumerated().map { i, label in
+                StackPoint(interval: label, series: name, value: stacked.values[s][i])
+            }
+        }
+    }
+
+    private func trendPoints(_ stacked: CustomReportData.Stacked, trends: [CustomReportData.Trend]) -> [StackPoint] {
+        guard let first = stacked.intervalLabels.first, let last = stacked.intervalLabels.last else { return [] }
+        return zip(stacked.seriesNames, trends).flatMap { name, trend in
+            [StackPoint(interval: first, series: name, value: trend.startUnits),
+             StackPoint(interval: last, series: name, value: trend.endUnits)]
+        }
+    }
+
     private struct StackPoint: Identifiable {
         let interval: String
         let series: String
         let value: Double
         var id: String { interval + "|" + series }
+    }
+
+    /// Financial chart axes otherwise reveal the underlying totals.
+    private struct BalanceHiding: ViewModifier {
+        let hidden: Bool
+        func body(content: Content) -> some View {
+            content
+                .chartYAxis(hidden ? .hidden : .automatic)
+                .accessibilityHidden(hidden)
+        }
     }
 }

--- a/Actuali/Actuali/Views/Reports/Widgets/CustomReportWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/CustomReportWidgetView.swift
@@ -36,17 +36,7 @@ struct CustomReportWidgetView: View {
             if bars.isEmpty {
                 emptyText
             } else {
-                Chart(Array(bars.enumerated()), id: \.offset) { _, bar in
-                    BarMark(
-                        x: .value("Label", bar.label),
-                        y: .value("Amount", bar.valueUnits)
-                    )
-                    .foregroundStyle(signed
-                        ? (bar.valueUnits < 0 ? Color.red : Color.green)
-                        : Color.accentColor)
-                }
-                .frame(height: 180)
-                .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
+                barChart(bars, signed: signed)
             }
 
         case .stacked(let stacked):
@@ -103,8 +93,11 @@ struct CustomReportWidgetView: View {
             }
 
         case .area(let bars):
-            if bars.count < 2 {
+            if bars.isEmpty {
                 emptyText
+            } else if bars.count < 2 {
+                // An area has no width with one interval; show it as a bar.
+                barChart(bars, signed: false)
             } else {
                 Chart(Array(bars.enumerated()), id: \.offset) { _, bar in
                     AreaMark(
@@ -215,8 +208,8 @@ struct CustomReportWidgetView: View {
     }
 
     /// Single ring: palette by position. Two rings: each category takes its
-    /// group's colour lightened by position within the group, as upstream's
-    /// DonutGraph buildColorMap does (0.15 … 0.65 toward white).
+    /// group's colour lightened by position within the group, matching
+    /// upstream's DonutGraph buildColorMap (0.15 + index / count * 0.5).
     private func sliceColors(_ slices: [CustomReportData.Slice], groups: [CustomReportData.Bar]) -> [Color] {
         guard !groups.isEmpty else {
             return slices.indices.map { Self.palette[$0 % Self.palette.count] }
@@ -246,6 +239,20 @@ struct CustomReportWidgetView: View {
     }
 
     // MARK: - Helpers
+
+    private func barChart(_ bars: [CustomReportData.Bar], signed: Bool) -> some View {
+        Chart(Array(bars.enumerated()), id: \.offset) { _, bar in
+            BarMark(
+                x: .value("Label", bar.label),
+                y: .value("Amount", bar.valueUnits)
+            )
+            .foregroundStyle(signed
+                ? (bar.valueUnits < 0 ? Color.red : Color.green)
+                : Color.accentColor)
+        }
+        .frame(height: 180)
+        .modifier(BalanceHiding(hidden: budgetStore.hideBalances))
+    }
 
     private var emptyText: some View {
         Text("No data in range")

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
@@ -152,21 +152,24 @@ struct BudgetDatabaseReportsFetchTests {
                 ALTER TABLE custom_reports ADD COLUMN date_static INTEGER DEFAULT 0;
                 ALTER TABLE custom_reports ADD COLUMN include_current INTEGER DEFAULT 0;
                 ALTER TABLE custom_reports ADD COLUMN sort_by TEXT DEFAULT 'desc';
+                ALTER TABLE custom_reports ADD COLUMN show_trend_lines INTEGER DEFAULT 0;
+                ALTER TABLE custom_reports ADD COLUMN trim_intervals INTEGER DEFAULT 0;
 
                 INSERT INTO custom_reports
                     (id, name, mode, group_by, balance_type, interval, graph_type,
                      date_range, date_static, start_date, end_date, include_current,
                      show_empty, show_offbudget, show_hidden, show_uncategorized,
-                     sort_by, conditions, conditions_op, tombstone)
+                     sort_by, show_trend_lines, trim_intervals,
+                     conditions, conditions_op, tombstone)
                 VALUES
                     ('r1', 'Category Spending', 'total', 'Category', 'Payment', 'Monthly',
                      'BarGraph', 'All time', 0, '2025-08-30', '2026-04-26', 1,
-                     0, 0, 0, 0, 'name',
+                     0, 0, 0, 0, 'name', 1, 1,
                      '[{"field":"transfer","op":"is","value":false,"type":"boolean"}]',
                      'and', 0),
                     ('r2', 'Deleted', 'total', 'Category', 'Payment', 'Monthly',
                      'BarGraph', 'All time', 0, NULL, NULL, 1,
-                     0, 0, 0, 0, 'desc', NULL, 'and', 1);
+                     0, 0, 0, 0, 'desc', 0, 0, NULL, 'and', 1);
             """)
         }
 
@@ -182,6 +185,8 @@ struct BudgetDatabaseReportsFetchTests {
         #expect(r1.dateStatic == false)
         #expect(r1.includeCurrent == true)
         #expect(r1.sortBy == "name")
+        #expect(r1.showTrendLines == true)
+        #expect(r1.trimIntervals == true)
         #expect(r1.startDate == "2025-08-30")
         #expect(r1.endDate == "2026-04-26")
         #expect(r1.conditions?.first?.field == "transfer")
@@ -216,6 +221,8 @@ struct BudgetDatabaseReportsFetchTests {
         #expect(r1.dateStatic == false)
         #expect(r1.includeCurrent == false)
         #expect(r1.sortBy == "desc")
+        #expect(r1.showTrendLines == false)
+        #expect(r1.trimIntervals == false)
         #expect(r1.conditions == nil)
         #expect(r1.conditionsOp == "or")
     }

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
@@ -178,12 +178,12 @@ struct BudgetDatabaseReportsFetchTests {
 
         try await db.dbQueueForTesting.write { conn in
             // A synced budget file carries upstream columns the app's own
-            // migration doesn't create; add them so the fetch reads real values.
+            // migrations don't create; add them so the fetch reads real values.
+            // (show_trend_lines is already added by migration 1780099200000.)
             try conn.execute(sql: """
                 ALTER TABLE custom_reports ADD COLUMN date_static INTEGER DEFAULT 0;
                 ALTER TABLE custom_reports ADD COLUMN include_current INTEGER DEFAULT 0;
                 ALTER TABLE custom_reports ADD COLUMN sort_by TEXT DEFAULT 'desc';
-                ALTER TABLE custom_reports ADD COLUMN show_trend_lines INTEGER DEFAULT 0;
                 ALTER TABLE custom_reports ADD COLUMN trim_intervals INTEGER DEFAULT 0;
 
                 INSERT INTO custom_reports

--- a/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
+++ b/Actuali/ActualiTests/Services/Database/BudgetDatabaseReportsFetchTests.swift
@@ -111,6 +111,37 @@ struct BudgetDatabaseReportsFetchTests {
         #expect(transfer?.transferAcct == "acct-savings")
     }
 
+    /// Merging payees leaves the old id on the transaction row; Actual's
+    /// transaction view resolves it through payee_mapping, so reports must
+    /// see the surviving payee or a Payee-grouped report drops the history.
+    @Test func resolvesMergedPayeeThroughMapping() async throws {
+        let (db, url) = try makeDatabase()
+        defer { cleanup(url) }
+
+        try await db.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-kept', 'Coffee Shop', NULL);
+
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-kept',   'payee-kept'),
+                    ('payee-merged', 'payee-kept');
+
+                INSERT INTO transactions (id, acct, description, amount, date) VALUES
+                    ('t-old',  'acct-checking', 'payee-merged', -550, 20260601),
+                    ('t-new',  'acct-checking', 'payee-kept',   -450, 20260602),
+                    ('t-none', 'acct-checking', NULL,           -100, 20260603);
+            """)
+        }
+
+        let txns = try await db.fetchTransactionsForReports()
+        let old = txns.first { $0.id == "t-old" }
+        #expect(old?.payeeId == "payee-kept")
+        #expect(old?.payeeName == "Coffee Shop")
+        #expect(txns.first { $0.id == "t-new" }?.payeeId == "payee-kept")
+        #expect(txns.first { $0.id == "t-none" }?.payeeId == nil)
+    }
+
     @Test func excludesSplitParentsAndOrphanedChildren() async throws {
         let (db, url) = try makeDatabase()
         defer { cleanup(url) }

--- a/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
@@ -53,12 +53,13 @@ struct CustomReportEngineTests {
         graph: String, sortBy: String = "desc",
         showEmpty: Bool = false, showOffBudget: Bool = false, showUncategorized: Bool = false,
         showTrendLines: Bool = false, trimIntervals: Bool = false,
+        dateRange: String = "All time",
         staticRange: (start: String, end: String)? = nil,
         conditions: [WidgetRuleCondition]? = nil
     ) -> CustomReportConfig {
         CustomReportConfig(
             id: "r", name: "Test", mode: mode, groupBy: groupBy, balanceType: balance,
-            interval: interval, graphType: graph, dateRange: "All time",
+            interval: interval, graphType: graph, dateRange: dateRange,
             dateStatic: staticRange != nil,
             startDate: staticRange?.start, endDate: staticRange?.end,
             includeCurrent: true, showEmpty: showEmpty,
@@ -356,7 +357,41 @@ struct CustomReportEngineTests {
         #expect(foodOnly.map(\.valueUnits) == [1000.0])
     }
 
+    @Test func budgetedSurvivesInvertedRange() {
+        // "Last year" on a budget whose history starts this year resolves to
+        // a start after its end (ReportDateRange clamps the start to the
+        // earliest transaction). That is an empty chart, not a trap.
+        var ctx = reportContext
+        ctx.budgetEntries = [
+            BudgetAnalysisBudgetEntry(month: 202606, categoryId: "c-food", amountCents: 50_000),
+        ]
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Category", balance: "Budgeted",
+                           interval: "Monthly", graph: "BarGraph", dateRange: "Last year"),
+            transactions: sampleTxs, reportContext: ctx, filterContext: .empty, today: today)
+        guard case .bars(let bars, _) = data.kind else {
+            Issue.record("expected bars, got \(data.kind)"); return
+        }
+        #expect(bars.isEmpty)
+    }
+
     // MARK: - Donut
+
+    @Test func donutOverIntervals() {
+        // Upstream allows Interval grouping on a total-mode donut: one wedge
+        // per interval, empty intervals dropped.
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Interval", balance: "Payment",
+                           interval: "Monthly", graph: "DonutGraph"),
+            transactions: sampleTxs, reportContext: reportContext,
+            filterContext: .empty, today: today)
+        guard case .donut(let slices, let groups) = data.kind else {
+            Issue.record("expected donut, got \(data.kind)"); return
+        }
+        #expect(groups.isEmpty)
+        #expect(slices.map(\.label) == ["Jun '26", "Jul '26"])
+        #expect(slices.map(\.valueUnits) == [300.0, 50.0])
+    }
 
     @Test func donutDropsZeroSlices() {
         let data = CustomReportEngine.compute(

--- a/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
@@ -9,7 +9,9 @@ struct CustomReportEngineTests {
         return c.date(from: DateComponents(year: 2026, month: 7, day: 11))!
     }()
 
-    // Two groups, two categories each; "Secret" hidden category for visibility tests.
+    // Two expense groups, two categories each; "Secret" hidden category for
+    // visibility tests; an income group so Budgeted can skip it. Payees and
+    // accounts for the Payee/Account groupings.
     private var reportContext: CustomReportEngine.ReportContext {
         CustomReportEngine.ReportContext(
             categories: [
@@ -17,19 +19,30 @@ struct CustomReportEngineTests {
                 Category(id: "c-rent", name: "Rent", groupId: "g-living", isIncome: false, hidden: false, sortOrder: 1),
                 Category(id: "c-fun", name: "Fun", groupId: "g-play", isIncome: false, hidden: false, sortOrder: 2),
                 Category(id: "c-hidden", name: "Secret", groupId: "g-play", isIncome: false, hidden: true, sortOrder: 3),
+                Category(id: "c-salary", name: "Salary", groupId: "g-income", isIncome: true, hidden: false, sortOrder: 4),
             ],
             groups: [
                 CategoryGroup(id: "g-living", name: "Living", isIncome: false, hidden: false, sortOrder: 0, categories: []),
                 CategoryGroup(id: "g-play", name: "Play", isIncome: false, hidden: false, sortOrder: 1, categories: []),
+                CategoryGroup(id: "g-income", name: "Income", isIncome: true, hidden: false, sortOrder: 2, categories: []),
             ],
             offBudgetAccountIds: [],
-            firstDayOfWeekIdx: 0)
+            firstDayOfWeekIdx: 0,
+            payees: [
+                Payee(id: "p-store", name: "Store", transferAccountId: nil, tombstone: false),
+                Payee(id: "p-xfer", name: "", transferAccountId: "a-savings", tombstone: false),
+            ],
+            accounts: [
+                Account(id: "a1", name: "Checking", type: .checking, offBudget: false, closed: false, sortOrder: 0, balance: 0),
+                Account(id: "a-savings", name: "Savings", type: .savings, offBudget: false, closed: false, sortOrder: 1, balance: 0),
+                Account(id: "a-off", name: "Brokerage", type: .investment, offBudget: true, closed: false, sortOrder: 2, balance: 0),
+            ])
     }
 
     private func tx(_ id: String, date: Int, amount: Int, category: String?,
-                    account: String = "a1") -> Transaction {
+                    account: String = "a1", payee: String? = nil) -> Transaction {
         Transaction(id: id, accountId: account, date: date, amount: amount,
-                    payeeId: nil, payeeName: nil, categoryId: category, categoryName: nil,
+                    payeeId: payee, payeeName: nil, categoryId: category, categoryName: nil,
                     notes: nil, cleared: true, reconciled: false, transferId: nil,
                     isParent: false, parentId: nil, tombstone: false,
                     sortOrder: nil, importedPayee: nil)
@@ -38,14 +51,20 @@ struct CustomReportEngineTests {
     private func config(
         mode: String, groupBy: String, balance: String, interval: String,
         graph: String, sortBy: String = "desc",
-        showOffBudget: Bool = false, showUncategorized: Bool = false
+        showEmpty: Bool = false, showOffBudget: Bool = false, showUncategorized: Bool = false,
+        showTrendLines: Bool = false, trimIntervals: Bool = false,
+        staticRange: (start: String, end: String)? = nil,
+        conditions: [WidgetRuleCondition]? = nil
     ) -> CustomReportConfig {
         CustomReportConfig(
             id: "r", name: "Test", mode: mode, groupBy: groupBy, balanceType: balance,
-            interval: interval, graphType: graph, dateRange: "All time", dateStatic: false,
-            startDate: nil, endDate: nil, includeCurrent: true, showEmpty: false,
+            interval: interval, graphType: graph, dateRange: "All time",
+            dateStatic: staticRange != nil,
+            startDate: staticRange?.start, endDate: staticRange?.end,
+            includeCurrent: true, showEmpty: showEmpty,
             showOffBudget: showOffBudget, showHidden: false, showUncategorized: showUncategorized,
-            sortBy: sortBy, conditions: nil, conditionsOp: "and")
+            sortBy: sortBy, showTrendLines: showTrendLines, trimIntervals: trimIntervals,
+            conditions: conditions, conditionsOp: "and")
     }
 
     private var sampleTxs: [Transaction] {
@@ -118,14 +137,14 @@ struct CustomReportEngineTests {
     }
 
     @Test func unsupportedOptionsAreNamed() {
-        let donut = CustomReportEngine.compute(
+        let barLine = CustomReportEngine.compute(
             config: config(mode: "total", groupBy: "Category", balance: "Payment",
-                           interval: "Monthly", graph: "DonutGraph"),
+                           interval: "Monthly", graph: "BarLineGraph"),
             transactions: [], reportContext: reportContext, filterContext: .empty, today: today)
-        guard case .unsupported(let reason) = donut.kind else {
-            Issue.record("expected unsupported, got \(donut.kind)"); return
+        guard case .unsupported(let reason) = barLine.kind else {
+            Issue.record("expected unsupported, got \(barLine.kind)"); return
         }
-        #expect(reason.contains("DonutGraph"))
+        #expect(reason.contains("BarLineGraph"))
 
         let missing = CustomReportEngine.compute(
             config: nil, transactions: [], reportContext: reportContext,
@@ -220,5 +239,246 @@ struct CustomReportEngineTests {
         }
         #expect(rows.map(\.name) == ["Jun '26", "Jul '26"])
         #expect(rows.map(\.totalUnits) == [-300.0, -50.0])
+    }
+
+    // MARK: - groupBy Payee / Account
+
+    @Test func payeeBarsUseStoreOrderAndSkipPayeeless() {
+        // Upstream matches `payee === item.id` with no synthetic rows, so a
+        // tx without a payee lands nowhere; transfer payees show the linked
+        // account's name (v_payees).
+        let txs = [
+            tx("1", date: 20260601, amount: -10_000, category: "c-food", payee: "p-store"),
+            tx("2", date: 20260615, amount: -4_000,  category: "c-rent", payee: "p-xfer"),
+            tx("3", date: 20260701, amount: -5_000,  category: "c-fun"),   // no payee
+        ]
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Payee", balance: "Payment",
+                           interval: "Monthly", graph: "BarGraph", sortBy: "budget"),
+            transactions: txs, reportContext: reportContext, filterContext: .empty, today: today)
+        guard case .bars(let bars, _) = data.kind else {
+            Issue.record("expected bars, got \(data.kind)"); return
+        }
+        #expect(bars.map(\.label) == ["Store", "Savings"])
+        #expect(bars.map(\.valueUnits) == [100.0, 40.0])
+    }
+
+    @Test func accountBarsFollowShowOffBudget() {
+        var ctx = reportContext
+        ctx.offBudgetAccountIds = ["a-off"]
+        let txs = [
+            tx("1", date: 20260601, amount: -10_000, category: "c-food"),
+            tx("2", date: 20260615, amount: -4_000,  category: nil, account: "a-off"),
+        ]
+        func run(showOffBudget: Bool) -> [CustomReportData.Bar] {
+            let data = CustomReportEngine.compute(
+                config: config(mode: "total", groupBy: "Account", balance: "Payment",
+                               interval: "Monthly", graph: "BarGraph", sortBy: "budget",
+                               showOffBudget: showOffBudget),
+                transactions: txs, reportContext: ctx, filterContext: .empty, today: today)
+            guard case .bars(let bars, _) = data.kind else { return [] }
+            return bars
+        }
+        #expect(run(showOffBudget: true).map(\.label) == ["Checking", "Brokerage"])
+        #expect(run(showOffBudget: true).map(\.valueUnits) == [100.0, 40.0])
+        #expect(run(showOffBudget: false).map(\.label) == ["Checking"])
+    }
+
+    // MARK: - Net Payment / Net Deposit
+
+    @Test func netPaymentUsesRowTotalNotBucketSum() {
+        // Food: -100 in Jun, +150 in Jul → whole-range net +50. Upstream's
+        // recalculate() derives netDebts from that net, so the row is empty
+        // under Net Payment and 50 under Net Deposit; per-interval values
+        // still split by bucket.
+        let txs = [
+            tx("1", date: 20260601, amount: -10_000, category: "c-food"),
+            tx("2", date: 20260701, amount: 15_000,  category: "c-food"),
+        ]
+        func run(balance: String, graph: String) -> CustomReportData.Kind {
+            CustomReportEngine.compute(
+                config: config(mode: graph == "BarGraph" ? "total" : "time", groupBy: "Category",
+                               balance: balance, interval: "Monthly", graph: graph),
+                transactions: txs, reportContext: reportContext, filterContext: .empty, today: today).kind
+        }
+        guard case .bars(let payment, _) = run(balance: "Net Payment", graph: "BarGraph"),
+              case .bars(let deposit, _) = run(balance: "Net Deposit", graph: "BarGraph"),
+              case .stacked(let perMonth) = run(balance: "Net Deposit", graph: "StackedBarGraph") else {
+            Issue.record("expected bars and stacked"); return
+        }
+        #expect(payment.isEmpty)
+        #expect(deposit.map(\.label) == ["Food"])
+        #expect(deposit.map(\.valueUnits) == [50.0])
+        #expect(perMonth.values == [[0.0, 150.0]])
+    }
+
+    @Test func netPaymentPerIntervalBars() {
+        // Jun net -300 → 300; Jul net -50 (income row dropped) → 50.
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Interval", balance: "Net Payment",
+                           interval: "Monthly", graph: "BarGraph"),
+            transactions: sampleTxs, reportContext: reportContext,
+            filterContext: .empty, today: today)
+        guard case .bars(let bars, let signed) = data.kind else {
+            Issue.record("expected bars, got \(data.kind)"); return
+        }
+        #expect(signed == false)
+        #expect(bars.map(\.valueUnits) == [300.0, 50.0])
+    }
+
+    // MARK: - Budgeted
+
+    @Test func budgetedReadsBudgetCellsAndOnlyCategoryConditions() {
+        // Upstream budgetDataQuery: months in range, non-income categories,
+        // and only category / category_group conditions apply.
+        var ctx = reportContext
+        ctx.budgetEntries = [
+            BudgetAnalysisBudgetEntry(month: 202605, categoryId: "c-food", amountCents: 99_900),   // before range
+            BudgetAnalysisBudgetEntry(month: 202606, categoryId: "c-food", amountCents: 50_000),
+            BudgetAnalysisBudgetEntry(month: 202606, categoryId: "c-rent", amountCents: 120_000),
+            BudgetAnalysisBudgetEntry(month: 202607, categoryId: "c-food", amountCents: 50_000),
+            BudgetAnalysisBudgetEntry(month: 202606, categoryId: "c-salary", amountCents: 300_000), // income
+        ]
+        func run(conditions: [WidgetRuleCondition]?) -> [CustomReportData.Bar] {
+            let data = CustomReportEngine.compute(
+                config: config(mode: "total", groupBy: "Category", balance: "Budgeted",
+                               interval: "Monthly", graph: "BarGraph", sortBy: "budget",
+                               conditions: conditions),
+                transactions: sampleTxs, reportContext: ctx, filterContext: .empty, today: today)
+            guard case .bars(let bars, _) = data.kind else { return [] }
+            return bars
+        }
+        let accountOnly = run(conditions: [.makeMock(op: "is", field: "account", stringValue: "a-off")])
+        #expect(accountOnly.map(\.label) == ["Food", "Rent"])
+        #expect(accountOnly.map(\.valueUnits) == [1000.0, 1200.0])
+        let foodOnly = run(conditions: [.makeMock(op: "is", field: "category", stringValue: "c-food")])
+        #expect(foodOnly.map(\.label) == ["Food"])
+        #expect(foodOnly.map(\.valueUnits) == [1000.0])
+    }
+
+    // MARK: - Donut
+
+    @Test func donutDropsZeroSlices() {
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Category", balance: "Payment",
+                           interval: "Monthly", graph: "DonutGraph", showEmpty: true),
+            transactions: sampleTxs, reportContext: reportContext,
+            filterContext: .empty, today: today)
+        guard case .donut(let slices, let groups) = data.kind else {
+            Issue.record("expected donut, got \(data.kind)"); return
+        }
+        #expect(groups.isEmpty)
+        #expect(slices.map(\.label) == ["Rent", "Food", "Fun"])   // desc; empties gone
+        #expect(slices.map(\.valueUnits) == [200.0, 100.0, 50.0])
+        #expect(slices.allSatisfy { $0.group == nil })
+    }
+
+    @Test func donutTwoRingsAlignSlicesToGroups() {
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "CategoryGroup", balance: "Payment",
+                           interval: "Monthly", graph: "DonutGraph"),
+            transactions: sampleTxs, reportContext: reportContext,
+            filterContext: .empty, today: today)
+        guard case .donut(let slices, let groups) = data.kind else {
+            Issue.record("expected donut, got \(data.kind)"); return
+        }
+        #expect(groups.map(\.label) == ["Living", "Play"])       // desc: 300 vs 50
+        #expect(groups.map(\.valueUnits) == [300.0, 50.0])
+        #expect(slices.map(\.label) == ["Rent", "Food", "Fun"])  // grouped, desc within group
+        #expect(slices.map(\.group) == [0, 0, 1])
+        for (gi, group) in groups.enumerated() {
+            let members = slices.filter { $0.group == gi }.map(\.valueUnits).reduce(0, +)
+            #expect(members == group.valueUnits)
+        }
+    }
+
+    // MARK: - Line / Area
+
+    @Test func lineSeriesMatchStackedAndCarryTrends() {
+        func run(showTrendLines: Bool) -> CustomReportData.Kind {
+            CustomReportEngine.compute(
+                config: config(mode: "time", groupBy: "Category", balance: "Payment",
+                               interval: "Monthly", graph: "LineGraph", showTrendLines: showTrendLines),
+                transactions: sampleTxs, reportContext: reportContext,
+                filterContext: .empty, today: today).kind
+        }
+        guard case .lines(let plain, let noTrends) = run(showTrendLines: false),
+              case .lines(let withTrends, let trends) = run(showTrendLines: true) else {
+            Issue.record("expected lines"); return
+        }
+        #expect(noTrends.isEmpty)
+        #expect(plain == withTrends)
+        #expect(plain.seriesNames == ["Rent", "Food", "Fun"])
+        #expect(plain.values == [[200.0, 0.0], [100.0, 0.0], [0.0, 50.0]])
+        // One trend per series; Rent [200, 0] fits a straight line exactly.
+        #expect(trends.count == 3)
+        #expect(trends[0] == .init(startUnits: 200.0, endUnits: 0.0))
+    }
+
+    @Test func trendLineIsLeastSquares() throws {
+        #expect(CustomReportEngine.trend([1, 2, 3]) == .init(startUnits: 1.0, endUnits: 3.0))
+        #expect(CustomReportEngine.trend([2, 2]) == .init(startUnits: 2.0, endUnits: 2.0))
+        // y = 1, 3, 2 → slope 0.5, intercept 1.5
+        let fitted = try #require(CustomReportEngine.trend([1, 3, 2]))
+        #expect(abs(fitted.startUnits - 1.5) < 1e-9)
+        #expect(abs(fitted.endUnits - 2.5) < 1e-9)
+        #expect(CustomReportEngine.trend([5]) == nil)
+    }
+
+    @Test func areaEmitsOnePointPerInterval() {
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Interval", balance: "Payment",
+                           interval: "Monthly", graph: "AreaGraph"),
+            transactions: sampleTxs, reportContext: reportContext,
+            filterContext: .empty, today: today)
+        guard case .area(let points) = data.kind else {
+            Issue.record("expected area, got \(data.kind)"); return
+        }
+        #expect(points.map(\.label) == ["Jun '26", "Jul '26"])
+        #expect(points.map(\.valueUnits) == [300.0, 50.0])
+    }
+
+    // MARK: - Trim intervals / sort
+
+    @Test func trimIntervalsDropsEmptyEdges() {
+        // Static Mar–Aug range with activity only in May and June.
+        let txs = [
+            tx("1", date: 20260510, amount: -10_000, category: "c-food"),
+            tx("2", date: 20260620, amount: -5_000,  category: "c-fun"),
+        ]
+        func run(trim: Bool, groupBy: String) -> [String] {
+            let data = CustomReportEngine.compute(
+                config: config(mode: "time", groupBy: groupBy, balance: "Payment",
+                               interval: "Monthly", graph: groupBy == "Interval" ? "BarGraph" : "StackedBarGraph",
+                               trimIntervals: trim, staticRange: ("2026-03-01", "2026-08-31")),
+                transactions: txs, reportContext: reportContext, filterContext: .empty, today: today)
+            switch data.kind {
+            case .stacked(let s): return s.intervalLabels
+            case .bars(let bars, _): return bars.map(\.label)
+            default: return []
+            }
+        }
+        #expect(run(trim: false, groupBy: "Category").count == 6)
+        #expect(run(trim: true, groupBy: "Category") == ["May '26", "Jun '26"])
+        #expect(run(trim: true, groupBy: "Interval") == ["May '26", "Jun '26"])
+    }
+
+    @Test func descSortIsSignedForNet() {
+        // Upstream sortData compares the signed metric, so under Net the
+        // biggest inflow comes first and the biggest outflow last.
+        let txs = [
+            tx("1", date: 20260601, amount: -10_000, category: "c-food"),
+            tx("2", date: 20260601, amount: 25_000,  category: "c-rent"),
+            tx("3", date: 20260601, amount: -5_000,  category: "c-fun"),
+        ]
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Category", balance: "Net",
+                           interval: "Monthly", graph: "BarGraph"),
+            transactions: txs, reportContext: reportContext, filterContext: .empty, today: today)
+        guard case .bars(let bars, _) = data.kind else {
+            Issue.record("expected bars, got \(data.kind)"); return
+        }
+        #expect(bars.map(\.label) == ["Rent", "Fun", "Food"])
+        #expect(bars.map(\.valueUnits) == [250.0, -50.0, -100.0])
     }
 }

--- a/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
+++ b/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
@@ -29,6 +29,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
         return app
     }
 
+    @MainActor
     private func selectViewStyle(_ style: String, in app: XCUIApplication) {
         let picker = app.buttons.matching(
             NSPredicate(format: "label BEGINSWITH 'View Style'")


### PR DESCRIPTION
## Why

The Reports tab could only render a custom report if it used BarGraph, StackedBarGraph or TableGraph, grouped by Category, Group or Interval, with the Payment, Deposit or Net balance type. Anything else saved in the web app showed an "isn't supported yet" card. Every other dashboard widget type already renders natively, so the custom report card was the last gap to parity with the web app's report types.

Closes #423
Closes #364

## What

Custom report cards now render every option the web app's report builder can save:

- **Graph types:** DonutGraph (single ring, and the two-ring Category+Group layout with categories shaded from their group's colour), LineGraph (with optional dashed least-squares trend lines) and AreaGraph, alongside the existing bar, stacked bar and table graphs.
- **Group by:** Payee and Account, in addition to Category, Group and Interval. Transfer payees are labelled with the linked account's name, as the web app does.
- **Balance types:** Net Payment, Net Deposit and Budgeted. Budgeted reads budget cells for the months in range instead of transactions, honouring only category conditions like upstream.
- **Trim intervals:** empty leading and trailing intervals are dropped when the report has it enabled.
- Two smaller parity fixes that came out of porting `custom-spreadsheet.ts`: a row's total is now the metric over its whole-range aggregate (so Net Payment hides a category that is negative in one month but positive overall), and "desc"/"asc" sort by the signed value rather than the absolute value, which only changes the order of Net reports.
- `hideBalances` is respected on the new charts: axes are hidden, the donut legend goes through the masked balance formatter, and the charts are hidden from accessibility.

Intentional simplifications, each marked with a `ponytail:` comment: the table graph stays a totals-only list in time mode rather than a per-interval column grid, the area graph uses one accent gradient instead of a split positive/negative gradient, and a Budgeted report on a Daily or Weekly interval lands the month's budget on the 1st where the web app renders an empty chart.

## How it was tested

- `CustomReportEngineTests`: 12 new cases covering Payee and Account grouping, Net Payment and Net Deposit (row-level and per-interval), Budgeted with and without category conditions, single-ring and two-ring donut slice ordering and alignment, line series and trend-line math, area points, interval trimming, and signed sorting. Existing cases updated for the new option matrix.
- `BudgetDatabaseReportsFetchTests`: `show_trend_lines` and `trim_intervals` are read when present and default to false on budget files that lack the columns.
- Full `ActualiTests` unit suite run locally on the iOS Simulator: <!-- fill in simulator + iOS version -->.
- Manual check on the simulator with a synced budget containing one report of each graph type, including a Category+Group donut and a LineGraph with trend lines on, in both light and dark mode and with Hide Balances toggled.