### PR TITLE
Remove Detailed budget view

### DIFF
--- a/Actuali/Actuali/Models/Budget.swift
+++ b/Actuali/Actuali/Models/Budget.swift
@@ -241,7 +241,7 @@ extension CategoryBudget {
     }
 }
 
-/// Column sums for one category group, shown in the detailed style's group
+/// Column sums for one category group, shown in the Compact style's group
 /// header the way the PWA's table totals its group rows. Always built from a
 /// group's full category list — "Hide Spent Categories" trims which rows are
 /// drawn, and a header total that quietly dropped those categories would

--- a/Actuali/Actuali/Models/BudgetDisplayStyle.swift
+++ b/Actuali/Actuali/Models/BudgetDisplayStyle.swift
@@ -6,6 +6,7 @@ enum BudgetDisplayStyle: String, CaseIterable {
     case clean
     case compact
 
+    /// Detailed was removed in GH #442; keep its saved value opening Compact.
     static func resolved(from raw: String?) -> BudgetDisplayStyle {
         if raw == "detailed" { return .compact }
         return raw.flatMap(BudgetDisplayStyle.init(rawValue:)) ?? .clean

--- a/Actuali/Actuali/Models/BudgetDisplayStyle.swift
+++ b/Actuali/Actuali/Models/BudgetDisplayStyle.swift
@@ -1,10 +1,13 @@
 /// How the Budget tab lays out its summary and category rows (actios-96wa).
 /// `clean` is the card look from the App Store screenshots — category name
-/// with a large Available amount and Budgeted/Spent captions. `detailed` is
-/// the PWA-style table of Budgeted/Spent/Balance pill columns. `compact` adapts
+/// with a large Available amount and Budgeted/Spent captions. `compact` adapts
 /// the companion app's plain monthly table while retaining Actuali behavior.
 enum BudgetDisplayStyle: String, CaseIterable {
     case clean
-    case detailed
     case compact
+
+    static func resolved(from raw: String?) -> BudgetDisplayStyle {
+        if raw == "detailed" { return .compact }
+        return raw.flatMap(BudgetDisplayStyle.init(rawValue:)) ?? .clean
+    }
 }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -366,7 +366,7 @@ final class BudgetStore: ObservableObject {
     }
 
     /// Whether the Compact Budget view style shows its pinned monthly overview.
-    /// This is independent of the Clean and Detailed summaries and defaults on.
+    /// This is independent of the Clean summary and defaults on.
     @Published var showCompactBudgetOverview: Bool = true {
         didSet {
             UserDefaults.standard.set(
@@ -429,7 +429,7 @@ final class BudgetStore: ObservableObject {
         }
     }
 
-    /// Whether the Detailed and Compact styles' group headers total their columns.
+    /// Whether the Compact style's group headers total their columns.
     /// Persisted to UserDefaults, defaults to on. Groups with long names are
     /// the reason this is optional: the totals cost the name real width, and
     /// not every budget file makes the sums worth it.
@@ -1231,9 +1231,9 @@ final class BudgetStore: ObservableObject {
             _appearanceMode = Published(initialValue: mode)
         }
         _startTab = Published(initialValue: StartTab.persisted)
-        _budgetDisplayStyle = Published(initialValue: BudgetDisplayStyle(
-            rawValue: defaults.string(forKey: "budgetDisplayStyle") ?? ""
-        ) ?? .clean)
+        _budgetDisplayStyle = Published(initialValue: BudgetDisplayStyle.resolved(
+            from: defaults.string(forKey: "budgetDisplayStyle")
+        ))
         _showCompactBudgetOverview = Published(
             initialValue: persistedBool("showCompactBudgetOverview", default: true))
         _showCompactSpentColumn = Published(

--- a/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetOptionsMenu.swift
@@ -52,8 +52,6 @@ struct BudgetOptionsMenu: View {
             Picker("Layout", selection: $budgetStore.budgetDisplayStyle) {
                 Label("Clean", systemImage: "list.bullet.rectangle")
                     .tag(BudgetDisplayStyle.clean)
-                Label("Detailed", systemImage: "rectangle.grid.1x2")
-                    .tag(BudgetDisplayStyle.detailed)
                 Label("Compact", systemImage: "list.bullet")
                     .tag(BudgetDisplayStyle.compact)
             }

--- a/Actuali/Actuali/Views/Budget/BudgetView.swift
+++ b/Actuali/Actuali/Views/Budget/BudgetView.swift
@@ -28,17 +28,6 @@ private let monthShortTitleFormatter: DateFormatter = {
     return formatter
 }()
 
-/// Shared metrics for the budget table's three numeric columns, so the
-/// summary captions, group totals and category pills line up vertically
-/// like the PWA's table.
-enum BudgetColumn {
-    static let width: CGFloat = 70
-    // Tight: every point between the columns comes out of the category
-    // name, which wraps early on a phone ("Caravan Parks 🏕" drops its
-    // emoji to a second line).
-    static let spacing: CGFloat = 4
-}
-
 /// Style-specific list metrics live behind one exhaustive switch so adding a
 /// display style cannot silently inherit another style's spacing or background.
 private struct BudgetListMetrics {
@@ -53,11 +42,6 @@ private struct BudgetListMetrics {
             sectionSpacing = .default
             horizontalContentMargin = 4
             topContentMargin = 20
-            showsTopFade = true
-        case .detailed:
-            sectionSpacing = .custom(14)
-            horizontalContentMargin = 4
-            topContentMargin = 16
             showsTopFade = true
         case .compact:
             sectionSpacing = .custom(0)
@@ -173,7 +157,6 @@ struct BudgetView: View {
     private var uncategorizedShape: AnyShape {
         switch budgetStore.budgetDisplayStyle {
         case .clean: AnyShape(RoundedRectangle(cornerRadius: 24))
-        case .detailed: AnyShape(Capsule())
         case .compact: AnyShape(Rectangle())
         }
     }
@@ -334,45 +317,6 @@ struct BudgetView: View {
                 )
                 .textCase(nil)
             }
-        case .detailed:
-            // The group row lives inside the card (first row, tinted) like
-            // the PWA's table, so its totals share the exact column grid of
-            // the rows below.
-            Section {
-                BudgetGroupHeader(
-                    name: group.name,
-                    isCollapsed: isCollapsed,
-                    isHidden: group.isHidden,
-                    onSetHidden: {
-                        setCategoryGroupHidden(group.id, hidden: $0)
-                    },
-                    totals: budgetStore.showGroupTotals ? group.totals : nil,
-                    onToggleCollapse: { toggleCollapsed(group.id) },
-                    reservesTwoLines: true
-                )
-                .listRowBackground(Color(.tertiarySystemFill))
-                .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
-                if !isCollapsed {
-                    ForEach(group.categories) { category in
-                        CategoryBudgetRow(
-                            category: category,
-                            isHidden: category.hidden,
-                            isDimmed: category.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(category.categoryId, hidden: $0)
-                            },
-                            addsGroupBottomPadding:
-                                category.id == group.categories.last?.id,
-                            onShowDetails: { selectedCategory = $0 },
-                            onEditBudget: { editingCategory = $0 },
-                            // Name shows all time, Spent shows
-                            // the displayed month (GH #56).
-                            onShowTransactions: showTransactions,
-                            onMoveMoney: moveMoney
-                        )
-                    }
-                }
-            }
         case .compact:
             Section {
                 if !isCollapsed {
@@ -434,7 +378,6 @@ struct BudgetView: View {
                                 setCategoryHidden(income.categoryId, hidden: $0)
                             },
                             showsBudgeted: budget.toBudget == nil,
-                            isDetailed: false,
                             onShowTransactions: showTransactions
                         )
                     }
@@ -457,38 +400,6 @@ struct BudgetView: View {
                     }
                 )
                 .textCase(nil)
-            }
-        case .detailed:
-            Section {
-                BudgetGroupHeader(
-                    name: name,
-                    isCollapsed: isCollapsed,
-                    isHidden: group?.hidden == true,
-                    onSetHidden: onSetHidden,
-                    receivedTotal: budget.totalIncome,
-                    onToggleCollapse: {
-                        toggleCollapsed(Self.incomeGroupCollapseID)
-                    },
-                    usesTableNumberFormat: true,
-                    reservesTwoLines: true
-                )
-                .listRowBackground(Color(.tertiarySystemFill))
-                .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 16))
-                if !isCollapsed {
-                    ForEach(categories) { income in
-                        IncomeCategoryRow(
-                            income: income,
-                            isHidden: income.hidden,
-                            isDimmed: income.isEffectivelyHidden,
-                            onSetHidden: {
-                                setCategoryHidden(income.categoryId, hidden: $0)
-                            },
-                            showsBudgeted: budget.toBudget == nil,
-                            isDetailed: true,
-                            onShowTransactions: showTransactions
-                        )
-                    }
-                }
             }
         case .compact:
             Section {
@@ -661,10 +572,8 @@ struct BudgetView: View {
                 .padding(.bottom, 8)
             }
 
-            // Summary card: the clean style reads as a 2x2 grid of currency
-            // amounts; the detailed style's captioned columns double as the
-            // column headers for the table below. It sits above the List (not
-            // inside it) so it stays pinned while the table scrolls (GH #155).
+            // Keep the summary above the List so it stays pinned while the
+            // table scrolls (GH #155).
             if !isCompact
                 || budgetStore.showCompactBudgetOverview {
                 Group {
@@ -675,18 +584,6 @@ struct BudgetView: View {
                             .padding(.vertical, 8)
                             .background(
                                 RoundedRectangle(cornerRadius: 24)
-                                    .fill(Color(.secondarySystemGroupedBackground))
-                            )
-                    case .detailed:
-                        TableBudgetSummary(budget: budget)
-                            // Fine-tune the fixed-width columns against the
-                            // amount pills in the rows below.
-                            .padding(.leading, 4)
-                            .padding(.trailing, 4)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 10)
-                            .background(
-                                Capsule()
                                     .fill(Color(.secondarySystemGroupedBackground))
                             )
                     case .compact:
@@ -1091,125 +988,9 @@ struct BudgetCheckInStrip: View {
     }
 }
 
-struct CategoryBudgetRow: View {
-    @EnvironmentObject var budgetStore: BudgetStore
-    let category: CategoryBudget
-    var isHidden = false
-    var isDimmed = false
-    var onSetHidden: ((Bool) -> Void)?
-    var addsGroupBottomPadding = false
-    var onShowDetails: (CategoryBudget) -> Void = { _ in }
-    var onEditBudget: (CategoryBudget) -> Void = { _ in }
-    /// Push the category's transactions: month narrows to one "yyyy-MM",
-    /// nil means all time (GH #56).
-    var onShowTransactions: (CategoryBudget, String?) -> Void = { _, _ in }
-    /// Open the move-money sheet for this category's balance (GH #128).
-    var onMoveMoney: (CategoryBudget) -> Void = { _ in }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            // One PWA-style table line: name, then the Budgeted/Spent/Balance
-            // pills in their fixed columns. Each element keeps its own tap
-            // action (our enhancement over the PWA's read-only cells).
-            HStack(spacing: BudgetColumn.spacing) {
-                Button {
-                    onShowDetails(category)
-                } label: {
-                    HStack(spacing: 5) {
-                        if budgetStore.showCategoryStatusDots {
-                            CompactCategoryStatusDot(state: category.progressState)
-                        }
-                        TwoLineName(
-                            text: category.categoryName,
-                            font: .subheadline,
-                            minimumScaleFactor: 0.85
-                        )
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Details for \(category.categoryName)")
-                Spacer(minLength: 4)
-                Button {
-                    onEditBudget(category)
-                } label: {
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(category.budgeted),
-                        dimmed: category.budgeted == 0
-                    )
-                }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("Edit budgeted amount for \(category.categoryName)")
-                Button {
-                    onShowTransactions(category, category.month)
-                } label: {
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(category.spent),
-                        dimmed: category.spent == 0
-                    )
-                }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("Transactions for \(category.categoryName) in \(MonthPicker.title(for: category.month))")
-                // A zero balance has nothing to move and nothing to cover, so
-                // it stays a plain cell.
-                Button {
-                    onMoveMoney(category)
-                } label: {
-                    BudgetAmountPill(
-                        text: budgetStore.displayBudgetCell(category.available),
-                        color: balanceTint
-                    )
-                }
-                .buttonStyle(.borderless)
-                .disabled(category.available == 0)
-                .accessibilityLabel(category.isOverspent
-                    ? "Cover overspending for \(category.categoryName)"
-                    : "Move money from \(category.categoryName)")
-                .rolloverIndicator(category.carryoverEnabled, color: balanceTint)
-            }
-            if budgetStore.showBudgetProgressBars, category.showsProgressBar {
-                CategoryProgressBar(
-                    fraction: category.progressFraction,
-                    state: category.progressState
-                )
-            }
-        }
-        .listRowInsets(EdgeInsets(
-            top: 4,
-            leading: 12,
-            bottom: addsGroupBottomPadding && budgetStore.showBudgetProgressBars
-                && category.showsProgressBar ? 10 : 4,
-            trailing: 16
-        ))
-        .opacity(isDimmed ? 0.5 : 1)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if let onSetHidden {
-                Button {
-                    onSetHidden(!isHidden)
-                } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
-                }
-                .tint(isHidden ? .accentColor : .secondary)
-            }
-        }
-        .modifier(CategoryRowContextMenu(
-            category: category,
-            isHidden: isHidden,
-            onSetHidden: onSetHidden,
-            onShowDetails: onShowDetails,
-            onEditBudget: onEditBudget,
-            onShowTransactions: onShowTransactions,
-            onMoveMoney: onMoveMoney
-        ))
-    }
-
-    private var balanceTint: Color {
-        balanceColor(category, goalsEnabled: budgetStore.goalTemplatesEnabled, zero: .secondary)
-    }
-}
-
 /// Clean-style category row, matching the App Store screenshots: name and a
 /// large Available amount up top, the progress bar beneath, then tappable
-/// Budgeted/Spent captions. Same tap actions as the detailed table's cells.
+/// Budgeted/Spent captions.
 struct CleanCategoryBudgetRow: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let category: CategoryBudget
@@ -1470,59 +1251,6 @@ struct CleanBudgetSummary: View {
     }
 }
 
-/// PWA-style summary bar: unallocated funds lead, and the three captioned
-/// columns double as the column headers for the table below.
-struct TableBudgetSummary: View {
-    @EnvironmentObject var budgetStore: BudgetStore
-    let budget: BudgetMonth
-
-    var body: some View {
-        HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-            // Envelope budgets lead with unallocated funds; tracking
-            // budgets have no to-budget concept, so lead with income
-            // received instead.
-            if let toBudget = budget.toBudget {
-                SummaryStat(
-                    label: "To Budget",
-                    value: budgetStore.displayBudgetCell(toBudget),
-                    valueColor: toBudget >= 0 ? .green : .red
-                )
-            } else {
-                SummaryStat(
-                    label: "Income",
-                    value: budgetStore.displayBudgetCell(budget.totalIncome)
-                )
-            }
-            Spacer(minLength: 4)
-            SummaryColumn(
-                label: "Budgeted",
-                value: budgetStore.displayBudgetCell(budget.totalBudgeted)
-            )
-            SummaryColumn(
-                label: "Spent",
-                value: budgetStore.displayBudgetCell(budget.totalSpent)
-            )
-            // Envelope budgets total the category balances; tracking budgets
-            // report savings instead — actual for a finished month, projected
-            // for the current/future month.
-            if budget.toBudget != nil {
-                SummaryColumn(
-                    label: "Balance",
-                    value: budgetStore.displayBudgetCell(budget.totalAvailable),
-                    valueColor: budget.totalAvailable >= 0 ? .green : .red
-                )
-            } else {
-                let value = trackingSavings(budget)
-                SummaryColumn(
-                    label: trackingSavingsLabel(budget),
-                    value: budgetStore.displayBudgetCell(value),
-                    valueColor: value >= 0 ? .green : .red
-                )
-            }
-        }
-    }
-}
-
 /// The leading figure in the summary bar (To Budget / Income).
 struct SummaryStat: View {
     let label: String
@@ -1545,154 +1273,36 @@ struct SummaryStat: View {
     }
 }
 
-/// One captioned column in the summary bar, sized to line up with the
-/// category pills below it.
-struct SummaryColumn: View {
-    let label: String
-    let value: String
-    var valueColor: Color = .primary
-
-    var body: some View {
-        VStack(alignment: .trailing, spacing: 2) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(.footnote.weight(.semibold))
-                .monospacedDigit()
-                .foregroundColor(valueColor)
-                .lineLimit(1)
-                .minimumScaleFactor(0.6)
-                .animatedAmount(value)
-        }
-        .frame(width: BudgetColumn.width, alignment: .trailing)
-    }
-}
-
-/// One amount cell in the budget table, in the PWA's pill style.
-struct BudgetAmountPill: View {
-    let text: String
-    var color: Color = .primary
-    var dimmed = false
-
-    var body: some View {
-        Text(text)
-            .font(.footnote)
-            .monospacedDigit()
-            .lineLimit(1)
-            .minimumScaleFactor(0.6)
-            .foregroundStyle(dimmed ? Color.secondary : color)
-            .animatedAmount(text)
-            .padding(.vertical, 3)
-            .frame(width: BudgetColumn.width, alignment: .trailing)
-            .contentShape(.rect)
-    }
-}
-
-/// A `BudgetAmountPill` with a small caption above it, naming the column
-/// ("Budgeted" / "Spent" / "Balance") the same way the pinned summary bar's
-/// columns are captioned. Used by the detailed group header's totals so a
-/// group row reads the same as the summary above it, rather than leaving the
-/// person to cross-reference bare numbers against the summary's labels.
-private struct CaptionedAmountPill: View {
-    let label: String
-    let text: String
-    var color: Color = .primary
-    var dimmed = false
-
-    var body: some View {
-        VStack(alignment: .trailing, spacing: 2) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-            BudgetAmountPill(text: text, color: color, dimmed: dimmed)
-        }
-        .frame(width: BudgetColumn.width, alignment: .trailing)
-    }
-}
-
-/// Group header row: collapse control and group name, plus the group's
-/// Budgeted, Spent and Balance totals in the table's three rightmost
-/// columns, each captioned the same way the pinned summary bar is.
-///
-/// The way to hide/show the group depends on the display style:
-/// - **Clean style** uses a three‑dot ellipsis menu (because section headers
-///   don't support swipe actions reliably).
-/// - **Detailed style** uses a swipe‑to‑hide gesture, matching category rows.
+/// Clean section header with collapse and visibility controls.
 struct BudgetGroupHeader: View {
     @EnvironmentObject var budgetStore: BudgetStore
     let name: String
     let isCollapsed: Bool
     var isHidden = false
     var onSetHidden: ((Bool) -> Void)?
-    /// The detailed style totals its columns here; the clean style's header
-    /// is a plain section title above the card, so it leaves this nil.
-    var totals: CategoryGroupTotals?
-    /// Income groups use the same header shell but have one meaningful total:
-    /// money received. It occupies the trailing column where expense groups
-    /// show their balance.
+    /// Income groups show the money received beside their name.
     var receivedTotal: Int? = nil
     let onToggleCollapse: () -> Void
-    /// Detailed tables omit currency symbols from their numeric columns;
-    /// clean headers retain the app-wide currency presentation.
-    var usesTableNumberFormat = false
-    /// The detailed style reserves two lines so group rows stay equal-height
-    /// whether names wrap or not (GH #252); the clean style's plain section
-    /// titles keep their natural height.
-    var reservesTwoLines = false
     var body: some View {
         HStack(spacing: 8) {
             Button(action: onToggleCollapse) {
-                HStack(alignment: .top, spacing: BudgetColumn.spacing) {
-                    // Nested so the chevron centers against the name (which can
-                    // run one or two lines) rather than pinning to the top of
-                    // the row alongside the totals' captions.
-                    HStack(spacing: BudgetColumn.spacing) {
+                HStack(alignment: .top, spacing: 4) {
+                    // Keep the chevron centered against a name that can wrap.
+                    HStack(spacing: 4) {
                         DisclosureChevron(
                             isExpanded: !isCollapsed,
                             font: .caption2.weight(.semibold)
                         )
                         .foregroundStyle(.secondary)
-                        if reservesTwoLines {
-                            TwoLineName(
-                                text: name,
-                                font: .subheadline.weight(.semibold),
-                                minimumScaleFactor: 0.85
-                            )
+                        Text(name)
+                            .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.primary)
-                        } else {
-                            Text(name)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.85)
-                        }
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.85)
                     }
                     Spacer(minLength: 4)
-                    if let totals {
-                        CaptionedAmountPill(
-                            label: "Budgeted",
-                            text: budgetStore.displayBudgetCell(totals.budgeted),
-                            dimmed: totals.budgeted == 0
-                        )
-                        CaptionedAmountPill(
-                            label: "Spent",
-                            text: budgetStore.displayBudgetCell(totals.spent),
-                            dimmed: totals.spent == 0
-                        )
-                        CaptionedAmountPill(
-                            label: "Balance",
-                            text: budgetStore.displayBudgetCell(totals.balance),
-                            // Same three-way treatment as the category rows, so a
-                            // group that lands on zero doesn't read as healthy.
-                            color: totals.balance < 0
-                                ? .red
-                                : (totals.balance == 0 ? .secondary : .green)
-                        )
-                    } else if let receivedTotal {
-                        Text("Received \(receivedText(receivedTotal))")
+                    if let receivedTotal {
+                        Text("Received \(budgetStore.displayBalance(receivedTotal))")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -1706,7 +1316,7 @@ struct BudgetGroupHeader: View {
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("Toggles the group's categories")
 
-            if budgetStore.budgetDisplayStyle == .clean, let onSetHidden {
+            if let onSetHidden {
                 Menu {
                     Button {
                         onSetHidden(!isHidden)
@@ -1724,50 +1334,14 @@ struct BudgetGroupHeader: View {
             }
         }
         .opacity(isHidden ? 0.5 : 1)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if budgetStore.budgetDisplayStyle == .detailed, let onSetHidden {
-                Button {
-                    onSetHidden(!isHidden)
-                } label: {
-                    Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
-                }
-                .tint(isHidden ? .accentColor : .secondary)
-            }
-        }
     }
 
-    /// The pills are decoration to VoiceOver once the button carries its own
-    /// label, so the totals have to be spoken here or they're lost. Currency
-    /// formatting, not the table's symbol-less cells, reads better aloud.
     private var accessibilityLabel: String {
         let state = isCollapsed ? "collapsed" : "expanded"
         if let receivedTotal {
             return "\(name), \(state), received \(budgetStore.displayBalance(receivedTotal))"
         }
-        guard let totals else { return "\(name), \(state)" }
-        return Self.totalsAccessibilityLabel(
-            name: name,
-            isCollapsed: isCollapsed,
-            budgeted: budgetStore.displayBalance(totals.budgeted),
-            spent: budgetStore.displayBalance(totals.spent),
-            balance: budgetStore.displayBalance(totals.balance)
-        )
-    }
-
-    nonisolated static func totalsAccessibilityLabel(
-        name: String,
-        isCollapsed: Bool,
-        budgeted: String,
-        spent: String,
-        balance: String
-    ) -> String {
-        "\(name), \(isCollapsed ? "collapsed" : "expanded"), budgeted \(budgeted), spent \(spent), balance \(balance)"
-    }
-
-    private func receivedText(_ amount: Int) -> String {
-        usesTableNumberFormat
-            ? budgetStore.displayBudgetCell(amount)
-            : budgetStore.displayBalance(amount)
+        return "\(name), \(state)"
     }
 }
 
@@ -1780,18 +1354,17 @@ struct IncomeCategoryRow: View {
     var isDimmed = false
     var onSetHidden: ((Bool) -> Void)?
     var showsBudgeted = false
-    var isDetailed = false
     var onShowTransactions: (IncomeCategory, String?) -> Void = { _, _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: isDetailed ? BudgetColumn.spacing : 8) {
+            HStack(spacing: 8) {
                 Button {
                     onShowTransactions(income, nil)
                 } label: {
                     TwoLineName(
                         text: income.categoryName,
-                        font: isDetailed ? .subheadline : .body,
+                        font: .body,
                         minimumScaleFactor: 0.85
                     )
                 }
@@ -1801,15 +1374,8 @@ struct IncomeCategoryRow: View {
                 Spacer()
 
                 Button { onShowTransactions(income, income.month) } label: {
-                    if isDetailed {
-                        BudgetAmountPill(
-                            text: budgetStore.displayBudgetCell(income.received),
-                            color: income.received > 0 ? .green : .secondary
-                        )
-                    } else {
-                        Text(budgetStore.displayBalance(income.received))
-                            .foregroundColor(income.received > 0 ? .green : .secondary)
-                    }
+                    Text(budgetStore.displayBalance(income.received))
+                        .foregroundColor(income.received > 0 ? .green : .secondary)
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Transactions for \(income.categoryName) in \(MonthPicker.title(for: income.month))")
@@ -1822,7 +1388,7 @@ struct IncomeCategoryRow: View {
         }
         .listRowInsets(EdgeInsets(
             top: 4,
-            leading: isDetailed ? 12 : 16,
+            leading: 16,
             bottom: 4,
             trailing: 16
         ))

--- a/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
+++ b/Actuali/Actuali/Views/Budget/CompactBudgetRenderer.swift
@@ -780,7 +780,7 @@ extension View {
         switch style {
         case .compact:
             listStyle(.plain)
-        case .clean, .detailed:
+        case .clean:
             self
         }
     }

--- a/Actuali/Actuali/Views/Settings/BudgetViewSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/BudgetViewSettingsView.swift
@@ -12,7 +12,6 @@ struct BudgetViewSettingsView: View {
             Section {
                 Picker("View Style", selection: $budgetStore.budgetDisplayStyle) {
                     Text("Clean").tag(BudgetDisplayStyle.clean)
-                    Text("Detailed").tag(BudgetDisplayStyle.detailed)
                     Text("Compact").tag(BudgetDisplayStyle.compact)
                 }
 
@@ -28,7 +27,7 @@ struct BudgetViewSettingsView: View {
                 Text("Presentation")
             } footer: {
                 if budgetStore.budgetDisplayStyle == .clean {
-                    Text("Group Totals are available in Detailed and Compact views.")
+                    Text("Group Totals are available in Compact view.")
                 }
             }
 

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDisplayStyleTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDisplayStyleTests.swift
@@ -37,7 +37,7 @@ struct BudgetStoreDisplayStyleTests {
     }
 
     @Test func onlyCleanAndCompactAreSupported() {
-        #expect(BudgetDisplayStyle.allCases.map(\.rawValue) == ["clean", "compact"])
+        #expect(Set(BudgetDisplayStyle.allCases.map(\.rawValue)) == ["clean", "compact"])
     }
 
     @Test func detailedPreferenceMigratesToCompact() {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDisplayStyleTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreDisplayStyleTests.swift
@@ -36,11 +36,24 @@ struct BudgetStoreDisplayStyleTests {
         }
     }
 
+    @Test func onlyCleanAndCompactAreSupported() {
+        #expect(BudgetDisplayStyle.allCases.map(\.rawValue) == ["clean", "compact"])
+    }
+
+    @Test func detailedPreferenceMigratesToCompact() {
+        #expect(BudgetDisplayStyle.resolved(from: "detailed") == .compact)
+    }
+
+    @Test func supportedAndMissingPreferencesResolve() {
+        #expect(BudgetDisplayStyle.resolved(from: "clean") == .clean)
+        #expect(BudgetDisplayStyle.resolved(from: "compact") == .compact)
+        #expect(BudgetDisplayStyle.resolved(from: nil) == .clean)
+        #expect(BudgetDisplayStyle.resolved(from: "unknown") == .clean)
+    }
+
     @Test func selectionPersistsToUserDefaults() {
         withSavedDefaults(for: [styleKey]) {
             let store = BudgetStore.previewInstance()
-            store.budgetDisplayStyle = .detailed
-            #expect(UserDefaults.standard.string(forKey: styleKey) == "detailed")
             store.budgetDisplayStyle = .compact
             #expect(UserDefaults.standard.string(forKey: styleKey) == "compact")
             store.budgetDisplayStyle = .clean

--- a/Actuali/ActualiTests/Views/BudgetViewTests.swift
+++ b/Actuali/ActualiTests/Views/BudgetViewTests.swift
@@ -21,15 +21,4 @@ struct BudgetViewTests {
         #expect(ids == ["essentials", "lifestyle"])
     }
 
-    @Test func groupHeaderLabelIncludesBudgetedTotal() {
-        let label = BudgetGroupHeader.totalsAccessibilityLabel(
-            name: "Everyday",
-            isCollapsed: false,
-            budgeted: "$100.00",
-            spent: "-$40.00",
-            balance: "$60.00"
-        )
-
-        #expect(label == "Everyday, expanded, budgeted $100.00, spent -$40.00, balance $60.00")
-    }
 }

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -84,7 +84,11 @@ final class BudgetDisplayStyleUITests: XCTestCase {
     func testLegacyDetailedStyleOpensCompact() throws {
         let app = XCUIApplication()
         // NSArgumentDomain: seeds the persisted preference for this launch.
-        app.launchArguments = ["-loadDemoData", "-budgetDisplayStyle", "detailed", "-showCompactBudgetOverview", "YES"]
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "detailed",
+            "-showCompactBudgetOverview", "YES",
+            "-collapsedBudgetGroups", "",
+        ]
         app.launch()
 
         app.tabBars.buttons["Budget"].tap()

--- a/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
+++ b/Actuali/ActualiUITests/BudgetDisplayStyleUITests.swift
@@ -74,30 +74,28 @@ final class BudgetDisplayStyleUITests: XCTestCase {
         )
 
         optionsMenu.tap()
-        app.buttons["Detailed"].tap()
-        XCTAssertFalse(budgetedCaption(in: app).waitForExistence(timeout: 5),
-                       "detailed rows replace the captions")
-
-        optionsMenu.tap()
+        XCTAssertFalse(app.buttons["Detailed"].exists)
         app.buttons["Clean"].tap()
         XCTAssertTrue(budgetedCaption(in: app).waitForExistence(timeout: 5),
                       "toggling back restores the clean rows")
     }
 
     @MainActor
-    func testDetailedStyleShowsPillTableWithoutCaptions() throws {
+    func testLegacyDetailedStyleOpensCompact() throws {
         let app = XCUIApplication()
         // NSArgumentDomain: seeds the persisted preference for this launch.
-        app.launchArguments = ["-loadDemoData", "-budgetDisplayStyle", "detailed"]
+        app.launchArguments = ["-loadDemoData", "-budgetDisplayStyle", "detailed", "-showCompactBudgetOverview", "YES"]
         app.launch()
 
         app.tabBars.buttons["Budget"].tap()
 
-        let groceries = app.buttons["Details for Groceries"].firstMatch
+        let groceries = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH 'Details for Groceries'")
+        ).firstMatch
         XCTAssertTrue(groceries.waitForExistence(timeout: 10),
                       "demo data should show the Essentials categories")
-        XCTAssertFalse(budgetedCaption(in: app).exists,
-                       "detailed rows show pill cells, not 'Budgeted:' captions")
+        XCTAssertTrue(app.descendants(matching: .any)["compactBudgetOverview"]
+            .waitForExistence(timeout: 5), "the removed Detailed preference opens Compact")
     }
 
     @MainActor

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -76,11 +76,6 @@ final class BudgetGroupCollapseUITests: XCTestCase {
     }
 
     @MainActor
-    func testDetailedGroupSwipeHidesAndShowsExpenseGroup() throws {
-        try assertGroupHidesAndShowsExpenseGroup(displayStyle: "detailed")
-    }
-
-    @MainActor
     func testCompactGroupContextMenuHidesAndShowsExpenseGroup() throws {
         try assertGroupHidesAndShowsExpenseGroup(displayStyle: "compact")
     }
@@ -173,7 +168,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
             XCTAssertTrue(expanded.waitForExistence(timeout: 5))
         }
 
-        setGroupHidden(true, displayStyle: displayStyle, app: app, group: essentials)
+        setGroupHidden(true, app: app, group: essentials)
         XCTAssertTrue(essentials.waitForNonExistence(timeout: 5))
 
         let optionsMenu = app.buttons["Budget options"]
@@ -188,7 +183,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         showHidden.tap()
         XCTAssertTrue(essentials.waitForExistence(timeout: 5))
 
-        setGroupHidden(false, displayStyle: displayStyle, app: app, group: essentials)
+        setGroupHidden(false, app: app, group: essentials)
 
         optionsMenu.tap()
         XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
@@ -200,17 +195,12 @@ final class BudgetGroupCollapseUITests: XCTestCase {
     @MainActor
     private func setGroupHidden(
         _ hidden: Bool,
-        displayStyle: String,
         app: XCUIApplication,
         group: XCUIElement
     ) {
         let wasCollapsed = group.label.contains("collapsed")
 
-        if displayStyle == "compact" {
-            group.press(forDuration: 1)
-        } else {
-            group.swipeLeft()
-        }
+        group.press(forDuration: 1)
         XCTAssertEqual(
             group.label.contains("collapsed"),
             wasCollapsed,
@@ -222,10 +212,10 @@ final class BudgetGroupCollapseUITests: XCTestCase {
     }
 
     @MainActor
-    func testDetailedIncomeGroupHasNoHideAction() throws {
+    func testCompactIncomeGroupHasNoHideAction() throws {
         let app = XCUIApplication()
         app.launchArguments = [
-            "-loadDemoData", "-budgetDisplayStyle", "detailed", "-initialTab", "1",
+            "-loadDemoData", "-budgetDisplayStyle", "compact", "-initialTab", "1",
         ]
         app.launch()
 
@@ -237,7 +227,7 @@ final class BudgetGroupCollapseUITests: XCTestCase {
         }
         XCTAssertTrue(income.waitForExistence(timeout: 5))
 
-        income.swipeLeft()
+        income.press(forDuration: 1)
         XCTAssertFalse(app.buttons["Hide"].waitForExistence(timeout: 2),
                        "the Income group must not offer a hide action")
     }
@@ -245,11 +235,6 @@ final class BudgetGroupCollapseUITests: XCTestCase {
     @MainActor
     func testIncomeGroupMatchesCollapseBehaviorInCleanStyle() throws {
         try assertIncomeGroupCollapses(displayStyle: "clean")
-    }
-
-    @MainActor
-    func testIncomeGroupMatchesCollapseBehaviorInDetailedStyle() throws {
-        try assertIncomeGroupCollapses(displayStyle: "detailed")
     }
 
     @MainActor

--- a/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
+++ b/Actuali/ActualiUITests/BudgetGroupCollapseUITests.swift
@@ -77,7 +77,56 @@ final class BudgetGroupCollapseUITests: XCTestCase {
 
     @MainActor
     func testCompactGroupContextMenuHidesAndShowsExpenseGroup() throws {
-        try assertGroupHidesAndShowsExpenseGroup(displayStyle: "compact")
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-loadDemoData", "-budgetDisplayStyle", "compact",
+            "-showHiddenCategories", "NO", "-initialTab", "1",
+        ]
+        app.launch()
+
+        let essentials = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Essentials, ")
+        ).firstMatch
+        XCTAssertTrue(essentials.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["Options for Essentials"].exists)
+
+        let expanded = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Essentials, expanded")
+        ).firstMatch
+        let collapsed = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Essentials, collapsed")
+        ).firstMatch
+        if collapsed.exists {
+            collapsed.tap()
+        }
+        XCTAssertTrue(expanded.waitForExistence(timeout: 5))
+        expanded.tap()
+        XCTAssertTrue(collapsed.waitForExistence(timeout: 5))
+        collapsed.tap()
+        XCTAssertTrue(expanded.waitForExistence(timeout: 5))
+
+        setGroupHidden(true, app: app, group: essentials)
+        XCTAssertTrue(essentials.waitForNonExistence(timeout: 5))
+
+        let optionsMenu = app.buttons["Budget options"]
+        optionsMenu.tap()
+        let showHidden = app.buttons.matching(
+            NSPredicate(
+                format: "label IN %@",
+                ["Show Hidden Categories", "Hidden Categories"]
+            )
+        ).firstMatch
+        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
+        showHidden.tap()
+        XCTAssertTrue(essentials.waitForExistence(timeout: 5))
+
+        setGroupHidden(false, app: app, group: essentials)
+
+        optionsMenu.tap()
+        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
+        showHidden.tap()
+        XCTAssertTrue(essentials.waitForExistence(timeout: 5),
+                      "the group should remain visible after hidden categories are turned off")
     }
 
     @MainActor
@@ -134,62 +183,6 @@ final class BudgetGroupCollapseUITests: XCTestCase {
             headerTravel + 30,
             "the category row should continue under the pinned compact group header"
         )
-    }
-
-    @MainActor
-    private func assertGroupHidesAndShowsExpenseGroup(displayStyle: String) throws {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "-loadDemoData", "-budgetDisplayStyle", displayStyle,
-            "-showHiddenCategories", "NO", "-initialTab", "1",
-        ]
-        app.launch()
-
-        let essentials = app.buttons.matching(
-            NSPredicate(format: "label BEGINSWITH %@", "Essentials, ")
-        ).firstMatch
-        XCTAssertTrue(essentials.waitForExistence(timeout: 10))
-        if displayStyle == "compact" {
-            XCTAssertFalse(app.buttons["Options for Essentials"].exists)
-
-            let expanded = app.buttons.matching(
-                NSPredicate(format: "label BEGINSWITH %@", "Essentials, expanded")
-            ).firstMatch
-            let collapsed = app.buttons.matching(
-                NSPredicate(format: "label BEGINSWITH %@", "Essentials, collapsed")
-            ).firstMatch
-            if collapsed.exists {
-                collapsed.tap()
-            }
-            XCTAssertTrue(expanded.waitForExistence(timeout: 5))
-            expanded.tap()
-            XCTAssertTrue(collapsed.waitForExistence(timeout: 5))
-            collapsed.tap()
-            XCTAssertTrue(expanded.waitForExistence(timeout: 5))
-        }
-
-        setGroupHidden(true, app: app, group: essentials)
-        XCTAssertTrue(essentials.waitForNonExistence(timeout: 5))
-
-        let optionsMenu = app.buttons["Budget options"]
-        optionsMenu.tap()
-        let showHidden = app.buttons.matching(
-            NSPredicate(
-                format: "label IN %@",
-                ["Show Hidden Categories", "Hidden Categories"]
-            )
-        ).firstMatch
-        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
-        showHidden.tap()
-        XCTAssertTrue(essentials.waitForExistence(timeout: 5))
-
-        setGroupHidden(false, app: app, group: essentials)
-
-        optionsMenu.tap()
-        XCTAssertTrue(showHidden.waitForExistence(timeout: 5))
-        showHidden.tap()
-        XCTAssertTrue(essentials.waitForExistence(timeout: 5),
-                      "the group should remain visible after hidden categories are turned off")
     }
 
     @MainActor

--- a/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
+++ b/Actuali/ActualiUITests/BudgetOptionsMenuUITests.swift
@@ -32,18 +32,19 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         XCTAssertTrue(optionsMenu.waitForExistence(timeout: 10))
         optionsMenu.tap()
 
-        for option in ["Clean", "Detailed", "Compact", "Expand All Groups",
+        for option in ["Clean", "Compact", "Expand All Groups",
                        "Collapse All Groups", "Status Filters",
                        "Hide Spent Categories", "Show Hidden Categories"] {
             XCTAssertTrue(app.buttons[option].waitForExistence(timeout: 5),
                           "the options menu should offer '\(option)'")
         }
+        XCTAssertFalse(app.buttons["Detailed"].exists)
         for compactOption in ["Show Overview", "Show Spent Column"] {
             XCTAssertFalse(app.buttons[compactOption].exists,
                            "Clean should not offer the Compact-only '\(compactOption)' control")
         }
         XCTAssertFalse(app.buttons["Group Totals"].exists,
-                       "Group Totals remains exclusive to Detailed")
+                       "Group Totals remains exclusive to Compact")
     }
 
     @MainActor
@@ -67,10 +68,10 @@ final class BudgetOptionsMenuUITests: XCTestCase {
         XCTAssertFalse(app.buttons["Progress Indicators"].exists,
                        "Compact uses the shared Budget Progress Bars setting")
 
-        app.buttons["Detailed"].tap()
+        app.buttons["Clean"].tap()
         optionsMenu.tap()
-        XCTAssertTrue(app.buttons["Group Totals"].waitForExistence(timeout: 5),
-                      "Detailed keeps its existing Group Totals control")
+        XCTAssertTrue(app.buttons["Compact"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Group Totals"].exists)
         XCTAssertFalse(app.buttons["Show Overview"].exists)
         XCTAssertFalse(app.buttons["Show Spent Column"].exists)
         XCTAssertFalse(app.buttons["Progress Indicators"].exists)

--- a/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
+++ b/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
@@ -36,10 +36,10 @@ final class BudgetViewSettingsUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(picker.waitForExistence(timeout: 5), "View Style picker not found")
         picker.tap()
-        XCTAssertFalse(app.buttons["Detailed"].exists)
 
         let option = app.buttons[style]
         XCTAssertTrue(option.waitForExistence(timeout: 5), "\(style) option not found")
+        XCTAssertFalse(app.buttons["Detailed"].exists)
         option.tap()
         XCTAssertTrue(app.navigationBars["Budget View"].waitForExistence(timeout: 5))
     }

--- a/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
+++ b/Actuali/ActualiUITests/BudgetViewSettingsUITests.swift
@@ -36,6 +36,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(picker.waitForExistence(timeout: 5), "View Style picker not found")
         picker.tap()
+        XCTAssertFalse(app.buttons["Detailed"].exists)
 
         let option = app.buttons[style]
         XCTAssertTrue(option.waitForExistence(timeout: 5), "\(style) option not found")
@@ -65,8 +66,8 @@ final class BudgetViewSettingsUITests: XCTestCase {
         XCTAssertTrue(groupTotals.waitForExistence(timeout: 5), "Group Totals toggle not found")
         XCTAssertFalse(groupTotals.isEnabled, "Clean view should disable Group Totals")
 
-        selectViewStyle("Detailed", in: app)
-        XCTAssertTrue(groupTotals.isEnabled, "Detailed view should enable Group Totals")
+        selectViewStyle("Compact", in: app)
+        XCTAssertTrue(groupTotals.isEnabled, "Compact view should enable Group Totals")
 
         app.tabBars.buttons["Budget"].tap()
         let headerWithTotals = app.buttons.matching(
@@ -74,7 +75,7 @@ final class BudgetViewSettingsUITests: XCTestCase {
         ).firstMatch
         XCTAssertTrue(
             headerWithTotals.waitForExistence(timeout: 10),
-            "Detailed view should show totals in the group header"
+            "Compact view should show totals in the group header"
         )
 
         openBudgetViewSettings(in: app)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is an unofficial community project. It is not affiliated with or endorsed b
 
 - Category-by-category budgeted vs. spent with progress bars, month-to-month carryover, and in-app editing of budgeted amounts
 - Move money between categories and cover overspending
-- Two layouts — a clean card look or a detailed PWA-style table — plus group header totals, a pinned summary bar, expand/collapse all, and an option to hide categories with nothing left to spend
+- Two layouts — a clean card look or a compact monthly table — plus group header totals, a pinned summary bar, expand/collapse all, and an option to hide categories with nothing left to spend
 - Overspent categories surface as a tab badge that opens the affected list; an uncategorized-transactions view catches the rest
 - Envelope (`zero_budgets`) and tracking (`reflect_budgets`) budgets are both supported
 


### PR DESCRIPTION
Remove Detailed from the Budget options menu and Settings, leaving Clean and Compact. Existing `detailed` preferences resolve to Compact; new users still default to Clean.

Delete the Detailed renderer, pill columns, and its unused header options. Update layout and settings tests, replace the Detailed launch test with a Compact migration check, and remove tests for the retired Detailed-only rendering and group controls. No new layout features or changes to Compact's options.

Verified locally:
- Added regression tests and observed both fail before implementing the removal and legacy preference mapping.
- Full unit suite on iOS 26.5: `1794 tests in 211 suites passed`.
- Full unit suite on iOS 18.5: `1794 tests in 211 suites passed`.
- Feature UI checks (legacy preference, live switching, Settings layout/group totals): `Executed 3 tests, with 0 failures`.
- Budget group and options-menu suites: 7 and 4 tests passed respectively.
- Swift compiler/type checking, syntax parsing of all 13 changed Swift files, `git diff --check`, and the `sadscan` commit hook passed. The repo has no dedicated lint command.

The broader 26-test UI run was not fully green. After correcting the migration test's category-label selector, its focused rerun passed. The status-dot settings test also passed on rerun without changes. Two other failures were reproduced on untouched baseline commit `418606d`: the Compact tracking-income currency-label assertion (baseline iOS 18), and the progress-bar settings toggle test (iOS 26). Those existing issues are outside this feature's scope.

Fixes #442
