### PR TITLE
Use the active locale at runtime

### DIFF
--- a/Actuali/Actuali/AppIntents/AppIntentError.swift
+++ b/Actuali/Actuali/AppIntents/AppIntentError.swift
@@ -10,6 +10,9 @@ enum LogTransactionError: Error, LocalizedError, CustomLocalizedStringResourceCo
     case accountUnavailable
     case invalidAmount(received: String)
     case noAmountReceived
+    case transactionAlreadyExists
+    case transactionSuppressedByRule
+    case transactionNeedsRecovery
     case writeFailed(underlying: String)
 
     var errorDescription: String? {
@@ -26,6 +29,19 @@ enum LogTransactionError: Error, LocalizedError, CustomLocalizedStringResourceCo
         bundle: Bundle
     ) -> String {
         String(localized: resource(for: error, locale: locale, bundle: bundle))
+    }
+
+    static func wrapping(_ error: any Error) -> Self {
+        if let error = error as? Self { return error }
+        guard let loggerError = error as? TransactionLogger.LoggerError else {
+            return .writeFailed(underlying: error.localizedDescription)
+        }
+        switch loggerError {
+        case .noBudgetLoaded: return .noBudgetLoaded
+        case .transactionAlreadyExists: return .transactionAlreadyExists
+        case .transactionSuppressedByRule: return .transactionSuppressedByRule
+        case .transactionNeedsRecovery: return .transactionNeedsRecovery
+        }
     }
 
     private static func resource(
@@ -45,6 +61,15 @@ enum LogTransactionError: Error, LocalizedError, CustomLocalizedStringResourceCo
             return LocalizedStringResource("intent.error.invalidAmount \(shown)", locale: locale, bundle: bundle)
         case .noAmountReceived:
             return LocalizedStringResource("intent.error.noAmountReceived", locale: locale, bundle: bundle)
+        case .transactionAlreadyExists:
+            return LocalizedStringResource(
+                "This transaction was already saved.", locale: locale, bundle: bundle)
+        case .transactionSuppressedByRule:
+            return LocalizedStringResource(
+                "A transaction rule suppressed this transaction.", locale: locale, bundle: bundle)
+        case .transactionNeedsRecovery:
+            return LocalizedStringResource(
+                "This import needs review before it can be approved.", locale: locale, bundle: bundle)
         case .writeFailed(let underlying):
             return LocalizedStringResource("intent.error.writeFailed \(String(describing: underlying))", locale: locale, bundle: bundle)
         }

--- a/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
+++ b/Actuali/Actuali/AppIntents/LogTransactionIntent.swift
@@ -171,8 +171,7 @@ struct LogTransactionIntent: AppIntent {
             )
             return Self.result(dialogText: dialogText, showConfirmation: showConfirmation)
         } catch {
-            let mapped: LogTransactionError = (error as? LogTransactionError)
-                ?? .writeFailed(underlying: error.localizedDescription)
+            let mapped = LogTransactionError.wrapping(error)
             await reportFailure(mapped)
             throw mapped
         }
@@ -184,7 +183,8 @@ struct LogTransactionIntent: AppIntent {
         await store.ensureBudgetReady()
         let amountCents = AmountParser.parse(amount).flatMap { Transaction.cents(fromDollars: $0) }
         await TransactionLogNotifier.notifyFailure(
-            message: error.errorDescription ?? "Unknown error",
+            message: LogTransactionError.localizedString(
+                for: error, locale: .autoupdatingCurrent, bundle: .main),
             payee: payee,
             amountCents: amountCents ?? 0,
             currencyCode: store.currencyCode,

--- a/Actuali/Actuali/Models/AppearanceMode.swift
+++ b/Actuali/Actuali/Models/AppearanceMode.swift
@@ -16,10 +16,14 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     }
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .system: return String(localized: "System")
-        case .light: return String(localized: "Light")
-        case .dark: return String(localized: "Dark")
+        case .system: return ReportStrings.text("System", locale: locale, bundle: bundle)
+        case .light: return ReportStrings.text("Light", locale: locale, bundle: bundle)
+        case .dark: return ReportStrings.text("Dark", locale: locale, bundle: bundle)
         }
     }
 }

--- a/Actuali/Actuali/Models/AppearanceMode.swift
+++ b/Actuali/Actuali/Models/AppearanceMode.swift
@@ -15,10 +15,6 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
         }
     }
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .system: return ReportStrings.text("System", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/PendingImport.swift
+++ b/Actuali/Actuali/Models/PendingImport.swift
@@ -49,14 +49,33 @@ enum PendingImportReviewRequirement: Hashable {
     case confirmActiveBudgetCurrency(source: String?, budget: String)
 
     var prompt: String {
+        prompt(locale: .autoupdatingCurrent)
+    }
+
+    func prompt(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .adoptIntoActiveBudget:
-            return String(localized: "I confirm that this import should be adopted into the active budget.")
+            return ReportStrings.text(
+                "I confirm that this import should be adopted into the active budget.",
+                locale: locale,
+                bundle: bundle
+            )
         case let .confirmActiveBudgetCurrency(source, budget):
             if let source {
-                return String(localized: "I confirm that the numeric amount is in the active budget currency (\(budget)); no conversion from \(source) will be performed.")
+                return ReportStrings.format(
+                    "I confirm that the numeric amount is in the active budget currency (%@); no conversion from %@ will be performed.",
+                    budget,
+                    source,
+                    locale: locale,
+                    bundle: bundle
+                )
             }
-            return String(localized: "I confirm that the numeric amount should be treated as the active budget currency (\(budget)); no conversion will be performed.")
+            return ReportStrings.format(
+                "I confirm that the numeric amount should be treated as the active budget currency (%@); no conversion will be performed.",
+                budget,
+                locale: locale,
+                bundle: bundle
+            )
         }
     }
 }

--- a/Actuali/Actuali/Models/PendingImport.swift
+++ b/Actuali/Actuali/Models/PendingImport.swift
@@ -48,10 +48,6 @@ enum PendingImportReviewRequirement: Hashable {
     case adoptIntoActiveBudget
     case confirmActiveBudgetCurrency(source: String?, budget: String)
 
-    var prompt: String {
-        prompt(locale: .autoupdatingCurrent)
-    }
-
     func prompt(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .adoptIntoActiveBudget:

--- a/Actuali/Actuali/Models/Rule.swift
+++ b/Actuali/Actuali/Models/Rule.swift
@@ -40,10 +40,14 @@ struct Rule: Identifiable, Equatable, Hashable {
         }
 
         var label: String {
+            label(locale: .autoupdatingCurrent)
+        }
+
+        func label(locale: Locale, bundle: Bundle = .main) -> String {
             switch self {
-            case .pre: return String(localized: "Pre")
-            case .default: return String(localized: "Default")
-            case .post: return String(localized: "Post")
+            case .pre: return ReportStrings.text("Pre", locale: locale, bundle: bundle)
+            case .default: return ReportStrings.text("Default", locale: locale, bundle: bundle)
+            case .post: return ReportStrings.text("Post", locale: locale, bundle: bundle)
             }
         }
     }

--- a/Actuali/Actuali/Models/Rule.swift
+++ b/Actuali/Actuali/Models/Rule.swift
@@ -39,10 +39,6 @@ struct Rule: Identifiable, Equatable, Hashable {
             }
         }
 
-        var label: String {
-            label(locale: .autoupdatingCurrent)
-        }
-
         func label(locale: Locale, bundle: Bundle = .main) -> String {
             switch self {
             case .pre: return ReportStrings.text("Pre", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/ScheduleSummary.swift
+++ b/Actuali/Actuali/Models/ScheduleSummary.swift
@@ -7,10 +7,6 @@ enum ScheduleAmountOp: String, Hashable, CaseIterable {
     case isApprox = "isapprox"
     case isBetween = "isbetween"
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .isExactly: ReportStrings.text("is exactly", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/ScheduleSummary.swift
+++ b/Actuali/Actuali/Models/ScheduleSummary.swift
@@ -8,10 +8,14 @@ enum ScheduleAmountOp: String, Hashable, CaseIterable {
     case isBetween = "isbetween"
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .isExactly: String(localized: "is exactly")
-        case .isApprox: String(localized: "is approximately")
-        case .isBetween: String(localized: "is between")
+        case .isExactly: ReportStrings.text("is exactly", locale: locale, bundle: bundle)
+        case .isApprox: ReportStrings.text("is approximately", locale: locale, bundle: bundle)
+        case .isBetween: ReportStrings.text("is between", locale: locale, bundle: bundle)
         }
     }
 }

--- a/Actuali/Actuali/Models/StartTab.swift
+++ b/Actuali/Actuali/Models/StartTab.swift
@@ -20,11 +20,15 @@ enum StartTab: String, CaseIterable, Identifiable {
     }
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .accounts: return String(localized: "Accounts")
-        case .budget: return String(localized: "Budget")
-        case .addTransaction: return String(localized: "Add Transaction")
-        case .reports: return String(localized: "Reports")
+        case .accounts: return ReportStrings.text("Accounts", locale: locale, bundle: bundle)
+        case .budget: return ReportStrings.text("Budget", locale: locale, bundle: bundle)
+        case .addTransaction: return ReportStrings.text("Add Transaction", locale: locale, bundle: bundle)
+        case .reports: return ReportStrings.text("Reports", locale: locale, bundle: bundle)
         }
     }
 

--- a/Actuali/Actuali/Models/StartTab.swift
+++ b/Actuali/Actuali/Models/StartTab.swift
@@ -19,10 +19,6 @@ enum StartTab: String, CaseIterable, Identifiable {
         }
     }
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .accounts: return ReportStrings.text("Accounts", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/TransactionDisplayMode.swift
+++ b/Actuali/Actuali/Models/TransactionDisplayMode.swift
@@ -7,9 +7,13 @@ enum TransactionDisplayMode: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .flat: return String(localized: "Flat List")
-        case .groupedByDate: return String(localized: "Grouped by Date")
+        case .flat: return ReportStrings.text("Flat List", locale: locale, bundle: bundle)
+        case .groupedByDate: return ReportStrings.text("Grouped by Date", locale: locale, bundle: bundle)
         }
     }
 

--- a/Actuali/Actuali/Models/TransactionDisplayMode.swift
+++ b/Actuali/Actuali/Models/TransactionDisplayMode.swift
@@ -6,10 +6,6 @@ enum TransactionDisplayMode: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .flat: return ReportStrings.text("Flat List", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/UncategorizedTapAction.swift
+++ b/Actuali/Actuali/Models/UncategorizedTapAction.swift
@@ -10,10 +10,6 @@ enum UncategorizedTapAction: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .categoryPicker: return ReportStrings.text("Category Picker", locale: locale, bundle: bundle)

--- a/Actuali/Actuali/Models/UncategorizedTapAction.swift
+++ b/Actuali/Actuali/Models/UncategorizedTapAction.swift
@@ -11,9 +11,13 @@ enum UncategorizedTapAction: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .categoryPicker: return String(localized: "Category Picker")
-        case .transactionEditor: return String(localized: "Transaction Editor")
+        case .categoryPicker: return ReportStrings.text("Category Picker", locale: locale, bundle: bundle)
+        case .transactionEditor: return ReportStrings.text("Transaction Editor", locale: locale, bundle: bundle)
         }
     }
     

--- a/Actuali/Actuali/Services/Budget/BudgetAutomations.swift
+++ b/Actuali/Actuali/Services/Budget/BudgetAutomations.swift
@@ -16,30 +16,38 @@ enum AutomationDisplayType: String, CaseIterable, Identifiable, Sendable {
     static let singleton: Set<AutomationDisplayType> = [.limit, .refill, .remainder, .goal]
 
     var label: String {
+        label(locale: .autoupdatingCurrent)
+    }
+
+    func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .fixed: String(localized: "Fixed amount")
-        case .schedule: String(localized: "Cover schedule")
-        case .by: String(localized: "Save by date")
-        case .percentage: String(localized: "% of income")
-        case .historical: String(localized: "From history")
-        case .limit: String(localized: "Balance cap")
-        case .refill: String(localized: "Refill to cap")
-        case .remainder: String(localized: "Whatever is left")
-        case .goal: String(localized: "Long-term goal")
+        case .fixed: ReportStrings.text("Fixed amount", locale: locale, bundle: bundle)
+        case .schedule: ReportStrings.text("Cover schedule", locale: locale, bundle: bundle)
+        case .by: ReportStrings.text("Save by date", locale: locale, bundle: bundle)
+        case .percentage: ReportStrings.text("% of income", locale: locale, bundle: bundle)
+        case .historical: ReportStrings.text("From history", locale: locale, bundle: bundle)
+        case .limit: ReportStrings.text("Balance cap", locale: locale, bundle: bundle)
+        case .refill: ReportStrings.text("Refill to cap", locale: locale, bundle: bundle)
+        case .remainder: ReportStrings.text("Whatever is left", locale: locale, bundle: bundle)
+        case .goal: ReportStrings.text("Long-term goal", locale: locale, bundle: bundle)
         }
     }
 
     var explanation: String {
+        explanation(locale: .autoupdatingCurrent)
+    }
+
+    func explanation(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
-        case .fixed: String(localized: "Add a set amount every month, week, day, or year.")
-        case .schedule: String(localized: "Save up for a scheduled transaction.")
-        case .by: String(localized: "Spread a target amount across the months until a deadline.")
-        case .percentage: String(localized: "A share of this month's or last month's income.")
-        case .historical: String(localized: "Use past months: average, a specific month, or a copy.")
-        case .limit: String(localized: "Stop budgeting to this category once the balance reaches a cap.")
-        case .refill: String(localized: "Top the category back up to the balance cap each month.")
-        case .remainder: String(localized: "Split any remaining To Budget across these categories.")
-        case .goal: String(localized: "Set a long-term savings target. This changes the coloring of the balance on the budget page to be based on progress towards the target rather than the current month funding progress.")
+        case .fixed: ReportStrings.text("Add a set amount every month, week, day, or year.", locale: locale, bundle: bundle)
+        case .schedule: ReportStrings.text("Save up for a scheduled transaction.", locale: locale, bundle: bundle)
+        case .by: ReportStrings.text("Spread a target amount across the months until a deadline.", locale: locale, bundle: bundle)
+        case .percentage: ReportStrings.text("A share of this month's or last month's income.", locale: locale, bundle: bundle)
+        case .historical: ReportStrings.text("Use past months: average, a specific month, or a copy.", locale: locale, bundle: bundle)
+        case .limit: ReportStrings.text("Stop budgeting to this category once the balance reaches a cap.", locale: locale, bundle: bundle)
+        case .refill: ReportStrings.text("Top the category back up to the balance cap each month.", locale: locale, bundle: bundle)
+        case .remainder: ReportStrings.text("Split any remaining To Budget across these categories.", locale: locale, bundle: bundle)
+        case .goal: ReportStrings.text("Set a long-term savings target. This changes the coloring of the balance on the budget page to be based on progress towards the target rather than the current month funding progress.", locale: locale, bundle: bundle)
         }
     }
 

--- a/Actuali/Actuali/Services/Budget/BudgetAutomations.swift
+++ b/Actuali/Actuali/Services/Budget/BudgetAutomations.swift
@@ -15,10 +15,6 @@ enum AutomationDisplayType: String, CaseIterable, Identifiable, Sendable {
     /// plus goal which the editor also adds through a dedicated button).
     static let singleton: Set<AutomationDisplayType> = [.limit, .refill, .remainder, .goal]
 
-    var label: String {
-        label(locale: .autoupdatingCurrent)
-    }
-
     func label(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .fixed: ReportStrings.text("Fixed amount", locale: locale, bundle: bundle)
@@ -31,10 +27,6 @@ enum AutomationDisplayType: String, CaseIterable, Identifiable, Sendable {
         case .remainder: ReportStrings.text("Whatever is left", locale: locale, bundle: bundle)
         case .goal: ReportStrings.text("Long-term goal", locale: locale, bundle: bundle)
         }
-    }
-
-    var explanation: String {
-        explanation(locale: .autoupdatingCurrent)
     }
 
     func explanation(locale: Locale, bundle: Bundle = .main) -> String {

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -113,7 +113,9 @@ enum BudgetStoreError: LocalizedError, Equatable {
         case .ruleEmptyValue(let field):
             return ReportStrings.format(
                 "error.ruleEmptyValue %@",
-                RuleSchema.label(field: field, locale: locale, bundle: bundle),
+                RuleSchema.sentenceCased(
+                    RuleSchema.label(field: field, locale: locale, bundle: bundle),
+                    locale: locale),
                 locale: locale,
                 bundle: bundle
             )

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -39,67 +39,93 @@ enum BudgetStoreError: LocalizedError, Equatable {
     case bankSyncNotConfigured
 
     var errorDescription: String? {
+        message(locale: .autoupdatingCurrent)
+    }
+
+    func message(locale: Locale, bundle: Bundle = .main) -> String {
         switch self {
         case .syncNotConfigured:
-            return String(localized: "error.syncNotConfigured")
+            return ReportStrings.text("error.syncNotConfigured", locale: locale, bundle: bundle)
         case .transferAccountsMatch:
-            return String(localized: "error.transferAccountsMatch")
+            return ReportStrings.text("error.transferAccountsMatch", locale: locale, bundle: bundle)
         case .transferAmountNotPositive:
-            return String(localized: "error.transferAmountNotPositive")
+            return ReportStrings.text("error.transferAmountNotPositive", locale: locale, bundle: bundle)
         case .transferPayeeMissing:
-            return String(localized: "error.transferPayeeMissing")
+            return ReportStrings.text("error.transferPayeeMissing", locale: locale, bundle: bundle)
         case .transferCategoriesMatch:
-            return String(localized: "error.transferCategoriesMatch")
+            return ReportStrings.text("error.transferCategoriesMatch", locale: locale, bundle: bundle)
         case .transferAmountExceedsSource:
-            return String(localized: "error.transferAmountExceedsSource")
+            return ReportStrings.text("error.transferAmountExceedsSource", locale: locale, bundle: bundle)
         case .invalidAmount:
-            return String(localized: "error.invalidAmount")
+            return ReportStrings.text("error.invalidAmount", locale: locale, bundle: bundle)
         case .missingTransferDestination:
-            return String(localized: "error.missingTransferDestination")
+            return ReportStrings.text("error.missingTransferDestination", locale: locale, bundle: bundle)
         case .payeeCreationFailed(let message):
-            return String(format: String(localized: "error.payeeCreationFailed %@"), message)
+            return ReportStrings.format(
+                "error.payeeCreationFailed %@", message, locale: locale, bundle: bundle)
         case .transferPartnerMissing:
-            return String(localized: "error.transferPartnerMissing")
+            return ReportStrings.text("error.transferPartnerMissing", locale: locale, bundle: bundle)
         case .cannotConvertToTransfer:
-            return String(localized: "error.cannotConvertToTransfer")
+            return ReportStrings.text("error.cannotConvertToTransfer", locale: locale, bundle: bundle)
         case .cannotConvertToSplit:
-            return String(localized: "error.cannotConvertToSplit")
+            return ReportStrings.text("error.cannotConvertToSplit", locale: locale, bundle: bundle)
         case .splitNeedsTwoLines:
-            return String(localized: "error.splitNeedsTwoLines")
+            return ReportStrings.text("error.splitNeedsTwoLines", locale: locale, bundle: bundle)
         case .splitAmountMismatch:
-            return String(localized: "error.splitAmountMismatch")
+            return ReportStrings.text("error.splitAmountMismatch", locale: locale, bundle: bundle)
         case .invalidAccountName:
-            return String(localized: "error.invalidAccountName")
+            return ReportStrings.text("error.invalidAccountName", locale: locale, bundle: bundle)
         case .accountCreationFailed(let message):
-            return String(format: String(localized: "error.accountCreationFailed %@"), message)
+            return ReportStrings.format(
+                "error.accountCreationFailed %@", message, locale: locale, bundle: bundle)
         case .invalidCategoryName:
-            return String(localized: "error.invalidCategoryName")
+            return ReportStrings.text("error.invalidCategoryName", locale: locale, bundle: bundle)
         case .invalidCategoryGroupName:
-            return String(localized: "error.invalidCategoryGroupName")
+            return ReportStrings.text("error.invalidCategoryGroupName", locale: locale, bundle: bundle)
         case .categoryCreationFailed(let message):
-            return String(format: String(localized: "error.categoryCreationFailed %@"), message)
+            return ReportStrings.format(
+                "error.categoryCreationFailed %@", message, locale: locale, bundle: bundle)
         case .categoryUpdateFailed(let message):
-            return String(format: String(localized: "error.categoryUpdateFailed %@"), message)
+            return ReportStrings.format(
+                "error.categoryUpdateFailed %@", message, locale: locale, bundle: bundle)
         case .categoryGroupCreationFailed(let message):
-            return String(format: String(localized: "error.categoryGroupCreationFailed %@"), message)
+            return ReportStrings.format(
+                "error.categoryGroupCreationFailed %@", message, locale: locale, bundle: bundle)
         case .ruleNeedsCondition:
-            return String(localized: "error.ruleNeedsCondition")
+            return ReportStrings.text("error.ruleNeedsCondition", locale: locale, bundle: bundle)
         case .ruleNeedsAction:
-            return String(localized: "error.ruleNeedsAction")
+            return ReportStrings.text("error.ruleNeedsAction", locale: locale, bundle: bundle)
         case .ruleInvalidCondition(let field, let op):
-            return String(format: String(localized: "error.ruleInvalidCondition %@ %@"), RuleSchema.label(op: op), RuleSchema.label(field: field))
+            return ReportStrings.format(
+                "error.ruleInvalidCondition %@ %@",
+                RuleSchema.label(
+                    op: op,
+                    type: RuleSchema.fieldType(field),
+                    locale: locale,
+                    bundle: bundle
+                ),
+                RuleSchema.label(field: field, locale: locale, bundle: bundle),
+                locale: locale,
+                bundle: bundle
+            )
         case .ruleInvalidAction:
-            return String(localized: "error.ruleInvalidAction")
+            return ReportStrings.text("error.ruleInvalidAction", locale: locale, bundle: bundle)
         case .ruleEmptyValue(let field):
-            return String(format: String(localized: "error.ruleEmptyValue %@"), RuleSchema.label(field: field).capitalized)
+            return ReportStrings.format(
+                "error.ruleEmptyValue %@",
+                RuleSchema.label(field: field, locale: locale, bundle: bundle),
+                locale: locale,
+                bundle: bundle
+            )
         case .ruleInvalidPattern(let pattern):
-            return String(format: String(localized: "error.ruleInvalidPattern %@"), pattern)
+            return ReportStrings.format(
+                "error.ruleInvalidPattern %@", pattern, locale: locale, bundle: bundle)
         case .ruleOwnedBySchedule:
-            return String(localized: "error.ruleOwnedBySchedule")
+            return ReportStrings.text("error.ruleOwnedBySchedule", locale: locale, bundle: bundle)
         case .ruleNotSerializable:
-            return String(localized: "error.ruleNotSerializable")
+            return ReportStrings.text("error.ruleNotSerializable", locale: locale, bundle: bundle)
         case .bankSyncNotConfigured:
-            return String(localized: "error.bankSyncNotConfigured")
+            return ReportStrings.text("error.bankSyncNotConfigured", locale: locale, bundle: bundle)
         }
     }
 }
@@ -6638,7 +6664,9 @@ final class BudgetStore: ObservableObject {
                 categoryGroups: Dictionary(categoryGroups.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first }),
                 accounts: Dictionary(accounts.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first })
             ),
-            formatAmount: { [weak self] cents in self?.formatCurrency(cents) ?? "\(cents)" }
+            formatAmount: { [weak self] cents, locale in
+                self?.formatCurrency(cents, locale: locale) ?? "\(cents)"
+            }
         )
     }
 

--- a/Actuali/Actuali/Services/PendingImportApprover.swift
+++ b/Actuali/Actuali/Services/PendingImportApprover.swift
@@ -17,33 +17,83 @@ final class PendingImportApprover {
         case sourceCurrencyMismatch(source: String, budget: String)
         case reviewConfirmationRequired
         case suppressedByRule
+        case noBudgetLoaded
+        case transactionNeedsRecovery
         case writeFailed(String)
         case alreadyApproved
 
         var errorDescription: String? {
+            message(locale: .autoupdatingCurrent)
+        }
+
+        nonisolated func message(locale: Locale, bundle: Bundle = .main) -> String {
             switch self {
             case .invalidAmount:
-                return String(localized: "Transaction amount is missing or invalid.")
+                return ReportStrings.text(
+                    "Transaction amount is missing or invalid.", locale: locale, bundle: bundle)
             case .noAccountAvailable:
-                return String(localized: "No matching or default account available.")
+                return ReportStrings.text(
+                    "No matching or default account available.", locale: locale, bundle: bundle)
             case .accountClosed:
-                return String(localized: "The target account is closed.")
+                return ReportStrings.text(
+                    "The target account is closed.", locale: locale, bundle: bundle)
             case .budgetMismatch:
-                return String(localized: "This import belongs to a different budget and cannot be approved here.")
+                return ReportStrings.text(
+                    "This import belongs to a different budget and cannot be approved here.",
+                    locale: locale,
+                    bundle: bundle
+                )
             case .budgetIdentityRequired:
-                return String(localized: "This import needs review before it can be approved.")
+                return ReportStrings.text(
+                    "This import needs review before it can be approved.",
+                    locale: locale,
+                    bundle: bundle
+                )
             case .sourceCurrencyRequired:
-                return String(localized: "This import needs review before it can be approved.")
+                return ReportStrings.text(
+                    "This import needs review before it can be approved.",
+                    locale: locale,
+                    bundle: bundle
+                )
             case .sourceCurrencyMismatch(let source, let budget):
-                return String(localized: "This import is in \(source), but the active budget uses \(budget). Review and confirm the transaction before saving.")
+                return ReportStrings.format(
+                    "This import is in %@, but the active budget uses %@. Review and confirm the transaction before saving.",
+                    source,
+                    budget,
+                    locale: locale,
+                    bundle: bundle
+                )
             case .reviewConfirmationRequired:
-                return String(localized: "Review and confirm this import before saving it.")
+                return ReportStrings.text(
+                    "Review and confirm this import before saving it.",
+                    locale: locale,
+                    bundle: bundle
+                )
             case .suppressedByRule:
-                return String(localized: "A transaction rule suppressed this import, so it remains pending.")
+                return ReportStrings.text(
+                    "A transaction rule suppressed this import, so it remains pending.",
+                    locale: locale,
+                    bundle: bundle
+                )
+            case .noBudgetLoaded:
+                return ReportStrings.text(
+                    "Open Actuali and select a budget first.", locale: locale, bundle: bundle)
+            case .transactionNeedsRecovery:
+                return ReportStrings.text(
+                    "This import needs review before it can be approved.",
+                    locale: locale,
+                    bundle: bundle
+                )
             case .writeFailed(let message):
-                return String(localized: "Failed to save transaction: \(message)")
+                return ReportStrings.format(
+                    "Failed to save transaction: %@",
+                    message,
+                    locale: locale,
+                    bundle: bundle
+                )
             case .alreadyApproved:
-                return String(localized: "This pending import was already saved.")
+                return ReportStrings.text(
+                    "This pending import was already saved.", locale: locale, bundle: bundle)
             }
         }
     }
@@ -52,6 +102,23 @@ final class PendingImportApprover {
 
     init(store: BudgetStore) {
         self.store = store
+    }
+
+    nonisolated static func localizedErrorMessage(
+        for error: any Error,
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String {
+        if let error = error as? ApproveError {
+            return error.message(locale: locale, bundle: bundle)
+        }
+        if let error = error as? PendingImportStore.StoreError {
+            return error.message(locale: locale, bundle: bundle)
+        }
+        if let error = error as? BudgetStoreError {
+            return error.message(locale: locale, bundle: bundle)
+        }
+        return error.localizedDescription
     }
 
     /// Resolves an account for direct approval. Automatic approval is only
@@ -169,8 +236,12 @@ final class PendingImportApprover {
             throw ApproveError.alreadyApproved
         } catch TransactionLogger.LoggerError.transactionSuppressedByRule {
             throw ApproveError.suppressedByRule
+        } catch TransactionLogger.LoggerError.noBudgetLoaded {
+            throw ApproveError.noBudgetLoaded
         } catch TransactionLogger.LoggerError.transactionNeedsRecovery {
-            throw ApproveError.writeFailed("This import needs review before it can be approved.")
+            throw ApproveError.transactionNeedsRecovery
+        } catch let error as BudgetStoreError {
+            throw error
         } catch {
             logger.error("Pending import log failed: \(error.localizedDescription, privacy: .public)")
             throw ApproveError.writeFailed(error.localizedDescription)
@@ -208,7 +279,7 @@ final class PendingImportApprover {
 
         let financialId = Self.financialId(for: item)
         guard store.databaseForLogger != nil else {
-            throw TransactionLogger.LoggerError.noBudgetLoaded
+            throw ApproveError.noBudgetLoaded
         }
         let payeeName = form.payeeName.trimmingCharacters(in: .whitespacesAndNewlines)
         let payee = payeeName.isEmpty ? nil : try await store.findOrCreatePayee(name: payeeName)

--- a/Actuali/Actuali/Services/PendingImportStore.swift
+++ b/Actuali/Actuali/Services/PendingImportStore.swift
@@ -13,9 +13,18 @@ final class PendingImportStore: ObservableObject {
         case saveFailed(String)
 
         var errorDescription: String? {
+            message(locale: .autoupdatingCurrent)
+        }
+
+        nonisolated func message(locale: Locale, bundle: Bundle = .main) -> String {
             switch self {
             case .saveFailed(let message):
-                return String(localized: "Failed to save pending imports: \(message)")
+                return ReportStrings.format(
+                    "Failed to save pending imports: %@",
+                    message,
+                    locale: locale,
+                    bundle: bundle
+                )
             }
         }
     }

--- a/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
@@ -523,7 +523,6 @@ enum CustomReportEngine {
 
     private static func dayFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
-        f.calendar = cal
         f.dateFormat = "yy-MM-dd"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale
@@ -533,7 +532,6 @@ enum CustomReportEngine {
 
     private static func monthFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
-        f.calendar = cal
         f.dateFormat = "MMM ''yy"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale
@@ -543,7 +541,6 @@ enum CustomReportEngine {
 
     private static func yearFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
-        f.calendar = cal
         f.dateFormat = "yyyy"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale

--- a/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/CustomReportEngine.swift
@@ -523,6 +523,7 @@ enum CustomReportEngine {
 
     private static func dayFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
+        f.calendar = cal
         f.dateFormat = "yy-MM-dd"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale
@@ -532,6 +533,7 @@ enum CustomReportEngine {
 
     private static func monthFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
+        f.calendar = cal
         f.dateFormat = "MMM ''yy"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale
@@ -541,6 +543,7 @@ enum CustomReportEngine {
 
     private static func yearFormatter(locale: Locale) -> DateFormatter {
         let f = DateFormatter()
+        f.calendar = cal
         f.dateFormat = "yyyy"
         f.timeZone = TimeZone(identifier: "UTC")
         f.locale = locale

--- a/Actuali/Actuali/Services/Reports/Engines/SankeyEngine.swift
+++ b/Actuali/Actuali/Services/Reports/Engines/SankeyEngine.swift
@@ -595,7 +595,7 @@ enum SankeyEngine {
         groupOtherCategories(&graph, topN: topN, categorySort: categorySort,
                              locale: locale, bundle: bundle)
         sortGraph(&graph, categorySort: categorySort, categoryGroups: categoryGroups)
-        addPercentageLabels(&graph)
+        addPercentageLabels(&graph, locale: locale)
         cleanUpNodes(&graph)
         addHiddenNodes(&graph)
         filterGraphByLayers(&graph, from: layerFrom, to: layerTo)
@@ -829,7 +829,7 @@ enum SankeyEngine {
 
     // MARK: Labels / cleanup
 
-    static func addPercentageLabels(_ graph: inout SankeyGraph) {
+    static func addPercentageLabels(_ graph: inout SankeyGraph, locale: Locale = .current) {
         var layerSums: [SankeyLayer: Int] = [:]
         for key in graph.keys {
             guard let layer = graph[key]?.type else { continue }
@@ -838,8 +838,9 @@ enum SankeyEngine {
         for key in graph.keys {
             guard let node = graph[key] else { continue }
             let total = layerSums[node.type] ?? 1
-            let percentage = total != 0 ? Double(getNodeValue(graph, key)) / Double(total) * 100 : 0
-            graph.nodes[key]?.percentageLabel = String(format: "%.1f%%", percentage)
+            let percentage = total != 0 ? Double(getNodeValue(graph, key)) / Double(total) : 0
+            graph.nodes[key]?.percentageLabel = percentage.formatted(
+                .percent.locale(locale).precision(.fractionLength(1)))
         }
     }
 
@@ -996,6 +997,7 @@ enum SankeyEngine {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM yyyy"
         formatter.locale = locale
+        formatter.calendar = calendar
         formatter.timeZone = TimeZone(identifier: "UTC")
         return formatter.string(from: date)
     }

--- a/Actuali/Actuali/Services/Rules/RuleSchema.swift
+++ b/Actuali/Actuali/Services/Rules/RuleSchema.swift
@@ -185,4 +185,8 @@ enum RuleSchema {
         }
         return ReportStrings.text(key, locale: locale, bundle: bundle)
     }
+
+    static func sentenceCased(_ text: String, locale: Locale) -> String {
+        text.prefix(1).uppercased(with: locale) + text.dropFirst()
+    }
 }

--- a/Actuali/Actuali/Services/Rules/RuleSchema.swift
+++ b/Actuali/Actuali/Services/Rules/RuleSchema.swift
@@ -99,69 +99,90 @@ enum RuleSchema {
 
     // MARK: - Labels (util/rule.ts mapField / friendlyOp)
 
-    static func label(field: String, options: [String: RuleValue]? = nil) -> String {
+    static func label(
+        field: String,
+        options: [String: RuleValue]? = nil,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
         switch field {
-        case "imported_payee": return String(localized: "rule.field.importedPayee")
-        case "payee_name": return String(localized: "rule.field.payeeName")
+        case "imported_payee": return ReportStrings.text("rule.field.importedPayee", locale: locale, bundle: bundle)
+        case "payee_name": return ReportStrings.text("rule.field.payeeName", locale: locale, bundle: bundle)
         case "amount":
-            if options?["inflow"]?.boolValue == true { return String(localized: "rule.field.amountInflow") }
-            if options?["outflow"]?.boolValue == true { return String(localized: "rule.field.amountOutflow") }
-            return String(localized: "rule.field.amount")
-        case "category_group": return String(localized: "rule.field.categoryGroup")
-        case "payee": return String(localized: "rule.field.payee")
-        case "category": return String(localized: "rule.field.category")
-        case "account": return String(localized: "rule.field.account")
-        case "date": return String(localized: "rule.field.date")
-        case "notes": return String(localized: "rule.field.notes")
-        case "cleared": return String(localized: "rule.field.cleared")
-        case "reconciled": return String(localized: "rule.field.reconciled")
-        case "transfer": return String(localized: "rule.field.transfer")
-        case "parent": return String(localized: "rule.field.parent")
+            if options?["inflow"]?.boolValue == true {
+                return ReportStrings.text("rule.field.amountInflow", locale: locale, bundle: bundle)
+            }
+            if options?["outflow"]?.boolValue == true {
+                return ReportStrings.text("rule.field.amountOutflow", locale: locale, bundle: bundle)
+            }
+            return ReportStrings.text("rule.field.amount", locale: locale, bundle: bundle)
+        case "category_group": return ReportStrings.text("rule.field.categoryGroup", locale: locale, bundle: bundle)
+        case "payee": return ReportStrings.text("rule.field.payee", locale: locale, bundle: bundle)
+        case "category": return ReportStrings.text("rule.field.category", locale: locale, bundle: bundle)
+        case "account": return ReportStrings.text("rule.field.account", locale: locale, bundle: bundle)
+        case "date": return ReportStrings.text("rule.field.date", locale: locale, bundle: bundle)
+        case "notes": return ReportStrings.text("rule.field.notes", locale: locale, bundle: bundle)
+        case "cleared": return ReportStrings.text("rule.field.cleared", locale: locale, bundle: bundle)
+        case "reconciled": return ReportStrings.text("rule.field.reconciled", locale: locale, bundle: bundle)
+        case "transfer": return ReportStrings.text("rule.field.transfer", locale: locale, bundle: bundle)
+        case "parent": return ReportStrings.text("rule.field.parent", locale: locale, bundle: bundle)
         default: return field
         }
     }
 
-    static func summaryLabel(field: String, options: [String: RuleValue]? = nil) -> String {
+    static func summaryLabel(
+        field: String,
+        options: [String: RuleValue]? = nil,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
         switch field {
-        case "payee": return String(localized: "rule.summary.field.payee")
-        case "category": return String(localized: "rule.summary.field.category")
-        case "account": return String(localized: "rule.summary.field.account")
-        case "date": return String(localized: "rule.summary.field.date")
-        case "notes": return String(localized: "rule.summary.field.notes")
-        case "cleared": return String(localized: "rule.summary.field.cleared")
-        case "reconciled": return String(localized: "rule.summary.field.reconciled")
-        case "transfer": return String(localized: "rule.summary.field.transfer")
-        case "parent": return String(localized: "rule.summary.field.parent")
-        default: return label(field: field, options: options)
+        case "payee": return ReportStrings.text("rule.summary.field.payee", locale: locale, bundle: bundle)
+        case "category": return ReportStrings.text("rule.summary.field.category", locale: locale, bundle: bundle)
+        case "account": return ReportStrings.text("rule.summary.field.account", locale: locale, bundle: bundle)
+        case "date": return ReportStrings.text("rule.summary.field.date", locale: locale, bundle: bundle)
+        case "notes": return ReportStrings.text("rule.summary.field.notes", locale: locale, bundle: bundle)
+        case "cleared": return ReportStrings.text("rule.summary.field.cleared", locale: locale, bundle: bundle)
+        case "reconciled": return ReportStrings.text("rule.summary.field.reconciled", locale: locale, bundle: bundle)
+        case "transfer": return ReportStrings.text("rule.summary.field.transfer", locale: locale, bundle: bundle)
+        case "parent": return ReportStrings.text("rule.summary.field.parent", locale: locale, bundle: bundle)
+        default: return label(field: field, options: options, locale: locale, bundle: bundle)
         }
     }
 
-    static func label(op: String, type: RuleFieldType? = nil) -> String {
+    static func label(
+        op: String,
+        type: RuleFieldType? = nil,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
+        let key: String
         switch op {
-        case "is": return String(localized: "rule.op.is")
-        case "isNot": return String(localized: "rule.op.isNot")
-        case "oneOf": return String(localized: "rule.op.oneOf")
-        case "notOneOf": return String(localized: "rule.op.notOneOf")
-        case "isapprox": return String(localized: "rule.op.isApprox")
-        case "isbetween": return String(localized: "rule.op.isBetween")
-        case "contains": return String(localized: "rule.op.contains")
-        case "doesNotContain": return String(localized: "rule.op.doesNotContain")
-        case "matches": return String(localized: "rule.op.matches")
-        case "hasTags": return String(localized: "rule.op.hasAllTags")
-        case "hasAnyTag": return String(localized: "rule.op.hasAnyTag")
-        case "onBudget": return String(localized: "rule.op.isOnBudget")
-        case "offBudget": return String(localized: "rule.op.isOffBudget")
-        case "gt": return String(localized: type == .date ? "rule.op.isAfter" : "rule.op.isGreaterThan")
-        case "gte": return String(localized: type == .date ? "rule.op.isAfterOrEquals" : "rule.op.isGreaterThanOrEquals")
-        case "lt": return String(localized: type == .date ? "rule.op.isBefore" : "rule.op.isLessThan")
-        case "lte": return String(localized: type == .date ? "rule.op.isBeforeOrEquals" : "rule.op.isLessThanOrEquals")
-        case "set": return String(localized: "rule.op.set")
-        case "set-split-amount": return String(localized: "rule.op.allocate")
-        case "link-schedule": return String(localized: "rule.op.linkSchedule")
-        case "prepend-notes": return String(localized: "rule.op.prependNotes")
-        case "append-notes": return String(localized: "rule.op.appendNotes")
-        case "delete-transaction": return String(localized: "rule.op.deleteTransaction")
+        case "is": key = "rule.op.is"
+        case "isNot": key = "rule.op.isNot"
+        case "oneOf": key = "rule.op.oneOf"
+        case "notOneOf": key = "rule.op.notOneOf"
+        case "isapprox": key = "rule.op.isApprox"
+        case "isbetween": key = "rule.op.isBetween"
+        case "contains": key = "rule.op.contains"
+        case "doesNotContain": key = "rule.op.doesNotContain"
+        case "matches": key = "rule.op.matches"
+        case "hasTags": key = "rule.op.hasAllTags"
+        case "hasAnyTag": key = "rule.op.hasAnyTag"
+        case "onBudget": key = "rule.op.isOnBudget"
+        case "offBudget": key = "rule.op.isOffBudget"
+        case "gt": key = type == .date ? "rule.op.isAfter" : "rule.op.isGreaterThan"
+        case "gte": key = type == .date ? "rule.op.isAfterOrEquals" : "rule.op.isGreaterThanOrEquals"
+        case "lt": key = type == .date ? "rule.op.isBefore" : "rule.op.isLessThan"
+        case "lte": key = type == .date ? "rule.op.isBeforeOrEquals" : "rule.op.isLessThanOrEquals"
+        case "set": key = "rule.op.set"
+        case "set-split-amount": key = "rule.op.allocate"
+        case "link-schedule": key = "rule.op.linkSchedule"
+        case "prepend-notes": key = "rule.op.prependNotes"
+        case "append-notes": key = "rule.op.appendNotes"
+        case "delete-transaction": key = "rule.op.deleteTransaction"
         default: return op
         }
+        return ReportStrings.text(key, locale: locale, bundle: bundle)
     }
 }

--- a/Actuali/Actuali/Services/Rules/RuleSummary.swift
+++ b/Actuali/Actuali/Services/Rules/RuleSummary.swift
@@ -17,72 +17,118 @@ struct RuleSummary {
 
     let names: Names
     /// Formats cents the way the rest of the app does (`BudgetStore.formatCurrency`).
-    let formatAmount: (Int) -> String
+    let formatAmount: (Int, Locale) -> String
 
-    func condition(_ condition: Rule.Condition) -> String {
-        let field = RuleSchema.summaryLabel(field: condition.field, options: condition.options)
-        let op = RuleSchema.label(op: condition.op, type: RuleSchema.fieldType(condition.field))
+    func condition(
+        _ condition: Rule.Condition,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
+        let field = RuleSchema.summaryLabel(
+            field: condition.field, options: condition.options,
+            locale: locale, bundle: bundle)
+        let op = RuleSchema.label(
+            op: condition.op, type: RuleSchema.fieldType(condition.field),
+            locale: locale, bundle: bundle)
         switch condition.op {
         case "onBudget", "offBudget":
-            return String(format: String(localized: "%@ %@"), field, op)
+            return ReportStrings.format("%@ %@", field, op, locale: locale, bundle: bundle)
         default:
-            return String(format: String(localized: "%@ %@ %@"), field, op, value(condition.value, field: condition.field))
+            return ReportStrings.format(
+                "%@ %@ %@", field, op,
+                value(condition.value, field: condition.field, locale: locale, bundle: bundle),
+                locale: locale, bundle: bundle)
         }
     }
 
-    func action(_ action: Rule.Action) -> String {
+    func action(
+        _ action: Rule.Action,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
         switch action.op {
         case "set":
-            guard let field = action.field else { return RuleSchema.label(op: action.op) }
+            guard let field = action.field else {
+                return RuleSchema.label(op: action.op, locale: locale, bundle: bundle)
+            }
+            let fieldLabel = RuleSchema.summaryLabel(field: field, locale: locale, bundle: bundle)
             if let template = action.options?["template"]?.stringValue {
-                return String(format: String(localized: "set %@ to template %@"), RuleSchema.summaryLabel(field: field), template)
+                return ReportStrings.format(
+                    "set %@ to template %@", fieldLabel, template,
+                    locale: locale, bundle: bundle)
             }
             if let formula = action.options?["formula"]?.stringValue {
-                return String(format: String(localized: "set %@ to formula %@"), RuleSchema.summaryLabel(field: field), formula)
+                return ReportStrings.format(
+                    "set %@ to formula %@", fieldLabel, formula,
+                    locale: locale, bundle: bundle)
             }
-            return String(format: String(localized: "set %@ to %@"), RuleSchema.summaryLabel(field: field), value(action.value, field: field))
+            return ReportStrings.format(
+                "set %@ to %@", fieldLabel,
+                value(action.value, field: field, locale: locale, bundle: bundle),
+                locale: locale, bundle: bundle)
         case "prepend-notes", "append-notes":
-            return String(format: String(localized: "%@ %@"), RuleSchema.label(op: action.op), action.value.stringValue ?? "")
+            return ReportStrings.format(
+                "%@ %@", RuleSchema.label(op: action.op, locale: locale, bundle: bundle),
+                action.value.stringValue ?? "", locale: locale, bundle: bundle)
         case "link-schedule":
-            return String(localized: "link schedule")
+            return ReportStrings.text("link schedule", locale: locale, bundle: bundle)
         case "delete-transaction":
-            return String(localized: "delete transaction")
+            return ReportStrings.text("delete transaction", locale: locale, bundle: bundle)
         case "set-split-amount":
-            return String(localized: "allocate a split amount")
+            return ReportStrings.text("allocate a split amount", locale: locale, bundle: bundle)
         default:
-            return RuleSchema.label(op: action.op)
+            return RuleSchema.label(op: action.op, locale: locale, bundle: bundle)
         }
     }
 
     /// Everything a rule says, in one line — the string the search box filters on.
-    func searchText(_ rule: Rule) -> String {
-        (rule.conditions.map(condition) + rule.actions.map(action))
+    func searchText(
+        _ rule: Rule,
+        locale: Locale = .autoupdatingCurrent,
+        bundle: Bundle = .main
+    ) -> String {
+        (rule.conditions.map { condition($0, locale: locale, bundle: bundle) }
+         + rule.actions.map { action($0, locale: locale, bundle: bundle) })
             .joined(separator: " ")
-            .lowercased()
+            .lowercased(with: locale)
     }
 
-    private func value(_ value: RuleValue, field: String) -> String {
+    private func value(
+        _ value: RuleValue,
+        field: String,
+        locale: Locale,
+        bundle: Bundle
+    ) -> String {
         switch value {
         case .null:
-            return String(localized: "nothing")
+            return ReportStrings.text("nothing", locale: locale, bundle: bundle)
         case .bool(let flag):
-            return flag ? String(localized: "yes") : String(localized: "no")
+            return ReportStrings.text(flag ? "yes" : "no", locale: locale, bundle: bundle)
         case .list(let items):
-            let rendered = items.map { self.value($0, field: field) }
-            return rendered.isEmpty ? String(localized: "nothing") : rendered.joined(separator: ", ")
+            let rendered = items.map {
+                self.value($0, field: field, locale: locale, bundle: bundle)
+            }
+            return rendered.isEmpty
+                ? ReportStrings.text("nothing", locale: locale, bundle: bundle)
+                : rendered.joined(separator: ", ")
         case .object:
             guard let between = value.betweenValue else { return "" }
-            return String(format: String(localized: "%@ and %@"), formatAmount(Int(between.num1)), formatAmount(Int(between.num2)))
+            return ReportStrings.format(
+                "%@ and %@", formatAmount(Int(between.num1), locale),
+                formatAmount(Int(between.num2), locale), locale: locale, bundle: bundle)
         case .number(let number):
             guard RuleSchema.fieldType(field) == .number else { return "\(Int(number))" }
-            return formatAmount(Int(number))
+            return formatAmount(Int(number), locale)
         case .string(let text):
             switch field {
             case "payee": return names.payees[text] ?? text
             case "category": return names.categories[text] ?? text
             case "category_group": return names.categoryGroups[text] ?? text
             case "account": return names.accounts[text] ?? text
-            default: return text.isEmpty ? String(localized: "nothing") : text
+            default:
+                return text.isEmpty
+                    ? ReportStrings.text("nothing", locale: locale, bundle: bundle)
+                    : text
             }
         }
     }

--- a/Actuali/Actuali/Services/TransactionLogger.swift
+++ b/Actuali/Actuali/Services/TransactionLogger.swift
@@ -17,15 +17,30 @@ final class TransactionLogger {
         case transactionNeedsRecovery
 
         var errorDescription: String? {
+            message()
+        }
+
+        func message(
+            locale: Locale = .autoupdatingCurrent,
+            bundle: Bundle = .main
+        ) -> String {
             switch self {
             case .noBudgetLoaded:
-                return String(localized: "Open Actuali and select a budget first.")
+                return ReportStrings.text(
+                    "Open Actuali and select a budget first.",
+                    locale: locale, bundle: bundle)
             case .transactionAlreadyExists:
-                return String(localized: "This transaction was already saved.")
+                return ReportStrings.text(
+                    "This transaction was already saved.",
+                    locale: locale, bundle: bundle)
             case .transactionSuppressedByRule:
-                return String(localized: "A transaction rule suppressed this transaction.")
+                return ReportStrings.text(
+                    "A transaction rule suppressed this transaction.",
+                    locale: locale, bundle: bundle)
             case .transactionNeedsRecovery:
-                return String(localized: "This import needs review before it can be approved.")
+                return ReportStrings.text(
+                    "This import needs review before it can be approved.",
+                    locale: locale, bundle: bundle)
             }
         }
     }

--- a/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
+++ b/Actuali/Actuali/Views/Accounts/PendingImportsView.swift
@@ -19,6 +19,7 @@ struct PendingImportsView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @ObservedObject private var store = PendingImportStore.shared
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.locale) private var locale
 
     @State private var editingItem: PendingImport?
     @State private var errorMessage: String?
@@ -46,7 +47,10 @@ struct PendingImportsView: View {
                             .buttonStyle(.plain)
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) {
-                                    do { try store.remove(id: item.id) } catch { errorMessage = error.localizedDescription }
+                                    do { try store.remove(id: item.id) } catch {
+                                        errorMessage = PendingImportApprover.localizedErrorMessage(
+                                            for: error, locale: locale)
+                                    }
                                 } label: {
                                     Label("Dismiss", systemImage: "trash")
                                 }
@@ -121,7 +125,8 @@ struct PendingImportsView: View {
                     do { try store.remove(id: item.id) } catch {
                         editingItem = nil
                         deferredFailureCount = nil
-                        errorMessage = error.localizedDescription
+                        errorMessage = PendingImportApprover.localizedErrorMessage(
+                            for: error, locale: locale)
                     }
                 }
             } catch PendingImportApprover.ApproveError.noAccountAvailable {
@@ -163,7 +168,8 @@ struct PendingImportsView: View {
                     do { try store.remove(id: item.id) } catch {
                         editingItem = nil
                         deferredFailureCount = nil
-                        errorMessage = error.localizedDescription
+                        errorMessage = PendingImportApprover.localizedErrorMessage(
+                            for: error, locale: locale)
                     }
                 }
             } catch {
@@ -171,7 +177,8 @@ struct PendingImportsView: View {
                     isProcessing = false
                     editingItem = nil
                     deferredFailureCount = nil
-                    errorMessage = error.localizedDescription
+                    errorMessage = PendingImportApprover.localizedErrorMessage(
+                        for: error, locale: locale)
                 }
             }
         }
@@ -219,7 +226,7 @@ struct PendingImportsView: View {
                 case .failure(let count):
                     editingItem = nil
                     deferredFailureCount = nil
-                    errorMessage = Self.approvalFailureMessage(count: count)
+                    errorMessage = Self.approvalFailureMessage(count: count, locale: locale)
                 }
             }
         }
@@ -229,7 +236,7 @@ struct PendingImportsView: View {
         guard let count = deferredFailureCount else { return }
         deferredFailureCount = nil
         editingItem = nil
-        errorMessage = Self.approvalFailureMessage(count: count)
+        errorMessage = Self.approvalFailureMessage(count: count, locale: locale)
     }
 
     nonisolated static func bulkApprovalDisposition(
@@ -245,7 +252,8 @@ struct PendingImportsView: View {
              .budgetIdentityRequired, .sourceCurrencyRequired,
              .sourceCurrencyMismatch, .reviewConfirmationRequired:
             return .review
-        case .invalidAmount, .suppressedByRule, .writeFailed:
+        case .invalidAmount, .suppressedByRule, .noBudgetLoaded,
+             .transactionNeedsRecovery, .writeFailed:
             return .failure
         }
     }
@@ -279,7 +287,12 @@ struct PendingImportsView: View {
         if let accountId = targetAccountId {
             let approver = PendingImportApprover(store: budgetStore)
             VStack(spacing: 0) {
-                if let context = currencyContext(for: item) {
+                if let context = Self.currencyContext(
+                    for: item,
+                    activeBudgetId: budgetStore.currentBudgetId,
+                    budgetCurrency: budgetStore.currencyCode,
+                    locale: locale
+                ) {
                     Text(context)
                         .font(.callout)
                         .foregroundStyle(.orange)
@@ -318,21 +331,46 @@ struct PendingImportsView: View {
         }
     }
 
-    private func currencyContext(for item: PendingImport) -> String? {
+    nonisolated static func currencyContext(
+        for item: PendingImport,
+        activeBudgetId: String?,
+        budgetCurrency: String,
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String? {
         if let originBudgetId = item.originBudgetId,
-           originBudgetId != budgetStore.currentBudgetId {
-            return String(localized: "This import belongs to a different budget. Review and confirm adoption into the active budget before saving.")
+           originBudgetId != activeBudgetId {
+            return ReportStrings.text(
+                "This import belongs to a different budget. Review and confirm adoption into the active budget before saving.",
+                locale: locale,
+                bundle: bundle
+            )
         }
         guard let sourceCurrencyCode = item.sourceCurrencyCode else {
             if item.originBudgetId == nil {
-                return String(localized: "This older import has no budget identity. Review and save it to adopt it into the active budget.")
+                return ReportStrings.text(
+                    "This older import has no budget identity. Review and save it to adopt it into the active budget.",
+                    locale: locale,
+                    bundle: bundle
+                )
             }
-            return String(localized: "Currency was not identified. Active budget: \(PendingImport.normalizedCurrencyCode(budgetStore.currencyCode)). Review and confirm before saving.")
+            return ReportStrings.format(
+                "Currency was not identified. Active budget: %@. Review and confirm before saving.",
+                PendingImport.normalizedCurrencyCode(budgetCurrency),
+                locale: locale,
+                bundle: bundle
+            )
         }
         let source = PendingImport.normalizedCurrencyCode(sourceCurrencyCode)
-        let budget = PendingImport.normalizedCurrencyCode(budgetStore.currencyCode)
+        let budget = PendingImport.normalizedCurrencyCode(budgetCurrency)
         guard source != budget else { return nil }
-        return String(localized: "Source currency: \(source). Active budget: \(budget). Review and confirm before saving.")
+        return ReportStrings.format(
+            "Source currency: %@. Active budget: %@. Review and confirm before saving.",
+            source,
+            budget,
+            locale: locale,
+            bundle: bundle
+        )
     }
 
     private func resolveAccountId(for item: PendingImport) -> String? {
@@ -356,7 +394,7 @@ private struct PendingImportRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
-                Text(item.payee ?? String(localized: "Unknown Payee"))
+                Text(item.payee ?? PendingImportsView.unknownPayee(locale: locale))
                     .font(.headline)
                 Spacer()
                 if let amount = item.amount {
@@ -383,7 +421,7 @@ private struct PendingImportRow: View {
 
             HStack {
                 if let hint = item.cardHint {
-                    Text(String(format: String(localized: "Card ••%@"), hint))
+                    Text(PendingImportsView.cardLabel(hint, locale: locale))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -406,6 +444,18 @@ private struct PendingImportRow: View {
 }
 
 extension PendingImportsView {
+    nonisolated static func unknownPayee(locale: Locale, bundle: Bundle = .main) -> String {
+        ReportStrings.text("Unknown Payee", locale: locale, bundle: bundle)
+    }
+
+    nonisolated static func cardLabel(
+        _ hint: String,
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String {
+        ReportStrings.format("Card ••%@", hint, locale: locale, bundle: bundle)
+    }
+
     nonisolated static func amountString(
         _ amount: Double,
         isIncome: Bool,

--- a/Actuali/Actuali/Views/Budget/Automations/AutomationEntryEditor.swift
+++ b/Actuali/Actuali/Views/Budget/Automations/AutomationEntryEditor.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// and the editor/* form components.
 struct AutomationEntryEditor: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.locale) private var locale
     @Binding var entry: AutomationEntry
     let error: AutomationError?
     let data: BudgetStore.AutomationEditorData
@@ -49,7 +50,7 @@ struct AutomationEntryEditor: View {
                 }
             } else {
                 Section {
-                    Text(entry.displayType.explanation)
+                    Text(entry.displayType.explanation(locale: locale))
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -81,7 +82,7 @@ struct AutomationEntryEditor: View {
                 Button("Delete Automation", role: .destructive, action: onDelete)
             }
         }
-        .navigationTitle(entry.displayType.label)
+        .navigationTitle(entry.displayType.label(locale: locale))
         .navigationBarTitleDisplayMode(.inline)
     }
 
@@ -98,10 +99,10 @@ struct AutomationEntryEditor: View {
                     entry = BudgetAutomations.convert(entry, to: type)
                 } label: {
                     VStack(alignment: .leading, spacing: 4) {
-                        Label(type.label, systemImage: type.systemImage)
+                        Label(type.label(locale: locale), systemImage: type.systemImage)
                             .font(.caption.weight(.semibold))
                             .lineLimit(1)
-                        Text(type.explanation)
+                        Text(type.explanation(locale: locale))
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Actuali/Actuali/Views/Budget/Automations/BudgetAutomationsSheet.swift
+++ b/Actuali/Actuali/Views/Budget/Automations/BudgetAutomationsSheet.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct BudgetAutomationsSheet: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.locale) private var locale
     let categoryId: String
     let month: String
 
@@ -284,7 +285,7 @@ struct BudgetAutomationsSheet: View {
         } label: {
             row(
                 icon: entry.displayType.systemImage,
-                title: entry.displayType.label,
+                title: entry.displayType.label(locale: locale),
                 subtitle: entryError?.shortMessage ?? sentence(for: entry.template),
                 trailing: AutomationDisplayType.nonContribution.contains(entry.displayType)
                     ? nil : contributions[entry.id].map(budgetStore.displayBalance),

--- a/Actuali/Actuali/Views/Reports/DashboardView.swift
+++ b/Actuali/Actuali/Views/Reports/DashboardView.swift
@@ -371,7 +371,8 @@ struct DashboardView: View {
                         SankeyBudgetInput.Entry(month: $0.month, categoryId: $0.categoryId, amountCents: $0.amountCents)
                     }),
                     today: Date(),
-                    context: conditionsContext
+                    context: conditionsContext,
+                    locale: locale
                 )
             } content: { data in
                 SankeyWidgetView(displayName: widget.displayName, data: data)

--- a/Actuali/Actuali/Views/Reports/Widgets/MonteCarloWidgetView.swift
+++ b/Actuali/Actuali/Views/Reports/Widgets/MonteCarloWidgetView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 import Charts
 
+enum MonteCarloWidgetFormatting {
+    static func percentage(_ value: Double, locale: Locale) -> String {
+        (value / 100).formatted(
+            .percent.locale(locale).precision(.fractionLength(0...1)))
+    }
+}
+
 /// Dashboard card for the Monte Carlo retirement simulation. Mirrors
 /// upstream MonteCarloCard.tsx: headline success rate to the target age,
 /// plus the compact fan chart (p10-p90 band, p25-p75 band, p50 line) from
@@ -25,8 +32,7 @@ struct MonteCarloWidgetView: View {
                 Text(displayName).font(.headline)
                 Spacer()
                 VStack(alignment: .trailing, spacing: 2) {
-                    Text(successPercent.formatted(
-                        .number.locale(locale).precision(.fractionLength(0...1))) + "%")
+                    Text(MonteCarloWidgetFormatting.percentage(successPercent, locale: locale))
                         .font(.subheadline.weight(.semibold))
                         .monospacedDigit()
                     Text(ReportStrings.format(

--- a/Actuali/Actuali/Views/Rules/RuleEditorView.swift
+++ b/Actuali/Actuali/Views/Rules/RuleEditorView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct RuleEditorView: View {
     @EnvironmentObject var budgetStore: BudgetStore
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.locale) private var locale
 
     /// Conditions and actions need stable identities for `ForEach` while the
     /// user edits them, and two identical rows are legitimate — so the editor
@@ -42,7 +43,7 @@ struct RuleEditorView: View {
             Section {
                 Picker("Stage", selection: $stage) {
                     ForEach(Rule.Stage.allCases, id: \.self) { stage in
-                        Text(stage.label).tag(stage)
+                        Text(stage.label(locale: locale)).tag(stage)
                     }
                 }
                 .pickerStyle(.segmented)

--- a/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
+++ b/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
@@ -36,6 +36,7 @@ private func ruleChoices(for field: String, in store: BudgetStore) -> [(id: Stri
 /// type. Field/op lists come from `RuleSchema`, which is the same metadata the
 /// engine validates against.
 struct RuleConditionEditor: View {
+    @Environment(\.locale) private var locale
     @Binding var condition: Rule.Condition
 
     var body: some View {
@@ -43,14 +44,16 @@ struct RuleConditionEditor: View {
             HStack {
                 Picker("Field", selection: fieldBinding) {
                     ForEach(RuleSchema.conditionFields, id: \.self) { field in
-                        Text(RuleSchema.label(field: field).capitalized).tag(field)
+                        Text(RuleValueEditorLocalization.fieldLabel(
+                            field, locale: locale)).tag(field)
                     }
                 }
                 .labelsHidden()
 
                 Picker("Operator", selection: opBinding) {
                     ForEach(RuleSchema.validOps(for: condition.field), id: \.self) { op in
-                        Text(RuleSchema.label(op: op, type: RuleSchema.fieldType(condition.field))).tag(op)
+                        Text(RuleValueEditorLocalization.operatorLabel(
+                            op, field: condition.field, locale: locale)).tag(op)
                     }
                 }
                 .labelsHidden()
@@ -113,13 +116,15 @@ struct RuleConditionEditor: View {
 
 /// One action row: `set <field> to <value>`, plus the note ops.
 struct RuleActionEditor: View {
+    @Environment(\.locale) private var locale
     @Binding var action: Rule.Action
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Picker("Action", selection: opBinding) {
                 ForEach(["set", "prepend-notes", "append-notes", "delete-transaction"], id: \.self) { op in
-                    Text(RuleSchema.label(op: op).capitalized).tag(op)
+                    Text(RuleValueEditorLocalization.operatorLabel(
+                        op, locale: locale)).tag(op)
                 }
             }
             .labelsHidden()
@@ -127,7 +132,8 @@ struct RuleActionEditor: View {
             if action.op == "set" {
                 Picker("Field", selection: fieldBinding) {
                     ForEach(RuleSchema.actionFields, id: \.self) { field in
-                        Text(RuleSchema.label(field: field).capitalized).tag(field)
+                        Text(RuleValueEditorLocalization.fieldLabel(
+                            field, locale: locale)).tag(field)
                     }
                 }
                 .labelsHidden()
@@ -331,7 +337,9 @@ struct RuleValueEditor: View {
                 value: betweenBinding("num2")
             )
         } else {
-            RuleAmountField(value: $value)
+            RuleAmountField(
+                label: RuleValueEditorLocalization.amountLabel(locale: locale),
+                value: $value)
         }
 
         if showsDirection {
@@ -409,6 +417,32 @@ enum RuleValueEditorLocalization {
     static let value: String.LocalizationValue = "Value"
     static let values: String.LocalizationValue = "Values"
 
+    static func amountLabel(
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String {
+        ReportStrings.text("Amount", locale: locale, bundle: bundle)
+    }
+
+    static func fieldLabel(
+        _ field: String,
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String {
+        RuleSchema.label(field: field, locale: locale, bundle: bundle)
+    }
+
+    static func operatorLabel(
+        _ op: String,
+        field: String? = nil,
+        locale: Locale,
+        bundle: Bundle = .main
+    ) -> String {
+        RuleSchema.label(
+            op: op, type: field.flatMap(RuleSchema.fieldType),
+            locale: locale, bundle: bundle)
+    }
+
     static func selectedCount(
         _ count: Int,
         locale: Locale = .current,
@@ -425,7 +459,7 @@ enum RuleValueEditorLocalization {
 /// input ("10.", "1,50") isn't destroyed mid-keystroke — a binding that reparsed
 /// on every character would zero the value as the user typed.
 private struct RuleAmountField: View {
-    var label = "Amount"
+    let label: String
     @Binding var value: RuleValue
     @State private var text = ""
 
@@ -453,6 +487,7 @@ private struct RuleAmountField: View {
 /// Multi-select for `oneOf` / `notOneOf` id conditions.
 struct RuleIdMultiPicker: View {
     @EnvironmentObject var budgetStore: BudgetStore
+    @Environment(\.locale) private var locale
     let field: String
     @Binding var value: RuleValue
 
@@ -479,7 +514,8 @@ struct RuleIdMultiPicker: View {
             }
             .buttonStyle(.plain)
         }
-        .navigationTitle(RuleSchema.label(field: field).capitalized)
+        .navigationTitle(RuleValueEditorLocalization.fieldLabel(
+            field, locale: locale))
         .navigationBarTitleDisplayMode(.inline)
     }
 

--- a/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
+++ b/Actuali/Actuali/Views/Rules/RuleValueEditors.swift
@@ -429,7 +429,9 @@ enum RuleValueEditorLocalization {
         locale: Locale,
         bundle: Bundle = .main
     ) -> String {
-        RuleSchema.label(field: field, locale: locale, bundle: bundle)
+        RuleSchema.sentenceCased(
+            RuleSchema.label(field: field, locale: locale, bundle: bundle),
+            locale: locale)
     }
 
     static func operatorLabel(
@@ -438,9 +440,10 @@ enum RuleValueEditorLocalization {
         locale: Locale,
         bundle: Bundle = .main
     ) -> String {
-        RuleSchema.label(
+        let label = RuleSchema.label(
             op: op, type: field.flatMap(RuleSchema.fieldType),
             locale: locale, bundle: bundle)
+        return field == nil ? RuleSchema.sentenceCased(label, locale: locale) : label
     }
 
     static func selectedCount(

--- a/Actuali/Actuali/Views/Rules/RulesListView.swift
+++ b/Actuali/Actuali/Views/Rules/RulesListView.swift
@@ -23,6 +23,7 @@ enum RuleRowLocalization {
 /// rule, search over that summary text, and swipe to delete.
 struct RulesListView: View {
     @EnvironmentObject var budgetStore: BudgetStore
+    @Environment(\.locale) private var locale
     @State private var searchText = ""
     @State private var editingRule: Rule?
     @State private var isCreating = false
@@ -31,9 +32,12 @@ struct RulesListView: View {
     private var summary: RuleSummary { budgetStore.ruleSummary }
 
     private var filteredRules: [Rule] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(with: locale)
         guard !query.isEmpty else { return budgetStore.rules }
-        return budgetStore.rules.filter { summary.searchText($0).contains(query) }
+        return budgetStore.rules.filter {
+            summary.searchText($0, locale: locale).contains(query)
+        }
     }
 
     var body: some View {
@@ -152,7 +156,7 @@ private struct RuleRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
-                Text(rule.stage.label.uppercased())
+                Text(rule.stage.label(locale: locale).uppercased(with: locale))
                     .font(.caption2.weight(.semibold))
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
@@ -166,9 +170,12 @@ private struct RuleRow: View {
                 }
             }
 
-            labelled(RuleRowLocalization.fragment("IF", locale: locale), lines: rule.conditions.map(summary.condition),
+            labelled(RuleRowLocalization.fragment("IF", locale: locale),
+                     lines: rule.conditions.map { summary.condition($0, locale: locale) },
                      joiner: RuleRowLocalization.joiner(isAnd: rule.conditionsOp == .and, locale: locale))
-            labelled(RuleRowLocalization.fragment("THEN", locale: locale), lines: rule.actions.map(summary.action), joiner: nil)
+            labelled(RuleRowLocalization.fragment("THEN", locale: locale),
+                     lines: rule.actions.map { summary.action($0, locale: locale) },
+                     joiner: nil)
         }
         .padding(.vertical, 2)
     }

--- a/Actuali/Actuali/Views/Schedules/ScheduleEditView.swift
+++ b/Actuali/Actuali/Views/Schedules/ScheduleEditView.swift
@@ -228,7 +228,7 @@ struct ScheduleEditView: View {
 
             Picker(String(localized: "Matches"), selection: $amountOp) {
                 ForEach(ScheduleAmountOp.allCases, id: \.self) { op in
-                    Text(op.label).tag(op)
+                    Text(op.label(locale: locale)).tag(op)
                 }
             }
 

--- a/Actuali/Actuali/Views/Settings/DisplaySettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/DisplaySettingsView.swift
@@ -75,6 +75,7 @@ private let currencyOptions = [
 
 struct DisplaySettingsView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.locale) private var locale
     @State private var dashboardPages: [DashboardPage] = []
 
     /// Routes the picker's selection through `setCurrencyCode`, which
@@ -139,7 +140,7 @@ struct DisplaySettingsView: View {
             Section("Appearance") {
                 Picker("Appearance", selection: $budgetStore.appearanceMode) {
                     ForEach(AppearanceMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
+                        Text(mode.label(locale: locale)).tag(mode)
                     }
                 }
             }
@@ -147,7 +148,7 @@ struct DisplaySettingsView: View {
             Section {
                 Picker("Start Page", selection: $budgetStore.startTab) {
                     ForEach(StartTab.allCases) { tab in
-                        Text(tab.label).tag(tab)
+                        Text(tab.label(locale: locale)).tag(tab)
                     }
                 }
 

--- a/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/TransactionAutomationSettingsView.swift
@@ -4,6 +4,7 @@ import UserNotifications
 
 struct TransactionAutomationSettingsView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+    @Environment(\.locale) private var locale
     @State private var transactionNotificationsEnabled = TransactionNotificationSettings().isEnabled
     @State private var creditCardDueNotificationsEnabled = CreditCardNotificationSettings().isEnabled
     @State private var notificationPermissionDenied = false
@@ -71,13 +72,13 @@ struct TransactionAutomationSettingsView: View {
             Section(String(localized: "Transaction Behavior")) {
                 Picker(String(localized: "View Transactions As"), selection: $budgetStore.transactionDisplayMode) {
                     ForEach(TransactionDisplayMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
+                        Text(mode.label(locale: locale)).tag(mode)
                     }
                 }
 
                 Picker(String(localized: "Uncategorized Action"), selection: $budgetStore.uncategorizedTapAction) {
                     ForEach(UncategorizedTapAction.allCases) { action in
-                        Text(action.label).tag(action)
+                        Text(action.label(locale: locale)).tag(action)
                     }
                 }
             }

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -463,7 +463,7 @@ struct AddTransactionView: View {
                     Section {
                         ForEach(reviewRequirements, id: \.self) { requirement in
                             Toggle(
-                                requirement.prompt,
+                                requirement.prompt(locale: locale),
                                 isOn: Binding(
                                     get: { confirmedReviewRequirements.contains(requirement) },
                                     set: { isConfirmed in
@@ -765,7 +765,8 @@ struct AddTransactionView: View {
                 NotificationRouter.shared.pendingAccountNavigation = form.accountId
             }
         } catch {
-            errorMessage = error.localizedDescription
+            errorMessage = PendingImportApprover.localizedErrorMessage(
+                for: error, locale: locale)
         }
     }
 

--- a/Actuali/ActualiTests/AppIntents/LogTransactionIntentTests.swift
+++ b/Actuali/ActualiTests/AppIntents/LogTransactionIntentTests.swift
@@ -43,6 +43,23 @@ struct LogTransactionIntentTests {
         #expect(error.errorDescription == String(localized: error.localizedStringResource))
     }
 
+    @MainActor @Test func loggerErrorsRemainTypedUntilPresentation() {
+        let locale = Locale(identifier: "fr_FR")
+        let mapped = LogTransactionError.wrapping(
+            TransactionLogger.LoggerError.transactionSuppressedByRule)
+
+        guard case .transactionSuppressedByRule = mapped else {
+            Issue.record("Expected a typed suppressed-by-rule error")
+            return
+        }
+        #expect(LogTransactionError.localizedString(
+            for: mapped, locale: locale, bundle: appBundle
+        ) == "Une règle de transaction a ignoré cette transaction.")
+        #expect(TransactionLogger.LoggerError.transactionAlreadyExists.message(
+            locale: locale, bundle: appBundle
+        ) == "Cette transaction a déjà été enregistrée.")
+    }
+
     @Test func balanceErrorsUseRequestedLocale() {
         let expected: [(Locale, String)] = [
             (Locale(identifier: "en_US"), "Account was not found. Select a valid account in your shortcut."),

--- a/Actuali/ActualiTests/Models/RuleModelTests.swift
+++ b/Actuali/ActualiTests/Models/RuleModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Actuali
 
@@ -5,6 +6,13 @@ import Testing
 /// names must come back out internal (`description`, `acct`) or the web app and
 /// the sync engine will read a rule we wrote as a different rule.
 struct RuleModelTests {
+
+    @Test func stageLabelUsesRequestedLocale() {
+        let bundle = Bundle(identifier: "com.mfazz.ActualiOS")!
+        #expect(Rule.Stage.pre.label(
+            locale: Locale(identifier: "fr_FR"), bundle: bundle
+        ) == "Avant")
+    }
 
     @Test func parsesInternalFieldNamesToPublicOnes() throws {
         let rule = try Rule.parse(

--- a/Actuali/ActualiTests/Models/TransactionDisplayModeTests.swift
+++ b/Actuali/ActualiTests/Models/TransactionDisplayModeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Actuali
 
@@ -23,7 +24,9 @@ struct TransactionDisplayModeTests {
     }
 
     @Test func labelsAreDescriptive() {
-        #expect(TransactionDisplayMode.flat.label == "Flat List")
-        #expect(TransactionDisplayMode.groupedByDate.label == "Grouped by Date")
+        let locale = Locale(identifier: "en_US")
+        let bundle = Bundle(identifier: "com.mfazz.ActualiOS")!
+        #expect(TransactionDisplayMode.flat.label(locale: locale, bundle: bundle) == "Flat List")
+        #expect(TransactionDisplayMode.groupedByDate.label(locale: locale, bundle: bundle) == "Grouped by Date")
     }
 }

--- a/Actuali/ActualiTests/Services/Budget/BudgetAutomationsTests.swift
+++ b/Actuali/ActualiTests/Services/Budget/BudgetAutomationsTests.swift
@@ -6,6 +6,16 @@ struct BudgetAutomationsTests {
 
     private let appBundle = Bundle(identifier: "com.mfazz.ActualiOS")!
 
+    @Test func displayTypeTextUsesRequestedLocale() {
+        let locale = Locale(identifier: "fr_FR")
+        #expect(AutomationDisplayType.fixed.label(
+            locale: locale, bundle: appBundle
+        ) == "Montant fixe")
+        #expect(AutomationDisplayType.fixed.explanation(
+            locale: locale, bundle: appBundle
+        ) == "Ajouter un montant fixe chaque mois, semaine, jour ou année.")
+    }
+
     private func parse(_ line: String) throws -> GoalTemplate {
         try GoalTemplateParser.parse(line)
     }

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreRulesTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreRulesTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Actuali
 
@@ -6,6 +7,8 @@ import Testing
 /// actually run.
 @MainActor
 struct BudgetStoreRulesTests {
+
+    private let appBundle = Bundle(identifier: "com.mfazz.ActualiOS")!
 
     private func rule(
         conditions: [Rule.Condition],
@@ -43,6 +46,18 @@ struct BudgetStoreRulesTests {
                 .init(op: "oneOf", field: "notes", value: .list([.string("a")]), options: nil)
             ]))
         }
+    }
+
+    @Test func validationErrorsLocalizeNestedRuleLabels() {
+        let locale = Locale(identifier: "fr_FR")
+        #expect(BudgetStoreError.ruleInvalidCondition(
+            field: "notes", op: "oneOf"
+        ).message(locale: locale, bundle: appBundle) == "\"est parmi\" ne peut pas être utilisé avec Notes.")
+        #expect(BudgetStoreError.ruleInvalidCondition(
+            field: "date", op: "gt"
+        ).message(locale: locale, bundle: appBundle) == "\"est après\" ne peut pas être utilisé avec Date.")
+        #expect(BudgetStoreError.ruleEmptyValue(field: "notes")
+            .message(locale: locale, bundle: appBundle) == "Notes doit avoir une valeur.")
     }
 
     @Test func rejectsIsBetweenWithoutARange() {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreRulesTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreRulesTests.swift
@@ -58,6 +58,8 @@ struct BudgetStoreRulesTests {
         ).message(locale: locale, bundle: appBundle) == "\"est après\" ne peut pas être utilisé avec Date.")
         #expect(BudgetStoreError.ruleEmptyValue(field: "notes")
             .message(locale: locale, bundle: appBundle) == "Notes doit avoir une valeur.")
+        #expect(BudgetStoreError.ruleEmptyValue(field: "amount")
+            .message(locale: Locale(identifier: "en_US"), bundle: appBundle) == "Amount needs a value.")
     }
 
     @Test func rejectsIsBetweenWithoutARange() {

--- a/Actuali/ActualiTests/Services/PendingImportApproverTests.swift
+++ b/Actuali/ActualiTests/Services/PendingImportApproverTests.swift
@@ -438,6 +438,26 @@ struct PendingImportApproverTests {
         #expect(try databaseRowCount(at: url) == 0)
     }
 
+    @Test func editedImportWithoutDatabaseKeepsStructuredError() async {
+        let store = makeStore()
+        store.accounts = [account("acct_checking", "Checking")]
+        let item = PendingImport(
+            originBudgetId: store.currentBudgetId,
+            amount: 12.50,
+            sourceCurrencyCode: store.currencyCode,
+            payee: "Coffee"
+        )
+        let form = BudgetStore.TransactionForm(
+            accountId: "acct_checking", type: .expense, amount: "12.50",
+            payeeName: "Coffee", transferToAccountId: nil, categoryId: nil,
+            notes: "edited", date: Date(), cleared: false
+        )
+
+        await #expect(throws: PendingImportApprover.ApproveError.noBudgetLoaded) {
+            try await PendingImportApprover(store: store).saveEdited(item, form: form)
+        }
+    }
+
     @Test func editedForeignBudgetImportRequiresServiceConfirmation() async throws {
         let (store, url) = try await makeWritableStore()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/CustomReportEngineTests.swift
@@ -3,6 +3,8 @@ import Testing
 @testable import Actuali
 
 struct CustomReportEngineTests {
+    private let englishLocale = Locale(identifier: "en_US")
+
     private let today = { // 2026-07-11 UTC
         var c = Calendar(identifier: .gregorian)
         c.timeZone = TimeZone(identifier: "UTC")!
@@ -101,7 +103,7 @@ struct CustomReportEngineTests {
             config: config(mode: "total", groupBy: "Interval", balance: "Net",
                            interval: "Monthly", graph: "BarGraph"),
             transactions: sampleTxs, reportContext: reportContext,
-            filterContext: .empty, today: today)
+            filterContext: .empty, today: today, locale: englishLocale)
         guard case .bars(let bars, let signed) = data.kind else {
             Issue.record("expected bars, got \(data.kind)"); return
         }
@@ -115,7 +117,7 @@ struct CustomReportEngineTests {
             config: config(mode: "time", groupBy: "Group", balance: "Payment",
                            interval: "Monthly", graph: "StackedBarGraph"),
             transactions: sampleTxs, reportContext: reportContext,
-            filterContext: .empty, today: today)
+            filterContext: .empty, today: today, locale: englishLocale)
         guard case .stacked(let s) = data.kind else {
             Issue.record("expected stacked, got \(data.kind)"); return
         }
@@ -135,6 +137,20 @@ struct CustomReportEngineTests {
             Issue.record("expected stacked, got \(data.kind)"); return
         }
         #expect(s.intervalLabels == ["26-06-28"])
+    }
+
+    @Test func intervalLabelsKeepGregorianCalendarForNonGregorianLocale() {
+        let data = CustomReportEngine.compute(
+            config: config(mode: "total", groupBy: "Interval", balance: "Payment",
+                           interval: "Yearly", graph: "BarGraph",
+                           staticRange: ("2026-01-01", "2026-12-31")),
+            transactions: [tx("1", date: 20260701, amount: -5_000, category: "c-fun")],
+            reportContext: reportContext, filterContext: .empty, today: today,
+            locale: Locale(identifier: "th_TH"))
+        guard case .bars(let bars, _) = data.kind else {
+            Issue.record("expected bars, got \(data.kind)"); return
+        }
+        #expect(bars.map(\.label) == ["2026"])
     }
 
     @Test func unsupportedOptionsAreNamed() {
@@ -186,7 +202,8 @@ struct CustomReportEngineTests {
                 config: config(mode: "total", groupBy: groupBy, balance: "Payment",
                                interval: "Monthly", graph: "BarGraph", sortBy: "budget",
                                showOffBudget: true),
-                transactions: txs, reportContext: ctx, filterContext: .empty, today: today)
+                transactions: txs, reportContext: ctx, filterContext: .empty, today: today,
+                locale: englishLocale)
         }
         guard case .bars(let byCategory, _) = run(groupBy: "Category").kind,
               case .bars(let byGroup, _) = run(groupBy: "Group").kind,
@@ -217,7 +234,8 @@ struct CustomReportEngineTests {
                 config: config(mode: "total", groupBy: groupBy, balance: "Payment",
                                interval: "Monthly", graph: "BarGraph", sortBy: "budget",
                                showUncategorized: true),
-                transactions: txs, reportContext: reportContext, filterContext: .empty, today: today)
+                transactions: txs, reportContext: reportContext, filterContext: .empty,
+                today: today, locale: englishLocale)
         }
         guard case .bars(let byCategory, _) = run(groupBy: "Category").kind,
               case .bars(let byGroup, _) = run(groupBy: "Group").kind else {
@@ -234,7 +252,7 @@ struct CustomReportEngineTests {
             config: config(mode: "total", groupBy: "Interval", balance: "Net",
                            interval: "Monthly", graph: "TableGraph"),
             transactions: sampleTxs, reportContext: reportContext,
-            filterContext: .empty, today: today)
+            filterContext: .empty, today: today, locale: englishLocale)
         guard case .table(let rows) = data.kind else {
             Issue.record("expected table, got \(data.kind)"); return
         }
@@ -384,7 +402,7 @@ struct CustomReportEngineTests {
             config: config(mode: "total", groupBy: "Interval", balance: "Payment",
                            interval: "Monthly", graph: "DonutGraph"),
             transactions: sampleTxs, reportContext: reportContext,
-            filterContext: .empty, today: today)
+            filterContext: .empty, today: today, locale: englishLocale)
         guard case .donut(let slices, let groups) = data.kind else {
             Issue.record("expected donut, got \(data.kind)"); return
         }
@@ -478,7 +496,7 @@ struct CustomReportEngineTests {
             config: config(mode: "total", groupBy: "Interval", balance: "Payment",
                            interval: "Monthly", graph: "AreaGraph"),
             transactions: sampleTxs, reportContext: reportContext,
-            filterContext: .empty, today: today)
+            filterContext: .empty, today: today, locale: englishLocale)
         guard case .area(let points) = data.kind else {
             Issue.record("expected area, got \(data.kind)"); return
         }
@@ -499,7 +517,8 @@ struct CustomReportEngineTests {
                 config: config(mode: "time", groupBy: groupBy, balance: "Payment",
                                interval: "Monthly", graph: groupBy == "Interval" ? "BarGraph" : "StackedBarGraph",
                                trimIntervals: trim, staticRange: ("2026-03-01", "2026-08-31")),
-                transactions: txs, reportContext: reportContext, filterContext: .empty, today: today)
+                transactions: txs, reportContext: reportContext, filterContext: .empty,
+                today: today, locale: englishLocale)
             switch data.kind {
             case .stacked(let s): return s.intervalLabels
             case .bars(let bars, _): return bars.map(\.label)

--- a/Actuali/ActualiTests/Services/Reports/MonteCarloEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/MonteCarloEngineTests.swift
@@ -7,6 +7,13 @@ import Testing
 /// computed with the upstream mulberry32/Box-Muller PRNG in node.
 struct MonteCarloEngineTests {
 
+    @Test func widgetPercentageUsesInjectedLocale() {
+        #expect(MonteCarloWidgetFormatting.percentage(
+            85.5, locale: Locale(identifier: "en_US")) == "85.5%")
+        #expect(MonteCarloWidgetFormatting.percentage(
+            85.5, locale: Locale(identifier: "fr_FR")) == "85,5\u{00A0}%")
+    }
+
     /// Upstream makePot: custom preset, mean 0.06, stdDev 0.1, balance 50M cents.
     private func pot(
         id: String = "pot-1",

--- a/Actuali/ActualiTests/Services/Reports/SankeyEngineTests.swift
+++ b/Actuali/ActualiTests/Services/Reports/SankeyEngineTests.swift
@@ -6,6 +6,8 @@ import Testing
 /// engine-level compute coverage.
 struct SankeyEngineTests {
 
+    private let englishLocale = Locale(identifier: "en_US")
+
     // 2024-01-15 UTC, so the default (nil) time frame is 2024-01.
     private var asOf: Date {
         var c = DateComponents(); c.year = 2024; c.month = 1; c.day = 15
@@ -161,10 +163,14 @@ struct SankeyEngineTests {
         graph.addValueToLink(from: "node1", to: "target", value: 250)
         graph.addValueToLink(from: "node2", to: "target", value: 750)
 
-        SankeyEngine.addPercentageLabels(&graph)
+        SankeyEngine.addPercentageLabels(&graph, locale: Locale(identifier: "en_US"))
 
         #expect(graph["node1"]?.percentageLabel == "25.0%")
         #expect(graph["node2"]?.percentageLabel == "75.0%")
+
+        SankeyEngine.addPercentageLabels(&graph, locale: Locale(identifier: "fr_FR"))
+        #expect(graph["node1"]?.percentageLabel == "25,0\u{00A0}%")
+        #expect(graph["node2"]?.percentageLabel == "75,0\u{00A0}%")
     }
 
     @Test func addPercentageLabelsUsesGraphLayerNotDepth() {
@@ -178,7 +184,7 @@ struct SankeyEngineTests {
         graph.addValueToLink(from: "income-cat", to: "account-incoming", value: 300)
         graph.addValueToLink(from: "account-root", to: "group", value: 100)
 
-        SankeyEngine.addPercentageLabels(&graph)
+        SankeyEngine.addPercentageLabels(&graph, locale: Locale(identifier: "en_US"))
 
         #expect(graph["account-root"]?.percentageLabel == "25.0%")
         #expect(graph["account-incoming"]?.percentageLabel == "75.0%")
@@ -273,7 +279,10 @@ struct SankeyEngineTests {
                                       fromPreviousMonthCents: 200,
                                       lastMonthOverspentCents: 0, forNextMonthCents: 300)
 
-        let graph = SankeyEngine.createBudgetGraph(entries, budget: input, startMonth: "2024-01", endMonth: "2024-01")
+        let graph = SankeyEngine.createBudgetGraph(
+            entries, budget: input, startMonth: "2024-01", endMonth: "2024-01",
+            locale: englishLocale
+        )
 
         #expect(graph["c_salary"] != nil)
         #expect(graph["c_groceries"] != nil)
@@ -286,7 +295,10 @@ struct SankeyEngineTests {
 
     @Test func createBudgetGraphMarksOverbudgeted() {
         let input = SankeyBudgetInput(entries: [], toBudgetCents: -500)
-        let graph = SankeyEngine.createBudgetGraph([], budget: input, startMonth: "2024-01", endMonth: "2024-01")
+        let graph = SankeyEngine.createBudgetGraph(
+            [], budget: input, startMonth: "2024-01", endMonth: "2024-01",
+            locale: englishLocale
+        )
 
         #expect(graph["to_budget"]?.isNegative == true)
         #expect(graph["to_budget"]?.name == "Overbudgeted")
@@ -370,7 +382,7 @@ struct SankeyEngineTests {
 
         let data = SankeyEngine.compute(
             meta: meta(topN: 2), transactions: transactions, categoryGroups: groups,
-            today: asOf, context: context
+            today: asOf, context: context, locale: englishLocale
         )
 
         // per-group sort buckets into the category group's Other node
@@ -390,7 +402,7 @@ struct SankeyEngineTests {
 
         let grouped = SankeyEngine.compute(
             meta: meta(groupAccounts: true), transactions: transactions, categoryGroups: groups,
-            today: asOf, context: context
+            today: asOf, context: context, locale: englishLocale
         )
         #expect(node(grouped, key: "all_income")?.name == "Income")
         #expect(node(grouped, key: "a_checking") == nil)
@@ -454,7 +466,7 @@ struct SankeyEngineTests {
 
         let data = SankeyEngine.compute(
             meta: meta(mode: "budgeted"), transactions: transactions, categoryGroups: groups,
-            budget: budget, today: asOf, context: context
+            budget: budget, today: asOf, context: context, locale: englishLocale
         )
 
         #expect(node(data, key: "budgeted")?.name == "Budgeted")
@@ -476,5 +488,24 @@ struct SankeyEngineTests {
         // "To budget" sits in the group layer with no child, so it gets a
         // hidden child chain to pin its column.
         #expect(data.nodes.map(\.key).contains("to_budget_category__HIDDEN"))
+    }
+
+    @Test func budgetedMonthLabelsUseGregorianYear() {
+        let budget = SankeyBudgetInput(fromPreviousMonthCents: 1)
+        let data = SankeyEngine.compute(
+            meta: meta(mode: "budgeted"), transactions: [], categoryGroups: groups,
+            budget: budget, today: asOf, context: context,
+            locale: Locale(identifier: "th_TH@calendar=buddhist")
+        )
+
+        #expect(node(data, key: "from_previous_month")?.name.contains("2023") == true)
+        #expect(node(data, key: "from_previous_month")?.name.contains("2566") == false)
+
+        let french = SankeyEngine.compute(
+            meta: meta(mode: "budgeted"), transactions: [], categoryGroups: groups,
+            budget: budget, today: asOf, context: context,
+            locale: Locale(identifier: "fr_FR"), bundle: Bundle(identifier: "com.mfazz.ActualiOS")!
+        )
+        #expect(node(french, key: "from_previous_month")?.name == "De déc. 2023")
     }
 }

--- a/Actuali/ActualiTests/Services/Rules/RuleSummaryTests.swift
+++ b/Actuali/ActualiTests/Services/Rules/RuleSummaryTests.swift
@@ -5,6 +5,8 @@ import Testing
 /// The IF/THEN text on the rules list, and the string its search box matches.
 struct RuleSummaryTests {
 
+    private let englishLocale = Locale(identifier: "en_US")
+
     private let summary = RuleSummary(
         names: .init(
             payees: ["payee-1": "Woolworths"],
@@ -12,31 +14,36 @@ struct RuleSummaryTests {
             categoryGroups: ["grp-1": "Daily"],
             accounts: ["acct-1": "Checking"]
         ),
-        formatAmount: { cents in "$\(Double(cents) / 100)" }
+        formatAmount: { cents, _ in "$\(Double(cents) / 100)" }
     )
+
+    private var appBundle: Bundle {
+        Bundle(identifier: "com.mfazz.ActualiOS")!
+    }
 
     @Test func namesIdsInsteadOfShowingUUIDs() {
         let condition = Rule.Condition(op: "is", field: "payee",
                                        value: .string("payee-1"), options: nil)
-        #expect(summary.condition(condition) == "payee is Woolworths")
+        #expect(summary.condition(condition, locale: englishLocale) == "payee is Woolworths")
     }
 
     @Test func labelsAmountDirectionFromOptions() {
         let condition = Rule.Condition(op: "gt", field: "amount", value: .number(5000),
                                        options: ["outflow": .bool(true)])
-        #expect(summary.condition(condition).hasPrefix("amount (outflow) is greater than"))
+        #expect(summary.condition(condition, locale: englishLocale)
+            .hasPrefix("amount (outflow) is greater than"))
     }
 
     @Test func rendersOpsWithoutAValue() {
         let condition = Rule.Condition(op: "offBudget", field: "account",
                                        value: .null, options: nil)
-        #expect(summary.condition(condition) == "account is off budget")
+        #expect(summary.condition(condition, locale: englishLocale) == "account is off budget")
     }
 
     @Test func describesActions() {
         let action = Rule.Action(op: "set", field: "category",
                                  value: .string("cat-1"), options: nil)
-        #expect(summary.action(action) == "set category to Groceries")
+        #expect(summary.action(action, locale: englishLocale) == "set category to Groceries")
     }
 
     @Test func searchTextCoversConditionsAndActions() {
@@ -49,6 +56,21 @@ struct RuleSummaryTests {
         let text = summary.searchText(rule)
         #expect(text.contains("woolies"))
         #expect(text.contains("groceries"))
+    }
+
+    @Test func summaryUsesRequestedLocaleForConditionsAndActions() {
+        let locale = Locale(identifier: "fr_FR")
+        let condition = Rule.Condition(
+            op: "gt", field: "date", value: .string("2026-01-01"), options: nil)
+        let action = Rule.Action(
+            op: "set", field: "category", value: .string("cat-1"), options: nil)
+
+        #expect(summary.condition(
+            condition, locale: locale, bundle: appBundle
+        ) == "date est après 2026-01-01")
+        #expect(summary.action(
+            action, locale: locale, bundle: appBundle
+        ) == "définir catégorie sur Groceries")
     }
 
     @Test func ruleRowFragmentsUseRequestedLocale() {

--- a/Actuali/ActualiTests/Services/Schedules/ScheduleConditionsTests.swift
+++ b/Actuali/ActualiTests/Services/Schedules/ScheduleConditionsTests.swift
@@ -9,6 +9,13 @@ struct ScheduleConditionsTests {
 
     private let fixedDate = ScheduleDateCondition.fixed(DayDate(yyyymmdd: 20260813)!)
 
+    @Test func amountOperatorLabelUsesRequestedLocale() {
+        let bundle = Bundle(identifier: "com.mfazz.ActualiOS")!
+        #expect(ScheduleAmountOp.isExactly.label(
+            locale: Locale(identifier: "fr_FR"), bundle: bundle
+        ) == "est exactement")
+    }
+
     private func fields(
         payee: String? = "payee-1",
         account: String? = "acct-1",

--- a/Actuali/ActualiTests/Views/DisplaySettingsViewTests.swift
+++ b/Actuali/ActualiTests/Views/DisplaySettingsViewTests.swift
@@ -4,6 +4,17 @@ import Testing
 
 struct DisplaySettingsViewTests {
 
+    private let appBundle = Bundle(identifier: "com.mfazz.ActualiOS")!
+
+    @Test func settingsLabelsUseRequestedLocale() {
+        let locale = Locale(identifier: "fr_FR")
+
+        #expect(AppearanceMode.system.label(locale: locale, bundle: appBundle) == "Système")
+        #expect(StartTab.accounts.label(locale: locale, bundle: appBundle) == "Comptes")
+        #expect(TransactionDisplayMode.flat.label(locale: locale, bundle: appBundle) == "Liste simple")
+        #expect(UncategorizedTapAction.categoryPicker.label(locale: locale, bundle: appBundle) == "Sélecteur de catégories")
+    }
+
     @Test func rejectsResultsFromStaleBudgetOrDatabase() {
         let oldDatabase = NSObject()
         let currentDatabase = NSObject()

--- a/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
+++ b/Actuali/ActualiTests/Views/PendingImportsResolveAccountTests.swift
@@ -25,6 +25,58 @@ struct PendingImportsResolveAccountTests {
             == "2 transactions n’ont pas pu être approuvées. Vérifiez leurs détails.")
     }
 
+    @Test func reviewStringsUseInjectedLocale() {
+        let locale = Locale(identifier: "fr_FR")
+        #expect(PendingImportsView.currencyContext(
+            for: PendingImport(originBudgetId: "other-budget", sourceCurrencyCode: "EUR"),
+            activeBudgetId: "active-budget",
+            budgetCurrency: "USD",
+            locale: locale,
+            bundle: appBundle
+        ) == "Cette importation appartient à un autre budget. Vérifiez et confirmez son adoption dans le budget actif avant de l'enregistrer.")
+        #expect(PendingImportsView.currencyContext(
+            for: PendingImport(originBudgetId: "active-budget", sourceCurrencyCode: "EUR"),
+            activeBudgetId: "active-budget",
+            budgetCurrency: "USD",
+            locale: locale,
+            bundle: appBundle
+        ) == "Devise source : EUR. Budget actif : USD. Vérifiez et confirmez avant d’enregistrer.")
+        #expect(PendingImportsView.unknownPayee(locale: locale, bundle: appBundle)
+            == "Bénéficiaire inconnu")
+        #expect(PendingImportsView.cardLabel("1234", locale: locale, bundle: appBundle)
+            == "Carte ••1234")
+    }
+
+    @Test func errorsUseInjectedLocale() {
+        let locale = Locale(identifier: "fr_FR")
+        #expect(PendingImportApprover.localizedErrorMessage(
+            for: PendingImportApprover.ApproveError.sourceCurrencyMismatch(
+                source: "EUR", budget: "USD"),
+            locale: locale,
+            bundle: appBundle
+        ) == "Cette importation est en EUR, mais le budget actif utilise USD. Vérifiez et confirmez la transaction avant de l’enregistrer.")
+        #expect(PendingImportApprover.localizedErrorMessage(
+            for: PendingImportStore.StoreError.saveFailed("disk full"),
+            locale: locale,
+            bundle: appBundle
+        ) == "Impossible d'enregistrer les importations en attente : disk full")
+        #expect(PendingImportApprover.localizedErrorMessage(
+            for: BudgetStoreError.invalidAmount,
+            locale: locale,
+            bundle: appBundle
+        ) == "Montant invalide")
+        #expect(PendingImportApprover.localizedErrorMessage(
+            for: PendingImportApprover.ApproveError.noBudgetLoaded,
+            locale: locale,
+            bundle: appBundle
+        ) == "Ouvrez Actuali et sélectionnez d'abord un budget.")
+        #expect(PendingImportApprover.localizedErrorMessage(
+            for: PendingImportApprover.ApproveError.transactionNeedsRecovery,
+            locale: locale,
+            bundle: appBundle
+        ) == "Cette importation doit être examinée avant de pouvoir être approuvée.")
+    }
+
     @Test func bulkApprovalFailuresRecoverConsistently() {
         #expect(PendingImportsView.bulkApprovalDisposition(
             for: PendingImportApprover.ApproveError.alreadyApproved
@@ -171,7 +223,15 @@ struct PendingImportsResolveAccountTests {
             .confirmActiveBudgetCurrency(source: "EUR", budget: "USD")
         ])
         #expect(requirements.count == 2)
-        #expect(requirements[1].prompt.contains("no conversion"))
+        #expect(requirements[1].prompt(
+            locale: Locale(identifier: "en_US"), bundle: appBundle
+        ).contains("no conversion"))
+        #expect(requirements[0].prompt(
+            locale: Locale(identifier: "fr_FR"), bundle: appBundle
+        ) == "Je confirme que cette importation doit être adoptée dans le budget actif.")
+        #expect(requirements[1].prompt(
+            locale: Locale(identifier: "fr_FR"), bundle: appBundle
+        ) == "Je confirme que le montant numérique est dans la devise du budget actif (USD) ; aucune conversion depuis EUR ne sera effectuée.")
     }
 
     @Test func unknownCurrencyRequiresIndependentAcknowledgement() {

--- a/Actuali/ActualiTests/Views/RuleValueEditorsTests.swift
+++ b/Actuali/ActualiTests/Views/RuleValueEditorsTests.swift
@@ -57,4 +57,18 @@ struct RuleValueEditorsTests {
             }
         }
     }
+
+    @Test func editorLabelsUseRequestedLocale() {
+        let locale = Locale(identifier: "fr_FR")
+
+        #expect(RuleValueEditorLocalization.amountLabel(
+            locale: locale, bundle: appBundle
+        ) == "Montant")
+        #expect(RuleValueEditorLocalization.fieldLabel(
+            "category_group", locale: locale, bundle: appBundle
+        ) == "groupe de catégories")
+        #expect(RuleValueEditorLocalization.operatorLabel(
+            "gt", field: "date", locale: locale, bundle: appBundle
+        ) == "est après")
+    }
 }

--- a/Actuali/ActualiTests/Views/RuleValueEditorsTests.swift
+++ b/Actuali/ActualiTests/Views/RuleValueEditorsTests.swift
@@ -66,9 +66,12 @@ struct RuleValueEditorsTests {
         ) == "Montant")
         #expect(RuleValueEditorLocalization.fieldLabel(
             "category_group", locale: locale, bundle: appBundle
-        ) == "groupe de catégories")
+        ) == "Groupe de catégories")
         #expect(RuleValueEditorLocalization.operatorLabel(
             "gt", field: "date", locale: locale, bundle: appBundle
         ) == "est après")
+        #expect(RuleValueEditorLocalization.operatorLabel(
+            "set", locale: locale, bundle: appBundle
+        ) == "Définir")
     }
 }

--- a/Actuali/ActualiTests/Views/TransactionLocalizationTests.swift
+++ b/Actuali/ActualiTests/Views/TransactionLocalizationTests.swift
@@ -130,4 +130,20 @@ struct TransactionLocalizationTests {
             ) == expectedValue)
         }
     }
+
+    @Test func ruleFieldLabelsKeepTheCatalogCasing() {
+        let expected = [
+            ("fr_FR", "groupe de catégories"),
+            ("es_ES", "grupo de categorías"),
+            ("it_IT", "gruppo di categorie")
+        ]
+
+        for (localeIdentifier, expectedValue) in expected {
+            #expect(ReportStrings.text(
+                "rule.field.categoryGroup",
+                locale: Locale(identifier: localeIdentifier),
+                bundle: appBundle
+            ) == expectedValue)
+        }
+    }
 }


### PR DESCRIPTION
## Why

The translated catalog can only help when strings are resolved with the locale that SwiftUI or App Intents is actually using. Several model labels, rule summaries, import errors, and report values were still formatted through process defaults, which could leave runtime text in the wrong language, use locale-specific non-Gregorian years, or render percentages with English separators.

This is a focused follow-up to #430.

## What

- Pass the active SwiftUI locale through settings, budget automations, schedules, rules, pending imports, transaction logging, and App Intent error reporting.
- Keep structured errors intact until presentation so nested field names and failure details are localized once, in the requested locale.
- Make rule labels, summaries, search normalization, and amount formatting locale-aware.
- Keep Actual budget periods on the Gregorian calendar while localizing report month labels, Sankey labels, and Sankey/Monte Carlo percentages with Foundation format styles.
- Add explicit French, Portuguese, German, Swedish, and Thai coverage, and make English fixture expectations independent of the simulator language.

## How it was tested

- Runtime-localization suites under `fr-FR`: 233 tests, no failures or skips
- Full non-UI unit suite under `en-US`: 2,096 tests, no failures or skips
- `python3 dev/scripts/validate-localization.py`: 1,221 source keys, 25 App Shortcut phrases, 1,541 catalog entries, 7 locales
- Localization-validator suite: 54 tests, no failures
- Release simulator build from fresh DerivedData
- `build-for-testing` for the complete `Actuali` scheme, including UI-test and widget compilation
- `git diff --check` and workspace diagnostics

## Screenshots

Not applicable; this changes localized runtime text and formatting without changing layout.