### PR TITLE
Allow transfers in split transactions

### DIFF
--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -4203,6 +4203,11 @@ final class BudgetStore: ObservableObject {
                         var deletedChild = child
                         deletedChild.tombstone = true
                         deleted.append(deletedChild)
+                        if let partnerId = child.transferId,
+                           var partner = try await database.fetchTransaction(id: partnerId) {
+                            partner.tombstone = true
+                            deleted.append(partner)
+                        }
                     }
                 } catch {
                     // Skip the parent when its children couldn't be read —
@@ -4568,8 +4573,9 @@ final class BudgetStore: ObservableObject {
         var isOpposite: Bool
         var notes: String
         var payeeName: String
+        var payeeId: String?
 
-        init(id: UUID = UUID(), childId: String? = nil, categoryId: String? = nil, amount: String = "", isOpposite: Bool = false, notes: String = "", payeeName: String = "") {
+        init(id: UUID = UUID(), childId: String? = nil, categoryId: String? = nil, amount: String = "", isOpposite: Bool = false, notes: String = "", payeeName: String = "", payeeId: String? = nil) {
             self.id = id
             self.childId = childId
             self.categoryId = categoryId
@@ -4577,6 +4583,7 @@ final class BudgetStore: ObservableObject {
             self.isOpposite = isOpposite
             self.notes = notes
             self.payeeName = payeeName
+            self.payeeId = payeeId
         }
     }
 
@@ -4587,6 +4594,7 @@ final class BudgetStore: ObservableObject {
         var amountCents: Int
         var notes: String?
         var payeeName: String? = nil
+        var payeeId: String? = nil
         var childId: String? = nil
     }
 
@@ -4644,6 +4652,7 @@ final class BudgetStore: ObservableObject {
                 amountCents: sign * (line.isOpposite ? -cents : cents),
                 notes: line.notes.isEmpty ? nil : line.notes,
                 payeeName: payeeName.isEmpty ? nil : payeeName,
+                payeeId: line.payeeId,
                 childId: line.childId
             )
         }
@@ -4752,42 +4761,86 @@ final class BudgetStore: ObservableObject {
                 importedPayee: payeeName
             )
             var children: [Transaction] = []
+            var transferPartners: [Transaction] = []
             for (index, line) in lines.enumerated() {
                 // Children inherit the parent's payee unless the line names
                 // its own (Actual's makeChild semantics).
                 let childPayeeId: String?
                 let childPayeeName: String?
-                if let lineName = line.payeeName, lineName != payeeName {
+                if let selectedPayeeId = line.payeeId {
+                    childPayeeId = selectedPayeeId
+                    childPayeeName = line.payeeName
+                } else if let lineName = line.payeeName, lineName != payeeName {
                     childPayeeId = try await resolvePayeeId(name: lineName, editing: nil)
                     childPayeeName = lineName
                 } else {
                     childPayeeId = payeeId
                     childPayeeName = payeeName
                 }
+                let childId = UUID().uuidString
+                let transferAccountId = childPayeeId.flatMap { selectedId in
+                    payees.first { $0.id == selectedId }?.transferAccountId
+                }
+                let partnerId = transferAccountId.map { _ in UUID().uuidString }
+                let childCategoryId = transferAccountId.map { destinationId in
+                    !offBudgetAccountIds.contains(form.accountId)
+                        && offBudgetAccountIds.contains(destinationId) ? line.categoryId : nil
+                } ?? line.categoryId
                 children.append(Transaction(
-                    id: UUID().uuidString,
+                    id: childId,
                     accountId: form.accountId,
                     date: date,
                     amount: line.amountCents,
                     payeeId: childPayeeId,
                     payeeName: childPayeeName,
-                    categoryId: line.categoryId,
+                    categoryId: childCategoryId,
                     categoryName: nil,
                     notes: line.notes,
                     cleared: form.cleared,
                     reconciled: false,
-                    transferId: nil,
+                    transferId: partnerId,
                     isParent: false,
                     parentId: parentId,
                     tombstone: false,
                     sortOrder: parentSort - Double(index + 1),
                     importedPayee: nil
                 ))
+                if let transferAccountId, let partnerId {
+                    guard transferAccountId != form.accountId else {
+                        throw BudgetStoreError.transferAccountsMatch
+                    }
+                    guard let sourcePayee = transferPayee(forAccountId: form.accountId) else {
+                        throw BudgetStoreError.transferPayeeMissing
+                    }
+                    transferPartners.append(Transaction(
+                        id: partnerId,
+                        accountId: transferAccountId,
+                        date: date,
+                        amount: -line.amountCents,
+                        payeeId: sourcePayee.id,
+                        payeeName: nil,
+                        categoryId: nil,
+                        categoryName: nil,
+                        notes: line.notes,
+                        cleared: false,
+                        reconciled: false,
+                        transferId: childId,
+                        isParent: false,
+                        parentId: nil,
+                        tombstone: false,
+                        sortOrder: nil,
+                        importedPayee: nil
+                    ))
+                }
             }
             guard let syncClient else {
                 throw BudgetStoreError.syncNotConfigured
             }
-            try await syncClient.createSplit(parent: parent, children: children)
+            try await syncClient.createSplit(
+                parent: parent,
+                children: children,
+                transferPartners: transferPartners
+            )
             await refreshDataOnly()
             if form.recordLocation, let payeeId {
                 recordPayeeLocationIfAppropriate(payeeId: payeeId)
@@ -4865,6 +4918,55 @@ final class BudgetStore: ObservableObject {
         }
     }
 
+    private func resolveSplitPayee(
+        _ line: SplitPlanLine,
+        inheritedId: String?,
+        inheritedName: String?,
+        editing: Transaction?
+    ) async throws -> (id: String?, name: String?, transferAccountId: String?) {
+        if let id = line.payeeId {
+            let transferAccountId = payees.first { $0.id == id }?.transferAccountId
+                ?? (editing?.payeeId == id ? editing?.transferAcct : nil)
+            return (id, line.payeeName, transferAccountId)
+        }
+        if let name = line.payeeName, name != inheritedName {
+            return (try await resolvePayeeId(name: name, editing: editing), name, nil)
+        }
+        return (inheritedId, inheritedName, nil)
+    }
+
+    private func splitTransferPartner(
+        id: String,
+        child: Transaction,
+        destinationAccountId: String
+    ) throws -> Transaction {
+        guard destinationAccountId != child.accountId else {
+            throw BudgetStoreError.transferAccountsMatch
+        }
+        guard let sourcePayee = transferPayee(forAccountId: child.accountId) else {
+            throw BudgetStoreError.transferPayeeMissing
+        }
+        return Transaction(
+            id: id,
+            accountId: destinationAccountId,
+            date: child.date,
+            amount: -child.amount,
+            payeeId: sourcePayee.id,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: child.notes,
+            cleared: false,
+            reconciled: false,
+            transferId: child.id,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+    }
+
     /// Apply an edited split form to an existing split parent: the parent
     /// takes the form's total/payee/notes/date/cleared, lines with a
     /// `childId` update their child row, lines without one become new
@@ -4922,62 +5024,91 @@ final class BudgetStore: ObservableObject {
             // own (Actual's makeChild semantics). A line whose payee matched
             // the parent's loads back as "inherit", so a parent payee edit
             // follows through here just like cascadeSharedFieldsToChildren.
-            let childPayeeId: String?
-            let childPayeeName: String?
-            if let lineName = line.payeeName, lineName != payeeName {
-                childPayeeId = try await resolvePayeeId(name: lineName, editing: existing)
-                childPayeeName = lineName
-            } else {
-                childPayeeId = payeeId
-                childPayeeName = payeeName
-            }
+            let resolvedPayee = try await resolveSplitPayee(
+                line, inheritedId: payeeId, inheritedName: payeeName, editing: existing)
+            if existing == nil { nextNewSort -= 1 }
+            var updated = Transaction(
+                id: existing?.id ?? UUID().uuidString,
+                accountId: form.accountId,
+                date: date,
+                amount: line.amountCents,
+                payeeId: resolvedPayee.id,
+                payeeName: resolvedPayee.name,
+                categoryId: resolvedPayee.transferAccountId.map { destinationId in
+                    !offBudgetAccountIds.contains(form.accountId)
+                        && offBudgetAccountIds.contains(destinationId) ? line.categoryId : nil
+                } ?? line.categoryId,
+                categoryName: nil,
+                notes: line.notes,
+                cleared: form.cleared,
+                reconciled: existing?.reconciled ?? false,
+                transferId: existing?.transferId,
+                isParent: false,
+                parentId: original.id,
+                tombstone: false,
+                sortOrder: existing?.sortOrder ?? nextNewSort,
+                importedPayee: nil
+            )
 
-            if let existing {
-                let updated = Transaction(
-                    id: existing.id,
-                    accountId: form.accountId,
-                    date: date,
-                    amount: line.amountCents,
-                    payeeId: childPayeeId,
-                    payeeName: childPayeeName,
-                    categoryId: line.categoryId,
-                    categoryName: nil,
-                    notes: line.notes,
-                    cleared: form.cleared,
-                    reconciled: existing.reconciled,
-                    transferId: existing.transferId,
-                    isParent: false,
-                    parentId: original.id,
-                    tombstone: false,
-                    sortOrder: existing.sortOrder
-                )
+            if let destinationAccountId = resolvedPayee.transferAccountId {
+                guard destinationAccountId != form.accountId else {
+                    throw BudgetStoreError.transferAccountsMatch
+                }
+                guard let sourcePayee = transferPayee(forAccountId: form.accountId) else {
+                    throw BudgetStoreError.transferPayeeMissing
+                }
+                let partnerId = existing?.transferId ?? UUID().uuidString
+                updated.transferId = partnerId
+                if let existing, let existingPartnerId = existing.transferId {
+                    guard let originalPartner = try await database.fetchTransaction(id: existingPartnerId) else {
+                        throw BudgetStoreError.transferPartnerMissing
+                    }
+                    var partner = originalPartner
+                    partner.accountId = destinationAccountId
+                    partner.amount = -updated.amount
+                    partner.payeeId = sourcePayee.id
+                    partner.date = date
+                    partner.notes = line.notes
+                    let changes = Self.changedFields(original: existing, updated: updated)
+                    if !changes.isEmpty {
+                        try await syncClient.updateTransaction(updated, changedFields: changes)
+                    }
+                    let partnerChanges = Self.changedFields(
+                        original: originalPartner,
+                        updated: partner
+                    )
+                    if !partnerChanges.isEmpty {
+                        try await syncClient.updateTransaction(partner, changedFields: partnerChanges)
+                    }
+                } else {
+                    let partner = try splitTransferPartner(
+                        id: partnerId, child: updated,
+                        destinationAccountId: destinationAccountId)
+                    if let existing {
+                        try await syncClient.convertToTransfer(
+                            leg: updated,
+                            changedFields: Self.changedFields(original: existing, updated: updated),
+                            partner: partner
+                        )
+                    } else {
+                        try await syncClient.createTransfer(source: updated, target: partner)
+                    }
+                }
+            } else if let existing {
+                updated.transferId = nil
                 let changes = Self.changedFields(original: existing, updated: updated)
                 if !changes.isEmpty {
                     try await syncClient.updateTransaction(updated, changedFields: changes)
                 }
+                if let partnerId = existing.transferId,
+                   var partner = try await database.fetchTransaction(id: partnerId) {
+                    partner.tombstone = true
+                    try await syncClient.updateTransaction(partner, changedFields: ["tombstone"])
+                }
             } else {
-                nextNewSort -= 1
                 // Rules are skipped, matching createSplit — the user just
                 // spelled out every field on this line explicitly.
-                try await syncClient.createTransaction(Transaction(
-                    id: UUID().uuidString,
-                    accountId: form.accountId,
-                    date: date,
-                    amount: line.amountCents,
-                    payeeId: childPayeeId,
-                    payeeName: childPayeeName,
-                    categoryId: line.categoryId,
-                    categoryName: nil,
-                    notes: line.notes,
-                    cleared: form.cleared,
-                    reconciled: false,
-                    transferId: nil,
-                    isParent: false,
-                    parentId: original.id,
-                    tombstone: false,
-                    sortOrder: nextNewSort,
-                    importedPayee: nil
-                ), applyRules: false)
+                try await syncClient.createTransaction(updated, applyRules: false)
             }
         }
 
@@ -4988,6 +5119,11 @@ final class BudgetStore: ObservableObject {
             var deleted = child
             deleted.tombstone = true
             try await syncClient.updateTransaction(deleted, changedFields: ["tombstone"])
+            if let partnerId = child.transferId,
+               var partner = try await database.fetchTransaction(id: partnerId) {
+                partner.tombstone = true
+                try await syncClient.updateTransaction(partner, changedFields: ["tombstone"])
+            }
         }
 
         await refreshDataOnly()
@@ -5143,34 +5279,42 @@ final class BudgetStore: ObservableObject {
         var nextSort = original.sortOrder ?? Date().timeIntervalSince1970 * 1000
         for line in lines {
             nextSort -= 1
-            let childPayeeId: String?
-            let childPayeeName: String?
-            if let lineName = line.payeeName, lineName != payeeName {
-                childPayeeId = try await resolvePayeeId(name: lineName, editing: nil)
-                childPayeeName = lineName
-            } else {
-                childPayeeId = payeeId
-                childPayeeName = payeeName
-            }
-            try await syncClient.createTransaction(Transaction(
+            let resolvedPayee = try await resolveSplitPayee(
+                line, inheritedId: payeeId, inheritedName: payeeName, editing: nil)
+            let partnerId = resolvedPayee.transferAccountId.map { _ in UUID().uuidString }
+            let child = Transaction(
                 id: UUID().uuidString,
                 accountId: form.accountId,
                 date: date,
                 amount: line.amountCents,
-                payeeId: childPayeeId,
-                payeeName: childPayeeName,
-                categoryId: line.categoryId,
+                payeeId: resolvedPayee.id,
+                payeeName: resolvedPayee.name,
+                categoryId: resolvedPayee.transferAccountId.map { destinationId in
+                    !offBudgetAccountIds.contains(form.accountId)
+                        && offBudgetAccountIds.contains(destinationId) ? line.categoryId : nil
+                } ?? line.categoryId,
                 categoryName: nil,
                 notes: line.notes,
                 cleared: form.cleared,
                 reconciled: false,
-                transferId: nil,
+                transferId: partnerId,
                 isParent: false,
                 parentId: original.id,
                 tombstone: false,
                 sortOrder: nextSort,
                 importedPayee: nil
-            ), applyRules: false)
+            )
+            if let destinationAccountId = resolvedPayee.transferAccountId,
+               let partnerId {
+                try await syncClient.createTransfer(
+                    source: child,
+                    target: splitTransferPartner(
+                        id: partnerId, child: child,
+                        destinationAccountId: destinationAccountId)
+                )
+            } else {
+                try await syncClient.createTransaction(child, applyRules: false)
+            }
         }
 
         await refreshDataOnly()
@@ -5229,6 +5373,11 @@ final class BudgetStore: ObservableObject {
             var deleted = child
             deleted.tombstone = true
             try await syncClient.updateTransaction(deleted, changedFields: ["tombstone"])
+            if let partnerId = child.transferId,
+               var partner = try await database.fetchTransaction(id: partnerId) {
+                partner.tombstone = true
+                try await syncClient.updateTransaction(partner, changedFields: ["tombstone"])
+            }
         }
 
         await refreshDataOnly()

--- a/Actuali/Actuali/Services/BudgetStore.swift
+++ b/Actuali/Actuali/Services/BudgetStore.swift
@@ -4822,7 +4822,7 @@ final class BudgetStore: ObservableObject {
                         categoryId: nil,
                         categoryName: nil,
                         notes: line.notes,
-                        cleared: false,
+                        cleared: form.cleared,
                         reconciled: false,
                         transferId: childId,
                         isParent: false,
@@ -4924,15 +4924,36 @@ final class BudgetStore: ObservableObject {
         inheritedName: String?,
         editing: Transaction?
     ) async throws -> (id: String?, name: String?, transferAccountId: String?) {
-        if let id = line.payeeId {
-            let transferAccountId = payees.first { $0.id == id }?.transferAccountId
-                ?? (editing?.payeeId == id ? editing?.transferAcct : nil)
-            return (id, line.payeeName, transferAccountId)
+        var resolved = knownSplitPayee(
+            line, inheritedId: inheritedId, inheritedName: inheritedName, editing: editing)
+        if resolved.id == nil, let name = line.payeeName, name != inheritedName {
+            resolved.id = try await resolvePayeeId(name: name, editing: editing)
         }
+        return (
+            resolved.id,
+            resolved.name,
+            splitTransferAccountId(payeeId: resolved.id, editing: editing)
+        )
+    }
+
+    private func knownSplitPayee(
+        _ line: SplitPlanLine,
+        inheritedId: String?,
+        inheritedName: String?,
+        editing: Transaction?
+    ) -> (id: String?, name: String?) {
+        if let id = line.payeeId { return (id, line.payeeName) }
         if let name = line.payeeName, name != inheritedName {
-            return (try await resolvePayeeId(name: name, editing: editing), name, nil)
+            if name == editing?.payeeName { return (editing?.payeeId, name) }
+            return (payees.first { $0.name.lowercased() == name.lowercased() }?.id, name)
         }
-        return (inheritedId, inheritedName, nil)
+        return (inheritedId, inheritedName)
+    }
+
+    private func splitTransferAccountId(payeeId: String?, editing: Transaction?) -> String? {
+        guard let payeeId else { return nil }
+        return payees.first { $0.id == payeeId }?.transferAccountId
+            ?? (editing?.payeeId == payeeId ? editing?.transferAcct : nil)
     }
 
     private func splitTransferPartner(
@@ -4956,7 +4977,7 @@ final class BudgetStore: ObservableObject {
             categoryId: nil,
             categoryName: nil,
             notes: child.notes,
-            cleared: false,
+            cleared: child.cleared,
             reconciled: false,
             transferId: child.id,
             isParent: false,
@@ -4983,6 +5004,43 @@ final class BudgetStore: ObservableObject {
             throw BudgetStoreError.syncNotConfigured
         }
 
+        let existingChildren = try await database.fetchChildTransactions(parentId: original.id)
+        let childrenById = Dictionary(uniqueKeysWithValues: existingChildren.map { ($0.id, $0) })
+        var existingPartners: [String: Transaction] = [:]
+        let inheritedName = form.payeeName.isEmpty ? nil : form.payeeName
+        let inheritedId: String? = if form.payeeName.isEmpty {
+            nil
+        } else if form.payeeName == original.payeeName {
+            original.payeeId
+        } else {
+            payees.first { $0.name.lowercased() == form.payeeName.lowercased() }?.id
+        }
+        let transferLines = lines.compactMap { line -> (SplitPlanLine, String)? in
+            let editing = line.childId.flatMap { childrenById[$0] }
+            let payee = knownSplitPayee(
+                line, inheritedId: inheritedId, inheritedName: inheritedName, editing: editing)
+            guard let destinationId = splitTransferAccountId(
+                payeeId: payee.id, editing: editing) else {
+                return nil
+            }
+            return (line, destinationId)
+        }
+        if !transferLines.isEmpty,
+           transferPayee(forAccountId: form.accountId) == nil {
+            throw BudgetStoreError.transferPayeeMissing
+        }
+        for (line, destinationId) in transferLines {
+            guard destinationId != form.accountId else {
+                throw BudgetStoreError.transferAccountsMatch
+            }
+            guard let childId = line.childId,
+                  let partnerId = childrenById[childId]?.transferId else { continue }
+            guard let partner = try await database.fetchTransaction(id: partnerId) else {
+                throw BudgetStoreError.transferPartnerMissing
+            }
+            existingPartners[partnerId] = partner
+        }
+
         let payeeId = try await resolvePayeeId(name: form.payeeName, editing: original)
         let payeeName = form.payeeName.isEmpty ? nil : form.payeeName
         let parent = Transaction(
@@ -5007,9 +5065,6 @@ final class BudgetStore: ObservableObject {
         if !parentChanges.isEmpty {
             try await syncClient.updateTransaction(parent, changedFields: parentChanges)
         }
-
-        let existingChildren = try await database.fetchChildTransactions(parentId: original.id)
-        let childrenById = Dictionary(uniqueKeysWithValues: existingChildren.map { ($0.id, $0) })
 
         // Existing children keep their sort_order (updates never move rows);
         // new lines slot in below the current minimum, preserving the order
@@ -5060,7 +5115,7 @@ final class BudgetStore: ObservableObject {
                 let partnerId = existing?.transferId ?? UUID().uuidString
                 updated.transferId = partnerId
                 if let existing, let existingPartnerId = existing.transferId {
-                    guard let originalPartner = try await database.fetchTransaction(id: existingPartnerId) else {
+                    guard let originalPartner = existingPartners[existingPartnerId] else {
                         throw BudgetStoreError.transferPartnerMissing
                     }
                     var partner = originalPartner
@@ -5069,6 +5124,7 @@ final class BudgetStore: ObservableObject {
                     partner.payeeId = sourcePayee.id
                     partner.date = date
                     partner.notes = line.notes
+                    partner.cleared = form.cleared
                     let changes = Self.changedFields(original: existing, updated: updated)
                     if !changes.isEmpty {
                         try await syncClient.updateTransaction(updated, changedFields: changes)

--- a/Actuali/Actuali/Services/Database/BudgetDatabase.swift
+++ b/Actuali/Actuali/Services/Database/BudgetDatabase.swift
@@ -2979,12 +2979,16 @@ final class BudgetDatabase: Sendable {
     func insertSplit(
         parent: Transaction,
         children: [Transaction],
+        transferPartners: [Transaction] = [],
         messages: [CRDTMessage]
     ) throws -> [CRDTMessage] {
         try dbQueue.write { db in
             try Self.insertTransactionRow(db, parent)
             for child in children {
                 try Self.insertTransactionRow(db, child)
+            }
+            for partner in transferPartners {
+                try Self.insertTransactionRow(db, partner)
             }
             return try Self.insertMessageRows(db, messages)
         }

--- a/Actuali/Actuali/Services/Sync/SyncClient.swift
+++ b/Actuali/Actuali/Services/Sync/SyncClient.swift
@@ -501,7 +501,11 @@ actor SyncClient {
     /// local-first). Like transfers, all rows and their CRDT messages commit
     /// in one SQLite transaction and rules are skipped — the caller builds
     /// every row explicitly.
-    func createSplit(parent: Transaction, children: [Transaction]) async throws {
+    func createSplit(
+        parent: Transaction,
+        children: [Transaction],
+        transferPartners: [Transaction] = []
+    ) async throws {
         guard let database else { throw SyncError.notConfigured }
 
         logger.debug("createSplit() - parent: \(parent.id, privacy: .private), children: \(children.count, privacy: .public)")
@@ -511,10 +515,18 @@ actor SyncClient {
         for child in children {
             messages += try await messageGenerator.messagesForInsert(child)
         }
+        for partner in transferPartners {
+            messages += try await messageGenerator.messagesForInsert(partner)
+        }
         logger.debug("Generated \(messages.count, privacy: .public) CRDT messages for split")
 
         // 2. Persist rows + messages in one DB transaction, then update merkle
-        for msg in try database.insertSplit(parent: parent, children: children, messages: messages) {
+        for msg in try database.insertSplit(
+            parent: parent,
+            children: children,
+            transferPartners: transferPartners,
+            messages: messages
+        ) {
             merkle = merkle.inserting(msg.timestamp)
         }
         merkle = merkle.pruned()

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -565,7 +565,8 @@ struct AddTransactionView: View {
     private func loadSplitChildren() async {
         guard let editing, editing.isParent, splitLines.isEmpty else { return }
         splitLines = await budgetStore.fetchSplitChildren(parentId: editing.id).map { child in
-            BudgetStore.SplitLineForm(
+            let overridesParentPayee = child.payeeId != editing.payeeId
+            return BudgetStore.SplitLineForm(
                 childId: child.id,
                 categoryId: child.categoryId,
                 amount: SplitEntryMath.amountString(fromCents: abs(child.amount)),
@@ -573,7 +574,12 @@ struct AddTransactionView: View {
                 // inside a spend split — keeps its flip on reload (GH #216).
                 isOpposite: (child.amount < 0) != (editing.amount < 0),
                 notes: child.notes ?? "",
-                payeeName: (child.payeeName != editing.payeeName ? child.payeeName : nil) ?? ""
+                payeeName: overridesParentPayee
+                    ? budgetStore.payees.first(where: { $0.id == child.payeeId }).map {
+                        PayeePickerView.displayName(for: $0, accounts: budgetStore.accounts)
+                    } ?? child.payeeName ?? ""
+                    : "",
+                payeeId: overridesParentPayee ? child.payeeId : nil
             )
         }
     }
@@ -585,6 +591,7 @@ struct AddTransactionView: View {
             ForEach($splitLines) { $line in
                 SplitLineRow(
                     line: $line,
+                    accountId: selectedAccountId,
                     txType: txType,
                     remainingCents: splitRemainingCents,
                     nearbyPayees: $nearbyPayees,
@@ -820,6 +827,7 @@ private struct SplitLineRow: View {
     @EnvironmentObject private var budgetStore: BudgetStore
     @Environment(\.locale) private var locale
     @Binding var line: BudgetStore.SplitLineForm
+    var accountId: String
     /// The transaction's direction, so the line's sign glyph can show its
     /// effective direction relative to it.
     var txType: TransactionType
@@ -920,11 +928,15 @@ private struct SplitLineRow: View {
                 PayeePickerView(
                     payeeName: line.payeeName,
                     nearbyPayees: $nearbyPayees,
+                    transferFromAccountId: accountId,
                     onSelect: { payee in
-                        line.payeeName = payee.name
+                        line.payeeId = payee.id
+                        line.payeeName = PayeePickerView.displayName(
+                            for: payee, accounts: budgetStore.accounts)
                         showPayeePicker = false
                     },
                     onCommit: { name in
+                        line.payeeId = nil
                         line.payeeName = name
                         showPayeePicker = false
                     },

--- a/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
+++ b/Actuali/Actuali/Views/Transactions/AddTransactionView.swift
@@ -936,7 +936,11 @@ private struct SplitLineRow: View {
                         showPayeePicker = false
                     },
                     onCommit: { name in
-                        line.payeeId = nil
+                        line.payeeId = PayeePickerView.committedPayeeId(
+                            currentName: line.payeeName,
+                            currentId: line.payeeId,
+                            committedName: name
+                        )
                         line.payeeName = name
                         showPayeePicker = false
                     },

--- a/Actuali/Actuali/Views/Transactions/PayeePickerView.swift
+++ b/Actuali/Actuali/Views/Transactions/PayeePickerView.swift
@@ -5,6 +5,7 @@ struct PayeePickerView: View {
     @EnvironmentObject private var budgetStore: BudgetStore
 
     @Binding var nearbyPayees: [NearbyPayee]
+    let transferFromAccountId: String?
     let onSelect: (Payee) -> Void
     let onCommit: (String) -> Void
     let onDeleteNearby: (NearbyPayee) -> Void
@@ -16,11 +17,13 @@ struct PayeePickerView: View {
     init(
         payeeName: String,
         nearbyPayees: Binding<[NearbyPayee]>,
+        transferFromAccountId: String? = nil,
         onSelect: @escaping (Payee) -> Void,
         onCommit: @escaping (String) -> Void,
         onDeleteNearby: @escaping (NearbyPayee) -> Void
     ) {
         _nearbyPayees = nearbyPayees
+        self.transferFromAccountId = transferFromAccountId
         self.onSelect = onSelect
         self.onCommit = onCommit
         self.onDeleteNearby = onDeleteNearby
@@ -32,7 +35,12 @@ struct PayeePickerView: View {
     }
 
     private var filteredPayees: [Payee] {
-        Self.filteredPayees(from: budgetStore.payees, searchText: trimmedSearchText)
+        Self.filteredPayees(
+            from: budgetStore.payees,
+            accounts: budgetStore.accounts,
+            transferFromAccountId: transferFromAccountId,
+            searchText: trimmedSearchText
+        )
     }
 
     nonisolated static func allowedPayees(_ payees: [Payee]) -> [Payee] {
@@ -45,35 +53,81 @@ struct PayeePickerView: View {
         from payees: [Payee],
         searchText: String
     ) -> [Payee] {
-        let usablePayees = allowedPayees(payees)
+        filteredPayees(
+            from: payees, accounts: [], transferFromAccountId: nil,
+            searchText: searchText
+        )
+    }
+
+    nonisolated static func filteredPayees(
+        from payees: [Payee],
+        accounts: [Account],
+        transferFromAccountId: String?,
+        searchText: String
+    ) -> [Payee] {
+        let accountNames = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0.name) })
+        let openAccountIds = Set(accounts.filter { !$0.closed }.map(\.id))
+        let usablePayees = payees.filter { payee in
+            guard !payee.tombstone else { return false }
+            guard let transferAccountId = payee.transferAccountId else { return true }
+            return transferFromAccountId != nil
+                && transferAccountId != transferFromAccountId
+                && openAccountIds.contains(transferAccountId)
+        }
+        func name(_ payee: Payee) -> String {
+            displayName(for: payee, accountNames: accountNames)
+        }
 
         guard !searchText.isEmpty else {
-            return usablePayees
-                .sorted {
-                    $0.name.localizedCaseInsensitiveCompare($1.name)
+            let sorted = usablePayees.sorted {
+                    name($0).localizedCaseInsensitiveCompare(name($1))
                         == .orderedAscending
                 }
-                .prefix(20)
-                .map { $0 }
+            guard transferFromAccountId != nil else {
+                return Array(sorted.prefix(20))
+            }
+            return Array(sorted.filter { $0.transferAccountId == nil }.prefix(20))
+                + sorted.filter { $0.transferAccountId != nil }
         }
 
         let lower = searchText.lowercased()
 
         return usablePayees
-            .filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+            .filter { name($0).localizedCaseInsensitiveContains(searchText) }
             .sorted { lhs, rhs in
-                let lhsPrefix = lhs.name.lowercased().hasPrefix(lower)
-                let rhsPrefix = rhs.name.lowercased().hasPrefix(lower)
+                let lhsName = name(lhs)
+                let rhsName = name(rhs)
+                let lhsPrefix = lhsName.lowercased().hasPrefix(lower)
+                let rhsPrefix = rhsName.lowercased().hasPrefix(lower)
 
                 if lhsPrefix != rhsPrefix {
                     return lhsPrefix
                 }
 
-                return lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+                return lhsName.localizedCaseInsensitiveCompare(rhsName)
                     == .orderedAscending
             }
             .prefix(20)
             .map { $0 }
+    }
+
+    nonisolated static func displayName(
+        for payee: Payee,
+        accounts: [Account]
+    ) -> String {
+        displayName(
+            for: payee,
+            accountNames: Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0.name) })
+        )
+    }
+
+    private nonisolated static func displayName(
+        for payee: Payee,
+        accountNames: [String: String]
+    ) -> String {
+        guard let accountId = payee.transferAccountId,
+              let accountName = accountNames[accountId] else { return payee.name }
+        return "\(String(localized: "Transfer")): \(accountName)"
     }
 
     private var nonSuggestedPayees: [Payee] {
@@ -111,7 +165,7 @@ struct PayeePickerView: View {
             onSelect(payee)
         } label: {
             Label {
-                Text(payee.name)
+                Text(Self.displayName(for: payee, accounts: budgetStore.accounts))
                     .foregroundStyle(.primary)
             } icon: {
                 Image(systemName: "clock.arrow.circlepath")

--- a/Actuali/Actuali/Views/Transactions/PayeePickerView.swift
+++ b/Actuali/Actuali/Views/Transactions/PayeePickerView.swift
@@ -160,6 +160,14 @@ struct PayeePickerView: View {
         }
     }
 
+    nonisolated static func committedPayeeId(
+        currentName: String,
+        currentId: String?,
+        committedName: String
+    ) -> String? {
+        currentName == committedName ? currentId : nil
+    }
+
     private func payeeButton(_ payee: Payee) -> some View {
         Button {
             onSelect(payee)

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
@@ -226,23 +226,29 @@ struct BudgetStoreSplitSaveTests {
             try db.execute(sql: """
                 INSERT INTO accounts (id, name, offbudget) VALUES
                     ('acct-1', 'Checking', 0),
+                    ('acct-savings', 'Savings', 0),
                     ('acct-retirement', 'Retirement', 1);
                 INSERT INTO payees (id, name, transfer_acct) VALUES
                     ('payee-checking', NULL, 'acct-1'),
+                    ('payee-savings', NULL, 'acct-savings'),
                     ('payee-retirement', NULL, 'acct-retirement');
                 INSERT INTO payee_mapping (id, targetId) VALUES
                     ('payee-checking', 'payee-checking'),
+                    ('payee-savings', 'payee-savings'),
                     ('payee-retirement', 'payee-retirement');
                 """)
         }
         store.accounts = [
             Account(id: "acct-1", name: "Checking", type: .checking,
                     offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
             Account(id: "acct-retirement", name: "Retirement", type: .investment,
-                    offBudget: true, closed: false, sortOrder: 1, balance: 0),
+                    offBudget: true, closed: false, sortOrder: 2, balance: 0),
         ]
         store.payees = [
             Payee(id: "payee-checking", name: "", transferAccountId: "acct-1"),
+            Payee(id: "payee-savings", name: "", transferAccountId: "acct-savings"),
             Payee(id: "payee-retirement", name: "", transferAccountId: "acct-retirement"),
         ]
 
@@ -250,13 +256,15 @@ struct BudgetStoreSplitSaveTests {
             categoryId: "cat-retirement", amount: "5.00", isOpposite: true)
         transferLine.payeeId = "payee-retirement"
         transferLine.payeeName = "Transfer: Retirement"
-        try await store.saveTransaction(form(
+        var splitForm = form(
             type: .income, amount: "10.00", payeeName: "Employer",
             splits: [
                 .init(categoryId: "cat-income", amount: "15.00"),
                 transferLine,
             ]
-        ))
+        )
+        splitForm.cleared = true
+        try await store.saveTransaction(splitForm)
 
         let all = try rows(path: path)
         #expect(all.count == 4)
@@ -266,11 +274,34 @@ struct BudgetStoreSplitSaveTests {
         #expect(transferChild["parent_id"] != nil)
         #expect(transferChild["amount"] == -500)
         #expect(transferChild["category"] == "cat-retirement")
+        #expect(transferChild["cleared"] == 1)
         #expect(partner["acct"] == "acct-retirement")
         #expect(partner["amount"] == 500)
+        #expect(partner["cleared"] == 1)
         #expect(partner["description"] == "payee-checking")
         #expect(partner["transferred_id"] == (transferChild["id"] as String))
         #expect(partner["parent_id"] == nil)
+
+        let parentRow = try #require(all.first { $0["isParent"] == 1 })
+        let parentId: String = try #require(parentRow["id"])
+        let originalParent = try #require(await database.fetchTransaction(id: parentId))
+        let incomeChild = try #require(all.first {
+            ($0["parent_id"] as String?) == parentId && ($0["id"] as String?) != (transferChild["id"] as String?)
+        })
+        var invalidTransferLine = BudgetStore.SplitLineForm(
+            childId: transferChild["id"], categoryId: "cat-retirement",
+            amount: "5.00", isOpposite: true,
+            payeeName: "Transfer: Savings", payeeId: "payee-savings")
+        invalidTransferLine.notes = "must not persist"
+        var invalidForm = form(type: .income, amount: "10.00", splits: [
+            .init(childId: incomeChild["id"], categoryId: "cat-income", amount: "15.00"),
+            invalidTransferLine,
+        ])
+        invalidForm.accountId = "acct-savings"
+        await #expect(throws: BudgetStoreError.transferAccountsMatch) {
+            try await store.saveTransaction(invalidForm, editing: originalParent)
+        }
+        #expect(try await database.fetchTransaction(id: parentId)?.accountId == "acct-1")
     }
 
     @Test func editingSplitTransferUpdatesItsPartner() async throws {
@@ -332,6 +363,7 @@ struct BudgetStoreSplitSaveTests {
             transferLine,
         ])
         edit.date = Transaction.date(fromYYYYMMDD: 20260902)
+        edit.cleared = true
 
         try await store.saveTransaction(edit, editing: original)
 
@@ -348,6 +380,132 @@ struct BudgetStoreSplitSaveTests {
         #expect(partner["amount"] == 600)
         #expect(partner["date"] == 20260902)
         #expect(partner["notes"] == "updated")
+        #expect(partner["cleared"] == 1)
+    }
+
+    @Test func inheritedTransferPayeePreservesChildPartners() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await database.dbQueueForTesting.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name) VALUES
+                    ('acct-1', 'Checking'), ('acct-savings', 'Savings');
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking', NULL, 'acct-1'),
+                    ('payee-savings', NULL, 'acct-savings');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking', 'payee-checking'),
+                    ('payee-savings', 'payee-savings');
+                INSERT INTO transactions
+                    (id, isParent, isChild, acct, description, amount, date,
+                     transferred_id, parent_id, sort_order)
+                VALUES
+                    ('parent', 1, 0, 'acct-1', 'payee-savings', -1000,
+                     20260901, NULL, NULL, 10),
+                    ('child-1', 0, 1, 'acct-1', 'payee-savings', -600,
+                     20260901, 'partner-1', 'parent', 9),
+                    ('child-2', 0, 1, 'acct-1', 'payee-savings', -400,
+                     20260901, 'partner-2', 'parent', 8),
+                    ('partner-1', 0, 0, 'acct-savings', 'payee-checking', 600,
+                     20260901, 'child-1', NULL, 7),
+                    ('partner-2', 0, 0, 'acct-savings', 'payee-checking', 400,
+                     20260901, 'child-2', NULL, 6);
+                """)
+        }
+        store.accounts = [
+            Account(id: "acct-1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+        ]
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-1"),
+            Payee(id: "payee-savings", name: "", transferAccountId: "acct-savings"),
+        ]
+        let original = Transaction(
+            id: "parent", accountId: "acct-1", date: 20260901, amount: -1000,
+            payeeId: "payee-savings", payeeName: "Savings", categoryId: nil,
+            categoryName: nil, notes: nil, cleared: false, reconciled: false,
+            transferId: nil, isParent: true, parentId: nil, tombstone: false,
+            sortOrder: 10, importedPayee: nil, transferAcct: "acct-savings")
+        var edit = form(amount: "10.00", payeeName: "Savings", splits: [
+            .init(childId: "child-1", amount: "6.00"),
+            .init(childId: "child-2", amount: "4.00"),
+        ])
+        edit.date = Transaction.date(fromYYYYMMDD: 20260901)
+
+        try await store.saveTransaction(edit, editing: original)
+
+        let byId = Dictionary(uniqueKeysWithValues: try rows(path: path).map {
+            ($0["id"] as String, $0)
+        })
+        #expect(byId["child-1"]?["transferred_id"] == "partner-1")
+        #expect(byId["child-2"]?["transferred_id"] == "partner-2")
+        #expect(byId["partner-1"]?["tombstone"] == 0)
+        #expect(byId["partner-2"]?["tombstone"] == 0)
+    }
+
+    @Test func missingTransferPayeeStillPreflightsPartnerBeforeParentWrite() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await database.dbQueueForTesting.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name) VALUES
+                    ('acct-1', 'Checking'), ('acct-savings', 'Savings');
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking', NULL, 'acct-1'),
+                    ('payee-savings', NULL, 'acct-savings');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking', 'payee-checking'),
+                    ('payee-savings', 'payee-savings');
+                INSERT INTO transactions
+                    (id, isParent, isChild, acct, description, amount, notes,
+                     date, transferred_id, parent_id, sort_order)
+                VALUES
+                    ('parent', 1, 0, 'acct-1', NULL, -1000, NULL,
+                     20260901, NULL, NULL, 10),
+                    ('child-1', 0, 1, 'acct-1', 'payee-savings', -600, NULL,
+                     20260901, 'missing-partner', 'parent', 9),
+                    ('child-2', 0, 1, 'acct-1', NULL, -400, NULL,
+                     20260901, NULL, 'parent', 8);
+                """)
+        }
+        store.accounts = [
+            Account(id: "acct-1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+        ]
+        // Simulate a transfer payee omitted from the in-memory list (for
+        // example because its linked account or payee was tombstoned).
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-1")
+        ]
+        let original = Transaction(
+            id: "parent", accountId: "acct-1", date: 20260901, amount: -1000,
+            payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: nil,
+            isParent: true, parentId: nil, tombstone: false, sortOrder: 10,
+            importedPayee: nil)
+        var transferLine = BudgetStore.SplitLineForm(
+            childId: "child-1", amount: "6.00", payeeId: "payee-savings")
+        transferLine.notes = "must not persist"
+        var edit = form(amount: "10.00", splits: [
+            transferLine,
+            .init(childId: "child-2", amount: "4.00"),
+        ])
+        edit.notes = "must not persist"
+
+        await #expect(throws: BudgetStoreError.transferPartnerMissing) {
+            try await store.saveTransaction(edit, editing: original)
+        }
+        let parent = try #require(await database.fetchTransaction(id: "parent"))
+        #expect(parent.accountId == "acct-1")
+        #expect(parent.notes == nil)
     }
 
     @Test func editingParentPayeeCascadesToChildrenThatMatchedIt() async throws {

--- a/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
+++ b/Actuali/ActualiTests/Services/BudgetStore/BudgetStoreSplitSaveTests.swift
@@ -217,6 +217,139 @@ struct BudgetStoreSplitSaveTests {
         #expect(all[2]["description"] == costco.id)   // inherits parent
     }
 
+    @Test func splitLineTransferCreatesPairedTransaction() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await database.dbQueueForTesting.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, offbudget) VALUES
+                    ('acct-1', 'Checking', 0),
+                    ('acct-retirement', 'Retirement', 1);
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking', NULL, 'acct-1'),
+                    ('payee-retirement', NULL, 'acct-retirement');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking', 'payee-checking'),
+                    ('payee-retirement', 'payee-retirement');
+                """)
+        }
+        store.accounts = [
+            Account(id: "acct-1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-retirement", name: "Retirement", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 1, balance: 0),
+        ]
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-1"),
+            Payee(id: "payee-retirement", name: "", transferAccountId: "acct-retirement"),
+        ]
+
+        var transferLine = BudgetStore.SplitLineForm(
+            categoryId: "cat-retirement", amount: "5.00", isOpposite: true)
+        transferLine.payeeId = "payee-retirement"
+        transferLine.payeeName = "Transfer: Retirement"
+        try await store.saveTransaction(form(
+            type: .income, amount: "10.00", payeeName: "Employer",
+            splits: [
+                .init(categoryId: "cat-income", amount: "15.00"),
+                transferLine,
+            ]
+        ))
+
+        let all = try rows(path: path)
+        #expect(all.count == 4)
+        let transferChild = try #require(all.first { $0["description"] == "payee-retirement" })
+        let partnerId: String = try #require(transferChild["transferred_id"])
+        let partner = try #require(all.first { $0["id"] == partnerId })
+        #expect(transferChild["parent_id"] != nil)
+        #expect(transferChild["amount"] == -500)
+        #expect(transferChild["category"] == "cat-retirement")
+        #expect(partner["acct"] == "acct-retirement")
+        #expect(partner["amount"] == 500)
+        #expect(partner["description"] == "payee-checking")
+        #expect(partner["transferred_id"] == (transferChild["id"] as String))
+        #expect(partner["parent_id"] == nil)
+    }
+
+    @Test func editingSplitTransferUpdatesItsPartner() async throws {
+        let (database, path) = try makeDatabase()
+        defer { cleanup(path) }
+        let store = try await makeStore(database: database)
+
+        try await database.dbQueueForTesting.write { db in
+            try db.execute(sql: """
+                INSERT INTO accounts (id, name, offbudget) VALUES
+                    ('acct-1', 'Checking', 0),
+                    ('acct-retirement', 'Retirement', 1);
+                INSERT INTO payees (id, name, transfer_acct) VALUES
+                    ('payee-checking', NULL, 'acct-1'),
+                    ('payee-retirement', NULL, 'acct-retirement');
+                INSERT INTO payee_mapping (id, targetId) VALUES
+                    ('payee-checking', 'payee-checking'),
+                    ('payee-retirement', 'payee-retirement');
+                INSERT INTO transactions
+                    (id, isParent, isChild, acct, category, description, amount,
+                     notes, date, transferred_id, parent_id, sort_order)
+                VALUES
+                    ('parent', 1, 0, 'acct-1', NULL, NULL, 1000,
+                     NULL, 20260901, NULL, NULL, 10),
+                    ('income', 0, 1, 'acct-1', 'cat-income', NULL, 1500,
+                     NULL, 20260901, NULL, 'parent', 9),
+                    ('retirement', 0, 1, 'acct-1', 'cat-retirement',
+                     'payee-retirement', -500, NULL, 20260901,
+                     'retirement-partner', 'parent', 8),
+                    ('retirement-partner', 0, 0, 'acct-retirement', NULL,
+                     'payee-checking', 500, NULL, 20260901,
+                     'retirement', NULL, 7);
+                """)
+        }
+        store.accounts = [
+            Account(id: "acct-1", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "acct-retirement", name: "Retirement", type: .investment,
+                    offBudget: true, closed: false, sortOrder: 1, balance: 0),
+        ]
+        store.payees = [
+            Payee(id: "payee-checking", name: "", transferAccountId: "acct-1"),
+            Payee(id: "payee-retirement", name: "", transferAccountId: "acct-retirement"),
+        ]
+
+        let original = Transaction(
+            id: "parent", accountId: "acct-1", date: 20260901, amount: 1000,
+            payeeId: nil, payeeName: nil, categoryId: nil, categoryName: nil,
+            notes: nil, cleared: false, reconciled: false, transferId: nil,
+            isParent: true, parentId: nil, tombstone: false, sortOrder: 10,
+            importedPayee: nil)
+        var transferLine = BudgetStore.SplitLineForm(
+            childId: "retirement", categoryId: "cat-retirement",
+            amount: "6.00", isOpposite: true,
+            notes: "updated", payeeName: "Transfer: Retirement")
+        transferLine.payeeId = "payee-retirement"
+        var edit = form(type: .income, amount: "11.00", splits: [
+            .init(childId: "income", categoryId: "cat-income", amount: "17.00"),
+            transferLine,
+        ])
+        edit.date = Transaction.date(fromYYYYMMDD: 20260902)
+
+        try await store.saveTransaction(edit, editing: original)
+
+        let byId = Dictionary(uniqueKeysWithValues: try rows(path: path).map {
+            ($0["id"] as String, $0)
+        })
+        let child = try #require(byId["retirement"])
+        let partner = try #require(byId["retirement-partner"])
+        #expect(child["description"] == "payee-retirement")
+        #expect(child["amount"] == -600)
+        #expect(child["date"] == 20260902)
+        #expect(child["notes"] == "updated")
+        #expect(partner["description"] == "payee-checking")
+        #expect(partner["amount"] == 600)
+        #expect(partner["date"] == 20260902)
+        #expect(partner["notes"] == "updated")
+    }
+
     @Test func editingParentPayeeCascadesToChildrenThatMatchedIt() async throws {
         let (database, path) = try makeDatabase()
         defer { cleanup(path) }

--- a/Actuali/ActualiTests/Views/Transactions/PayeePickerViewTests.swift
+++ b/Actuali/ActualiTests/Views/Transactions/PayeePickerViewTests.swift
@@ -74,6 +74,44 @@ struct PayeePickerViewTests {
         #expect(result.map(\.id) == ["1"])
     }
 
+    @Test func splitPickerIncludesOtherAccountsTransferPayees() {
+        let standard = payee(id: "1", name: "Store")
+        let ownAccount = payee(id: "2", name: "", transferAccountId: "checking")
+        let savings = payee(id: "3", name: "", transferAccountId: "savings")
+        let accounts = [
+            Account(id: "checking", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+        ]
+
+        let result = PayeePickerView.filteredPayees(
+            from: [standard, ownAccount, savings],
+            accounts: accounts,
+            transferFromAccountId: "checking",
+            searchText: "Savings"
+        )
+
+        #expect(result.map(\.id) == ["3"])
+    }
+
+    @Test func splitPickerDoesNotDropTransfersBehindPayeeLimit() {
+        let standard = (0..<25).map { payee(id: "p\($0)", name: "Payee \($0)") }
+        let transfer = payee(id: "transfer", name: "", transferAccountId: "savings")
+        let accounts = [
+            Account(id: "checking", name: "Checking", type: .checking,
+                    offBudget: false, closed: false, sortOrder: 0, balance: 0),
+            Account(id: "savings", name: "Savings", type: .savings,
+                    offBudget: false, closed: false, sortOrder: 1, balance: 0),
+        ]
+
+        let result = PayeePickerView.filteredPayees(
+            from: standard + [transfer], accounts: accounts,
+            transferFromAccountId: "checking", searchText: "")
+
+        #expect(result.contains { $0.id == "transfer" })
+    }
+
     @Test func customPayeeIsOnlyAllowedWhenNameDoesNotExistCaseInsensitively() {
         let existing = payee(id: "1", name: "Walmart")
 

--- a/Actuali/ActualiTests/Views/Transactions/PayeePickerViewTests.swift
+++ b/Actuali/ActualiTests/Views/Transactions/PayeePickerViewTests.swift
@@ -112,6 +112,19 @@ struct PayeePickerViewTests {
         #expect(result.contains { $0.id == "transfer" })
     }
 
+    @Test func committingUnchangedTransferNamePreservesItsId() {
+        #expect(PayeePickerView.committedPayeeId(
+            currentName: "Transfer: Savings",
+            currentId: "transfer",
+            committedName: "Transfer: Savings"
+        ) == "transfer")
+        #expect(PayeePickerView.committedPayeeId(
+            currentName: "Transfer: Savings",
+            currentId: "transfer",
+            committedName: "Coffee Shop"
+        ) == nil)
+    }
+
     @Test func customPayeeIsOnlyAllowedWhenNameDoesNotExistCaseInsensitively() {
         let existing = payee(id: "1", name: "Walmart")
 


### PR DESCRIPTION
Fixes #462

Split-line payee pickers now include transfer payees for every other open account, keep them visible beyond the standard 20-payee suggestion limit, and carry the selected payee ID through edit forms.

Saving a split transfer now creates the child leg and opposite account partner with reciprocal transfer IDs in the same database transaction. Editing, removing, collapsing, or deleting the split keeps the partner leg in sync. This matches the upstream child-transfer behavior in actualbudget/actual packages/loot-core/src/server/transactions/transfer.ts.

Verified:
- Focused picker and split-save suites: 21 tests passed.
- iOS 18.5 CI-equivalent unit suite: 2,090 tests in 225 suites passed.
- iOS 26.5 CI-equivalent unit suite: 2,090 tests in 225 suites passed.
- git diff --check: passed.
- Localization validator was run; it reports three pre-existing missing keys for the budget-selection UI. This change adds no catalog keys and uses the existing localized Transfer string.