### PR TITLE
Add Running balance

### DIFF
--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -95,7 +95,7 @@ struct Transaction: Identifiable, Hashable {
     /// Convert a dollar amount to integer cents, rounding half away from zero
     /// (e.g. 8.20 → 820, not 819 via truncation).
     /// - Returns: `nil` if the value is non-finite or outside the exactly
-    /// representable integer range of `Double` (±2^53).
+    ///   representable integer range of `Double` (±2^53).
     static func cents(fromDollars dollars: Double) -> Int? {
         let cents = (dollars * 100).rounded()
         guard cents.isFinite, abs(cents) <= 9_007_199_254_740_992 else { return nil }

--- a/Actuali/Actuali/Models/Transaction.swift
+++ b/Actuali/Actuali/Models/Transaction.swift
@@ -44,6 +44,10 @@ struct Transaction: Identifiable, Hashable {
     // populated by fetchTransactions for isParent rows, so the list row can
     // show the breakdown ("Food $6.00, Fun $4.00"). Display-only, not synced.
     var splitPortions: [SplitPortion]? = nil
+    // Display-only running balance used by account transaction registers.
+    // It is populated from the account's current balance in account detail
+    // views and is intentionally not part of CRDT sync.
+    var runningBalance: Int? = nil
 
     struct SplitPortion: Hashable {
         var categoryName: String?
@@ -91,7 +95,7 @@ struct Transaction: Identifiable, Hashable {
     /// Convert a dollar amount to integer cents, rounding half away from zero
     /// (e.g. 8.20 → 820, not 819 via truncation).
     /// - Returns: `nil` if the value is non-finite or outside the exactly
-    ///   representable integer range of `Double` (±2^53).
+    /// representable integer range of `Double` (±2^53).
     static func cents(fromDollars dollars: Double) -> Int? {
         let cents = (dollars * 100).rounded()
         guard cents.isFinite, abs(cents) <= 9_007_199_254_740_992 else { return nil }
@@ -182,6 +186,22 @@ extension Array where Element == Transaction {
         }
         return order.map { date in
             TransactionDateGroup(date: date, transactions: groupDict[date] ?? [])
+        }
+    }
+
+    /// Adds the register balance after each transaction to a newest-first
+    /// transaction list. Starting at the account's current balance means the
+    /// newest transaction shows the current balance, while each older row
+    /// walks backward by that row's amount. This remains correct as additional
+    /// pages are appended to `TransactionPager`, because the full loaded prefix
+    /// is recalculated each time.
+    func withRunningBalances(startingAt currentBalance: Int) -> [Transaction] {
+        var balance = currentBalance
+        return map { transaction in
+            var transaction = transaction
+            transaction.runningBalance = balance
+            balance -= transaction.amount
+            return transaction
         }
     }
 }

--- a/Actuali/Actuali/RunningBalance.xcstrings
+++ b/Actuali/Actuali/RunningBalance.xcstrings
@@ -1,0 +1,53 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Show Running Balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laufenden Kontostand anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Running Balance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar saldo acumulado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le solde courant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra saldo progressivo"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voortschrijdend saldo tonen"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar saldo acumulado"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -24,6 +24,7 @@ struct AccountDetailView: View {
     @State private var isSelecting = false
     @State private var selectedTransactionIds: Set<String> = []
     @State private var cycleSpend: Int = 0
+    @AppStorage("showAccountRunningBalance") private var showRunningBalance = true
 
     private var currentBalance: Int {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
@@ -35,7 +36,8 @@ struct AccountDetailView: View {
     /// in those states would make it look like the account balance changed when
     /// the user only changed the visible filter.
     private var shouldShowRunningBalance: Bool {
-        searchQuery == nil
+        showRunningBalance
+            && searchQuery == nil
             && !budgetStore.hideClearedTransactions
             && !budgetStore.hideReconciledTransactions
     }
@@ -120,25 +122,15 @@ struct AccountDetailView: View {
                 Button {
                     editingNote = true
                 } label: {
-                    // Tinted: an empty note row is an invitation to act, where
-                    // an existing note is content to read.
                     Label(String(localized: "common.addNote"), systemImage: "note.text.badge.plus")
                         .foregroundStyle(Color.accentColor)
                 }
-                // Plain: a tinted List button would tint the label twice over.
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("accountNoteRow")
             } else {
                 HStack(alignment: .top, spacing: 12) {
-                    // Attributed so markdown links and bare URLs in the note
-                    // are tappable (GH #190). That's also why this row is a
-                    // tap gesture rather than the Button the empty state uses:
-                    // a Button label swallows link taps, where links inside a
-                    // gesture-carrying row take precedence over the gesture.
                     Text(NoteLinkText.attributed(note.text))
                         .multilineTextAlignment(.leading)
-                        // Multi-line notes are the point — let the row grow
-                        // instead of truncating the guidance to one line.
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image(systemName: "pencil")
@@ -173,9 +165,6 @@ struct AccountDetailView: View {
     var body: some View {
         List {
             Section {
-                // Tapping the balance reveals the cleared/uncleared/reconciled
-                // split (GH #134), so the reconciled figure can be checked
-                // against a bank statement without starting a reconciliation.
                 Button {
                     withAnimation(AppAnimation.disclosure) { showingBreakdown.toggle() }
                 } label: {
@@ -184,7 +173,7 @@ struct AccountDetailView: View {
                         Spacer()
                         Text(budgetStore.displayBalance(currentBalance))
                             .fontWeight(.semibold)
-                            .animatedAmount(budgetStore.displayBalance(currentBalance)) 
+                            .animatedAmount(budgetStore.displayBalance(currentBalance))
                         if breakdown != nil {
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
@@ -200,9 +189,6 @@ struct AccountDetailView: View {
                     ? String(localized: "Hides the balance breakdown")
                     : String(localized: "Shows cleared, uncleared, and reconciled balances"))
 
-                // Headroom on a tracked card with a limit set — the figure a
-                // card's balance is actually judged against, so it stays visible
-                // rather than hiding behind the disclosure.
                 if let headroom = creditHeadroom {
                     breakdownRow(String(localized: "Available Credit"), amount: headroom.available)
                 }
@@ -224,9 +210,6 @@ struct AccountDetailView: View {
                     let endStr = Transaction.formattedDate(from: range.end.yyyymmdd, style: .abbreviated)
                     let dueSummary = cycle.dueSummary()
 
-                    // Collapsed by default like the balance breakdown above, but
-                    // the due date rides on the header row rather than hiding —
-                    // it's the part of this section worth acting on.
                     Button {
                         withAnimation(AppAnimation.disclosure) { showingBillingCycle.toggle() }
                     } label: {
@@ -278,9 +261,6 @@ struct AccountDetailView: View {
                                     }
                                 )
                             }
-                            // The sentinel rides in the last date section so
-                            // grouped mode doesn't grow a headerless section
-                            // (and its gap) of its own.
                             if pager.hasMore, group.id == groups.last?.id {
                                 TransactionPagingSentinel(pager: pager)
                             }
@@ -306,8 +286,6 @@ struct AccountDetailView: View {
                     }
                 }
             } else {
-                // Header stays put while the first page is still loading, so
-                // the screen doesn't reflow once the rows land.
                 Section("Recent Transactions") {
                     if pager != nil {
                         Text(searchQuery != nil
@@ -323,9 +301,6 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
-        // The header sections (balance, billing cycle, note) are one or two rows
-        // each, so the stock inset-grouped gaps pushed the transactions off
-        // screen. Tighter spacing top and between.
         .contentMargins(.top, 8, for: .scrollContent)
         .listSectionSpacing(.compact)
         .readableWidth()
@@ -379,6 +354,14 @@ struct AccountDetailView: View {
             }
             ToolbarItem(placement: .secondaryAction) {
                 TransactionGroupingToggle()
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Toggle(isOn: $showRunningBalance) {
+                    Label(
+                        showRunningBalance ? "Hide running balance" : "Show running balance",
+                        systemImage: showRunningBalance ? "eye.slash" : "eye"
+                    )
+                }
             }
             ToolbarItem(placement: .secondaryAction) {
                 Toggle(isOn: $budgetStore.hideClearedTransactions) {
@@ -435,8 +418,6 @@ struct AccountDetailView: View {
                 .environmentObject(budgetStore)
         }
         .sheet(isPresented: $editingNote, onDismiss: {
-            // Only the note needs re-reading — a note save doesn't touch
-            // transactions or the balance.
             Task { await reloadNote() }
         }) {
             NoteEditorView(
@@ -446,39 +427,23 @@ struct AccountDetailView: View {
             )
             .environmentObject(budgetStore)
         }
-        // Keyed on the account as well as the search: selecting another
-        // account in the iPad split layout reuses this view, and without the
-        // account in the key nothing would reload — the previous account's
-        // rows would sit under the new one's name and balance.
         .task(id: [account.id, searchText]) {
             if pagerAccountId != account.id {
-                // Drop the previous account's page and balance split rather
-                // than showing them while the new ones load — and its
-                // selection state, which was scoped to its rows.
                 pager = nil
                 breakdown = nil
                 cycleSpend = 0
                 isSelecting = false
                 selectedTransactionIds.removeAll()
             } else if searchQuery != nil {
-                // Debounce keystrokes; the initial (empty) load and account
-                // switches run immediately.
                 try? await Task.sleep(for: .milliseconds(250))
                 if Task.isCancelled { return }
             }
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
-            // The store republished its data — refresh the cached page. This
-            // is the single reload path for every mutation (row toggles,
-            // deletes, sheet edits, sync, scheduled posts), so those sites
-            // carry no reload calls of their own. Concurrent reloads are
-            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideClearedTransactions) {
-            // The pager's fetch closure reads the flag, so a reload is all a
-            // toggle flip needs.
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideReconciledTransactions) {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -25,6 +25,7 @@ struct AccountDetailView: View {
     @State private var selectedTransactionIds: Set<String> = []
     @State private var cycleSpend: Int = 0
     @AppStorage("showAccountRunningBalance") private var showRunningBalance = true
+    @State private var loadedFullHistory = false
 
     private var currentBalance: Int {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
@@ -36,10 +37,7 @@ struct AccountDetailView: View {
     /// in those states would make it look like the account balance changed when
     /// the user only changed the visible filter.
     private var shouldShowRunningBalance: Bool {
-        showRunningBalance
-            && searchQuery == nil
-            && !budgetStore.hideClearedTransactions
-            && !budgetStore.hideReconciledTransactions
+        showRunningBalance && loadedFullHistory
     }
 
     private var transactionsForDisplay: [Transaction] {
@@ -81,10 +79,15 @@ struct AccountDetailView: View {
     }
 
     private func reload() async {
+        let fullHistory = searchQuery == nil
+            && !budgetStore.hideClearedTransactions
+            && !budgetStore.hideReconciledTransactions
+        loadedFullHistory = false
         breakdown = await budgetStore.balanceBreakdown(accountId: account.id)
         await reloadNote()
         await reloadCycleSpend()
         await currentPager().loadFirstPage(search: searchQuery)
+        loadedFullHistory = fullHistory
     }
 
     private func reloadCycleSpend() async {
@@ -122,15 +125,25 @@ struct AccountDetailView: View {
                 Button {
                     editingNote = true
                 } label: {
+                    // Tinted: an empty note row is an invitation to act, where
+                    // an existing note is content to read.
                     Label(String(localized: "common.addNote"), systemImage: "note.text.badge.plus")
                         .foregroundStyle(Color.accentColor)
                 }
+                // Plain: a tinted List button would tint the label twice over.
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("accountNoteRow")
             } else {
                 HStack(alignment: .top, spacing: 12) {
+                    // Attributed so markdown links and bare URLs in the note
+                    // are tappable (GH #190). That's also why this row is a
+                    // tap gesture rather than the Button the empty state uses:
+                    // a Button label swallows link taps, where links inside a
+                    // gesture-carrying row take precedence over the gesture.
                     Text(NoteLinkText.attributed(note.text))
                         .multilineTextAlignment(.leading)
+                        // Multi-line notes are the point — let the row grow
+                        // instead of truncating the guidance to one line.
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image(systemName: "pencil")
@@ -165,6 +178,9 @@ struct AccountDetailView: View {
     var body: some View {
         List {
             Section {
+                // Tapping the balance reveals the cleared/uncleared/reconciled
+                // split (GH #134), so the reconciled figure can be checked
+                // against a bank statement without starting a reconciliation.
                 Button {
                     withAnimation(AppAnimation.disclosure) { showingBreakdown.toggle() }
                 } label: {
@@ -189,6 +205,9 @@ struct AccountDetailView: View {
                     ? String(localized: "Hides the balance breakdown")
                     : String(localized: "Shows cleared, uncleared, and reconciled balances"))
 
+                // Headroom on a tracked card with a limit set — the figure a
+                // card's balance is actually judged against, so it stays visible
+                // rather than hiding behind the disclosure.
                 if let headroom = creditHeadroom {
                     breakdownRow(String(localized: "Available Credit"), amount: headroom.available)
                 }
@@ -210,6 +229,9 @@ struct AccountDetailView: View {
                     let endStr = Transaction.formattedDate(from: range.end.yyyymmdd, style: .abbreviated)
                     let dueSummary = cycle.dueSummary()
 
+                    // Collapsed by default like the balance breakdown above, but
+                    // the due date rides on the header row rather than hiding —
+                    // it's the part of this section worth acting on.
                     Button {
                         withAnimation(AppAnimation.disclosure) { showingBillingCycle.toggle() }
                     } label: {
@@ -261,6 +283,9 @@ struct AccountDetailView: View {
                                     }
                                 )
                             }
+                            // The sentinel rides in the last date section so
+                            // grouped mode doesn't grow a headerless section
+                            // (and its gap) of its own.
                             if pager.hasMore, group.id == groups.last?.id {
                                 TransactionPagingSentinel(pager: pager)
                             }
@@ -286,6 +311,8 @@ struct AccountDetailView: View {
                     }
                 }
             } else {
+                // Header stays put while the first page is still loading, so
+                // the screen doesn't reflow once the rows land.
                 Section("Recent Transactions") {
                     if pager != nil {
                         Text(searchQuery != nil
@@ -301,6 +328,9 @@ struct AccountDetailView: View {
             }
         }
         .contentMargins(.horizontal, 6, for: .scrollContent)
+        // The header sections (balance, billing cycle, note) are one or two rows
+        // each, so the stock inset-grouped gaps pushed the transactions off
+        // screen. Tighter spacing top and between.
         .contentMargins(.top, 8, for: .scrollContent)
         .listSectionSpacing(.compact)
         .readableWidth()
@@ -358,7 +388,7 @@ struct AccountDetailView: View {
             ToolbarItem(placement: .secondaryAction) {
                 Toggle(isOn: $showRunningBalance) {
                     Label(
-                        showRunningBalance ? "Hide running balance" : "Show running balance",
+                        "Show Running Balance",
                         systemImage: showRunningBalance ? "eye.slash" : "eye"
                     )
                 }
@@ -418,6 +448,8 @@ struct AccountDetailView: View {
                 .environmentObject(budgetStore)
         }
         .sheet(isPresented: $editingNote, onDismiss: {
+            // Only the note needs re-reading — a note save doesn't touch
+            // transactions or the balance.
             Task { await reloadNote() }
         }) {
             NoteEditorView(
@@ -427,26 +459,45 @@ struct AccountDetailView: View {
             )
             .environmentObject(budgetStore)
         }
+        // Keyed on the account as well as the search: selecting another
+        // account in the iPad split layout reuses this view, and without the
+        // account in the key nothing would reload — the previous account's
+        // rows would sit under the new one's name and balance.
         .task(id: [account.id, searchText]) {
+            loadedFullHistory = false
             if pagerAccountId != account.id {
+                // Drop the previous account's page and balance split rather
+                // than showing them while the new ones load — and its
+                // selection state, which was scoped to its rows.
                 pager = nil
                 breakdown = nil
                 cycleSpend = 0
                 isSelecting = false
                 selectedTransactionIds.removeAll()
             } else if searchQuery != nil {
+                // Debounce keystrokes; the initial (empty) load and account
+                // switches run immediately.
                 try? await Task.sleep(for: .milliseconds(250))
                 if Task.isCancelled { return }
             }
             await reload()
         }
         .onChange(of: budgetStore.dataVersion) {
+            // The store republished its data — refresh the cached page. This
+            // is the single reload path for every mutation (row toggles,
+            // deletes, sheet edits, sync, scheduled posts), so those sites
+            // carry no reload calls of their own. Concurrent reloads are
+            // safe: the pager's generation counter keeps the newest.
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideClearedTransactions) {
+            // The pager's fetch closure reads the flag, so a reload is all a
+            // toggle flip needs.
+            loadedFullHistory = false
             Task { await reload() }
         }
         .onChange(of: budgetStore.hideReconciledTransactions) {
+            loadedFullHistory = false
             Task { await reload() }
         }
         .onChange(of: budgetStore.creditCardStatementDays[account.id]) {

--- a/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
+++ b/Actuali/Actuali/Views/Accounts/AccountDetailView.swift
@@ -29,6 +29,22 @@ struct AccountDetailView: View {
         budgetStore.accounts.first { $0.id == account.id }?.balance ?? account.balance
     }
 
+    /// Running balances are shown only when the account register contains its
+    /// complete transaction history. Filtered/search results omit rows that
+    /// would otherwise contribute to the balance, so showing a running balance
+    /// in those states would make it look like the account balance changed when
+    /// the user only changed the visible filter.
+    private var shouldShowRunningBalance: Bool {
+        searchQuery == nil
+            && !budgetStore.hideClearedTransactions
+            && !budgetStore.hideReconciledTransactions
+    }
+
+    private var transactionsForDisplay: [Transaction] {
+        guard shouldShowRunningBalance else { return pager?.transactions ?? [] }
+        return (pager?.transactions ?? []).withRunningBalances(startingAt: currentBalance)
+    }
+
     /// Limit and headroom for a tracked card with a limit set, else nil. Read
     /// once so the visible row and the breakdown row can't disagree.
     private var creditHeadroom: (limit: Int, available: Int)? {
@@ -244,8 +260,9 @@ struct AccountDetailView: View {
             }
 
             if let pager, !pager.transactions.isEmpty {
+                let displayedTransactions = transactionsForDisplay
                 if budgetStore.transactionDisplayMode == .groupedByDate {
-                    let groups = pager.transactions.groupedByDate()
+                    let groups = displayedTransactions.groupedByDate()
                     ForEach(groups) { group in
                         Section(group.title) {
                             ForEach(group.transactions) { transaction in
@@ -271,7 +288,7 @@ struct AccountDetailView: View {
                     }
                 } else {
                     Section("Recent Transactions") {
-                        ForEach(pager.transactions) { transaction in
+                        ForEach(displayedTransactions) { transaction in
                             TransactionListRow(
                                 transaction: transaction,
                                 showAccount: false,

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -480,13 +480,9 @@ struct TransactionRow: View {
                 Text(budgetStore.displayBalance(transaction.amount))
                     .foregroundColor(transaction.isOutflow ? .primary : .green)
                 if let runningBalance = transaction.runningBalance {
-                    HStack(spacing: 3) {
-                        Text("Balance")
-                            .foregroundStyle(.secondary)
-                        Text(budgetStore.displayBalance(runningBalance))
-                            .foregroundStyle(balanceColor(for: runningBalance))
-                    }
-                    .font(.caption)
+                    Text(budgetStore.displayBalance(runningBalance))
+                        .foregroundStyle(balanceColor(for: runningBalance))
+                        .font(.caption)
                 }
                 if showDate {
                     Text(transaction.dateFormatted)

--- a/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
+++ b/Actuali/Actuali/Views/Transactions/TransactionsListView.swift
@@ -479,6 +479,15 @@ struct TransactionRow: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(budgetStore.displayBalance(transaction.amount))
                     .foregroundColor(transaction.isOutflow ? .primary : .green)
+                if let runningBalance = transaction.runningBalance {
+                    HStack(spacing: 3) {
+                        Text("Balance")
+                            .foregroundStyle(.secondary)
+                        Text(budgetStore.displayBalance(runningBalance))
+                            .foregroundStyle(balanceColor(for: runningBalance))
+                    }
+                    .font(.caption)
+                }
                 if showDate {
                     Text(transaction.dateFormatted)
                         .font(.caption)

--- a/Actuali/ActualiTests/Models/TransactionRunningBalanceTests.swift
+++ b/Actuali/ActualiTests/Models/TransactionRunningBalanceTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Actuali
+
+struct TransactionRunningBalanceTests {
+    @Test
+    func runningBalanceWalksBackwardFromCurrentBalance() {
+        let rows = [
+            transaction(id: "1", amount: -3000),
+            transaction(id: "2", amount: 5000),
+            transaction(id: "3", amount: 8000)
+        ]
+
+        #expect(rows.withRunningBalances(startingAt: 10000).map(\.runningBalance) == [10000, 13000, 8000])
+    }
+
+    private func transaction(id: String, amount: Int) -> Transaction {
+        Transaction(
+            id: id,
+            accountId: "account",
+            date: 20260912,
+            amount: amount,
+            payeeId: nil,
+            payeeName: nil,
+            categoryId: nil,
+            categoryName: nil,
+            notes: nil,
+            cleared: false,
+            reconciled: false,
+            transferId: nil,
+            isParent: false,
+            parentId: nil,
+            tombstone: false,
+            sortOrder: nil,
+            importedPayee: nil
+        )
+    }
+}


### PR DESCRIPTION
## Why

Account transaction registers did not show the balance after each transaction, making it harder to track how the account balance changed over time.

## What

* Added running balances to On Budget and Off Budget account transaction registers.
* Added a toggle in the `…` menu to show or hide running balances.
* Running balances are hidden when searching or filtering cleared/reconciled transactions to avoid misleading values.
* Running balance formatting follows the account's existing number-format settings, including hidden decimal places.

## How it was tested

* Manually reviewed the account transaction register and running balance display.
* Verified the show/hide option in the `…` menu.
* Verified running balances respect the selected decimal-place formatting.
