### PR TITLE
Change lock icon color from blue to green

### DIFF
--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -508,7 +508,7 @@ struct ClearedIndicator: View {
         Group {
             if reconciled {
                 Image(systemName: "lock.fill")
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(.green)
                     .imageScale(.large)
             } else if cleared {
                 Image(systemName: "checkmark.circle.fill")


### PR DESCRIPTION
## Why

Changing the reconciled icon to green to match actual

## What

Changed lock.fill from blue to green

## How it was tested

Tested on iphone 17 pro sim
