### PR TITLE
Refactor SettingsView

### DIFF
--- a/Actuali/Actuali/Views/Settings/SettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/SettingsView.swift
@@ -1,7 +1,35 @@
 import SwiftUI
 
+private struct SettingsItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let systemImage: String
+    let destination: AnyView
+}
+
 struct SettingsView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
+
+    private var preferencesItems: [SettingsItem] {
+        [
+            SettingsItem(title: String(localized: "Budget View"), systemImage: "wallet.bifold", destination: AnyView(BudgetViewSettingsView())),
+            SettingsItem(title: String(localized: "Display"), systemImage: "iphone", destination: AnyView(DisplaySettingsView())),
+            SettingsItem(title: String(localized: "Privacy"), systemImage: "hand.raised", destination: AnyView(PrivacySettingsView())),
+            SettingsItem(title: String(localized: "Transactions & Automation"), systemImage: "arrow.left.arrow.right", destination: AnyView(TransactionAutomationSettingsView()))
+        ].sorted { $0.title < $1.title }
+    }
+
+    private var manageItems: [SettingsItem] {
+        var items = [
+            SettingsItem(title: String(localized: "Bank Sync (SimpleFIN & Wallet)"), systemImage: "building.columns", destination: AnyView(BankSyncSetupView())),
+            SettingsItem(title: "Bills & Calendar", systemImage: "calendar", destination: AnyView(BillsCalendarView())),
+            SettingsItem(title: String(localized: "Scheduled Transactions"), systemImage: "calendar.badge.clock", destination: AnyView(SchedulesListView()))
+        ]
+        if budgetStore.currentBudgetId != nil {
+            items.append(SettingsItem(title: String(localized: "Rules"), systemImage: "list.bullet.rectangle", destination: AnyView(RulesListView())))
+        }
+        return items.sorted { $0.title < $1.title }
+    }
 
     var body: some View {
         NavigationStack {
@@ -13,61 +41,24 @@ struct SettingsView: View {
                         Label(String(localized: "Connection & Data"), systemImage: "server.rack")
                     }
                 }
-
                 Section(String(localized: "Preferences")) {
-                    NavigationLink {
-                        BudgetViewSettingsView()
-                    } label: {
-                        Label(String(localized: "Budget View"), systemImage: "wallet.bifold")
-                    }
-
-                    NavigationLink {
-                        TransactionAutomationSettingsView()
-                    } label: {
-                        Label(String(localized: "Transactions & Automation"), systemImage: "arrow.left.arrow.right")
-                    }
-
-                    NavigationLink {
-                        DisplaySettingsView()
-                    } label: {
-                        Label(String(localized: "Display"), systemImage: "iphone")
-                    }
-
-                    NavigationLink {
-                        PrivacySettingsView()
-                    } label: {
-                        Label(String(localized: "Privacy"), systemImage: "hand.raised")
-                    }
-                }
-
-                Section(String(localized: "Manage")) {
-                    NavigationLink {
-                        BillsCalendarView()
-                    } label: {
-                        Label("Bills & Calendar", systemImage: "calendar")
-                    }
-
-                    NavigationLink {
-                        SchedulesListView()
-                    } label: {
-                        Label(String(localized: "Scheduled Transactions"), systemImage: "calendar.badge.clock")
-                    }
-
-                    if budgetStore.currentBudgetId != nil {
+                    ForEach(preferencesItems) { item in
                         NavigationLink {
-                            RulesListView()
+                            item.destination
                         } label: {
-                            Label(String(localized: "Rules"), systemImage: "list.bullet.rectangle")
+                            Label(item.title, systemImage: item.systemImage)
                         }
                     }
-
-                    NavigationLink {
-                        BankSyncSetupView()
-                    } label: {
-                        Label(String(localized: "Bank Sync (SimpleFIN & Wallet)"), systemImage: "building.columns")
+                }
+                Section(String(localized: "Manage")) {
+                    ForEach(manageItems) { item in
+                        NavigationLink {
+                            item.destination
+                        } label: {
+                            Label(item.title, systemImage: item.systemImage)
+                        }
                     }
                 }
-
                 Section(String(localized: "Information")) {
                     NavigationLink {
                         AboutSettingsView()
@@ -80,9 +71,6 @@ struct SettingsView: View {
             .navigationTitle(String(localized: "navigation.settings"))
             .contentMargins(.horizontal, 6, for: .scrollContent)
         }
-        // Keep the store-wide loading indicator above the navigation stack so
-        // operations started from any destination remain covered, not only
-        // work launched from the hub form.
         .overlay {
             if budgetStore.isLoading {
                 ProgressView()

--- a/Actuali/Actuali/Views/Settings/SettingsView.swift
+++ b/Actuali/Actuali/Views/Settings/SettingsView.swift
@@ -1,34 +1,37 @@
 import SwiftUI
 
-private struct SettingsItem: Identifiable {
-    let id = UUID()
+struct SettingsItem {
     let title: String
     let systemImage: String
-    let destination: AnyView
+    let destination: () -> AnyView
 }
 
 struct SettingsView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
-    private var preferencesItems: [SettingsItem] {
+    static var preferencesItems: [SettingsItem] {
         [
-            SettingsItem(title: String(localized: "Budget View"), systemImage: "wallet.bifold", destination: AnyView(BudgetViewSettingsView())),
-            SettingsItem(title: String(localized: "Display"), systemImage: "iphone", destination: AnyView(DisplaySettingsView())),
-            SettingsItem(title: String(localized: "Privacy"), systemImage: "hand.raised", destination: AnyView(PrivacySettingsView())),
-            SettingsItem(title: String(localized: "Transactions & Automation"), systemImage: "arrow.left.arrow.right", destination: AnyView(TransactionAutomationSettingsView()))
-        ].sorted { $0.title < $1.title }
+            SettingsItem(title: String(localized: "Budget View"), systemImage: "wallet.bifold", destination: { AnyView(BudgetViewSettingsView()) }),
+            SettingsItem(title: String(localized: "Display"), systemImage: "iphone", destination: { AnyView(DisplaySettingsView()) }),
+            SettingsItem(title: String(localized: "Privacy"), systemImage: "hand.raised", destination: { AnyView(PrivacySettingsView()) }),
+            SettingsItem(title: String(localized: "Transactions & Automation"), systemImage: "arrow.left.arrow.right", destination: { AnyView(TransactionAutomationSettingsView()) })
+        ].sorted { Self.titlePrecedes($0.title, $1.title) }
     }
 
-    private var manageItems: [SettingsItem] {
+    static func manageItems(includeRules: Bool) -> [SettingsItem] {
         var items = [
-            SettingsItem(title: String(localized: "Bank Sync (SimpleFIN & Wallet)"), systemImage: "building.columns", destination: AnyView(BankSyncSetupView())),
-            SettingsItem(title: "Bills & Calendar", systemImage: "calendar", destination: AnyView(BillsCalendarView())),
-            SettingsItem(title: String(localized: "Scheduled Transactions"), systemImage: "calendar.badge.clock", destination: AnyView(SchedulesListView()))
+            SettingsItem(title: String(localized: "Bank Sync (SimpleFIN & Wallet)"), systemImage: "building.columns", destination: { AnyView(BankSyncSetupView()) }),
+            SettingsItem(title: String(localized: "Bills & Calendar"), systemImage: "calendar", destination: { AnyView(BillsCalendarView()) }),
+            SettingsItem(title: String(localized: "Scheduled Transactions"), systemImage: "calendar.badge.clock", destination: { AnyView(SchedulesListView()) })
         ]
-        if budgetStore.currentBudgetId != nil {
-            items.append(SettingsItem(title: String(localized: "Rules"), systemImage: "list.bullet.rectangle", destination: AnyView(RulesListView())))
+        if includeRules {
+            items.append(SettingsItem(title: String(localized: "Rules"), systemImage: "list.bullet.rectangle", destination: { AnyView(RulesListView()) }))
         }
-        return items.sorted { $0.title < $1.title }
+        return items.sorted { Self.titlePrecedes($0.title, $1.title) }
+    }
+
+    nonisolated static func titlePrecedes(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
     }
 
     var body: some View {
@@ -42,18 +45,18 @@ struct SettingsView: View {
                     }
                 }
                 Section(String(localized: "Preferences")) {
-                    ForEach(preferencesItems) { item in
+                    ForEach(Self.preferencesItems, id: \.title) { item in
                         NavigationLink {
-                            item.destination
+                            item.destination()
                         } label: {
                             Label(item.title, systemImage: item.systemImage)
                         }
                     }
                 }
                 Section(String(localized: "Manage")) {
-                    ForEach(manageItems) { item in
+                    ForEach(Self.manageItems(includeRules: budgetStore.currentBudgetId != nil), id: \.title) { item in
                         NavigationLink {
-                            item.destination
+                            item.destination()
                         } label: {
                             Label(item.title, systemImage: item.systemImage)
                         }
@@ -71,6 +74,9 @@ struct SettingsView: View {
             .navigationTitle(String(localized: "navigation.settings"))
             .contentMargins(.horizontal, 6, for: .scrollContent)
         }
+        // Keep the store-wide loading indicator above the navigation stack so
+        // operations started from any destination remain covered, not only
+        // work launched from the hub form.
         .overlay {
             if budgetStore.isLoading {
                 ProgressView()

--- a/Actuali/ActualiTests/Views/SettingsViewTests.swift
+++ b/Actuali/ActualiTests/Views/SettingsViewTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import Actuali
+
+struct SettingsViewTests {
+
+    @Test @MainActor func sectionsAreSortedAndRulesAreConditional() {
+        #expect(SettingsView.preferencesItems.map(\.title) == [
+            "Budget View", "Display", "Privacy", "Transactions & Automation"
+        ])
+        #expect(SettingsView.manageItems(includeRules: false).map(\.title) == [
+            "Bank Sync (SimpleFIN & Wallet)", "Bills & Calendar", "Scheduled Transactions"
+        ])
+        #expect(SettingsView.manageItems(includeRules: true).map(\.title) == [
+            "Bank Sync (SimpleFIN & Wallet)", "Bills & Calendar", "Rules", "Scheduled Transactions"
+        ])
+    }
+
+    @Test func titlesSortCaseInsensitively() {
+        let titles = ["Banana", "apple"]
+
+        #expect(titles.sorted(by: SettingsView.titlePrecedes) == ["apple", "Banana"])
+    }
+}


### PR DESCRIPTION
Why

Preferences and Manage settings could drift out of alphabetical order as rows were added.

What

- Models each row as a title, SF Symbol, and lazy destination.
- Sorts localized titles with locale-aware, case-insensitive comparison.
- Uses stable title identity so view updates preserve row state.
- Keeps Rules conditional on an open budget.
- Keeps every settings title localized.

How it was tested

- Full unit suite on iOS 18.5 with the en-US test locale.
- Focused SettingsView tests cover section ordering and conditional Rules insertion.