### PR TITLE
Hide categories when editing off-budget transactions

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -4179,10 +4179,9 @@ final class BudgetStore: ObservableObject {
       @discardableResult
     func saveTransaction(_ form: TransactionForm, editing original: Transaction? = nil) async throws -> String? {
         var form = form
-        // The add form hides categories for off-budget accounts; normalize
+        // The form hides categories for off-budget accounts; normalize
         // here too so stale picker or split state cannot bypass that rule.
-        if original == nil, form.type != .transfer,
-           offBudgetAccountIds.contains(form.accountId) {
+        if form.type != .transfer, offBudgetAccountIds.contains(form.accountId) {
             form.categoryId = nil
             form.splits = []
         }

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -4184,6 +4184,7 @@ final class BudgetStore: ObservableObject {
         if form.type != .transfer, offBudgetAccountIds.contains(form.accountId) {
             form.categoryId = nil
             form.splits = []
+            form.collapseSplit = original?.isParent == true
         }
         let date = Transaction.yyyymmdd(from: form.date)
         let notes = form.notes.isEmpty ? nil : form.notes

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -174,7 +174,7 @@ struct AddTransactionView: View {
     }
 
     private var showsStandardCategoryFields: Bool {
-        isEditing || budgetStore.accounts.first { $0.id == selectedAccountId }?.offBudget != true
+        budgetStore.accounts.first { $0.id == selectedAccountId }?.offBudget != true
     }
 
     /// Converting keeps the edited row on its own side of the transfer, so

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSaveTransactionTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSaveTransactionTests.swift
@@ -270,7 +270,7 @@ struct BudgetStoreSaveTransactionTests {
         #expect(row["isParent"] == 0)
     }
 
-    @Test func editingAnOffBudgetTransactionDropsItsCategory() async throws {
+    @Test func editingAnOffBudgetTransactionDropsCategoriesAndSplits() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }
         let store = try await makeStore(database: database)
@@ -283,11 +283,18 @@ struct BudgetStoreSaveTransactionTests {
         try database.insertTransaction(original)
         var edit = form()
         edit.categoryId = "cat-food"
+        edit.splits = [
+            .init(categoryId: "cat-food", amount: "5.25"),
+            .init(categoryId: "cat-fun", amount: "5.25")
+        ]
 
         try await store.saveTransaction(edit, editing: original)
 
-        let row = try #require(try transactionRows(path: path).first)
+        let rows = try transactionRows(path: path)
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
         #expect(row["category"] == nil)
+        #expect(row["isParent"] == 0)
     }
 
     @Test func editingATransactionPreservesImportedPayeeAndCarriedFields() async throws {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSaveTransactionTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSaveTransactionTests.swift
@@ -270,6 +270,26 @@ struct BudgetStoreSaveTransactionTests {
         #expect(row["isParent"] == 0)
     }
 
+    @Test func editingAnOffBudgetTransactionDropsItsCategory() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        store.accounts = [
+            Account(id: "acct-1", name: "Brokerage", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 0, balance: 0)
+        ]
+        var original = transaction(payeeId: nil, payeeName: nil)
+        original.categoryId = "cat-food"
+        try database.insertTransaction(original)
+        var edit = form()
+        edit.categoryId = "cat-food"
+
+        try await store.saveTransaction(edit, editing: original)
+
+        let row = try #require(try transactionRows(path: path).first)
+        #expect(row["category"] == nil)
+    }
+
     @Test func editingATransactionPreservesImportedPayeeAndCarriedFields() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
@@ -420,6 +420,41 @@ struct BudgetStoreSplitSaveTests {
         #expect(messageRows == 3)
     }
 
+    @Test func editingAnOffBudgetSplitParentCollapsesIt() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+        store.accounts = [
+            Account(id: "acct-1", name: "Brokerage", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 0, balance: 0)
+        ]
+        try await database.dbQueueForTesting.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO transactions (id, acct, category, amount, date, isParent, isChild, parent_id, sort_order) VALUES
+                    ('parent', 'acct-1', NULL,       -1000, 20260601, 1, 0, NULL,     10),
+                    ('c-1',    'acct-1', 'cat-food',  -600, 20260601, 0, 1, 'parent',  9),
+                    ('c-2',    'acct-1', 'cat-fun',   -400, 20260601, 0, 1, 'parent',  8);
+            """)
+        }
+        let original = Transaction(
+            id: "parent", accountId: "acct-1", date: 20260601, amount: -1000,
+            payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: nil,
+            isParent: true, parentId: nil, tombstone: false, sortOrder: 10,
+            importedPayee: nil
+        )
+
+        try await store.saveTransaction(form(amount: "10.00"), editing: original)
+
+        let byId = Dictionary(uniqueKeysWithValues:
+            try rows(path: path).map { ($0["id"] as String, $0) })
+        let parent = try #require(byId["parent"])
+        #expect(parent["isParent"] == 0)
+        #expect(parent["category"] == nil)
+        #expect(byId["c-1"]?["tombstone"] == 1)
+        #expect(byId["c-2"]?["tombstone"] == 1)
+    }
+
     @Test func editingASplitParentProtectsAmountAndCategoryAndCascadesSharedFields() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }


### PR DESCRIPTION
Off-budget transaction edits now hide the category and split controls, matching the add flow and Actual Budget. The save path also strips stale category and split form state for edits, so UI state cannot persist an invalid category.

Verified with:
- `xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination "platform=iOS Simulator,id=3734574A-55AB-48C8-B395-892C1D46518F" -only-testing:ActualiTests/BudgetStoreSaveTransactionTests`
- `xcodebuild test -project Actuali/Actuali.xcodeproj -scheme Actuali -destination "platform=iOS Simulator,id=3734574A-55AB-48C8-B395-892C1D46518F" -skip-testing:ActualiUITests` (1,795 tests)
- `git diff --check`

Fixes #447